### PR TITLE
fix(security): close the two P0s from the 2026-09-03 audit

### DIFF
--- a/.github/workflows/coderabbit-apply.yml
+++ b/.github/workflows/coderabbit-apply.yml
@@ -65,19 +65,28 @@ jobs:
         contains(github.event.comment.body, '/coderabbit-apply'))
     runs-on: ubuntu-latest
     steps:
+      # The dispatch input is free text, so it reaches the shell through the
+      # environment (never expanded into the script) and must be a plain PR
+      # number before any step uses it.
       - name: Resolve PR number
         id: pr
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr }}
         run: |
-          NUM="${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr }}"
-          echo "number=$NUM" >> "$GITHUB_OUTPUT"
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "::error::PR number must be decimal digits, got: $PR_NUMBER"
+            exit 1
+          fi
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
       # Before anything is checked out: the token cannot push to a fork, and
       # a fork's code should never reach the agent step below.
       - name: Refuse to run on a fork branch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: |
-          IS_FORK=$(gh pr view ${{ steps.pr.outputs.number }} --repo "$GITHUB_REPOSITORY" --json isCrossRepository --jq .isCrossRepository)
+          IS_FORK=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json isCrossRepository --jq .isCrossRepository)
           if [ "$IS_FORK" = "true" ]; then
             echo "::error::PR is from a fork; the apply token cannot push to it."
             exit 1
@@ -94,7 +103,8 @@ jobs:
       - name: Check out the PR branch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr checkout ${{ steps.pr.outputs.number }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: gh pr checkout "$PR_NUMBER"
 
       # Secrets cannot be read in an `if:` directly, so map the key to an env var
       # and record whether it is set. Without it there is nothing to run — the job
@@ -116,7 +126,8 @@ jobs:
         if: steps.key.outputs.present == 'true'
         env:
           GH_TOKEN: ${{ secrets.APPLY_TOKEN || secrets.GITHUB_TOKEN }}
-        run: bash .github/scripts/gather-coderabbit.sh ${{ steps.pr.outputs.number }} > coderabbit-comments.md
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: bash .github/scripts/gather-coderabbit.sh "$PR_NUMBER" > coderabbit-comments.md
 
       - name: Anything to do?
         id: check
@@ -151,20 +162,45 @@ jobs:
             --allowedTools "Read,Edit,Write,Grep,Glob,Bash" \
             --dangerously-skip-permissions
 
-      - name: Commit and push what was applied
+      # The agent ran with Bash, so nothing it could have left behind in the
+      # checkout — a hook, a core.hooksPath, a url.insteadOf rewrite — may run
+      # or redirect once the token is in play. Hooks are off for the commit and
+      # the push, and the token exists only in the push step.
+      - name: Commit what was applied
+        id: commit
         if: steps.check.outputs.has_comments == 'true'
-        env:
-          PUSH_TOKEN: ${{ secrets.APPLY_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           # Never let the agent hand us a workflow or secret change.
           git checkout -- .github/workflows .github/scripts 2>/dev/null || true
           if [ -z "$(git status --porcelain)" ]; then
             echo "No changes — every comment was already addressed or judged invalid."
+            echo "made=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git config user.name "coderabbit-apply[bot]"
           git config user.email "coderabbit-apply[bot]@users.noreply.github.com"
           git add -A
-          git commit -m "chore: apply valid CodeRabbit review comments" \
+          git -c core.hooksPath=/dev/null commit --no-verify \
+            -m "chore: apply valid CodeRabbit review comments" \
             -m "Applied by the CodeRabbit auto-apply agent (.github/workflows/coderabbit-apply.yml). Invalid or stale suggestions were skipped; see the run log for the reasoning."
-          git push "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD
+          echo "made=true" >> "$GITHUB_OUTPUT"
+
+      - name: Push the commit
+        if: steps.commit.outputs.made == 'true'
+        env:
+          PUSH_TOKEN: ${{ secrets.APPLY_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          # The token is handed to git through askpass, not the remote URL, and
+          # only for GitHub's own password prompt: a rewritten host gets nothing.
+          ASKPASS="$RUNNER_TEMP/askpass.sh"
+          cat > "$ASKPASS" <<'EOF'
+          #!/bin/sh
+          case "$1" in
+            *"'https://x-access-token@github.com'"*) printf '%s\n' "$PUSH_TOKEN" ;;
+            *) exit 1 ;;
+          esac
+          EOF
+          chmod 700 "$ASKPASS"
+          GIT_ASKPASS="$ASKPASS" GIT_TERMINAL_PROMPT=0 \
+            git -c core.hooksPath=/dev/null -c credential.helper= \
+              push --no-verify "https://x-access-token@github.com/${GITHUB_REPOSITORY}.git" HEAD

--- a/.github/workflows/coderabbit-apply.yml
+++ b/.github/workflows/coderabbit-apply.yml
@@ -49,6 +49,10 @@ jobs:
   apply:
     # Run for: a manual dispatch; a CodeRabbit review that is not a plain
     # approval; or a maintainer comment carrying the command. Never for forks.
+    #
+    # "Maintainer" is enforced, not assumed: the repository is public, so
+    # without the author_association gate any GitHub account could type the
+    # command on any open PR and run a billed agent with push rights.
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request_review' &&
@@ -57,6 +61,7 @@ jobs:
         github.event.pull_request.head.repo.fork == false) ||
       (github.event_name == 'issue_comment' &&
         github.event.issue.pull_request != null &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
         contains(github.event.comment.body, '/coderabbit-apply'))
     runs-on: ubuntu-latest
     steps:
@@ -66,25 +71,30 @@ jobs:
           NUM="${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr }}"
           echo "number=$NUM" >> "$GITHUB_OUTPUT"
 
+      # Before anything is checked out: the token cannot push to a fork, and
+      # a fork's code should never reach the agent step below.
+      - name: Refuse to run on a fork branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          IS_FORK=$(gh pr view ${{ steps.pr.outputs.number }} --repo "$GITHUB_REPOSITORY" --json isCrossRepository --jq .isCrossRepository)
+          if [ "$IS_FORK" = "true" ]; then
+            echo "::error::PR is from a fork; the apply token cannot push to it."
+            exit 1
+          fi
+
+      # persist-credentials is off so the push token never lands in
+      # .git/config, where the agent — which runs with Bash — could read it.
+      # The push step below supplies the token itself, after the agent is done.
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          token: ${{ secrets.APPLY_TOKEN || secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Check out the PR branch
         env:
-          GH_TOKEN: ${{ secrets.APPLY_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr checkout ${{ steps.pr.outputs.number }}
-
-      - name: Refuse to run on a fork branch
-        env:
-          GH_TOKEN: ${{ secrets.APPLY_TOKEN || secrets.GITHUB_TOKEN }}
-        run: |
-          IS_FORK=$(gh pr view ${{ steps.pr.outputs.number }} --json isCrossRepository --jq .isCrossRepository)
-          if [ "$IS_FORK" = "true" ]; then
-            echo "PR is from a fork; the token cannot push to it. Skipping."
-            exit 78
-          fi
 
       # Secrets cannot be read in an `if:` directly, so map the key to an env var
       # and record whether it is set. Without it there is nothing to run — the job
@@ -143,6 +153,8 @@ jobs:
 
       - name: Commit and push what was applied
         if: steps.check.outputs.has_comments == 'true'
+        env:
+          PUSH_TOKEN: ${{ secrets.APPLY_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           # Never let the agent hand us a workflow or secret change.
           git checkout -- .github/workflows .github/scripts 2>/dev/null || true
@@ -155,4 +167,4 @@ jobs:
           git add -A
           git commit -m "chore: apply valid CodeRabbit review comments" \
             -m "Applied by the CodeRabbit auto-apply agent (.github/workflows/coderabbit-apply.yml). Invalid or stale suggestions were skipped; see the run log for the reasoning."
-          git push
+          git push "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD

--- a/apps/mobile/src/app/group/[id]/invite.tsx
+++ b/apps/mobile/src/app/group/[id]/invite.tsx
@@ -323,9 +323,7 @@ export default function InviteScreen() {
                   // matters. `shareVia` falls back to that sheet if the app is
                   // not installed.
                   onPress={() =>
-                    void (option.channel === 'share'
-                      ? shareQr(share)
-                      : shareVia(option.channel))
+                    void (option.channel === 'share' ? shareQr(share) : shareVia(option.channel))
                   }
                   style={({ pressed }) => ({
                     flex: 1,

--- a/packages/db/prisma/migrations/20260903120000_internal_rpc_grants/migration.sql
+++ b/packages/db/prisma/migrations/20260903120000_internal_rpc_grants/migration.sql
@@ -1,0 +1,92 @@
+-- The internal RPC families a signed-in caller could reach directly.
+--
+-- Two families of SECURITY DEFINER functions were only ever meant to be called
+-- from server code holding the service key, but carried the audit's stock
+-- `GRANT ALL ... TO authenticated`, which put them one PostgREST `rpc/` call
+-- away from any account:
+--
+--   • `baaki_storage_*` — the R2 cap ledger. `r2-sign`, `storage-sweep` and
+--     `storage-recount` call these with the service client and have already
+--     checked who the caller is. The functions themselves check nothing:
+--     `baaki_storage_release(bucket, path)` is a bare DELETE on
+--     `storage_objects`, whose BEFORE DELETE trigger queues the key for the
+--     sweep to remove from R2, and `baaki_storage_reserve` / `_record` take
+--     the acting identity as `p_profile_id`. A member could release another
+--     member's object, or reserve gigabytes against a stranger's free-tier cap.
+--
+--   • `baaki_next_*_seq` — the sync watermarks. Each does an unconditional
+--     `UPDATE ... SET updated_seq = updated_seq + 1 WHERE id = p_id`. Called in
+--     a loop against a group the caller is not in, it walks that group's
+--     watermark past every member's cursor and their mirrors stop receiving
+--     changes. Nothing in the app calls these; the `baaki_stamp_*` triggers do.
+--
+-- Both families are revoked from `authenticated` (and `anon`, for the default
+-- grant the hardening migration explains) and left to `service_role`.
+--
+-- ───────────────────────────────────── 1. the stamp triggers become definer ──
+--
+-- The `baaki_stamp_*` trigger functions are what actually take a sequence,
+-- and they are SECURITY INVOKER: when a member's own INSERT under RLS fires
+-- one, `baaki_next_group_seq` runs as `authenticated`, and revoking the grant
+-- would break that write. Making the trigger functions SECURITY DEFINER is
+-- the correct shape anyway — a trigger runs regardless of the firing user's
+-- EXECUTE privilege, cannot be called directly (it returns `trigger`), and its
+-- only job is to touch a counter the caller has no business reaching. They
+-- already pin search_path (anon_surface_hardening §1).
+--
+-- `baaki_stamp_group_seq` bumps the row in place and calls nothing; it is
+-- included so the six read the same.
+
+ALTER FUNCTION public.baaki_stamp_capture_seq() SECURITY DEFINER;
+ALTER FUNCTION public.baaki_stamp_category_tag_seq() SECURITY DEFINER;
+ALTER FUNCTION public.baaki_stamp_ghost_merge_seq() SECURITY DEFINER;
+ALTER FUNCTION public.baaki_stamp_group_seq() SECURITY DEFINER;
+ALTER FUNCTION public.baaki_stamp_personal_seq() SECURITY DEFINER;
+ALTER FUNCTION public.baaki_stamp_seq() SECURITY DEFINER;
+
+-- Now that they are definer they would show on the signed-out surface with
+-- their baseline `TO anon` grants. Nobody needs EXECUTE on a trigger function.
+REVOKE ALL ON FUNCTION public.baaki_stamp_capture_seq() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.baaki_stamp_category_tag_seq() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.baaki_stamp_ghost_merge_seq() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.baaki_stamp_group_seq() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.baaki_stamp_personal_seq() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.baaki_stamp_seq() FROM PUBLIC, anon, authenticated;
+-- The orphan-queue trigger was already definer and carries the same grant.
+REVOKE ALL ON FUNCTION public.baaki_storage_enqueue_orphan() FROM PUBLIC, anon, authenticated;
+
+-- ───────────────────────────────────────────── 2. the sequence functions ──
+
+REVOKE ALL ON FUNCTION public.baaki_next_capture_seq(p_owner uuid) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.baaki_next_category_tag_seq(p_owner uuid) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.baaki_next_ghost_merge_seq(p_owner uuid) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.baaki_next_group_seq(p_group_id uuid) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.baaki_next_personal_seq(p_owner uuid) FROM PUBLIC, anon, authenticated;
+
+-- ────────────────────────────────────────────── 3. the storage cap ledger ──
+--
+-- `baaki_storage_counts` is the helper the other two call to decide whether a
+-- profile is under the cap; on its own it answers "is this profile or group
+-- paid" for any id, which is nobody's business either.
+
+REVOKE ALL ON FUNCTION public.baaki_storage_counts(p_profile_id uuid, p_group_id uuid) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.baaki_storage_expire_pending(p_age interval) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.baaki_storage_orphan_clear(p_logical_bucket text, p_path text) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.baaki_storage_orphans(p_limit integer) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.baaki_storage_record(p_profile_id uuid, p_group_id uuid, p_logical_bucket text, p_path text, p_bytes bigint, p_content_type text) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.baaki_storage_recount(p_logical_bucket text, p_path text, p_bytes bigint, p_content_type text) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.baaki_storage_release(p_logical_bucket text, p_path text) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.baaki_storage_release_reservation(p_logical_bucket text, p_path text) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.baaki_storage_reserve(p_profile_id uuid, p_group_id uuid, p_logical_bucket text, p_path text, p_bytes bigint, p_content_type text) FROM PUBLIC, anon, authenticated;
+
+-- ─────────────────────────────────── 4. stop handing anon every new object ──
+--
+-- The baseline carries Supabase's stock default privileges, which grant every
+-- function and table created by `postgres` in `public` to `anon` at creation.
+-- That is the mechanism anon_surface_hardening describes and closes after the
+-- fact; this closes it at the source. Nothing signed-out has needed a new
+-- object since the three pre-sign-in tables, and each of those is granted by
+-- name. `authenticated` and `service_role` keep their defaults.
+
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public REVOKE ALL ON FUNCTIONS FROM anon;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public REVOKE ALL ON TABLES FROM anon;

--- a/packages/db/test/internal-rpcs.test.ts
+++ b/packages/db/test/internal-rpcs.test.ts
@@ -1,0 +1,149 @@
+/**
+ * The RPC families only server code may call.
+ *
+ * The storage cap ledger and the sync watermarks are SECURITY DEFINER functions
+ * with no caller check in their bodies, because the edge functions that call
+ * them (with the service key) have already done it. That only holds if a
+ * signed-in user cannot reach them directly — which, until
+ * `20260903120000_internal_rpc_grants`, they could.
+ *
+ * Asserted as whole sets, like the anon surface: the failure this guards
+ * against is a signature change minting a new function that picks the default
+ * grant back up.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { asRole, connect, expectDenied, seedGroup } from './helpers.js';
+
+let client: Client;
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client?.end();
+});
+
+/** Service-role only. Every one is definer, and none checks who is asking. */
+const INTERNAL = [
+  'baaki_next_capture_seq',
+  'baaki_next_category_tag_seq',
+  'baaki_next_ghost_merge_seq',
+  'baaki_next_group_seq',
+  'baaki_next_personal_seq',
+  'baaki_storage_counts',
+  'baaki_storage_expire_pending',
+  'baaki_storage_orphan_clear',
+  'baaki_storage_orphans',
+  'baaki_storage_record',
+  'baaki_storage_recount',
+  'baaki_storage_release',
+  'baaki_storage_release_reservation',
+  'baaki_storage_reserve',
+];
+
+/** Trigger functions: fired by the row write, never callable, so no grant at all. */
+const STAMP_TRIGGERS = [
+  'baaki_stamp_capture_seq',
+  'baaki_stamp_category_tag_seq',
+  'baaki_stamp_ghost_merge_seq',
+  'baaki_stamp_group_seq',
+  'baaki_stamp_personal_seq',
+  'baaki_stamp_seq',
+  'baaki_storage_enqueue_orphan',
+];
+
+async function grants(names: string[]) {
+  const { rows } = await client.query<{
+    proname: string;
+    prosecdef: boolean;
+    anon: boolean;
+    authenticated: boolean;
+    service_role: boolean;
+  }>(
+    `SELECT p.proname,
+            p.prosecdef,
+            has_function_privilege('anon', p.oid, 'EXECUTE') AS anon,
+            has_function_privilege('authenticated', p.oid, 'EXECUTE') AS authenticated,
+            has_function_privilege('service_role', p.oid, 'EXECUTE') AS service_role
+       FROM pg_proc p
+       JOIN pg_namespace n ON n.oid = p.pronamespace
+      WHERE n.nspname = 'public' AND p.proname = ANY($1)
+      ORDER BY 1`,
+    [names],
+  );
+  return rows;
+}
+
+describe('the internal RPC families', () => {
+  it('are reachable by service_role and by nobody else', async () => {
+    const rows = await grants(INTERNAL);
+    expect(rows.map((row) => row.proname)).toEqual(INTERNAL);
+    for (const row of rows) {
+      expect(row.prosecdef, `${row.proname} is definer`).toBe(true);
+      expect(row.anon, `${row.proname} reachable by anon`).toBe(false);
+      expect(row.authenticated, `${row.proname} reachable by authenticated`).toBe(false);
+      expect(row.service_role, `${row.proname} reachable by service_role`).toBe(true);
+    }
+  });
+
+  it('keeps the stamp triggers definer and ungranted', async () => {
+    const rows = await grants(STAMP_TRIGGERS);
+    expect(rows.map((row) => row.proname)).toEqual(STAMP_TRIGGERS);
+    for (const row of rows) {
+      expect(row.prosecdef, `${row.proname} is definer`).toBe(true);
+      expect(row.anon, `${row.proname} reachable by anon`).toBe(false);
+      expect(row.authenticated, `${row.proname} reachable by authenticated`).toBe(false);
+    }
+  });
+
+  it('refuses a member who tries to release another object or bump a watermark', async () => {
+    const group = await seedGroup(client, { memberCount: 2 });
+    const claims = { sub: group.profileIds[0], role: 'authenticated' };
+
+    const release = await asRole(client, 'authenticated', claims, () =>
+      expectDenied(
+        client.query(`SELECT public.baaki_storage_release('avatars', $1)`, ['x/y.webp']),
+      ),
+    );
+    expect(release).toMatch(/permission denied/);
+
+    const bump = await asRole(client, 'authenticated', claims, () =>
+      expectDenied(client.query(`SELECT public.baaki_next_group_seq($1)`, [group.groupId])),
+    );
+    expect(bump).toMatch(/permission denied/);
+
+    const reserve = await asRole(client, 'authenticated', claims, () =>
+      expectDenied(
+        client.query(
+          `SELECT public.baaki_storage_reserve($1, NULL, 'avatars', $2, 1, 'image/webp')`,
+          [group.profileIds[1], `${group.profileIds[1]}/a.webp`],
+        ),
+      ),
+    );
+    expect(reserve).toMatch(/permission denied/);
+  });
+
+  it("still stamps a member's own write through the trigger", async () => {
+    // The trigger takes the sequence as its definer, so a plain RLS write by a
+    // member — which is how comments arrive — keeps working with the grant gone.
+    const group = await seedGroup(client, { memberCount: 2 });
+    const { rows: before } = await client.query<{ updated_seq: string }>(
+      `SELECT updated_seq FROM groups WHERE id = $1`,
+      [group.groupId],
+    );
+
+    const { rows } = await client.query<{ updated_seq: string }>(
+      `INSERT INTO activity_log (id, group_id, actor_member_id, verb, object_type, payload)
+       VALUES ($1, $2, $3, 'added', 'expense', '{}'::jsonb)
+       RETURNING updated_seq`,
+      [randomUUID(), group.groupId, group.memberIds[0]],
+    );
+    expect(BigInt(rows[0]!.updated_seq)).toBeGreaterThan(BigInt(before[0]!.updated_seq));
+  });
+});


### PR DESCRIPTION
## What

Two P0s from the audit, one PR.

### 1. Internal RPC families reachable by any signed-in user

`baaki_storage_*` (the R2 cap ledger) and `baaki_next_*_seq` (the sync watermarks) are SECURITY DEFINER functions with no caller check in their bodies — the edge functions that call them via the service key had already done that. They were also granted to `authenticated`, so one PostgREST `rpc/` call could:

- `baaki_storage_release(bucket, path)` — delete any other member's `storage_objects` row; the BEFORE DELETE trigger queues the key and `storage-sweep` issues the R2 delete.
- `baaki_storage_reserve(p_profile_id, …)` — reserve gigabytes against a stranger's free-tier cap.
- `baaki_next_group_seq(any group id)` in a loop — push that group's watermark past every member's cursor so their mirrors stop syncing.

Confirmed against the live database before this change (`has_function_privilege('authenticated', …)` = true for all of them).

Migration `20260903120000_internal_rpc_grants`:
- revokes both families from `authenticated` and `anon`; `service_role` keeps them
- makes the six `baaki_stamp_*` trigger functions SECURITY DEFINER so a member's own RLS write still takes a sequence (trigger functions can't be called directly, so nothing is exposed), and drops their stray grants
- revokes Supabase's default privileges to `anon` on new functions/tables, closing at the source what `anon_surface_hardening` closed after the fact

New `packages/db/test/internal-rpcs.test.ts` asserts the grant sets, that a member gets `permission denied`, and that the trigger still stamps.

### 2. `coderabbit-apply.yml` could be triggered by anyone

The `issue_comment` arm only matched the body string. On a public repository that let any account run a billed `claude -p --dangerously-skip-permissions` job holding `contents: write`, with `APPLY_TOKEN` persisted in `.git/config` where an agent with Bash could read it.

- `author_association` must be OWNER / MEMBER / COLLABORATOR
- `persist-credentials: false`; the push step supplies the token itself after the agent has finished
- fork check moved before checkout and fails outright (`exit 78` is no longer neutral)

## Verified

- Fresh local Postgres: all migrations apply; full DB suite 59 files / 701 tests pass including the new one
- `scripts/check-definer-grants.mjs` OK
- Workflow: YAML unchanged by Prettier; logic reviewed by hand (no runner)

## Deploy

Migration only — `pnpm db:migrate` against prod, then re-run the grant query. No edge function change. Consider rotating `APPLY_TOKEN` given how long the trigger was open.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Restricted internal database operations to authorized server processes.
  * Prevented direct access to internal storage, synchronization, and trigger operations.
  * Blocked workflow commands from unauthorized accounts and pull requests from forked repositories.
  * Improved protection for credentials used during automated changes.

* **Tests**
  * Added coverage confirming internal operations remain protected while member updates continue synchronizing correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->