### PR TITLE
fix(auth): PKCE for provider sign-in on mobile and web, nonce on native Apple

### DIFF
--- a/apps/mobile/src/app/+native-intent.ts
+++ b/apps/mobile/src/app/+native-intent.ts
@@ -2,12 +2,13 @@
  * Rewrite incoming native deep links before expo-router tries to match them.
  *
  * The one link that needs rewriting is the OAuth callback. Google and Apple
- * sign-in redirect to `baaki://auth#access_token=…` — see
+ * sign-in redirect to `baaki://auth?code=…` — see
  * `makeRedirectUri({ scheme: 'baaki', path: 'auth' })` in `lib/auth.tsx`. The
- * token exchange is already done in-process: `WebBrowser.openAuthSessionAsync`
- * hands that URL straight back to the caller, which calls `setSession`. So by
- * the time the OS *also* delivers the link as an app intent, it carries nothing
- * left to do — and there is no `/auth` screen, so letting the router match it
+ * code exchange is already done in-process: `WebBrowser.openAuthSessionAsync`
+ * hands that URL straight back to the caller, which calls
+ * `exchangeCodeForSession` (a one-time code; a second delivery is worthless). So
+ * by the time the OS *also* delivers the link as an app intent, it carries
+ * nothing left to do — and there is no `/auth` screen, so letting the router match it
  * lands on "Unmatched Route — page could not be found" right after a successful
  * Google login. Send it to the root instead, where the session (now set)
  * decides between the tabs and the sign-in screen.

--- a/apps/mobile/src/app/group/[id]/invite.tsx
+++ b/apps/mobile/src/app/group/[id]/invite.tsx
@@ -323,9 +323,7 @@ export default function InviteScreen() {
                   // matters. `shareVia` falls back to that sheet if the app is
                   // not installed.
                   onPress={() =>
-                    void (option.channel === 'share'
-                      ? shareQr(share)
-                      : shareVia(option.channel))
+                    void (option.channel === 'share' ? shareQr(share) : shareVia(option.channel))
                   }
                   style={({ pressed }) => ({
                     flex: 1,

--- a/apps/mobile/src/lib/auth.tsx
+++ b/apps/mobile/src/lib/auth.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useEffect, useMemo, useState, type ReactNode
 import { Platform } from 'react-native';
 import type { Session } from '@/lib/backend';
 import { makeRedirectUri } from 'expo-auth-session';
+import * as Crypto from 'expo-crypto';
 import * as WebBrowser from 'expo-web-browser';
 
 import {
@@ -11,6 +12,7 @@ import {
   OAuthMethod,
   planAuth,
   readIdentifier,
+  readOAuthCallback,
   type Viewer,
 } from '@waves/core';
 
@@ -64,22 +66,22 @@ async function oauthThroughBrowser(
   const result = await WebBrowser.openAuthSessionAsync(data.url, redirectTo);
   if (result.type !== 'success') return undefined;
 
-  // The tokens come back in the URL fragment; nothing else reads them.
-  const fragment = result.url.split('#')[1] ?? '';
-  const params = new URLSearchParams(fragment);
-  const access_token = params.get('access_token');
-  const refresh_token = params.get('refresh_token');
-  if (!access_token || !refresh_token) {
-    // A link, rather than a sign-in, returns no tokens — the session it just
-    // added an identity to is the one already held.
+  // PKCE (`flowType` in lib/supabase.ts): the redirect carries a one-time
+  // code, and only this client holds the verifier that redeems it. The refresh
+  // token never travels through the URL, so another app that claims the same
+  // scheme and catches the redirect gets nothing it can use.
+  const callback = readOAuthCallback(result.url);
+  if (callback.kind === 'error') throw new Error(callback.message);
+  if (callback.kind === 'none') {
+    // A redirect that added nothing: the session it just linked an identity
+    // to is the one already held.
     const { data: current } = await backend.auth.getSession();
     return current.session;
   }
 
-  const { data: signedIn, error: sessionError } = await backend.auth.setSession({
-    access_token,
-    refresh_token,
-  });
+  const { data: signedIn, error: sessionError } = await backend.auth.exchangeCodeForSession(
+    callback.code,
+  );
   if (sessionError) throw sessionError;
   return signedIn.session;
 }
@@ -107,10 +109,16 @@ function loadAppleAuth(): AppleAuthModule | null {
  * Present Apple's native sheet and hand back the identity token plus, only on
  * the very first authorization, the person's name — Apple returns it once and
  * never again. `undefined` means they dismissed the sheet.
+ *
+ * The token is bound to this one request with a nonce: Apple is given its
+ * SHA-256 and stamps that into the identity token, Supabase is given the raw
+ * value and checks the hash matches. Without it, an identity token captured
+ * anywhere — another app, a log, an old device — is a valid sign-in here.
  */
 async function appleNativeCredential(apple: AppleAuthModule): Promise<
   | {
       identityToken: string;
+      nonce: string;
       fullName: {
         givenName: string | null;
         middleName: string | null;
@@ -119,17 +127,20 @@ async function appleNativeCredential(apple: AppleAuthModule): Promise<
     }
   | undefined
 > {
+  const nonce = Crypto.randomUUID();
+  const hashedNonce = await Crypto.digestStringAsync(Crypto.CryptoDigestAlgorithm.SHA256, nonce);
   try {
     const credential = await apple.signInAsync({
       requestedScopes: [
         apple.AppleAuthenticationScope.FULL_NAME,
         apple.AppleAuthenticationScope.EMAIL,
       ],
+      nonce: hashedNonce,
     });
     if (!credential.identityToken) {
       throw new Error('Apple sign-in returned no identity token');
     }
-    return { identityToken: credential.identityToken, fullName: credential.fullName };
+    return { identityToken: credential.identityToken, nonce, fullName: credential.fullName };
   } catch (error) {
     if ((error as { code?: string }).code === 'ERR_REQUEST_CANCELED') return undefined;
     throw error;
@@ -410,6 +421,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             const { data, error } = await backend.auth.signInWithIdToken({
               provider: 'apple',
               token: credential.identityToken,
+              nonce: credential.nonce,
             });
             if (error) throw error;
             // Apple hands over the name only on the first authorization; seed

--- a/apps/mobile/src/lib/backend/index.ts
+++ b/apps/mobile/src/lib/backend/index.ts
@@ -44,7 +44,7 @@ type BackendAuth = Pick<
   | 'signInWithOAuth'
   | 'linkIdentity'
   | 'signInWithIdToken'
-  | 'setSession'
+  | 'exchangeCodeForSession'
   | 'signOut'
   | 'resend'
 >;

--- a/apps/mobile/src/lib/supabase.ts
+++ b/apps/mobile/src/lib/supabase.ts
@@ -53,6 +53,12 @@ export const supabase = createClient(
       persistSession: !isServer,
       // No URL-based session handoff on native; deep links are handled explicitly.
       detectSessionInUrl: !isServer && Platform.OS === 'web',
+      // PKCE: the provider redirect carries a one-time code, not the session.
+      // The verifier that redeems it lives in this client's storage, so another
+      // app on the device that claims `baaki://` and catches the redirect holds
+      // nothing it can use. The implicit default put the refresh token itself in
+      // the URL fragment. The exchange happens in `lib/auth.tsx`.
+      flowType: 'pkce',
     },
   },
 );

--- a/apps/web/src/lib/baaki.ts
+++ b/apps/web/src/lib/baaki.ts
@@ -28,6 +28,11 @@ export const supabase = createClient(url, anonKey, {
     persistSession: true,
     autoRefreshToken: true,
     detectSessionInUrl: false,
+    // PKCE: Google sends back a one-time `code` that `auth/callback` redeems
+    // with the verifier held in this browser — never a refresh token in the
+    // URL. The callback page always expected a code; the implicit default
+    // meant it never arrived.
+    flowType: 'pkce',
   },
 });
 

--- a/packages/core/src/auth/identity.ts
+++ b/packages/core/src/auth/identity.ts
@@ -289,3 +289,40 @@ export function readIdentifier(raw: string): { kind: 'email' | 'phone'; value: s
   if (trimmed.includes('@')) return { kind: 'email', value: normaliseEmail(trimmed) };
   return { kind: 'phone', value: normalisePhone(trimmed) };
 }
+
+/**
+ * What the browser brought back from a provider sign-in.
+ *
+ * Under the PKCE flow the redirect carries a one-time `code` in the query
+ * string — not the session. Only the client that started the sign-in holds the
+ * verifier that turns it into a session, so a second app on the device that
+ * claims the same URL scheme and catches the redirect gets nothing it can use.
+ * The implicit flow this replaced put the refresh token itself in the URL
+ * fragment, which is exactly the thing such an app would want.
+ *
+ * The provider can also come back empty-handed with an `error` (and, from
+ * Supabase, an `error_description` worth showing). Anything else — no code, no
+ * error — is a redirect that did not add a session, which is what an identity
+ * *link* looks like.
+ */
+export type OAuthCallback =
+  { kind: 'code'; code: string } | { kind: 'error'; message: string } | { kind: 'none' };
+
+export function readOAuthCallback(url: string): OAuthCallback {
+  let params: URLSearchParams;
+  try {
+    // The custom scheme parses on its own (`baaki://auth?code=…`), but the
+    // triple-slash form puts `auth` in the pathname and needs a base.
+    params = new URL(url, 'waves://app').searchParams;
+  } catch {
+    return { kind: 'none' };
+  }
+  const code = params.get('code');
+  if (code) return { kind: 'code', code };
+  const error = params.get('error');
+  if (error) {
+    const description = params.get('error_description');
+    return { kind: 'error', message: description?.trim() || error };
+  }
+  return { kind: 'none' };
+}

--- a/packages/core/test/identity.test.ts
+++ b/packages/core/test/identity.test.ts
@@ -21,6 +21,7 @@ import {
   normalisePhoneInRegion,
   planAuth,
   readIdentifier,
+  readOAuthCallback,
   AuthMethod,
   type Viewer,
 } from '../src/index';
@@ -292,5 +293,48 @@ describe('one field for either', () => {
     // Asking "email or phone?" and then asking them to type it is a question
     // the text already answers — but the error still has to be the useful one.
     expect(() => readIdentifier('9876543210')).toThrow(/country code/);
+  });
+});
+
+describe('what the browser brings back from a provider', () => {
+  it('reads the one-time code out of the query string', () => {
+    expect(readOAuthCallback('baaki://auth?code=abc-123')).toEqual({
+      kind: 'code',
+      code: 'abc-123',
+    });
+  });
+
+  it('reads the code from the triple-slash form as well', () => {
+    expect(readOAuthCallback('baaki:///auth?code=abc-123')).toEqual({
+      kind: 'code',
+      code: 'abc-123',
+    });
+  });
+
+  it('never mistakes a token in the fragment for a session', () => {
+    // The implicit flow put the refresh token here. Under PKCE nothing reads
+    // the fragment: a redirect shaped like the old one is simply "nothing".
+    expect(readOAuthCallback('baaki://auth#access_token=a&refresh_token=b')).toEqual({
+      kind: 'none',
+    });
+  });
+
+  it('prefers the readable description of a provider error', () => {
+    expect(
+      readOAuthCallback(
+        'baaki://auth?error=access_denied&error_description=User+cancelled+the+request',
+      ),
+    ).toEqual({ kind: 'error', message: 'User cancelled the request' });
+  });
+
+  it('falls back to the bare error code', () => {
+    expect(readOAuthCallback('baaki://auth?error=server_error')).toEqual({
+      kind: 'error',
+      message: 'server_error',
+    });
+  });
+
+  it('treats an unparseable url as nothing rather than throwing', () => {
+    expect(readOAuthCallback('::not a url')).toEqual({ kind: 'none' });
   });
 });


### PR DESCRIPTION
## Why

Audit P1 (auth). Two findings, one PR:

1. **Mobile OAuth used the implicit flow.** `lib/supabase.ts` set no `flowType`, so Google/Apple sign-in redirected to `baaki://auth#access_token=…&refresh_token=…` and `lib/auth.tsx` read the tokens out of the fragment. A custom URL scheme has no ownership check on Android: another app that registers `baaki://` receives that redirect and holds a refresh token usable off-device. Web had the mirror bug — `auth/callback` expects `?code` but its client was implicit, so Google sign-in on web failed with "Missing authorization code" while a refresh token sat in the URL bar.
2. **Native Apple sign-in had no nonce.** `signInAsync` and `signInWithIdToken` ran without one, so the identity token was not bound to this request and a captured token could be replayed as a sign-in.

## What

- `flowType: 'pkce'` on the mobile and web clients. The redirect now carries a one-time `code`; the verifier that redeems it lives in the client's own storage (SecureStore on native), so a redirect caught by another app is worthless.
- `oauthThroughBrowser` exchanges the code with `exchangeCodeForSession`; nothing reads the URL fragment any more. Provider errors (`error` / `error_description`) surface as a thrown message instead of a silent "no tokens".
- `readOAuthCallback(url)` in `@waves/core` — pure, tested (code / error / none, incl. the triple-slash form and the old fragment shape).
- Backend port: `setSession` replaced by `exchangeCodeForSession` in `BackendAuth`.
- Apple: `Crypto.randomUUID()` nonce → SHA-256 to `signInAsync`, raw value to `signInWithIdToken`.
- `+native-intent.ts` comment updated (`?code=` shape).
- Carries the prettier fix for `invite.tsx` (main red on `format:check` since #624; same change as on #626, merges cleanly either order).

## Notes for the reviewer

- No Supabase dashboard change: PKCE is a client-side option and the redirect allow-list entry (`baaki://auth`) is unchanged. Apple nonce verification is automatic when a nonce is supplied.
- `linkIdentity` (guest upgrade, the ADR-006 common path) also returns a code under PKCE, so the link path goes through the same exchange; the "none" branch stays as the fallback that returns the held session.
- Not device-tested (no live provider on the emulator). JS-only on mobile: ships by OTA. Web: Vercel web project on merge.

## Gates

- `pnpm format` + `pnpm lint` clean
- `pnpm -r typecheck` clean
- `@waves/core` 833 tests, mobile 746 tests green
