### PR TITLE
fix(import): an imported settlement needs the payee's consent

### DIFF
--- a/apps/mobile/src/app/group/[id]/invite.tsx
+++ b/apps/mobile/src/app/group/[id]/invite.tsx
@@ -323,9 +323,7 @@ export default function InviteScreen() {
                   // matters. `shareVia` falls back to that sheet if the app is
                   // not installed.
                   onPress={() =>
-                    void (option.channel === 'share'
-                      ? shareQr(share)
-                      : shareVia(option.channel))
+                    void (option.channel === 'share' ? shareQr(share) : shareVia(option.channel))
                   }
                   style={({ pressed }) => ({
                     flex: 1,

--- a/apps/mobile/src/app/settings/import.tsx
+++ b/apps/mobile/src/app/settings/import.tsx
@@ -172,6 +172,7 @@ export default function ImportScreen() {
     expenses: number;
     ghosts: number;
     settlements: number;
+    settlementsPending: number;
   } | null>(null);
 
   /** Everyone starts as somebody new — see `load`. */
@@ -431,6 +432,7 @@ export default function ImportScreen() {
             expenses: result.expenses,
             ghosts: result.ghosts,
             settlements: result.settlements ?? 0,
+            settlementsPending: result.settlementsPending ?? 0,
           };
         } catch (caught) {
           // Keep the one precondition message as-is; wrap everything else in a
@@ -763,6 +765,11 @@ export default function ImportScreen() {
                 ? ` · ${plural(locale, done.ghosts, t.importLedger.peopleAdded)}`
                 : ''}
             </Text>
+            {done.settlementsPending > 0 ? (
+              <Text variant="caption" tone="muted">
+                {plural(locale, done.settlementsPending, t.importLedger.settlementsPending)}
+              </Text>
+            ) : null}
             <Button
               label={t.importLedger.openTheGroup}
               fullWidth

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -1243,6 +1243,8 @@ export interface ImportResult {
   expenses: number;
   ghosts: number;
   settlements?: number;
+  /** Of those, the ones that landed pending because somebody else on Waves has to confirm them. */
+  settlementsPending?: number;
   members: Record<string, string>;
 }
 

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -2084,6 +2084,7 @@ export interface UiStrings {
     importedCount: PluralForms;
     expenseCount: PluralForms;
     settlementCount: PluralForms;
+    settlementsPending: PluralForms;
     peopleCount: PluralForms;
     peopleAdded: PluralForms;
     rowsSkipped: PluralForms;
@@ -4218,6 +4219,10 @@ const en: UiStrings = {
     },
     expenseCount: { one: '{n} expense', other: '{n} expenses' },
     settlementCount: { one: '{n} settlement', other: '{n} settlements' },
+    settlementsPending: {
+      one: '{n} awaits confirmation from the person paid',
+      other: '{n} await confirmation from the people paid',
+    },
     peopleCount: { one: '{n} person', other: '{n} people' },
     peopleAdded: {
       one: '{n} person added, waiting to be claimed',
@@ -6433,6 +6438,10 @@ const ta: UiStrings = {
     },
     expenseCount: { one: '{n} செலவு', other: '{n} செலவுகள்' },
     settlementCount: { one: '{n} தீர்வு', other: '{n} தீர்வுகள்' },
+    settlementsPending: {
+      one: '{n} பணம் பெற்றவரின் உறுதிப்படுத்தலுக்காக காத்திருக்கிறது',
+      other: '{n} பணம் பெற்றவர்களின் உறுதிப்படுத்தலுக்காக காத்திருக்கின்றன',
+    },
     peopleCount: { one: '{n} நபர்', other: '{n} நபர்கள்' },
     peopleAdded: {
       one: '{n} நபர் சேர்க்கப்பட்டார், கோரப்படக் காத்திருக்கிறார்',
@@ -8596,6 +8605,10 @@ const hi: UiStrings = {
     },
     expenseCount: { one: '{n} खर्च', other: '{n} खर्च' },
     settlementCount: { one: '{n} निपटान', other: '{n} निपटान' },
+    settlementsPending: {
+      one: '{n} को भुगतान पाने वाले की पुष्टि का इंतज़ार है',
+      other: '{n} को भुगतान पाने वालों की पुष्टि का इंतज़ार है',
+    },
     peopleCount: { one: '{n} व्यक्ति', other: '{n} लोग' },
     peopleAdded: {
       one: '{n} व्यक्ति जोड़ा गया, दावे का इंतज़ार',
@@ -10923,6 +10936,14 @@ const ar: UiStrings = {
       few: '{n} تسويات',
       many: '{n} تسوية',
       other: '{n} تسوية',
+    },
+    settlementsPending: {
+      zero: 'لا شيء بانتظار التأكيد',
+      one: 'تسوية واحدة بانتظار تأكيد من استلم المبلغ',
+      two: 'تسويتان بانتظار تأكيد من استلم المبلغ',
+      few: '{n} تسويات بانتظار تأكيد من استلموا المبلغ',
+      many: '{n} تسوية بانتظار تأكيد من استلموا المبلغ',
+      other: '{n} تسوية بانتظار تأكيد من استلموا المبلغ',
     },
     peopleCount: {
       zero: 'لا أشخاص',

--- a/packages/db/prisma/migrations/20260903150000_import_ledger_settlement_consent/migration.sql
+++ b/packages/db/prisma/migrations/20260903150000_import_ledger_settlement_consent/migration.sql
@@ -1,0 +1,263 @@
+-- An imported settlement needs the same consent a recorded one does.
+--
+-- `baaki_import_ledger` used to insert settlements exactly as the file
+-- described them, `confirmed` by default, with no look at who the parties were.
+-- The transition guard only fires on UPDATE, so a row born `confirmed` was
+-- never checked by anything: any member could import
+-- `{from: me, to: <a member>, amount: <the debt>, status: "confirmed"}` and
+-- erase what they owed, without the payee ever seeing it (ADR-007 says the
+-- payee confirms; `baaki_record_settlement` writes `initiated` for that
+-- reason).
+--
+-- The rule now: a settlement lands `confirmed` only when the file says it was
+-- settled AND somebody who can vouch for the receipt is doing the import —
+--
+--   * the importer is the payee (they say they were paid), or
+--   * the payee is a ghost and the payer is the importer or another ghost.
+--     A ghost has no account to confirm from, and a ghost's whole ledger is
+--     already the importer's word (every ghost expense is) — the row lands
+--     exactly where `baaki_record_settlement` + the auto-confirm job would put
+--     it, minus the seven-day wait nobody could have used.
+--
+-- Anything else — the payee is another member on Waves, or the payer is —
+-- lands `initiated` with the clock started now, and follows the ordinary path:
+-- the payee confirms or disputes, the payer can cancel, and the auto-confirm
+-- job settles it after the same window as any other settle-up. That is the
+-- same power the payer already had by recording it themselves; the import
+-- adds none.
+--
+-- `at` from the file still dates a confirmed row. A row that lands `initiated`
+-- is dated now, on purpose: with the file's date the auto-confirm job would
+-- have confirmed a two-year-old "pending" row on its next run, which is the
+-- hole this migration closes wearing a different hat.
+--
+-- The result gains `settlementsPending` so the import screen can tell the
+-- user how many are waiting on somebody else.
+
+CREATE OR REPLACE FUNCTION public.baaki_import_ledger(p_group_id uuid, p_people jsonb, p_expenses jsonb, p_settlements jsonb DEFAULT '[]'::jsonb, p_origin text DEFAULT 'splitwise'::text) RETURNS jsonb
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+DECLARE
+  v_profile_id  uuid := public.baaki_current_profile_id();
+  v_author      uuid;
+  v_person      jsonb;
+  v_expense     jsonb;
+  v_settlement  jsonb;
+  v_name        text;
+  v_member      uuid;
+  v_names       jsonb := '{}'::jsonb;   -- name -> member id, as text
+  v_payers      jsonb;
+  v_shares      jsonb;
+  v_entry       record;
+  v_created     int := 0;
+  v_ghosts      int := 0;
+  v_settled     int := 0;
+  v_pending     int := 0;
+  v_mutation    uuid;
+  v_result      jsonb;
+  v_from        uuid;
+  v_to          uuid;
+  v_from_real   boolean;
+  v_to_real     boolean;
+  v_file_status text;
+  v_status      "SettlementStatus";
+  v_at          timestamptz;
+BEGIN
+  IF v_profile_id IS NULL OR NOT EXISTS (
+    SELECT 1 FROM public.group_members gm
+    WHERE gm.group_id = p_group_id AND gm.profile_id = v_profile_id AND gm.left_at IS NULL
+  ) THEN
+    RAISE EXCEPTION 'NOT_A_MEMBER: you are not in that group'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  v_author := public.baaki_my_member_id_for(p_group_id, v_profile_id);
+
+  IF jsonb_typeof(p_people) <> 'array' OR jsonb_array_length(p_people) = 0 THEN
+    RAISE EXCEPTION 'NO_PEOPLE: the import named nobody' USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Resolve every name to a member of this group up front, so an unmappable
+  -- one fails before a single row is written.
+  FOR v_person IN SELECT * FROM jsonb_array_elements(p_people) LOOP
+    v_name := btrim(COALESCE(v_person ->> 'name', ''));
+    IF v_name = '' THEN
+      RAISE EXCEPTION 'NO_PEOPLE: somebody in the file has no name'
+        USING ERRCODE = 'check_violation';
+    END IF;
+
+    IF (v_person ->> 'memberId') IS NOT NULL THEN
+      SELECT gm.id INTO v_member
+        FROM public.group_members gm
+       WHERE gm.id = (v_person ->> 'memberId')::uuid AND gm.group_id = p_group_id;
+      IF v_member IS NULL THEN
+        RAISE EXCEPTION 'UNKNOWN_MEMBER: % is not in this group', v_name
+          USING ERRCODE = 'foreign_key_violation';
+      END IF;
+    ELSE
+      INSERT INTO public.group_members (group_id, ghost_name, joined_via)
+      VALUES (p_group_id, v_name, 'ghost')
+      RETURNING id INTO v_member;
+      v_ghosts := v_ghosts + 1;
+    END IF;
+
+    v_names := v_names || jsonb_build_object(v_name, v_member::text);
+  END LOOP;
+
+  FOR v_expense IN SELECT * FROM jsonb_array_elements(p_expenses) LOOP
+    -- Names become member ids here rather than on the client, so the client
+    -- never gets to choose which member a row lands on.
+    SELECT COALESCE(jsonb_agg(jsonb_build_object(
+             'memberId', v_names ->> entry.key,
+             'amount',   entry.value #>> '{}'
+           )), '[]'::jsonb)
+      INTO v_payers
+      FROM jsonb_each(v_expense -> 'payers') AS entry;
+
+    SELECT COALESCE(jsonb_agg(jsonb_build_object(
+             'memberId', v_names ->> entry.key,
+             'amount',   entry.value #>> '{}'
+           )), '[]'::jsonb)
+      INTO v_shares
+      FROM jsonb_each(v_expense -> 'shares') AS entry;
+
+    FOR v_entry IN
+      SELECT key FROM jsonb_each(v_expense -> 'shares')
+      UNION
+      SELECT key FROM jsonb_each(v_expense -> 'payers')
+    LOOP
+      IF (v_names ->> v_entry.key) IS NULL THEN
+        RAISE EXCEPTION 'UNKNOWN_MEMBER: "%" appears in an expense but not in the people list',
+          v_entry.key USING ERRCODE = 'foreign_key_violation';
+      END IF;
+    END LOOP;
+
+    v_result := public.baaki_apply_expense(
+      p_group_id           => p_group_id,
+      p_expense_id         => NULL,
+      p_author_member_id   => v_author,
+      p_description        => COALESCE(v_expense ->> 'description', 'Imported expense'),
+      p_category           => v_expense ->> 'category',
+      p_expense_date       => (v_expense ->> 'date')::date,
+      p_currency           => upper(COALESCE(v_expense ->> 'currency', 'INR'))::char(3),
+      p_amount             => (v_expense ->> 'amount')::bigint,
+      -- 'exact' regardless of how the split was originally expressed: the
+      -- participants are new members with new ids, so a percentage or a set of
+      -- weights would have to be re-divided and could land a paisa somewhere
+      -- the file did not. The amounts are the amounts — and with an exact
+      -- split the shares ARE the split params, so there is nothing for the
+      -- server to recompute; `baaki_check_expense_totals` still refuses a
+      -- version whose payers or shares do not sum to the amount.
+      p_split_type         => 'exact',
+      p_split_params       => jsonb_build_object('kind', 'exact', 'amounts', (
+        SELECT COALESCE(jsonb_object_agg(v_names ->> entry.key, entry.value), '{}'::jsonb)
+          FROM jsonb_each(v_expense -> 'shares') AS entry
+      )),
+      p_payers             => v_payers,
+      p_shares             => v_shares,
+      p_client_mutation_id => (v_expense ->> 'clientMutationId')::uuid,
+      p_source             => 'imported'
+    );
+
+    -- A replayed row is one this import already wrote — a second tap, or a lost
+    -- response. Not an error, and not a second copy either (ADR-005).
+    IF COALESCE((v_result ->> 'replayed')::boolean, false) = false THEN
+      v_created := v_created + 1;
+    END IF;
+  END LOOP;
+
+  FOR v_settlement IN SELECT * FROM jsonb_array_elements(p_settlements) LOOP
+    IF (v_names ->> (v_settlement ->> 'from')) IS NULL
+       OR (v_names ->> (v_settlement ->> 'to')) IS NULL THEN
+      RAISE EXCEPTION 'UNKNOWN_MEMBER: a settlement names somebody who is not in the people list'
+        USING ERRCODE = 'foreign_key_violation';
+    END IF;
+
+    v_from := (v_names ->> (v_settlement ->> 'from'))::uuid;
+    v_to   := (v_names ->> (v_settlement ->> 'to'))::uuid;
+
+    v_mutation := (v_settlement ->> 'clientMutationId')::uuid;
+    -- Same idempotency rule as the expenses: a replayed import must not pay
+    -- somebody twice.
+    CONTINUE WHEN v_mutation IS NOT NULL AND EXISTS (
+      SELECT 1 FROM public.settlements s WHERE s.client_mutation_id = v_mutation
+    );
+
+    -- The file's word on the row, before anybody's consent is considered. A
+    -- status the ledger has no name for is refused rather than cast blind.
+    v_file_status := lower(COALESCE(v_settlement ->> 'status', 'confirmed'));
+    IF v_file_status NOT IN ('confirmed', 'auto_confirmed', 'initiated', 'disputed', 'cancelled') THEN
+      RAISE EXCEPTION 'INVALID_STATUS: a settlement cannot be imported as "%"', v_file_status
+        USING ERRCODE = 'check_violation';
+    END IF;
+
+    SELECT gm.profile_id IS NOT NULL INTO v_from_real
+      FROM public.group_members gm WHERE gm.id = v_from;
+    SELECT gm.profile_id IS NOT NULL INTO v_to_real
+      FROM public.group_members gm WHERE gm.id = v_to;
+
+    IF v_file_status IN ('confirmed', 'auto_confirmed') THEN
+      -- Settled, says the file. It stays settled only if the person doing the
+      -- import can vouch for the receipt: they are the payee, or the payee is
+      -- a ghost and the payer is nobody else on Waves. Otherwise the member it
+      -- names gets to confirm it, the way they would any settle-up (ADR-007).
+      IF v_to = v_author OR (NOT v_to_real AND (v_from = v_author OR NOT v_from_real)) THEN
+        v_status := 'confirmed';
+      ELSE
+        v_status := 'initiated';
+      END IF;
+    ELSE
+      v_status := v_file_status::"SettlementStatus";
+    END IF;
+
+    -- A confirmed row keeps the file's date. A pending one is dated now, so the
+    -- auto-confirm window starts when the people on Waves can first see it —
+    -- not years ago in the file.
+    v_at := CASE
+      WHEN v_status = 'initiated' THEN now()
+      ELSE COALESCE((v_settlement ->> 'at')::timestamptz, now())
+    END;
+
+    INSERT INTO public.settlements
+      (group_id, from_member_id, to_member_id, currency, amount, method, status, note,
+       initiated_at, confirmed_at, client_mutation_id)
+    VALUES (
+      p_group_id,
+      v_from,
+      v_to,
+      upper(COALESCE(v_settlement ->> 'currency', 'INR'))::char(3),
+      (v_settlement ->> 'amount')::bigint,
+      COALESCE(v_settlement ->> 'method', 'other')::"SettlementMethod",
+      v_status,
+      v_settlement ->> 'note',
+      v_at,
+      CASE WHEN v_status = 'confirmed' THEN v_at END,
+      v_mutation
+    );
+
+    IF v_status = 'initiated' THEN
+      v_pending := v_pending + 1;
+    END IF;
+    v_settled := v_settled + 1;
+  END LOOP;
+
+  INSERT INTO public.activity_log (group_id, actor_member_id, verb, object_type, object_id, payload)
+  VALUES (
+    p_group_id, v_author, 'imported', 'group', p_group_id,
+    jsonb_build_object(
+      'expenses', v_created, 'ghosts', v_ghosts, 'settlements', v_settled,
+      'settlementsPending', v_pending, 'from', p_origin
+    )
+  );
+
+  RETURN jsonb_build_object(
+    'groupId', p_group_id,
+    'expenses', v_created,
+    'ghosts', v_ghosts,
+    'settlements', v_settled,
+    'settlementsPending', v_pending,
+    'members', v_names
+  );
+END
+$$;

--- a/packages/db/prisma/migrations/20260903150000_import_ledger_settlement_consent/migration.sql
+++ b/packages/db/prisma/migrations/20260903150000_import_ledger_settlement_consent/migration.sql
@@ -261,3 +261,8 @@ BEGIN
   );
 END
 $$;
+
+-- CREATE OR REPLACE keeps the existing grants; restated so the caller model
+-- is explicit in the migration that (re)defines the function.
+REVOKE ALL ON FUNCTION public.baaki_import_ledger(uuid, jsonb, jsonb, jsonb, text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.baaki_import_ledger(uuid, jsonb, jsonb, jsonb, text) TO authenticated, service_role;

--- a/packages/db/test/m5-import-export.test.ts
+++ b/packages/db/test/m5-import-export.test.ts
@@ -15,7 +15,7 @@ import type { Client } from 'pg';
 
 import { parseBaakiExport } from '@waves/core';
 
-import { addEqualSplitExpense, big, connect, seedGroup } from './helpers.js';
+import { addEqualSplitExpense, big, connect, readTruth, seedGroup } from './helpers.js';
 
 let client: Client;
 
@@ -381,3 +381,166 @@ function asStrings(values: Readonly<Record<string, bigint>>): Record<string, str
     Object.entries(values).map(([name, value]) => [name, value.toString()]),
   );
 }
+
+/**
+ * A settlement the file calls settled is only settled if somebody who can vouch
+ * for the receipt is doing the import (ADR-007). Before this rule any member
+ * could import `{from: me, to: <a member>, status: "confirmed"}` and erase a
+ * debt without the payee ever seeing it — the transition guard is BEFORE
+ * UPDATE, so a row born confirmed was never looked at.
+ */
+describe('imported settlements and consent', () => {
+  interface Row {
+    status: string;
+    confirmed_at: string | null;
+    initiated_at: string;
+  }
+
+  async function importSettlements(
+    importerProfile: string,
+    groupId: string,
+    people: { name: string; memberId: string | null }[],
+    settlements: Record<string, unknown>[],
+  ): Promise<{ settlementsPending: number; settlements: number }> {
+    return asUser(importerProfile, async () => {
+      const result = await client.query(
+        `SELECT baaki_import_ledger($1, $2::jsonb, '[]'::jsonb, $3::jsonb, 'baaki') AS r`,
+        [
+          groupId,
+          JSON.stringify(people),
+          JSON.stringify(
+            settlements.map((settlement) => ({
+              clientMutationId: randomUUID(),
+              currency: 'INR',
+              amount: '900000',
+              method: 'cash',
+              status: 'confirmed',
+              at: '2024-01-01T00:00:00Z',
+              ...settlement,
+            })),
+          ),
+        ],
+      );
+      return result.rows[0]!.r as { settlementsPending: number; settlements: number };
+    });
+  }
+
+  async function rows(groupId: string): Promise<Row[]> {
+    const result = await client.query(
+      `SELECT status, confirmed_at, initiated_at FROM settlements
+        WHERE group_id = $1 ORDER BY created_at`,
+      [groupId],
+    );
+    return result.rows as Row[];
+  }
+
+  it('does not let the payer import their own debt as already paid', async () => {
+    const seeded = await seedGroup(client, { memberCount: 2 });
+    const [me, victim] = seeded.memberIds as [string, string];
+    await addEqualSplitExpense(client, {
+      groupId: seeded.groupId,
+      amount: 900000n,
+      payers: { [victim]: 900000n },
+      participants: [me],
+    });
+    const before = await readTruth(client, seeded.groupId);
+
+    const result = await importSettlements(
+      seeded.profileIds[0]!,
+      seeded.groupId,
+      [
+        { name: 'Me', memberId: me },
+        { name: 'Victim', memberId: victim },
+      ],
+      [{ from: 'Me', to: 'Victim' }],
+    );
+
+    // Lands pending, for the payee to confirm — and dated now, not with the
+    // file's date, or the auto-confirm job would settle it on its next run.
+    expect(result).toMatchObject({ settlements: 1, settlementsPending: 1 });
+    const [row] = await rows(seeded.groupId);
+    expect(row).toMatchObject({ status: 'initiated', confirmed_at: null });
+    expect(Date.now() - new Date(row!.initiated_at).getTime()).toBeLessThan(60_000);
+    expect(await readTruth(client, seeded.groupId)).toEqual(before);
+  });
+
+  it('lets the payee vouch for a payment they received', async () => {
+    const seeded = await seedGroup(client, { memberCount: 2 });
+    const [me, payer] = seeded.memberIds as [string, string];
+
+    const result = await importSettlements(
+      seeded.profileIds[0]!,
+      seeded.groupId,
+      [
+        { name: 'Me', memberId: me },
+        { name: 'Payer', memberId: payer },
+      ],
+      [{ from: 'Payer', to: 'Me' }],
+    );
+
+    expect(result).toMatchObject({ settlements: 1, settlementsPending: 0 });
+    const [row] = await rows(seeded.groupId);
+    expect(row!.status).toBe('confirmed');
+    // The file's date survives on a settled row.
+    expect(new Date(row!.confirmed_at!).toISOString()).toBe('2024-01-01T00:00:00.000Z');
+  });
+
+  it('takes the importer at their word for ghosts, and nobody else', async () => {
+    const seeded = await seedGroup(client, { memberCount: 2 });
+    const [me, other] = seeded.memberIds as [string, string];
+
+    const result = await importSettlements(
+      seeded.profileIds[0]!,
+      seeded.groupId,
+      [
+        { name: 'Me', memberId: me },
+        { name: 'Other', memberId: other },
+        { name: 'Ghost A', memberId: null },
+        { name: 'Ghost B', memberId: null },
+      ],
+      [
+        { from: 'Ghost A', to: 'Ghost B' }, // ghosts settling among themselves
+        { from: 'Me', to: 'Ghost A' }, // the importer paid a ghost
+        { from: 'Ghost A', to: 'Me' }, // a ghost paid the importer
+        { from: 'Other', to: 'Ghost B' }, // somebody on Waves "paid" a ghost — their claim to make
+        { from: 'Ghost B', to: 'Other' }, // a ghost "paid" somebody on Waves — theirs to confirm
+        { from: 'Other', to: 'Me', status: 'auto_confirmed' }, // settled in the file, payee imports
+      ],
+    );
+
+    expect(result).toMatchObject({ settlements: 6, settlementsPending: 2 });
+    expect((await rows(seeded.groupId)).map((row) => row.status)).toEqual([
+      'confirmed',
+      'confirmed',
+      'confirmed',
+      'initiated',
+      'initiated',
+      'confirmed',
+    ]);
+  });
+
+  it('carries a pending or cancelled row across as history, and refuses a made-up status', async () => {
+    const seeded = await seedGroup(client, { memberCount: 1 });
+    const [me] = seeded.memberIds as [string];
+    const people = [
+      { name: 'Me', memberId: me },
+      { name: 'Ghost', memberId: null },
+    ];
+
+    const result = await importSettlements(seeded.profileIds[0]!, seeded.groupId, people, [
+      { from: 'Ghost', to: 'Me', status: 'initiated' },
+      { from: 'Ghost', to: 'Me', status: 'cancelled' },
+    ]);
+    expect(result).toMatchObject({ settlements: 2, settlementsPending: 1 });
+    expect((await rows(seeded.groupId)).map((row) => row.status)).toEqual([
+      'initiated',
+      'cancelled',
+    ]);
+
+    await expect(
+      importSettlements(seeded.profileIds[0]!, seeded.groupId, people, [
+        { from: 'Ghost', to: 'Me', status: 'settled' },
+      ]),
+    ).rejects.toThrow(/INVALID_STATUS/);
+  });
+});


### PR DESCRIPTION
## Why

Audit P1: `baaki_import_ledger` inserted settlements verbatim, `confirmed` by default, with no party check. The settlement transition guard is `BEFORE UPDATE`, so a row born `confirmed` was never validated. Any member could import `{from: me, to: <member>, amount: <the debt>, status: "confirmed"}` and erase what they owed with no payee consent — the exact hole ADR-007's confirm step exists to close.

## What

**Migration `20260903150000_import_ledger_settlement_consent`** — `CREATE OR REPLACE` of `baaki_import_ledger`:

- A settlement lands `confirmed` only when the file says it was settled **and** the importer can vouch for the receipt:
  - the importer is the payee, or
  - the payee is a ghost and the payer is the importer or another ghost (a ghost has no account to confirm from; its ledger is already the importer's word, as every ghost expense is).
- Anything else — the payee or the payer is another member on Waves — lands `initiated`, dated **now** (not the file's date, or the auto-confirm job would settle a two-year-old "pending" row on its next run), and follows the ordinary path: payee confirms/disputes, payer cancels, auto-confirm after the usual window. Same power the payer already had by recording it themselves; the import adds none.
- File status must be one of the enum's names; anything else is refused (`INVALID_STATUS`) instead of a blind cast. `auto_confirmed` in the file is treated as settled.
- Result and activity payload gain `settlementsPending`.

**Mobile**: `ImportResult.settlementsPending`; the done screen adds one line ("N await confirmation from the people paid") in en/ta/hi/ar.

**Tests** (`packages/db/test/m5-import-export.test.ts`, 4 new): payer importing their own debt as paid lands pending + dated now + balance unmoved; payee vouching lands confirmed with the file's date; the six party combinations (ghost/importer/other member) land where the rule says; pending/cancelled rows carry as history; made-up status refused. Existing lossless export→import and Splitwise suites unchanged and green.

## Notes for the reviewer

- **Shares are deliberately not recomputed.** The audit also flagged client-computed shares against TDR §4. The import writes an *exact* split, so the shares are the split params by definition — a recompute is the identity. `baaki_check_expense_totals` (deferred constraint trigger) already refuses a version whose payers or shares don't sum to the amount. Noted in a comment at the call site.
- Splitwise imports are unaffected in practice: everyone but the importer is a ghost, so every payment row still lands `confirmed`.
- Carries the same prettier-only fix to `invite.tsx` as #626/#627 (main is red on `format:check`); merges cleanly in any order.

## Deploy

Migration only + JS (OTA). After merge: `pnpm db:migrate` on prod from a `main` checkout. No edge function change.

## Gates

`pnpm format`, `pnpm lint`, mobile `tsc --noEmit` clean; `packages/db` suites `m5-import-export`, `import-splitwise`, `anon-surface`, `definer-boundary` — 53 tests green on a fresh local Postgres with all migrations applied.
