### PR TITLE
fix(sync): a stale personal-scope cursor must never reach a uuid column

### DIFF
--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -1088,7 +1088,17 @@ async function pull(
   // per-group `maybeSingle` was the first of twelve serial round trips each
   // group cost, and twelve of anything serial is what made a five-group first
   // sync take seconds.
-  const groupList = [...groupIds];
+  // A group id is a bare uuid; every personal scope key carries a ':<name>'
+  // suffix (':ghost_merges', ':category_tags', ':personal'). The deletes above
+  // drop the *current* caller's scope keys, but a stale cursor from a previous
+  // account slips past them: a re-login leaves the old '<oldId>:ghost_merges'
+  // cursor in the client, it is sent on every poll, and its uuid no longer
+  // matches the computed `gmScope`, so the exact-key delete misses it. Handed to
+  // a uuid column ('.in(id, …)' on groups, '.eq(group_id, …)' per group) it is
+  // the '22P02 invalid input syntax for type uuid: "<id>:ghost_merges"' that
+  // floods the logs every poll. Keep only bare ids so no scoped key can reach a
+  // uuid column, whatever account minted it.
+  const groupList = [...groupIds].filter((id) => !id.includes(':'));
   const groupRows = new Map<string, Record<string, unknown>>();
   if (groupList.length > 0) {
     const { data, error } = await caller.from('groups').select('*').in('id', groupList);


### PR DESCRIPTION
## Incident
Prod logs flooded, **every poll**, with:
```
22P02  invalid input syntax for type uuid: "be31c6e9-…:ghost_merges"
```

## Cause
The group pull in `sync` builds its id set from `Object.keys(cursors)`, which includes the **personal-scope cursor keys** — `<id>:ghost_merges` (A38), `<id>:category_tags`, `<id>:personal`, and captures' bare `<id>`. Four `groupIds.delete(...)` calls strip the **current caller's** scope keys before the group query, but they delete by *exact key*. A **stale cursor from a previous account** — a re-login leaves the old `<oldId>:ghost_merges` in the client, and it's sent on every poll — carries a different uuid, so the recomputed `gmScope` never matches it. It slips past the deletes and reaches `.in('id', …)` on `groups` and `.eq('group_id', …)` per group, both **uuid** columns → 22P02, looping forever.

## Fix
Filter the group list to **bare ids** (no `:` scope suffix) rather than relying on the per-account exact-key deletes, so no scoped key — whatever account minted it — can ever be handed to a uuid column:
```ts
const groupList = [...groupIds].filter((id) => !id.includes(':'));
```
The four deletes are now redundant but kept as documentation of the scopes.

## Status
- **Deployed to prod** (`xvjzbpgcmotoahtqcxve`) — the flood stops within a poll cycle.
- Existing sync edge tests pass (4/4). Defensive one-liner; no behaviour change for valid ids.

## Follow-up (not in this PR)
The deeper cause is the client keeping personal-scope cursors across an account switch. Clearing the mirror's cursor map on sign-out / account-change would stop the stale key being sent at all — a client (OTA) change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization by excluding personal-scope cursors from group queries, preventing stale cursor data from affecting results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->