### PR TITLE
feat(maps): native Google Maps for the location picker

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -51,13 +51,44 @@ function googleServicesFile(): string | undefined {
   return existsSync(local) ? local : undefined;
 }
 
+/**
+ * The native Google Maps SDK key for a platform, or nothing when unset.
+ *
+ * `react-native-maps` with the Google provider needs an API key baked into the
+ * native manifest (Android) / Info.plist (iOS) — this is Google's sanctioned
+ * path for a mobile Maps key and MUST be locked down in the Cloud Console before
+ * release (Android package + SHA-1, iOS bundle id; and the Maps SDK APIs only).
+ * The key is not committed — this repo is public — so it is read at config time,
+ * a platform-specific var winning over the shared one. With none set the app
+ * still builds; the Google map just renders blank until a key is supplied.
+ */
+function googleMapsKey(platform: 'android' | 'ios'): string | undefined {
+  const perPlatform =
+    platform === 'android' ? process.env.GOOGLE_MAPS_ANDROID_KEY : process.env.GOOGLE_MAPS_IOS_KEY;
+  return perPlatform || process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY || undefined;
+}
+
 export default (): ExpoConfig => {
   const config = appJson.expo as ExpoConfig;
 
   const services = googleServicesFile();
-  const withPush: ExpoConfig = services
-    ? { ...config, android: { ...config.android, googleServicesFile: services } }
-    : config;
+  const androidBase = services
+    ? { ...config.android, googleServicesFile: services }
+    : config.android;
+
+  // Fold the native Maps SDK key into each platform's `config` block when one is
+  // set, so `expo prebuild` writes it into the manifest / Info.plist.
+  const androidKey = googleMapsKey('android');
+  const iosKey = googleMapsKey('ios');
+  const withPush: ExpoConfig = {
+    ...config,
+    android: androidKey
+      ? { ...androidBase, config: { ...androidBase?.config, googleMaps: { apiKey: androidKey } } }
+      : androidBase,
+    ios: iosKey
+      ? { ...config.ios, config: { ...config.ios?.config, googleMapsApiKey: iosKey } }
+      : config.ios,
+  };
 
   const organization = process.env.SENTRY_ORG;
   const project = process.env.SENTRY_PROJECT;

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -5,7 +5,10 @@
     "version": "0.1.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
-    "scheme": ["waves", "baaki"],
+    "scheme": [
+      "waves",
+      "baaki"
+    ],
     "userInterfaceStyle": "automatic",
     "backgroundColor": "#F3F1FB",
     "runtimeVersion": {
@@ -60,7 +63,9 @@
         {
           "microphonePermission": "Waves uses the microphone only while you hold the mic button, to write down what you say.",
           "speechRecognitionPermission": "Waves turns what you say into the note on an expense, so you can add one without typing at the table.",
-          "androidSpeechServicePackages": ["com.google.android.googlequicksearchbox"]
+          "androidSpeechServicePackages": [
+            "com.google.android.googlequicksearchbox"
+          ]
         }
       ],
       [
@@ -85,6 +90,7 @@
         }
       ],
       "./plugins/withShortNativeBuildPath",
+      "./plugins/withGradleMemory",
       "./plugins/withSideBySideDebug",
       "./plugins/withWavesWidgets",
       "./plugins/withWavesWear",

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -5,10 +5,7 @@
     "version": "0.1.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
-    "scheme": [
-      "waves",
-      "baaki"
-    ],
+    "scheme": ["waves", "baaki"],
     "userInterfaceStyle": "automatic",
     "backgroundColor": "#F3F1FB",
     "runtimeVersion": {
@@ -63,9 +60,7 @@
         {
           "microphonePermission": "Waves uses the microphone only while you hold the mic button, to write down what you say.",
           "speechRecognitionPermission": "Waves turns what you say into the note on an expense, so you can add one without typing at the table.",
-          "androidSpeechServicePackages": [
-            "com.google.android.googlequicksearchbox"
-          ]
+          "androidSpeechServicePackages": ["com.google.android.googlequicksearchbox"]
         }
       ],
       [

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -65,6 +65,7 @@
     "react-native-draggable-flatlist": "4.0.3",
     "react-native-gesture-handler": "~2.32.0",
     "react-native-get-sms-android": "^2.1.0",
+    "react-native-maps": "1.27.2",
     "react-native-qrcode-styled": "^0.4.0",
     "react-native-qrcode-svg": "^6.3.21",
     "react-native-reanimated": "4.5.3",

--- a/apps/mobile/plugins/withGradleMemory.js
+++ b/apps/mobile/plugins/withGradleMemory.js
@@ -1,0 +1,36 @@
+/**
+ * Give the Gradle daemon enough Metaspace to build this app in one clean pass.
+ *
+ * Expo's generated `gradle.properties` ships `-Xmx2048m -XX:MaxMetaspaceSize=512m`.
+ * That 512 MiB metaspace is enough for a warm, incremental build, but a full
+ * clean `assembleRelease` — every dependency's Kotlin/Java compiled at once,
+ * with `react-native-maps` now in the set — exhausts it, and the daemon dies
+ * mid-task with `java.lang.OutOfMemoryError: Metaspace`. The failure surfaces on
+ * whichever task was running (we saw it on `processReleaseGoogleServices`), not
+ * on the real cause, so it reads like an unrelated plugin error.
+ *
+ * `prebuild` regenerates `gradle.properties`, so raising it once by hand would
+ * not survive the next prebuild — anyone building would hit the same wall. This
+ * plugin re-applies the bump every prebuild: a roomier metaspace and heap, and
+ * the class-metadata GC that keeps long daemon sessions from creeping back up.
+ */
+
+const { withGradleProperties } = require('expo/config-plugins');
+
+// Heap and metaspace the clean build needs; `-XX:+UseCompressedClassPointers`
+// and class-unloading keep metaspace from growing unbounded across builds.
+const JVM_ARGS =
+  '-Xmx4096m -XX:MaxMetaspaceSize=1024m -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC';
+
+module.exports = function withGradleMemory(config) {
+  return withGradleProperties(config, (cfg) => {
+    const props = cfg.modResults;
+    // Drop any existing org.gradle.jvmargs so ours is the only one that stands.
+    const filtered = props.filter(
+      (item) => !(item.type === 'property' && item.key === 'org.gradle.jvmargs'),
+    );
+    filtered.push({ type: 'property', key: 'org.gradle.jvmargs', value: JVM_ARGS });
+    cfg.modResults = filtered;
+    return cfg;
+  });
+};

--- a/apps/mobile/src/components/GoogleMapSurface.tsx
+++ b/apps/mobile/src/components/GoogleMapSurface.tsx
@@ -1,0 +1,89 @@
+/**
+ * The native Google Maps surface for the location picker.
+ *
+ * Isolated in its own file for the same reason `VoiceCapture` is: it imports a
+ * native module (`react-native-maps`) whose JS throws on any binary built before
+ * that module existed. `LocationPickerSheet` reaches it through a guarded
+ * `require` (see `nativeMaps`) and falls back to the raster-tile map when it is
+ * not there — so an OTA update that carries this file to an older build degrades
+ * to tiles instead of crashing at launch.
+ *
+ * It draws only the map itself: a full-bleed Google `MapView` with a fixed
+ * centre pin, the point that gets saved. The map pans and pinch-zooms natively;
+ * the parent reads the resting centre from `onCenterChange` and drives
+ * programmatic moves (reseed, "use my location") through the `mapRef`.
+ */
+
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { View } from 'react-native';
+import MapView, { PROVIDER_GOOGLE, type Region } from 'react-native-maps';
+
+import { iconSize, useTheme } from '@waves/ui';
+
+import type { LatLng } from '@/lib/mapTiles';
+
+/**
+ * A region for a centre point. The deltas set the zoom: a tight span for a known
+ * point, a wide one for the "no starting point" world view. Longitude delta is
+ * derived from latitude by the frame's aspect so the map is not stretched.
+ */
+export function regionForCenter(center: LatLng, span: 'point' | 'world', aspect: number): Region {
+  const latitudeDelta = span === 'point' ? 0.01 : 90;
+  return {
+    latitude: center.lat,
+    longitude: center.lng,
+    latitudeDelta,
+    longitudeDelta: latitudeDelta * (aspect > 0 ? aspect : 1),
+  };
+}
+
+export type GoogleMapHandle = Pick<MapView, 'animateToRegion'>;
+
+export function GoogleMapSurface({
+  mapRef,
+  initialRegion,
+  onCenterChange,
+}: {
+  mapRef: React.RefObject<MapView | null>;
+  initialRegion: Region;
+  onCenterChange: (center: LatLng) => void;
+}): React.JSX.Element {
+  const theme = useTheme();
+  return (
+    <View style={{ flex: 1 }}>
+      <MapView
+        ref={mapRef}
+        provider={PROVIDER_GOOGLE}
+        style={{ flex: 1 }}
+        initialRegion={initialRegion}
+        onRegionChangeComplete={(region) =>
+          onCenterChange({ lat: region.latitude, lng: region.longitude })
+        }
+        showsUserLocation
+        showsMyLocationButton={false}
+        toolbarEnabled={false}
+      />
+      {/* Fixed centre pin — the point that gets saved, lifted so its tip sits on
+          the exact centre of the map. */}
+      <View
+        pointerEvents="none"
+        style={{
+          position: 'absolute',
+          left: 0,
+          right: 0,
+          top: 0,
+          bottom: 0,
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Ionicons
+          name="location"
+          size={iconSize.xxl}
+          color={theme.color.brand}
+          style={{ marginTop: -iconSize.xxl / 2 }}
+        />
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/LocationPickerSheet.tsx
+++ b/apps/mobile/src/components/LocationPickerSheet.tsx
@@ -13,11 +13,12 @@
  * is the only path here that asks for permission, and only when tapped.
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Image } from 'expo-image';
 import { ActivityIndicator, type LayoutChangeEvent, Modal, Pressable, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import type MapView from 'react-native-maps';
 
 import type { ExpenseLocation } from '@waves/core';
 import { Button, iconSize, Row, Text, useTheme } from '@waves/ui';
@@ -41,6 +42,7 @@ import {
   tileGrid,
   tileUrl,
 } from '@/lib/mapTiles';
+import { nativeMaps } from '@/lib/nativeMaps';
 
 const TILE_URL = process.env.EXPO_PUBLIC_MAP_TILE_URL || DEFAULT_TILE_URL;
 // Where the map opens when there is no starting point and no granted fix — a
@@ -69,6 +71,19 @@ export function LocationPickerSheet({
   const [locating, setLocating] = useState(false);
   const [saving, setSaving] = useState(false);
 
+  // The native Google map, when the module is in this build. Its imperative
+  // handle lets "use my location" and the on-open reseed fly the camera; a fresh
+  // `mapKey` per open remounts it so it always opens on the right region.
+  const useNativeMap = nativeMaps !== null;
+  const mapRef = useRef<MapView | null>(null);
+  const [mapKey, setMapKey] = useState(0);
+  const aspect = size.h > 0 ? size.w / size.h : 1;
+  const flyTo = (to: LatLng, span: 'point' | 'world'): void => {
+    if (useNativeMap && nativeMaps) {
+      mapRef.current?.animateToRegion(nativeMaps.regionForCenter(to, span, aspect), 350);
+    }
+  };
+
   // Re-seed the moment the sheet opens: an edit reopens on its saved point; a
   // fresh pick opens on the world view to tap or zoom into. Done during render
   // (the "adjust state when the input changes" pattern the expense form uses)
@@ -78,6 +93,9 @@ export function LocationPickerSheet({
     setSeededOpen(true);
     setCenter(initial ?? WORLD);
     setZoom(initial ? DEFAULT_ZOOM : WORLD_ZOOM);
+    // Remount the native map so it opens on the reseeded region (initialRegion
+    // is read once at mount).
+    if (useNativeMap) setMapKey((k) => k + 1);
   } else if (!visible && seededOpen) {
     setSeededOpen(false);
   }
@@ -92,11 +110,15 @@ export function LocationPickerSheet({
       if (active && loc) {
         setCenter({ lat: loc.lat, lng: loc.lng });
         setZoom(DEFAULT_ZOOM);
+        flyTo({ lat: loc.lat, lng: loc.lng }, 'point');
       }
     });
     return () => {
       active = false;
     };
+    // `flyTo` is stable enough for this one-shot on-open fix; re-running on its
+    // identity would refire the granted-location upgrade on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visible, initial]);
 
   const onLayout = (event: LayoutChangeEvent): void => {
@@ -118,6 +140,7 @@ export function LocationPickerSheet({
       if (result.ok) {
         setCenter({ lat: result.location.lat, lng: result.location.lng });
         setZoom(DEFAULT_ZOOM);
+        flyTo({ lat: result.location.lat, lng: result.location.lng }, 'point');
       }
     } finally {
       setLocating(false);
@@ -176,105 +199,126 @@ export function LocationPickerSheet({
           </View>
         </Row>
 
-        {/* The map. A Pressable captures the tap that moves the pin. */}
+        {/* The map. Native Google Maps when the module is in this build; the
+            keyless raster-tile map otherwise (an older build, an OTA fallback). */}
         <View style={{ flex: 1 }} onLayout={onLayout}>
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel={t.location.pickerHint}
-            onPress={(event) => onTapMap(event.nativeEvent.locationX, event.nativeEvent.locationY)}
-            style={{ flex: 1, backgroundColor: theme.color.bg }}
-          >
-            {tiles.map((tile) => (
-              <Image
-                key={`${tile.x}-${tile.y}-${tile.left}`}
-                source={{ uri: tileUrl(TILE_URL, tile.x, tile.y, zoom), headers: TILE_HEADERS }}
+          {useNativeMap && nativeMaps ? (
+            // Native Google map: pans and pinch-zooms itself, its own attribution
+            // baked in, the resting centre read back on pan-end. No tap-to-move,
+            // zoom buttons or credit overlay — the map owns all three.
+            <nativeMaps.GoogleMapSurface
+              key={mapKey}
+              mapRef={mapRef}
+              initialRegion={nativeMaps.regionForCenter(
+                center,
+                initial ? 'point' : 'world',
+                aspect,
+              )}
+              onCenterChange={setCenter}
+            />
+          ) : (
+            <>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={t.location.pickerHint}
+                onPress={(event) =>
+                  onTapMap(event.nativeEvent.locationX, event.nativeEvent.locationY)
+                }
+                style={{ flex: 1, backgroundColor: theme.color.bg }}
+              >
+                {tiles.map((tile) => (
+                  <Image
+                    key={`${tile.x}-${tile.y}-${tile.left}`}
+                    source={{ uri: tileUrl(TILE_URL, tile.x, tile.y, zoom), headers: TILE_HEADERS }}
+                    style={{
+                      position: 'absolute',
+                      left: tile.left,
+                      top: tile.top,
+                      width: TILE_SIZE,
+                      height: TILE_SIZE,
+                    }}
+                    contentFit="cover"
+                    transition={120}
+                    cachePolicy="memory-disk"
+                  />
+                ))}
+              </Pressable>
+
+              {/* Fixed centre pin — the point that gets saved. */}
+              <View
+                pointerEvents="none"
                 style={{
                   position: 'absolute',
-                  left: tile.left,
-                  top: tile.top,
-                  width: TILE_SIZE,
-                  height: TILE_SIZE,
-                }}
-                contentFit="cover"
-                transition={120}
-                cachePolicy="memory-disk"
-              />
-            ))}
-          </Pressable>
-
-          {/* Fixed centre pin — the point that gets saved. */}
-          <View
-            pointerEvents="none"
-            style={{
-              position: 'absolute',
-              left: 0,
-              right: 0,
-              top: 0,
-              bottom: 0,
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          >
-            <Ionicons
-              name="location"
-              size={iconSize.xxl}
-              color={theme.color.brand}
-              style={{ marginTop: -iconSize.xxl / 2 }}
-            />
-          </View>
-
-          {/* Zoom controls, stacked at the trailing edge. */}
-          <View
-            style={{
-              position: 'absolute',
-              right: theme.spacing.lg,
-              top: theme.spacing.lg,
-              gap: theme.spacing.sm,
-            }}
-          >
-            {(
-              [
-                ['add', () => setZoom((z) => clampZoom(z + 1)), t.location.zoomIn],
-                ['remove', () => setZoom((z) => clampZoom(z - 1)), t.location.zoomOut],
-              ] as const
-            ).map(([icon, onPress, label]) => (
-              <Pressable
-                key={icon}
-                accessibilityRole="button"
-                accessibilityLabel={label}
-                onPress={onPress}
-                style={({ pressed }) => ({
-                  width: 44,
-                  height: 44,
-                  borderRadius: theme.radius.md,
+                  left: 0,
+                  right: 0,
+                  top: 0,
+                  bottom: 0,
                   alignItems: 'center',
                   justifyContent: 'center',
-                  backgroundColor: theme.color.surface,
-                  opacity: pressed ? 0.7 : 1,
-                })}
+                }}
               >
-                <Ionicons name={icon} size={iconSize.md} color={theme.color.text} />
-              </Pressable>
-            ))}
-          </View>
+                <Ionicons
+                  name="location"
+                  size={iconSize.xxl}
+                  color={theme.color.brand}
+                  style={{ marginTop: -iconSize.xxl / 2 }}
+                />
+              </View>
 
-          {/* Attribution — required by the tile licence (OSM data, CARTO tiles). */}
-          <View
-            pointerEvents="none"
-            style={{
-              position: 'absolute',
-              right: 0,
-              bottom: 0,
-              paddingHorizontal: 4,
-              paddingVertical: 2,
-              backgroundColor: 'rgba(255, 255, 255, 0.7)',
-              borderTopLeftRadius: theme.radius.sm,
-            }}
-          >
-            <Text variant="micro" style={{ color: '#333', fontSize: 9 }}>
-              {TILE_ATTRIBUTION}
-            </Text>
-          </View>
+              {/* Zoom controls, stacked at the trailing edge. */}
+              <View
+                style={{
+                  position: 'absolute',
+                  right: theme.spacing.lg,
+                  top: theme.spacing.lg,
+                  gap: theme.spacing.sm,
+                }}
+              >
+                {(
+                  [
+                    ['add', () => setZoom((z) => clampZoom(z + 1)), t.location.zoomIn],
+                    ['remove', () => setZoom((z) => clampZoom(z - 1)), t.location.zoomOut],
+                  ] as const
+                ).map(([icon, onPress, label]) => (
+                  <Pressable
+                    key={icon}
+                    accessibilityRole="button"
+                    accessibilityLabel={label}
+                    onPress={onPress}
+                    style={({ pressed }) => ({
+                      width: 44,
+                      height: 44,
+                      borderRadius: theme.radius.md,
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      backgroundColor: theme.color.surface,
+                      opacity: pressed ? 0.7 : 1,
+                    })}
+                  >
+                    <Ionicons name={icon} size={iconSize.md} color={theme.color.text} />
+                  </Pressable>
+                ))}
+              </View>
+
+              {/* Attribution — required by the tile licence (OSM data, CARTO tiles). */}
+              <View
+                pointerEvents="none"
+                style={{
+                  position: 'absolute',
+                  right: 0,
+                  bottom: 0,
+                  paddingHorizontal: 4,
+                  paddingVertical: 2,
+                  backgroundColor: 'rgba(255, 255, 255, 0.7)',
+                  borderTopLeftRadius: theme.radius.sm,
+                }}
+              >
+                <Text variant="micro" style={{ color: '#333', fontSize: 9 }}>
+                  {TILE_ATTRIBUTION}
+                </Text>
+              </View>
+            </>
+          )}
         </View>
 
         {/* Footer: the hint, "use my location", and the confirm. */}

--- a/apps/mobile/src/lib/nativeMaps.ts
+++ b/apps/mobile/src/lib/nativeMaps.ts
@@ -1,0 +1,36 @@
+/**
+ * A non-throwing gate to the native Google Maps surface.
+ *
+ * `react-native-maps` is a native module: importing its JS on a binary built
+ * before the module was added throws at load, and nothing in React catches it —
+ * the app dies at launch (the same trap `expo-speech-recognition` sits behind in
+ * `VoiceMicPanel`). So the surface is reached only through this guarded
+ * `require`. When the native module is present `nativeMaps` carries the
+ * component and its region helper; when it is not — an older build an OTA update
+ * reached — it is `null`, and the caller falls back to the raster-tile map.
+ */
+
+import type {
+  GoogleMapSurface as GoogleMapSurfaceType,
+  regionForCenter,
+} from '@/components/GoogleMapSurface';
+
+interface NativeMaps {
+  GoogleMapSurface: typeof GoogleMapSurfaceType;
+  regionForCenter: typeof regionForCenter;
+}
+
+function load(): NativeMaps | null {
+  try {
+    // Reaching this file pulls in `react-native-maps`; a build without the native
+    // module throws here and we degrade to tiles rather than crashing. The cast is
+    // through `unknown` because the require's shape is only known at runtime.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require('@/components/GoogleMapSurface') as unknown as NativeMaps;
+    return typeof mod.GoogleMapSurface === 'function' ? mod : null;
+  } catch {
+    return null;
+  }
+}
+
+export const nativeMaps: NativeMaps | null = load();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,6 +285,9 @@ importers:
       react-native-get-sms-android:
         specifier: ^2.1.0
         version: 2.1.0(patch_hash=e72c594803865c47c2f801d4365965e702516c309f10d38bfe3a48a8c2c1f05d)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))
+      react-native-maps:
+        specifier: 1.27.2
+        version: 1.27.2(react-native-web@0.21.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
       react-native-qrcode-styled:
         specifier: ^0.4.0
         version: 0.4.0(react-native-svg@15.15.4(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
@@ -6314,6 +6317,17 @@ packages:
       react: '*'
       react-native: '*'
 
+  react-native-maps@1.27.2:
+    resolution: {integrity: sha512-VKr+xZ2RZGHHJlY6KhlafvGSmK0dq/tUu5uhfJ7K9rwN5pUdubdugzMKGDU/16lXmQSg7xbClKhRctj3Pm5F5g==}
+    engines: {node: '>= 20.19.4'}
+    peerDependencies:
+      react: '>= 18.3.1'
+      react-native: '>= 0.76.0'
+      react-native-web: '>= 0.11'
+    peerDependenciesMeta:
+      react-native-web:
+        optional: true
+
   react-native-qrcode-styled@0.4.0:
     resolution: {integrity: sha512-j5C5LFOr9KdAqm1snQX8UQH9RFRSH4FY1/7Ts/UvtR/5A9rmb61ZzIIW5d0RteY1D+DWVfnXDMhLmTJXXRgKpg==}
     engines: {node: '>= 16.0.0'}
@@ -11675,7 +11689,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.66.0(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.66.0(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14011,6 +14025,14 @@ snapshots:
     dependencies:
       react: 19.2.8
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1)
+
+  react-native-maps@1.27.2(react-native-web@0.21.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8):
+    dependencies:
+      '@types/geojson': 7946.0.16
+      react: 19.2.8
+      react-native: 0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1)
+    optionalDependencies:
+      react-native-web: 0.21.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 
   react-native-qrcode-styled@0.4.0(react-native-svg@15.15.4(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8):
     dependencies:


### PR DESCRIPTION
## What
Replace the location picker's keyless OSM/CARTO raster-tile map with a real, pannable **Google Maps** view, per request ("implement Google Maps instead of current maps").

## Changes
- **`react-native-maps@1.27.2`** (the Expo-57-bundled version) added.
- **`GoogleMapSurface`** — a native `MapView` (`PROVIDER_GOOGLE`) with a fixed centre pin; the resting centre is read back on pan-end. Isolated in its own file and reached through a **guarded `require`** (`lib/nativeMaps`), mirroring `VoiceCapture` behind `VoiceMicPanel`: a bare import of a native module crashes any binary that predates it (e.g. an OTA to an older build), so when the module is absent the picker **falls back to the existing tile map** instead of dying at launch.
- **`LocationPickerSheet`** renders the native surface when present, the tile map otherwise; "use my location" and the on-open reseed fly the native camera.
- **Maps SDK key** injected per platform in `app.config.ts` from the environment (`GOOGLE_MAPS_ANDROID_KEY` / `GOOGLE_MAPS_IOS_KEY`, or the shared `EXPO_PUBLIC_GOOGLE_MAPS_API_KEY`), **never committed**; prebuild bakes it into the manifest / Info.plist. With no key the app still builds; the map is blank until one is supplied.
- **`withGradleMemory`** config plugin: raise the Gradle daemon metaspace to 1 GiB. A full clean `assembleRelease` with the added native module exhausted the default 512 MiB and the daemon died mid-task with an `OutOfMemoryError` surfacing on an unrelated task. (This fix turns out to be needed for every clean build on the pinned toolchain, not only maps.)

The thumbnail (Static Maps) and the "open in maps" deep link stay Google as before.

## Security — the key must be restricted before release
A Maps key in a mobile app is baked into the binary and is **extractable by design**; the protection is Cloud-Console restriction:
- **Application restriction** → Android package `app.waves.mobile` + signing SHA-1 (and iOS bundle id).
- **API restriction** → *Maps SDK for Android* (+ *Maps Static API* for the thumbnail) only.

## Verified
- Native compile verified locally (prebuild + Gradle, `react-native-maps` autolinks cleanly on the Expo-57 pin).
- **Device-confirmed**: with the key set, the Google map renders (thumbnail shown by the reporter); interactive picker built into the test APK.
- mobile tsc + expo lint clean.

## Note (out of scope, surfaced by this work)
The repo's local `google-services.json` is **stale (pre-`waves` rebrand)** — it has no `app.waves.mobile` client, which fails *release* FCM builds (`processReleaseGoogleServices`). Unrelated to maps; needs an updated file from Firebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a native Google Maps experience to the mobile location picker, including pan, zoom, camera animation, center tracking, and a fixed center pin.
  - Added platform-specific Google Maps configuration for Android and iOS.
  - Added a fallback map experience for builds without native Maps support.

- **Bug Fixes**
  - Improved location-picker behavior when opening, granting location access, or selecting the current location.

- **Chores**
  - Increased Android build memory settings to improve build reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->