### PR TITLE
fix(sync): an unreadable row must not take the offline queue with it

### DIFF
--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -45,7 +45,7 @@ import {
 import { nudgeToSettle } from '@/data/api';
 import { expenseTitle } from '@/data/expenseTitle';
 import { GroupSkeleton } from '@/components/Skeletons';
-import { formatParts, type MemberId } from '@waves/core';
+import { deadLettered, formatParts, type MemberId } from '@waves/core';
 import { useBlockedUsers } from '@/data/blocked';
 import {
   actorName,
@@ -448,7 +448,7 @@ export default function GroupScreen() {
   // The refused-change state still needs somewhere to act (retry / discard), so
   // the header glyph is paired with the one banner that carries buttons; the
   // ambient offline / syncing states are the header glyph's job now (below).
-  const { rejected } = useSync();
+  const { queue, rejected } = useSync();
 
   const { group, members, expenses, settlements, activity } = useGroup(groupId);
   const ledger = useGroupLedger(groupId, profile?.id ?? null);
@@ -714,9 +714,13 @@ export default function GroupScreen() {
   // deleted. On a group whose ledger has never lost a row it is an answer to a
   // question nobody asked.
   const hasDeleted = expenses.rows.some((expense) => Boolean(expense.deleted_at));
-  // A refused change waiting on this group — the one sync state that still earns
-  // an inline card, because it needs a decision the header glyph cannot offer.
-  const refusedHere = rejected.some((item) => item.groupId === groupId);
+  // The two sync states that still earn an inline card, because both need a
+  // decision the header glyph cannot offer: a change the server refused, and a
+  // change that has stopped retrying (which also blocks everything queued
+  // behind it in this group — see `deadLettered` / `nextBatch` in @waves/core).
+  const stalledHere =
+    rejected.some((item) => item.groupId === groupId) ||
+    deadLettered(queue.filter((item) => item.groupId === groupId)).length > 0;
   const pendingForMe = (settlements.data ?? []).filter(
     (settlement) =>
       settlement.status === 'initiated' && settlement.to_member_id === ledger.myMemberId,
@@ -1072,11 +1076,11 @@ export default function GroupScreen() {
                   items={menuItems}
                 />
 
-                {/* Only the refused-change banner survives inline — it carries the
-              retry / discard buttons the header glyph cannot. Offline, queued and
-              in-flight now read from the glyph in the header, matching the
-              dashboard. */}
-                {refusedHere ? <SyncBanner groupId={groupId} /> : null}
+                {/* Only the banners that need a decision survive inline — they
+              carry the retry / discard buttons the header glyph cannot. Offline,
+              queued and in-flight now read from the glyph in the header,
+              matching the dashboard. */}
+                {stalledHere ? <SyncBanner groupId={groupId} /> : null}
 
                 {/* If the two independent balance computations ever disagree, say so
             rather than showing a number that might be wrong (ADR-004). */}

--- a/apps/mobile/src/app/group/[id]/invite.tsx
+++ b/apps/mobile/src/app/group/[id]/invite.tsx
@@ -323,9 +323,7 @@ export default function InviteScreen() {
                   // matters. `shareVia` falls back to that sheet if the app is
                   // not installed.
                   onPress={() =>
-                    void (option.channel === 'share'
-                      ? shareQr(share)
-                      : shareVia(option.channel))
+                    void (option.channel === 'share' ? shareQr(share) : shareVia(option.channel))
                   }
                   style={({ pressed }) => ({
                     flex: 1,

--- a/apps/mobile/src/components/SyncBanner.tsx
+++ b/apps/mobile/src/components/SyncBanner.tsx
@@ -11,6 +11,7 @@ import { useEffect, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Animated, Easing, Pressable, View } from 'react-native';
 
+import { deadLettered } from '@waves/core';
 import { Card, iconSize, Row, Text, useTheme } from '@waves/ui';
 
 import { plural, useStrings } from '@/i18n';
@@ -47,6 +48,13 @@ export function SyncStatusIcon({
   // global, since the network is not per-group.
   const refused = groupId ? rejected.filter((item) => item.groupId === groupId) : rejected;
   const pending = groupId ? queue.filter((item) => item.groupId === groupId) : queue;
+  // A mutation that has exhausted its retries is not "syncing" — it has stopped,
+  // and it blocks everything queued behind it in its group. Under the old
+  // glyph it still counted as pending, so the header said "sending 1 change…"
+  // forever while nothing was being sent. It needs the same decision a refusal
+  // does, so it gets the same red.
+  const stuck = deadLettered(pending);
+  const stopped = refused.length + stuck.length;
 
   const spin = useState(() => new Animated.Value(0))[0];
   const spinning = status === SyncStatus.Syncing && !reduceMotion;
@@ -77,11 +85,14 @@ export function SyncStatusIcon({
   // as an alert whatever it sits on.
   const neutral = onBrand ? theme.color.onBrand : theme.color.text;
   const state =
-    refused.length > 0
+    stopped > 0
       ? {
           icon: 'alert-circle' as const,
           color: theme.color.negative,
-          label: t.extras.oneChangeFailed,
+          label:
+            refused.length > 0
+              ? t.extras.oneChangeFailed
+              : plural(locale, stuck.length, t.sync.stuckCount),
         }
       : status === SyncStatus.Offline
         ? { icon: 'cloud-offline-outline' as const, color: neutral, label: t.misc.offlineSaved }
@@ -137,6 +148,7 @@ export function SyncBanner({ groupId }: { groupId?: string }) {
 
   const pending = groupId ? queue.filter((item) => item.groupId === groupId) : queue;
   const refused = groupId ? rejected.filter((item) => item.groupId === groupId) : rejected;
+  const stuck = deadLettered(pending);
 
   if (refused.length > 0) {
     const first = refused[0];
@@ -181,6 +193,66 @@ export function SyncBanner({ groupId }: { groupId?: string }) {
           </Pressable>
           <Pressable
             onPress={() => first && void discard(first.clientMutationId)}
+            accessibilityRole="button"
+            accessibilityLabel={t.extras.discardIt}
+            hitSlop={8}
+            style={({ pressed }) => ({
+              minHeight: 44,
+              justifyContent: 'center',
+              opacity: pressed ? 0.6 : 1,
+            })}
+          >
+            <Text variant="caption" tone="muted">
+              {t.extras.discardIt}
+            </Text>
+          </Pressable>
+        </Row>
+      </Card>
+    );
+  }
+
+  // Nothing refused, but something has stopped trying.
+  //
+  // `MAX_ATTEMPTS` backoffs is roughly eight and a half minutes of a transport
+  // that will not take this mutation — a payload an older server rejects at the
+  // edge, a body too large, a bug. `nextBatch` then skips the whole group, so
+  // everything entered after it in that group waits behind it with nothing on
+  // screen to say why. `deadLettered` has existed since the queue was written
+  // and was called from nowhere; this is the surface it was waiting for.
+  if (stuck.length > 0) {
+    // The head of the queue is what blocks the group — order is preserved
+    // within a group, so retrying or dropping the oldest is what actually gets
+    // the rest moving. `deadLettered` preserves queue order, so this is it.
+    const head = stuck[0];
+    return (
+      <Card style={{ backgroundColor: theme.color.negativeSoft, gap: theme.spacing.md }}>
+        <Row style={{ gap: theme.spacing.sm }}>
+          <Ionicons name="alert-circle" size={iconSize.md} color={theme.color.negative} />
+          <Text variant="subheading" tone="negative">
+            {plural(locale, stuck.length, t.sync.stuckCount)}
+          </Text>
+        </Row>
+        <Text variant="caption" tone="muted">
+          {t.sync.stuckExplain}
+        </Text>
+        <Row style={{ gap: theme.spacing.lg }}>
+          <Pressable
+            onPress={() => head && void retry(head.clientMutationId)}
+            accessibilityRole="button"
+            accessibilityLabel={t.extras.tryAgain}
+            hitSlop={8}
+            style={({ pressed }) => ({
+              minHeight: 44,
+              justifyContent: 'center',
+              opacity: pressed ? 0.6 : 1,
+            })}
+          >
+            <Text variant="caption" tone="brand">
+              {t.extras.tryAgain}
+            </Text>
+          </Pressable>
+          <Pressable
+            onPress={() => head && void discard(head.clientMutationId)}
             accessibilityRole="button"
             accessibilityLabel={t.extras.discardIt}
             hitSlop={8}

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -365,7 +365,7 @@ export function useHomeSummary(profileId: string | null) {
 
       if (snapshots.length > 0 || settlements.length > 0) withLedger.add(group.id);
 
-      const net = computeNetBalances(snapshots, settlements.map(toSettlementSnapshot));
+      const net = computeNetBalances(snapshots, toSettlementSnapshots(settlements));
       const mine = (membersByGroup.get(group.id) ?? []).find(
         (member) => member.profile_id === profileId,
       );
@@ -542,9 +542,9 @@ export function usePeopleBalances(profileId: string | null): LocalRead<PersonBal
       const snapshots = materialiseExpenses(mirror, queue, { groupId: group.id })
         .map((expense) => toSnapshot(expense as unknown as ExpenseRow))
         .filter((snapshot): snapshot is ExpenseSnapshot => snapshot !== null);
-      const settlementSnapshots = (
-        materialiseSettlements(mirror, queue, { groupId: group.id }) as unknown as SettlementRow[]
-      ).map(toSettlementSnapshot);
+      const settlementSnapshots = toSettlementSnapshots(
+        materialiseSettlements(mirror, queue, { groupId: group.id }) as unknown as SettlementRow[],
+      );
 
       const activity = lastActivityByMember(snapshots, settlementSnapshots);
       const edges = computePairwiseBalances(snapshots, settlementSnapshots);
@@ -849,34 +849,62 @@ export function useGroup(groupId: string) {
   };
 }
 
+/**
+ * Wire row → the shape the balance maths wants.
+ *
+ * Every one of these `BigInt(...)` calls throws a bare `SyntaxError` on a string
+ * that is not an integer — an amount from an older build, a truncated payload, a
+ * row overlaid from the offline queue. All of these run inside a render-time
+ * `useMemo`, so a throw here is not a wrong number on one line: it unmounts the
+ * screen, and because the row is on disk it does the same again on the next
+ * launch. Core's `toExpenseSnapshot` already guards exactly this; these two are
+ * the mobile copies that did not. A row that cannot be read is dropped instead —
+ * every caller filters nulls — which is one line missing from a list rather than
+ * a ledger nobody can open.
+ */
 export function toSnapshot(expense: ExpenseRow): ExpenseSnapshot | null {
   const version = expense.currentVersion;
   if (!version) return null;
-  return {
-    id: expense.id,
-    currency: version.currency,
-    amount: BigInt(version.amount),
-    payers: Object.fromEntries(version.payers.map((row) => [row.member_id, BigInt(row.amount)])),
-    shares: Object.fromEntries(version.shares.map((row) => [row.member_id, BigInt(row.amount)])),
-    date: version.expense_date,
-    deletedAt: expense.deleted_at,
-  };
+  try {
+    return {
+      id: expense.id,
+      currency: version.currency,
+      amount: BigInt(version.amount),
+      payers: Object.fromEntries(version.payers.map((row) => [row.member_id, BigInt(row.amount)])),
+      shares: Object.fromEntries(version.shares.map((row) => [row.member_id, BigInt(row.amount)])),
+      date: version.expense_date,
+      deletedAt: expense.deleted_at,
+    };
+  } catch {
+    return null;
+  }
 }
 
-export function toSettlementSnapshot(row: SettlementRow): SettlementSnapshot {
-  return {
-    id: row.id,
-    from: row.from_member_id,
-    to: row.to_member_id,
-    currency: row.currency,
-    amount: BigInt(row.amount),
-    status: row.status,
-    at: row.initiated_at,
-    allocations: row.allocations?.map((allocation) => ({
-      expenseId: allocation.expense_id,
-      amount: BigInt(allocation.amount),
-    })),
-  };
+export function toSettlementSnapshot(row: SettlementRow): SettlementSnapshot | null {
+  try {
+    return {
+      id: row.id,
+      from: row.from_member_id,
+      to: row.to_member_id,
+      currency: row.currency,
+      amount: BigInt(row.amount),
+      status: row.status,
+      at: row.initiated_at,
+      allocations: row.allocations?.map((allocation) => ({
+        expenseId: allocation.expense_id,
+        amount: BigInt(allocation.amount),
+      })),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** `toSettlementSnapshot` over a list, minus the rows that would not read. */
+export function toSettlementSnapshots(rows: readonly SettlementRow[]): SettlementSnapshot[] {
+  return rows
+    .map(toSettlementSnapshot)
+    .filter((snapshot): snapshot is SettlementSnapshot => snapshot !== null);
 }
 
 export interface GroupLedger {
@@ -905,7 +933,7 @@ export function useGroupLedger(groupId: string, myProfileId: string | null): Gro
     const snapshots = expenses.rows
       .map(toSnapshot)
       .filter((snapshot): snapshot is ExpenseSnapshot => snapshot !== null);
-    const settlementSnapshots = (settlements.data ?? []).map(toSettlementSnapshot);
+    const settlementSnapshots = toSettlementSnapshots(settlements.data ?? []);
 
     const net = computeNetBalances(snapshots, settlementSnapshots);
     const withPending = computeNetBalances(snapshots, settlementSnapshots, {

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -733,6 +733,12 @@ export interface UiStrings {
     waitingWifi: string;
     /** Banner while holding the queue for mobile data. */
     waitingCellular: string;
+    /** Banner heading when a change has given up retrying (see MAX_ATTEMPTS in
+     *  @waves/core). It blocks everything queued behind it in the same group,
+     *  so it needs a person to retry it or let it go. */
+    stuckCount: PluralForms;
+    /** The line under that heading: still saved, just not sent. */
+    stuckExplain: string;
   };
   /** The app lock, the delay before it asks again, and the way out. */
   lock: {
@@ -2970,6 +2976,12 @@ const en: UiStrings = {
     selected: 'selected',
     waitingWifi: 'Saved — waiting for Wi‑Fi to sync.',
     waitingCellular: 'Saved — waiting for mobile data to sync.',
+    stuckCount: {
+      one: '{n} change is stuck',
+      other: '{n} changes are stuck',
+    },
+    stuckExplain:
+      'Still saved on this phone — it just keeps failing to send. Try again, or let it go.',
   },
   lock: {
     title: 'Security',
@@ -5114,6 +5126,12 @@ const ta: UiStrings = {
     selected: 'தேர்ந்தெடுக்கப்பட்டது',
     waitingWifi: 'சேமிக்கப்பட்டது — ஒத்திசைக்க வைஃபைக்காகக் காத்திருக்கிறது.',
     waitingCellular: 'சேமிக்கப்பட்டது — ஒத்திசைக்க மொபைல் டேட்டாவுக்காகக் காத்திருக்கிறது.',
+    stuckCount: {
+      one: '{n} மாற்றம் சிக்கிக்கொண்டது',
+      other: '{n} மாற்றங்கள் சிக்கிக்கொண்டன',
+    },
+    stuckExplain:
+      'இந்த ஃபோனில் இன்னும் சேமிக்கப்பட்டுள்ளது — அனுப்ப முடியவில்லை. மீண்டும் முயற்சிக்கவும், அல்லது நீக்கிவிடவும்.',
   },
   lock: {
     title: 'பாதுகாப்பு',
@@ -7335,6 +7353,12 @@ const hi: UiStrings = {
     selected: 'चुना गया',
     waitingWifi: 'सहेजा गया — सिंक के लिए वाई‑फ़ाई की प्रतीक्षा है।',
     waitingCellular: 'सहेजा गया — सिंक के लिए मोबाइल डेटा की प्रतीक्षा है।',
+    stuckCount: {
+      one: '{n} बदलाव अटका है',
+      other: '{n} बदलाव अटके हैं',
+    },
+    stuckExplain:
+      'इस फ़ोन पर अब भी सहेजा है — बस भेजा नहीं जा पा रहा। दोबारा कोशिश करें, या हटा दें।',
   },
   lock: {
     title: 'सुरक्षा',
@@ -9495,6 +9519,15 @@ const ar: UiStrings = {
     selected: 'محدَّد',
     waitingWifi: 'محفوظ — بانتظار واي‑فاي للمزامنة.',
     waitingCellular: 'محفوظ — بانتظار بيانات الجوال للمزامنة.',
+    stuckCount: {
+      zero: 'لا تغييرات عالقة',
+      one: 'تغيير واحد عالق',
+      two: 'تغييران عالقان',
+      few: '{n} تغييرات عالقة',
+      many: '{n} تغييرًا عالقًا',
+      other: '{n} تغيير عالق',
+    },
+    stuckExplain: 'ما زال محفوظًا على هذا الهاتف — لكنه لا يُرسَل. أعد المحاولة، أو تجاهله.',
   },
   lock: {
     title: 'الأمان',

--- a/apps/mobile/src/sync/driver.ts
+++ b/apps/mobile/src/sync/driver.ts
@@ -13,6 +13,8 @@ import * as SQLite from 'expo-sqlite';
 
 import type { MirrorRow, QueuedMutation, SyncTable } from '@waves/core';
 
+import { reportHandled } from '@/lib/observability';
+
 import { mapYielding } from './hydrateChunk';
 import { decryptWith, destroyKey, encryptWith, isSealed, loadKey } from './rowCipher';
 import { Serial } from './serial';
@@ -33,6 +35,36 @@ const mirrorAad = (table: string, id: string, groupId: string, seq: number): str
 const queueAad = (clientMutationId: string, seq: number): string =>
   ['pending_mutations', clientMutationId, seq].join(AAD_SEP);
 const draftAad = (key: string): string => ['drafts', key].join(AAD_SEP);
+
+/**
+ * A row whose ciphertext will not open is skipped, not fatal.
+ *
+ * This used to wipe the whole database — every mirror row, every cursor, every
+ * autosaved draft, the unsent mutation queue and the key itself — on the first
+ * value that failed to decrypt. The realistic trigger is not corruption but an
+ * Android backup/restore: `SharedPreferences` travels to the new device and the
+ * Keystore entry does not, so `loadKey` mints a fresh DEK, the first AEAD tag
+ * fails, and every expense entered offline is destroyed before anyone sees it.
+ * A single truncated row did the same.
+ *
+ * So the reads below open row by row and drop only what will not open. An
+ * unreadable row was already unreadable; deleting its neighbours turns a partial
+ * loss into a total one. `pending_mutations` in particular is never deleted for
+ * a read failure — see `writeQueue`, which preserves the rows it could not read
+ * rather than replacing the table wholesale.
+ *
+ * Reported once per table per process: a cold start walks thousands of rows and
+ * one lost key would otherwise be thousands of identical Sentry events.
+ */
+const quarantineReported = new Set<string>();
+function reportQuarantine(table: string, skipped: number, total: number, cause: unknown): void {
+  if (skipped === 0 || quarantineReported.has(table)) return;
+  quarantineReported.add(table);
+  reportHandled(
+    cause instanceof Error ? cause : new Error(String(cause)),
+    `sync.quarantine.${table}[${skipped}/${total}]`,
+  );
+}
 
 const SCHEMA = `
 -- Wait for a held lock instead of throwing SQLITE_BUSY the instant the file is
@@ -85,6 +117,14 @@ class SqliteStore implements LocalStore {
   private database: SQLite.SQLiteDatabase | null = null;
   private opening: Promise<SQLite.SQLiteDatabase> | null = null;
   private readonly serial = new Serial();
+  /**
+   * Queue rows the last read could not open. They are held on disk rather than
+   * swept away by the next `writeQueue`: the ciphertext is all that is left of
+   * somebody's offline work, and a key restored later (or a bug fixed in a
+   * later build) can still open it. Nothing replays them — they are simply not
+   * destroyed. See {@link reportQuarantine}.
+   */
+  private quarantinedQueueIds: readonly string[] = [];
 
   async ready(): Promise<void> {
     await this.db();
@@ -175,24 +215,6 @@ class SqliteStore implements LocalStore {
     await database.execAsync(`PRAGMA wal_checkpoint(TRUNCATE)`);
   }
 
-  private async wipeLocalData(database: SQLite.SQLiteDatabase): Promise<void> {
-    await database.withTransactionAsync(async () => {
-      await database.runAsync(`DELETE FROM mirror_rows WHERE 1 = 1`);
-      await database.runAsync(`DELETE FROM pending_mutations WHERE 1 = 1`);
-      await database.runAsync(`DELETE FROM sync_cursors WHERE 1 = 1`);
-      await database.runAsync(`DELETE FROM drafts WHERE 1 = 1`);
-    });
-    await destroyKey();
-  }
-
-  private async recoverUnreadableLocalData<T>(
-    database: SQLite.SQLiteDatabase,
-    fallback: T,
-  ): Promise<T> {
-    await this.wipeLocalData(database);
-    return fallback;
-  }
-
   async putRows(rows: readonly StoredRow[]): Promise<void> {
     if (rows.length === 0) return;
     await this.serial.run(async () => {
@@ -240,19 +262,29 @@ class SqliteStore implements LocalStore {
       // whole mirror is decrypted and `JSON.parse`d here before `hydrated` flips,
       // and doing it in one synchronous burst froze the loading skeleton and the
       // first frame. The key is loaded once above; the per-row open is sync.
-      try {
-        return await mapYielding(rows, (row) => ({
-          table: row.table_name as SyncTable,
-          id: row.id,
-          groupId: row.group_id,
-          seq: row.seq,
-          row: JSON.parse(
-            decryptWith(key, row.json, mirrorAad(row.table_name, row.id, row.group_id, row.seq)),
-          ) as MirrorRow,
-        }));
-      } catch {
-        return this.recoverUnreadableLocalData(database, []);
-      }
+      // One row that will not open is one row missing from the ledger — which
+      // the next pull refills from the server. Every other row still hydrates.
+      let firstFailure: unknown;
+      let skipped = 0;
+      const opened = await mapYielding(rows, (row): StoredRow | null => {
+        try {
+          return {
+            table: row.table_name as SyncTable,
+            id: row.id,
+            groupId: row.group_id,
+            seq: row.seq,
+            row: JSON.parse(
+              decryptWith(key, row.json, mirrorAad(row.table_name, row.id, row.group_id, row.seq)),
+            ) as MirrorRow,
+          };
+        } catch (error) {
+          skipped += 1;
+          firstFailure ??= error;
+          return null;
+        }
+      });
+      reportQuarantine('mirror_rows', skipped, rows.length, firstFailure);
+      return opened.filter((row): row is StoredRow => row !== null);
     });
   }
 
@@ -293,17 +325,53 @@ class SqliteStore implements LocalStore {
         seq: number;
         json: string;
       }>(`SELECT client_mutation_id, seq, json FROM pending_mutations ORDER BY seq ASC`);
-      try {
-        return rows.map(
-          (row) =>
+      // The queue is the one table whose rows exist nowhere else — a mutation
+      // that has not synced is only here. So a row that will not open is
+      // remembered rather than dropped: `writeQueue` keeps its bytes on disk.
+      const queue: QueuedMutation[] = [];
+      const quarantined: string[] = [];
+      let firstFailure: unknown;
+      for (const row of rows) {
+        try {
+          queue.push(
             JSON.parse(
               decryptWith(key, row.json, queueAad(row.client_mutation_id, row.seq)),
             ) as QueuedMutation,
-        );
-      } catch {
-        return this.recoverUnreadableLocalData(database, []);
+          );
+        } catch (error) {
+          quarantined.push(row.client_mutation_id);
+          firstFailure ??= error;
+        }
       }
+      this.quarantinedQueueIds = quarantined;
+      reportQuarantine('pending_mutations', quarantined.length, rows.length, firstFailure);
+      return queue;
     });
+  }
+
+  /**
+   * Empty `pending_mutations` before it is rewritten — except the rows the last
+   * read could not open.
+   *
+   * The queue is persisted by replacement, so a plain `DELETE` here would let a
+   * decrypt failure quietly finish what the old whole-DB wipe started: the row
+   * vanishes from the in-memory queue on read, and the next write removes it
+   * from disk. Holding it back costs one unreadable row's bytes and keeps the
+   * only copy of that mutation. `WHERE 1 = 1` for the same reason the server
+   * needs it: a bare DELETE is one typo away from deleting everything.
+   */
+  private async clearQueueRows(database: SQLite.SQLiteDatabase): Promise<void> {
+    const held = this.quarantinedQueueIds;
+    if (held.length === 0) {
+      await database.runAsync(`DELETE FROM pending_mutations WHERE 1 = 1`);
+      return;
+    }
+    await database.runAsync(
+      `DELETE FROM pending_mutations WHERE client_mutation_id NOT IN (${held
+        .map(() => '?')
+        .join(', ')})`,
+      [...held],
+    );
   }
 
   writeQueue(queue: readonly QueuedMutation[]): Promise<void> {
@@ -311,10 +379,7 @@ class SqliteStore implements LocalStore {
       const database = await this.db();
       const key = await loadKey();
       await database.withTransactionAsync(async () => {
-        // `WHERE 1 = 1` for the same reason the server needs it: a bare DELETE
-        // is the kind of statement that is one typo away from deleting
-        // everything.
-        await database.runAsync(`DELETE FROM pending_mutations WHERE 1 = 1`);
+        await this.clearQueueRows(database);
         for (const mutation of queue) {
           await database.runAsync(
             `INSERT INTO pending_mutations (client_mutation_id, seq, json) VALUES (?, ?, ?)`,
@@ -341,10 +406,14 @@ class SqliteStore implements LocalStore {
         `SELECT json FROM drafts WHERE key = ?`,
         [key],
       );
+      if (!row) return null;
       try {
-        return row ? (JSON.parse(decryptWith(dek, row.json, draftAad(key))) as T) : null;
-      } catch {
-        return this.recoverUnreadableLocalData(database, null);
+        return JSON.parse(decryptWith(dek, row.json, draftAad(key))) as T;
+      } catch (error) {
+        // A draft is a convenience — an unreadable one is a form that opens
+        // blank, which is exactly what it would do if it had never been saved.
+        reportQuarantine('drafts', 1, 1, error);
+        return null;
       }
     });
   }
@@ -375,15 +444,23 @@ class SqliteStore implements LocalStore {
       const rows = await database.getAllAsync<{ key: string; json: string; saved_at: string }>(
         `SELECT key, json, saved_at FROM drafts ORDER BY saved_at DESC`,
       );
-      try {
-        return rows.map((row) => ({
-          key: row.key,
-          value: JSON.parse(decryptWith(dek, row.json, draftAad(row.key))) as unknown,
-          savedAt: row.saved_at,
-        }));
-      } catch {
-        return this.recoverUnreadableLocalData(database, []);
+      const drafts: { key: string; value: unknown; savedAt: string }[] = [];
+      let firstFailure: unknown;
+      let skipped = 0;
+      for (const row of rows) {
+        try {
+          drafts.push({
+            key: row.key,
+            value: JSON.parse(decryptWith(dek, row.json, draftAad(row.key))) as unknown,
+            savedAt: row.saved_at,
+          });
+        } catch (error) {
+          skipped += 1;
+          firstFailure ??= error;
+        }
       }
+      reportQuarantine('drafts', skipped, rows.length, firstFailure);
+      return drafts;
     });
   }
 
@@ -397,7 +474,7 @@ class SqliteStore implements LocalStore {
       await database.withTransactionAsync(async () => {
         await database.runAsync(`DELETE FROM mirror_rows WHERE group_id = ?`, [groupId]);
         await database.runAsync(`DELETE FROM sync_cursors WHERE group_id = ?`, [groupId]);
-        await database.runAsync(`DELETE FROM pending_mutations WHERE 1 = 1`);
+        await this.clearQueueRows(database);
         for (const mutation of queue) {
           await database.runAsync(
             `INSERT INTO pending_mutations (client_mutation_id, seq, json) VALUES (?, ?, ?)`,
@@ -427,10 +504,15 @@ class SqliteStore implements LocalStore {
       // drafts. All four now commit together or not at all.
       await database.withTransactionAsync(async () => {
         await database.runAsync(`DELETE FROM mirror_rows WHERE 1 = 1`);
+        // Unconditional, unlike `clearQueueRows`: quarantined rows are held
+        // against a lost key, not against the account being signed out. Sign-out
+        // is a privacy promise, and an unreadable row is still this person's
+        // data sitting on a phone somebody else is about to use.
         await database.runAsync(`DELETE FROM pending_mutations WHERE 1 = 1`);
         await database.runAsync(`DELETE FROM sync_cursors WHERE 1 = 1`);
         await database.runAsync(`DELETE FROM drafts WHERE 1 = 1`);
       });
+      this.quarantinedQueueIds = [];
       // Crypto-erase: with the rows gone, drop the key too. Any ciphertext still
       // physically present in the WAL or free pages is now unrecoverable, and the
       // next account on this device mints a fresh key rather than inheriting this

--- a/apps/mobile/test/localStore.test.ts
+++ b/apps/mobile/test/localStore.test.ts
@@ -120,6 +120,15 @@ class FakeDatabase {
         return;
       }
       if (statement === 'DELETE FROM pending_mutations') {
+        // The store holds back rows it could not decrypt (`clearQueueRows`), so
+        // this has to honour the NOT IN clause rather than always clearing.
+        if (source.includes('NOT IN')) {
+          const held = new Set(params as string[]);
+          for (const id of [...this.pendingMutations.keys()]) {
+            if (!held.has(id)) this.pendingMutations.delete(id);
+          }
+          return;
+        }
         this.pendingMutations.clear();
         return;
       }
@@ -252,6 +261,18 @@ vi.mock('expo-crypto', () => ({
   },
 }));
 
+// The store reports a quarantined row through the app's Sentry wrapper, which
+// statically imports @sentry/react-native (and through it react-native itself —
+// Flow syntax vitest cannot parse). Only the call matters here, so the module is
+// replaced by a spy and the reports are asserted below.
+const reports = vi.hoisted(() => [] as { error: unknown; where: string }[]);
+
+vi.mock('@/lib/observability', () => ({
+  reportHandled: (error: unknown, where: string) => {
+    reports.push({ error, where });
+  },
+}));
+
 vi.mock('expo-sqlite', () => ({
   openDatabaseAsync: async () => {
     openCalls += 1;
@@ -287,6 +308,7 @@ beforeEach(() => {
   secure.keystore.clear();
   secure.deletes = [];
   secure.gets = 0;
+  reports.length = 0;
 });
 
 describe('two callers, one connection', () => {
@@ -536,29 +558,135 @@ describe('at-rest encryption', () => {
     expect(await store.readDraft('d1')).toEqual({ note: 'legacy' });
   });
 
-  it('wipes unreadable encrypted local data and returns empty state', async () => {
+  /**
+   * The scenario this whole section exists for.
+   *
+   * An Android backup/restore carries the app's SQLite file but not its Keystore
+   * entry, so the new device mints a fresh DEK and every sealed row fails its
+   * AEAD tag. This used to wipe the database — including `pending_mutations`,
+   * where an expense entered on a plane is the only copy in the world. Nothing
+   * is deleted for a read failure now.
+   */
+  describe('a key the database no longer has', () => {
     const DEK = 'waves.mirror.dek.v1';
+
+    const seed = async (store: ReturnType<typeof createLocalStore>) => {
+      await store.putRows([
+        { table: 'expenses', id: 'e1', groupId: 'g1', seq: 1, row: { id: 'e1' } },
+      ] as never);
+      await store.writeCursors({ g1: 1 });
+      await store.writeQueue([mutation('a'), mutation('b')]);
+      await store.writeDraft('d1', { secret: 'draft' });
+    };
+
+    it('reads what it can and destroys nothing', async () => {
+      const store = createLocalStore();
+      await seed(store);
+
+      // The DB traveled; the device-only DEK did not.
+      await destroyKey();
+      const deletesBefore = secure.deletes.filter((key) => key === DEK).length;
+
+      // Unreadable, so absent from the read...
+      expect(await store.readRows()).toEqual([]);
+      expect(await store.readQueue()).toEqual([]);
+      expect(await store.readDraft('d1')).toBeNull();
+      expect(await store.listDrafts()).toEqual([]);
+      // ...but every byte is still on disk, and the key was not thrown away.
+      expect(database.mirrorRows.size).toBe(1);
+      expect(database.pendingMutations.size).toBe(2);
+      expect(database.drafts.size).toBe(1);
+      expect(secure.deletes.filter((key) => key === DEK).length).toBe(deletesBefore);
+      // Cursors are not encrypted, so they were never at risk either way.
+      expect(await store.readCursors()).toEqual({ g1: 1 });
+
+      // Reported once per table, not once per row: a cold start walks the whole
+      // mirror and a lost key would otherwise be thousands of identical events.
+      // This is the first failing read in the file, so these are all of them.
+      expect(reports.map((entry) => entry.where.replace(/\[.*$/, '')).sort()).toEqual([
+        'sync.quarantine.drafts',
+        'sync.quarantine.mirror_rows',
+        'sync.quarantine.pending_mutations',
+      ]);
+      const seen = reports.length;
+      await store.readRows();
+      await store.readQueue();
+      await store.listDrafts();
+      expect(reports).toHaveLength(seen);
+    });
+
+    it('keeps the unreadable queue rows through the next queue write', async () => {
+      const store = createLocalStore();
+      await seed(store);
+      await destroyKey();
+
+      // Hydration reads the queue (finding nothing it can open), then the app
+      // carries on and queues something new. The rewrite must not finish what
+      // the old wipe started.
+      expect(await store.readQueue()).toEqual([]);
+      await store.writeQueue([mutation('c')]);
+
+      expect([...database.pendingMutations.keys()].sort()).toEqual(['a', 'b', 'c']);
+      expect((await store.readQueue()).map((entry) => entry.clientMutationId)).toEqual(['c']);
+    });
+
+    it('keeps them through forgetGroup too', async () => {
+      const store = createLocalStore();
+      await seed(store);
+      await destroyKey();
+      await store.readQueue();
+
+      await store.forgetGroup('g1', []);
+
+      expect([...database.pendingMutations.keys()].sort()).toEqual(['a', 'b']);
+    });
+
+    it('still wipes everything on sign-out', async () => {
+      const store = createLocalStore();
+      await seed(store);
+      await destroyKey();
+      await store.readQueue();
+      const deletesBefore = secure.deletes.filter((key) => key === DEK).length;
+
+      // Quarantine protects a lost key, not a departing account: an unreadable
+      // row is still this person's data on a phone somebody else is about to use.
+      await store.reset();
+
+      expect(database.pendingMutations.size).toBe(0);
+      expect(database.mirrorRows.size).toBe(0);
+      expect(database.drafts.size).toBe(0);
+      expect(secure.deletes.filter((key) => key === DEK).length).toBe(deletesBefore + 1);
+    });
+  });
+
+  it('drops only the row it cannot open, not its neighbours', async () => {
     const store = createLocalStore();
     await store.putRows([
-      { table: 'expenses', id: 'e1', groupId: 'g1', seq: 1, row: { id: 'e1' } },
+      { table: 'expenses', id: 'e1', groupId: 'g1', seq: 1, row: { id: 'e1', amount: '100' } },
+      { table: 'expenses', id: 'e2', groupId: 'g1', seq: 2, row: { id: 'e2', amount: '200' } },
     ] as never);
-    await store.writeCursors({ g1: 1 });
-    await store.writeQueue([mutation('a')]);
-    await store.writeDraft('d1', { secret: 'draft' });
+    await store.writeQueue([mutation('a'), mutation('b')]);
+    await store.writeDraft('good', { amount: 1 });
+    await store.writeDraft('bad', { amount: 2 });
 
-    // Simulate restore/key loss: the DB traveled, but the device-only DEK did not.
-    await destroyKey();
-    const deletesBefore = secure.deletes.filter((key) => key === DEK).length;
+    // Corrupt exactly one row of each encrypted table — a truncated ciphertext
+    // fails the AEAD tag the same way a wrong key does.
+    const corrupt = (value: string) => `${value.slice(0, value.length - 8)}AAAAAAAA`;
+    const row = database.mirrorRows.get('expenses:e2');
+    if (row) row.json = corrupt(row.json);
+    const queued = database.pendingMutations.get('a');
+    if (queued) queued.json = corrupt(queued.json);
+    const draft = database.drafts.get('bad');
+    if (draft) draft.json = corrupt(draft.json);
 
-    expect(await store.readRows()).toEqual([]);
-    expect(await store.readCursors()).toEqual({});
-    expect(await store.readQueue()).toEqual([]);
-    expect(await store.readDraft('d1')).toBeNull();
-    expect(database.mirrorRows.size).toBe(0);
-    expect(database.pendingMutations.size).toBe(0);
-    expect(database.cursors.size).toBe(0);
-    expect(database.drafts.size).toBe(0);
-    expect(secure.deletes.filter((key) => key === DEK).length).toBe(deletesBefore + 1);
+    expect((await store.readRows()).map((entry) => entry.id)).toEqual(['e1']);
+    expect((await store.readQueue()).map((entry) => entry.clientMutationId)).toEqual(['b']);
+    expect((await store.listDrafts()).map((entry) => entry.key)).toEqual(['good']);
+    expect(await store.readDraft('good')).toEqual({ amount: 1 });
+    expect(await store.readDraft('bad')).toBeNull();
+    // And the corrupt queue row is still there, not swept up by the rewrite.
+    await store.writeQueue([mutation('b')]);
+    expect([...database.pendingMutations.keys()].sort()).toEqual(['a', 'b']);
   });
 
   it('destroys the key on reset (crypto-erase)', async () => {

--- a/packages/core/src/sync/mirror.ts
+++ b/packages/core/src/sync/mirror.ts
@@ -217,7 +217,18 @@ export function overlayPending(
 
   for (const mutation of [...queue].sort((a, b) => a.seq - b.seq)) {
     if (mutation.groupId !== options.groupId) continue;
-    applyPending(byId, mutation, options);
+    // Per mutation, because this runs inside a render-time useMemo and the
+    // queue is the one input nothing has validated. `pendingShares` reparses a
+    // payload written by an older build (or a truncated one), and a `MoneyError`
+    // thrown here propagates out of the component, through the error boundary,
+    // and — since the payload is on disk — again on every restart. One
+    // unmaterialisable mutation is one row missing from the list until it syncs
+    // or the user discards it; the rest of the ledger still renders.
+    try {
+      applyPending(byId, mutation, options);
+    } catch {
+      continue;
+    }
   }
 
   return [...byId.values()].sort((a, b) =>

--- a/packages/core/test/offlineDurability.test.ts
+++ b/packages/core/test/offlineDurability.test.ts
@@ -1,0 +1,237 @@
+/**
+ * What survives when the offline queue holds something the app cannot use.
+ *
+ * ADR-005 promises that a change is safe the moment it is saved on the phone.
+ * Two failures broke that promise in opposite directions, and both are asserted
+ * here:
+ *
+ *  1. A queued mutation the overlay cannot materialise threw out of a
+ *     render-time `useMemo`. The payload is on disk, so the throw repeated on
+ *     every launch — a crash loop the user cannot escape without reinstalling,
+ *     which takes the rest of the queue with it.
+ *  2. A mutation that exhausts `MAX_ATTEMPTS` stops being sent and blocks
+ *     everything queued behind it in its group. `deadLettered` has always
+ *     described that set; nothing ever called it, so the app said "sending 1
+ *     change…" forever and offered no way out.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  backoffMs,
+  deadLettered,
+  discard,
+  enqueue,
+  markFailed,
+  MAX_ATTEMPTS,
+  MutationKind,
+  nextBatch,
+  overlayPending,
+  parseAmount,
+  retryNow,
+  type MirrorExpense,
+  type MutationEnvelope,
+  type QueuedMutation,
+} from '../src/sync/index.js';
+
+const GROUP = 'group-1';
+const OTHER = 'group-2';
+
+const envelope = (
+  id: string,
+  payload: Record<string, unknown>,
+  groupId = GROUP,
+): MutationEnvelope => ({
+  clientMutationId: id,
+  kind: MutationKind.ExpenseCreate,
+  groupId,
+  clientCreatedAt: '2026-03-01T00:00:00.000Z',
+  payload,
+});
+
+const goodPayload = (expenseId: string) => ({
+  expenseId,
+  description: 'Chai',
+  expenseDate: '2026-03-01',
+  currency: 'INR',
+  amount: '900',
+  splitParams: { kind: 'equal' },
+  participants: ['m1', 'm2'],
+  payers: { m1: '900' },
+});
+
+/** The shape a build from six months ago, or a truncated write, can leave
+ *  behind: everything the overlay reads is present, and the amount is not a
+ *  number. `parseAmount` raises a typed MoneyError on it. */
+const badPayload = (expenseId: string) => ({
+  ...goodPayload(expenseId),
+  amount: 'nine hundred',
+});
+
+const queued = (envelopes: readonly MutationEnvelope[]): QueuedMutation[] =>
+  envelopes.reduce<QueuedMutation[]>((queue, item) => enqueue(queue, item), []);
+
+describe('a queued mutation the overlay cannot materialise', () => {
+  it('really is unparseable — the tests below are not asserting a no-op', () => {
+    // `pendingShares` calls exactly this on the queued payload's amount. If it
+    // ever stopped throwing, every test below would pass for the wrong reason.
+    expect(() => parseAmount(badPayload('e1').amount)).toThrow();
+  });
+
+  it('is dropped, and every other queued expense still renders', () => {
+    const queue = queued([
+      envelope('m-good-1', goodPayload('e1')),
+      envelope('m-bad', badPayload('e2')),
+      envelope('m-good-2', goodPayload('e3')),
+    ]);
+
+    const rows = overlayPending([], queue, { groupId: GROUP });
+
+    expect(rows.map((row) => row.id).sort()).toEqual(['e1', 'e3']);
+    expect(rows.every((row) => row.pending)).toBe(true);
+  });
+
+  it('leaves the server rows it was overlaying untouched', () => {
+    const server: MirrorExpense[] = [
+      {
+        id: 'e-server',
+        group_id: GROUP,
+        deleted_at: null,
+        created_at: '2026-02-01T00:00:00.000Z',
+        currentVersion: {
+          id: 'v1',
+          version_no: 1,
+          description: 'Dinner',
+          category: null,
+          category_meta: null,
+          expense_date: '2026-02-01',
+          currency: 'INR',
+          amount: '1000',
+          split_type: 'equal',
+          split_params: { kind: 'equal' },
+          author_member_id: 'm1',
+          notes: null,
+          payment_method: null,
+          receipt_share_url: null,
+          location: null,
+          created_at: '2026-02-01T00:00:00.000Z',
+          payers: [{ member_id: 'm1', amount: '1000' }],
+          shares: [
+            { member_id: 'm1', amount: '500' },
+            { member_id: 'm2', amount: '500' },
+          ],
+        },
+      } as MirrorExpense,
+    ];
+
+    const rows = overlayPending(server, queued([envelope('m-bad', badPayload('e2'))]), {
+      groupId: GROUP,
+    });
+
+    // The whole point: one bad queue entry must not take the ledger with it.
+    expect(rows).toEqual(server);
+  });
+
+  it('drops only the bad mutation, not the later edits of other expenses', () => {
+    const queue = queued([
+      envelope('m-bad', badPayload('e1')),
+      envelope('m-good', goodPayload('e2')),
+    ]);
+    // An update after the bad create, on a different expense, still applies.
+    const withUpdate: QueuedMutation[] = [
+      ...queue,
+      {
+        ...envelope('m-update', { ...goodPayload('e2'), description: 'Chai, again' }),
+        kind: MutationKind.ExpenseUpdate,
+        seq: 3,
+        attempts: 0,
+        nextAttemptAt: 0,
+        lastError: null,
+      },
+    ];
+
+    const rows = overlayPending([], withUpdate, { groupId: GROUP });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.currentVersion?.description).toBe('Chai, again');
+  });
+});
+
+describe('a mutation that has stopped retrying', () => {
+  /** Fail the whole queue until it gives up — how a dead transport really does
+   *  it: the batch goes out together and comes back failed together. */
+  const exhaust = (queue: QueuedMutation[]): QueuedMutation[] => {
+    let current = queue;
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt += 1) {
+      // Far enough past each backoff that the batch is eligible again.
+      const now = attempt * backoffMs(MAX_ATTEMPTS);
+      current = markFailed(current, nextBatch(current, { now }), 'network', now);
+    }
+    return current;
+  };
+
+  /** One mutation already at a given attempt count — the state the queue is
+   *  actually restored into from disk, without replaying the failures. */
+  const at = (id: string, attempts: number, groupId = GROUP): QueuedMutation => ({
+    ...envelope(id, goodPayload(`e-${id}`), groupId),
+    seq: Number(id.replace(/\D/g, '')),
+    attempts,
+    nextAttemptAt: attempts === 0 ? 0 : backoffMs(attempts),
+    lastError: attempts === 0 ? null : 'network',
+  });
+
+  it('reaches the ceiling through ordinary transport failures', () => {
+    const exhausted = exhaust(queued([envelope('m1', goodPayload('e1'))]));
+
+    expect(exhausted[0]?.attempts).toBe(MAX_ATTEMPTS);
+    expect(deadLettered(exhausted).map((item) => item.clientMutationId)).toEqual(['m1']);
+    // ~8.5 minutes of trying, and then nothing ever again without a person.
+    expect(nextBatch(exhausted, { now: Number.MAX_SAFE_INTEGER })).toEqual([]);
+  });
+
+  it('blocks its own group and nothing else — which is why it needs surfacing', () => {
+    const queue = [at('m1', MAX_ATTEMPTS), at('m2', 0, OTHER)];
+
+    const stuck = deadLettered(queue);
+    expect(stuck).toHaveLength(1);
+    expect(stuck[0]?.groupId).toBe(GROUP);
+
+    // The other group keeps syncing, so the app never looks broken — which is
+    // exactly how this stayed invisible.
+    const later = nextBatch(queue, { now: Number.MAX_SAFE_INTEGER });
+    expect(later.map((item) => item.clientMutationId)).toEqual(['m2']);
+  });
+
+  it('holds everything queued behind it in the same group', () => {
+    const queue = [at('m1', MAX_ATTEMPTS), at('m2', 0)];
+
+    // `m2` never left the phone, so it is not itself dead — it is just stuck,
+    // and there was nothing on screen to say so.
+    expect(deadLettered(queue).map((item) => item.clientMutationId)).toEqual(['m1']);
+    expect(nextBatch(queue, { now: Number.MAX_SAFE_INTEGER })).toEqual([]);
+  });
+
+  it('moves again once the user retries the head', () => {
+    const queue = [at('m1', MAX_ATTEMPTS), at('m2', 0)];
+
+    // The banner acts on the head, because within a group that is the one row
+    // blocking the rest.
+    const head = deadLettered(queue)[0];
+    const retried = retryNow(queue, head?.clientMutationId ?? '');
+
+    expect(deadLettered(retried)).toEqual([]);
+    expect(nextBatch(retried, { now: 0 }).map((item) => item.clientMutationId)).toEqual([
+      'm1',
+      'm2',
+    ]);
+  });
+
+  it('moves again once the user discards the head', () => {
+    const queue = [at('m1', MAX_ATTEMPTS), at('m2', 0)];
+
+    const head = deadLettered(queue)[0];
+    const dropped = discard(queue, head?.clientMutationId ?? '');
+
+    expect(deadLettered(dropped)).toEqual([]);
+    expect(nextBatch(dropped, { now: 0 }).map((item) => item.clientMutationId)).toEqual(['m2']);
+  });
+});


### PR DESCRIPTION
## Why

Three P1 findings from the offline-durability group of the 2026-09-03 audit. All three end the same way: work somebody entered on a phone with no signal disappears, or the screen it lives on will not open.

1. **`apps/mobile/src/sync/driver.ts` wiped the whole database on any decrypt failure.** `recoverUnreadableLocalData` called `wipeLocalData`, which deleted `mirror_rows`, `pending_mutations`, `sync_cursors` and `drafts`, then destroyed the DEK. The realistic trigger is not corruption but an Android backup/restore: `SharedPreferences` travels to the new device and the Keystore entry does not, so `loadOrCreateKey` mints a fresh DEK, the first AEAD tag fails, and every expense entered offline is destroyed silently. One truncated row did the same. The mirror can be refilled from the server; `pending_mutations` cannot — an unsynced mutation exists nowhere else.
2. **A dead-lettered mutation stalled its group's queue forever, invisibly.** `nextBatch` blocks a group whose head hit `MAX_ATTEMPTS`; `deadLettered()` has described that set since the queue was written and was called from nowhere. ~8.5 minutes of transport failure on one mutation and the header glyph said "sending 1 change…" forever, with no retry and no explanation.
3. **Unguarded parses in render-time `useMemo`s crash-looped through restart.** `overlayPending` → `pendingShares` reparses the queued amount, and mobile's `toSnapshot` / `toSettlementSnapshot` call `BigInt()` raw. The payload is on disk, so a throw repeats on every launch. Core's `toExpenseSnapshot` already try/catches exactly this.

## What

**Per-row decrypt with quarantine, never a wipe** — `apps/mobile/src/sync/driver.ts`

- `wipeLocalData` / `recoverUnreadableLocalData` are gone.
- `readRows`, `readQueue`, `readDraft` and `listDrafts` open row by row and drop only what will not open.
- Queue rows that fail are remembered in `quarantinedQueueIds`. `writeQueue` persists the queue by *replacement*, so a plain `DELETE` would have quietly finished what the wipe started; the new `clearQueueRows` deletes everything except the held ids. `forgetGroup` goes through the same helper.
- `reset()` (sign-out) still deletes everything, quarantine included, and still destroys the key — that is a privacy promise, not a lost key.
- Quarantines are reported to Sentry once per table per process (`sync.quarantine.<table>[skipped/total]`), because a cold start walks thousands of rows.

**Dead-letters surfaced** — `apps/mobile/src/components/SyncBanner.tsx`, `apps/mobile/src/app/group/[id]/index.tsx`, `apps/mobile/src/i18n/index.ts`

- `SyncStatusIcon` folds dead-letters into the existing red alert-circle branch — the one state reserved for "this needs a decision" — instead of counting them as ordinary pending work.
- `SyncBanner` gets a stuck card in the same shape as the refused card: count, explanation, **Try again** / **Discard**. It acts on the *head* of the group's dead-lettered queue, because within a group that is the one row blocking the rest.
- The group screen's inline-banner gate widened from `refusedHere` to `stalledHere`, or a stuck-only state would have rendered nothing.
- New keys `sync.stuckCount` (plural) and `sync.stuckExplain` in en/ta/hi/ar; Arabic uses the full CLDR set. Reuses the existing `extras.tryAgain` / `extras.discardIt`.

**Guarded replay** — `packages/core/src/sync/mirror.ts`, `apps/mobile/src/data/hooks.ts`

- `overlayPending` try/catches per mutation and drops the unmaterialisable one.
- `toSnapshot` and `toSettlementSnapshot` return `null` on an unparseable amount. `toSnapshot`'s three callers already filtered nulls; `toSettlementSnapshot` did not, so a `toSettlementSnapshots(rows)` helper filters at the three call sites.

## Notes for the reviewer

- The old test `wipes unreadable encrypted local data and returns empty state` asserted the exact behaviour this PR removes, so it is replaced by a `describe('a key the database no longer has')` block that asserts the opposite: reads return nothing, but `database.pendingMutations.size` is unchanged, the key is not deleted, the rows survive a subsequent `writeQueue` and `forgetGroup`, and `reset()` still clears everything.
- `driver.ts` now imports `@/lib/observability`, which statically imports `@sentry/react-native` (and through it react-native's Flow syntax, which vitest cannot parse). `localStore.test.ts` mocks the module and asserts the report-once behaviour on it.
- `deadLettered` was already exported from `@waves/core` via `export * from './queue'` — no core API surface added for the UI half.
- **Deliberately not done:** the `materialiseSettlements` / `materialiseMembers` / `materialiseGroups` overlays were left unguarded. They do field assignment, not parsing — the audit named `pendingShares` specifically, and wrapping three more loop bodies would have widened the diff without a failure mode to point at.
- **Deliberately not done:** no engine-side change to how mutations reach `MAX_ATTEMPTS`. `markFailed` / `backoffMs` / `retryNow` / `discard` already do the right thing; the finding was that nothing rendered the result.
- `apps/mobile/src/app/group/[id]/invite.tsx` is the prettier-only change main is currently red on. It is also carried by #626/#627/#628 and merges cleanly either way.

## Gates

Run on Windows node from the repo root unless noted.

| Gate | Result |
| --- | --- |
| `pnpm format` + `prettier --check` on the touched trees | clean |
| `pnpm lint` | exit 0 (admin, mobile, web) |
| `cd apps/mobile && npx tsc --noEmit` | clean |
| `cd packages/core && npx tsc --noEmit` | clean |
| `cd apps/mobile && npx vitest run` | 57 files, 750 tests passed |
| `cd packages/core && npx vitest run` | 57 files, 836 tests passed |

Needs a real device: the backup/restore scenario itself (install, queue an expense offline, restore onto a device without the Keystore entry, confirm the queue rows survive), and the stuck-card layout in RTL.
