### PR TITLE
experiment(nav): fold Activity into Home header (discardable)

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -339,6 +339,13 @@ export default function HomeScreen() {
               </Text>
             </Pressable>
             <SyncStatusIcon onBrand />
+            {/* EXPERIMENT (fold-activity-into-home): Activity left the bottom bar
+                  and lives here as a header shortcut. Remove this to revert. */}
+            <HeroIconButton
+              icon="pulse"
+              label={t.activity}
+              onPress={() => router.navigate('/activity')}
+            />
             {/* Start a group — moved up here from the action row, so it sits
                   just before the menu. Still the tour's "add a group" anchor. */}
             <TourTarget id="addGroup">

--- a/apps/mobile/src/components/AppTabBar.tsx
+++ b/apps/mobile/src/components/AppTabBar.tsx
@@ -54,18 +54,15 @@ export function AppTabBar() {
         label: t.friends,
         icon: (color) => <Ionicons name="people" size={iconSize.lg} color={color} />,
       },
-      {
-        key: 'activity',
-        label: t.activity,
-        icon: (color) => <Ionicons name="pulse" size={iconSize.lg} color={color} />,
-      },
+      // EXPERIMENT (fold-activity-into-home): Activity dropped from the bar and
+      // moved to a header shortcut on Home. Restore this entry to revert.
       {
         key: 'me',
         label: t.personal.tab,
         icon: (color) => <Ionicons name="wallet-outline" size={iconSize.lg} color={color} />,
       },
     ],
-    [t.activity, t.friends, t.home, t.personal.tab],
+    [t.friends, t.home, t.personal.tab],
   );
 
   // All bar destinations are tabs now. `navigate` switches to the existing tab


### PR DESCRIPTION
## Experiment — safe to discard

Trial of the nav review: does the bottom bar read better with **4 destinations + mic** instead of 5?

### Change
- **Bottom bar** drops from `Home · Friends · Activity · [mic] · Me` to `Home · Friends · [mic] · Me`.
- **Activity** moves to a **pulse glyph in the Home hero header** (top-right, next to sync / new-group / ⋯).
- The `/activity` route and screen are **untouched** — only *how it's reached* changes. Nothing about the feed itself moves.

### Why
Activity is read-only and overlaps what Home already surfaces; every group has its own feed. It's a "glance," not a daily destination — so it earns a shortcut, not a permanent tab slot. See the nav review discussion.

### Reversibility
Both edit sites carry an `EXPERIMENT (fold-activity-into-home)` comment. Reverting = restore the bar item + delete the header shortcut. No data, route, or schema change.

### Notes
- Bar with 3 items + center mic splits 2 | mic | 1 (left-heavy by one). Acceptable, but worth an eyeball on device — the main thing to judge.
- Pure JS, no native rebuild. `eslint` clean.
- Not device-tested.

If it doesn't feel nice on device: close this PR, delete the branch, done.