### PR TITLE
fix(invite): one-line join copy, copy-link inline with share row, drop reset section

### DIFF
--- a/apps/mobile/src/app/group/[id]/invite.tsx
+++ b/apps/mobile/src/app/group/[id]/invite.tsx
@@ -178,11 +178,12 @@ export default function InviteScreen() {
         <IconButton label={t.common.close} onPress={() => router.back()}>
           <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
         </IconButton>
+        {/* Title only. The group's name was a second line here, but the screen
+            is opened from inside that group — it said what the user already
+            knew, and a long name pushed the header out of shape. The name is
+            still in the invite the recipient gets. */}
         <View style={{ flex: 1, alignItems: 'center' }}>
           <Text variant="heading">{t.people.inviteTitle}</Text>
-          <Text variant="micro" tone="muted">
-            {label}
-          </Text>
         </View>
         <View style={{ width: 44 }} />
       </Row>
@@ -274,17 +275,21 @@ export default function InviteScreen() {
                   },
                   { channel: 'sms', label: t.extras.sms, icon: 'chatbubble', color: '#1E88E5' },
                   { channel: 'email', label: t.extras.email, icon: 'mail', color: '#EA4335' },
+                  // The last two are ours, not a third party's, so they wear the
+                  // app's own colour rather than a borrowed one — a pair at the
+                  // end of the row, and the only two that follow the theme into
+                  // dark mode.
                   {
                     channel: 'share',
                     label: t.common.share,
                     icon: 'share-social',
-                    color: '#7C4DFF',
+                    color: theme.color.brand,
                   },
                   {
                     channel: 'copy',
                     label: copied ? t.misc.copied : t.people.copyLink,
                     icon: copied ? 'checkmark' : 'copy-outline',
-                    color: '#546E7A',
+                    color: theme.color.brand,
                   },
                 ] as const
               ).map((option) => (

--- a/apps/mobile/src/app/group/[id]/invite.tsx
+++ b/apps/mobile/src/app/group/[id]/invite.tsx
@@ -7,7 +7,6 @@ import * as Sharing from 'expo-sharing';
 import { router, useLocalSearchParams } from 'expo-router';
 import {
   ActivityIndicator,
-  Alert,
   Linking,
   Platform,
   Pressable,
@@ -31,7 +30,7 @@ import {
   useScreenClearance,
 } from '@waves/ui';
 
-import { ensureGroupJoinToken, groupJoinLink, resetGroupJoinToken } from '@/data/api';
+import { ensureGroupJoinToken, groupJoinLink } from '@/data/api';
 import { friendlyError } from '@/lib/errors';
 import { useGroup } from '@/data/hooks';
 import { useSync } from '@/sync';
@@ -45,9 +44,10 @@ import { useStrings } from '@/i18n';
  * The link is one stable, re-showable token per group — the same one every open
  * and on every device — so the QR paints straight from the mirror with no server
  * round-trip once it exists. The first time a group is ever shared, the token is
- * minted on open (a brief spinner). An admin can Reset it, which rotates the
- * token and kills every copy of the old QR. Sharing and copying are separate
- * buttons that hand out the same link.
+ * minted on open (a brief spinner). Sharing and copying are peers on one row —
+ * WhatsApp, SMS, Email, the OS sheet and the clipboard all hand out the same
+ * link, so none of them is the "real" one. Rotating the token (an admin's lever
+ * against a link that has spread too far) is not reachable from here.
  */
 export default function InviteScreen() {
   const theme = useTheme();
@@ -72,10 +72,6 @@ export default function InviteScreen() {
 
   const joinToken = group.data?.join_token ?? ensured;
   const link = joinToken ? groupJoinLink(joinToken) : null;
-
-  const iAmAdmin =
-    (members.data ?? []).find((m) => m.profile_id === profile?.id && m.left_at === null)?.role ===
-    'admin';
 
   const ensure = async (): Promise<void> => {
     setBusy(true);
@@ -108,31 +104,6 @@ export default function InviteScreen() {
 
   const label = groupLabel(group.data, members.data ?? [], profile?.id);
   const message = t.people.shareMessage.replace('{group}', label).replace('{link}', link ?? '');
-
-  const reset = (): void => {
-    Alert.alert(t.people.resetLink, t.people.resetLinkBody, [
-      { text: t.common.cancel, style: 'cancel' },
-      {
-        text: t.people.resetLink,
-        style: 'destructive',
-        onPress: () => {
-          void (async () => {
-            setBusy(true);
-            setError(null);
-            try {
-              const token = await resetGroupJoinToken(groupId);
-              setEnsured(token);
-              void flush();
-            } catch (caught) {
-              setError(friendlyError(caught, t.couldNotSave, 'invite.reset'));
-            } finally {
-              setBusy(false);
-            }
-          })();
-        },
-      },
-    ]);
-  };
 
   const share = async (): Promise<void> => {
     if (!link) return;
@@ -226,12 +197,10 @@ export default function InviteScreen() {
         }}
         showsVerticalScrollIndicator={false}
       >
-        <Card style={{ gap: theme.spacing.md }}>
-          <Text variant="subheading">{t.people.anyoneWithLink}</Text>
-          <Text variant="caption" tone="muted">
-            {t.people.durableLinkBody}
-          </Text>
-        </Card>
+        {/* One sentence is the whole explanation the link needs. */}
+        <Text variant="caption" tone="muted" align="center">
+          {t.people.anyoneWithLink}
+        </Text>
 
         {link ? (
           <>
@@ -290,8 +259,10 @@ export default function InviteScreen() {
               </Text>
             </Card>
 
-            {/* The quick channels — WhatsApp, SMS, Email and the OS share sheet,
-                all on one straight row, each in its own brand colour. */}
+            {/* The quick channels — WhatsApp, SMS, Email, the OS share sheet and
+                the clipboard, all on one straight row, each in its own colour.
+                Copying is a peer here, not a button of its own: every item on
+                the row hands out the same link, only by a different road. */}
             <Row style={{ gap: theme.spacing.sm }}>
               {(
                 [
@@ -309,6 +280,12 @@ export default function InviteScreen() {
                     icon: 'share-social',
                     color: '#7C4DFF',
                   },
+                  {
+                    channel: 'copy',
+                    label: copied ? t.misc.copied : t.people.copyLink,
+                    icon: copied ? 'checkmark' : 'copy-outline',
+                    color: '#546E7A',
+                  },
                 ] as const
               ).map((option) => (
                 <Pressable
@@ -323,7 +300,11 @@ export default function InviteScreen() {
                   // matters. `shareVia` falls back to that sheet if the app is
                   // not installed.
                   onPress={() =>
-                    void (option.channel === 'share' ? shareQr(share) : shareVia(option.channel))
+                    void (option.channel === 'copy'
+                      ? copy()
+                      : option.channel === 'share'
+                        ? shareQr(share)
+                        : shareVia(option.channel))
                   }
                   style={({ pressed }) => ({
                     flex: 1,
@@ -332,11 +313,14 @@ export default function InviteScreen() {
                     opacity: pressed ? 0.6 : 1,
                   })}
                 >
+                  {/* Sized off the column rather than a fixed 56, so five items
+                      still fit — and stay round — on a narrow phone. */}
                   <View
                     style={{
-                      width: 56,
-                      height: 56,
-                      borderRadius: 28,
+                      width: '100%',
+                      maxWidth: 56,
+                      aspectRatio: 1,
+                      borderRadius: 999,
                       alignItems: 'center',
                       justifyContent: 'center',
                       backgroundColor: option.color,
@@ -344,44 +328,22 @@ export default function InviteScreen() {
                   >
                     <Ionicons name={option.icon} size={iconSize.lg} color="#ffffff" />
                   </View>
-                  <Text variant="caption" tone="muted">
+                  <Text variant="caption" tone="muted" align="center" numberOfLines={2}>
                     {option.label}
                   </Text>
                 </Pressable>
               ))}
             </Row>
-
-            <Button
-              label={copied ? t.people.linkCopied : t.people.copyLink}
-              variant="secondary"
-              size="lg"
-              fullWidth
-              onPress={() => void copy()}
-            />
-
-            {/* Rotating the link is an admin's lever, for when a link has spread
-                too far. It kills the current QR and every shared copy. */}
-            {iAmAdmin ? (
-              <Button
-                label={t.people.resetLink}
-                variant="ghost"
-                size="lg"
-                fullWidth
-                disabled={busy}
-                onPress={reset}
-                icon={
-                  <Ionicons name="refresh-outline" size={iconSize.md} color={theme.color.brand} />
-                }
-              />
-            ) : null}
-
-            <Text variant="micro" tone="muted" align="center">
-              {t.people.mintMistakeNote}
-            </Text>
           </>
         ) : error ? (
           // Minting failed — a retry, not a first step.
-          <Button label={t.people.createLink} size="lg" fullWidth onPress={() => void ensure()} />
+          <Button
+            label={t.people.createLink}
+            size="lg"
+            fullWidth
+            disabled={busy}
+            onPress={() => void ensure()}
+          />
         ) : (
           // First-ever share (or still loading): the durable link is being made.
           // Hold the QR's place so the screen reads as "your code is coming".

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1591,27 +1591,20 @@ export interface UiStrings {
     upiForGroup: string;
     upiForGroupNote: string;
     inviteTitle: string;
+    /** The whole explanation the join link gets — one plain sentence. */
     anyoneWithLink: string;
-    anyoneWithLinkBody: string;
     inviteLink: string;
     /** Caption over the invite QR code. */
     scanToJoin: string;
     whatsapp: string;
     shareAnotherWay: string;
+    /** The clipboard item on the invite screen's share row. */
     copyLink: string;
     createLink: string;
-    /** Body under "anyone with the link" — the durable-link explainer. */
-    durableLinkBody: string;
-    /** Admin action to rotate the durable link. */
-    resetLink: string;
-    /** Confirm body before rotating. */
-    resetLinkBody: string;
-    linkCopied: string;
     expires: string;
     usesBadge: string;
     shareMessage: string;
     emailSubject: string;
-    mintMistakeNote: string;
     hideContacts: string;
     browseContacts: string;
     /** Short label for the phone-contacts entry point. */
@@ -3740,28 +3733,18 @@ const en: UiStrings = {
     upiForGroupNote:
       'Overrides your account UPI ID here only — useful when one group settles to a different account.',
     inviteTitle: 'Invite people',
-    anyoneWithLink: 'Anyone with the link can join',
-    anyoneWithLinkBody:
-      'They do not need to install anything or make an account to see the group and add expenses.',
+    anyoneWithLink: 'Anyone with this link can join.',
     inviteLink: 'Invite link',
     scanToJoin: 'Scan to join',
     whatsapp: 'WhatsApp',
     shareAnotherWay: 'Share another way',
     copyLink: 'Copy link',
     createLink: 'Create an invite link',
-    durableLinkBody:
-      'Anyone with this link or QR can join. It stays the same every time — reset it if it spreads too far.',
-    resetLink: 'Reset link',
-    resetLinkBody:
-      'The current link and QR stop working. Everyone you already invited is unaffected.',
-    linkCopied: 'Link copied',
     expires: 'expires {when}',
     usesBadge: '{count} uses',
     shareMessage:
       'Join {group} on Waves to split expenses — no app or account needed to start: {link}',
     emailSubject: 'Join {group} on Waves',
-    mintMistakeNote:
-      'Made a link by mistake? Mint a new one — the old link keeps working until it expires, so only share links you mean to.',
     hideContacts: 'Hide contacts',
     browseContacts: 'Browse my contacts',
     contacts: 'Contacts',
@@ -5936,28 +5919,18 @@ const ta: UiStrings = {
     upiForGroupNote:
       'இங்கே மட்டும் உங்கள் கணக்கின் UPI ID ஐ மேலெழுதும் — ஒரு குழு வேறு கணக்குக்குத் தீர்க்கும்போது பயனுள்ளது.',
     inviteTitle: 'ஆட்களை அழை',
-    anyoneWithLink: 'இணைப்பு உள்ள யாரும் சேரலாம்',
-    anyoneWithLinkBody:
-      'குழுவைப் பார்க்கவும் செலவுகளைச் சேர்க்கவும் அவர்கள் எதையும் நிறுவவோ கணக்கு உருவாக்கவோ தேவையில்லை.',
+    anyoneWithLink: 'இந்த இணைப்பு உள்ள யாரும் சேரலாம்.',
     inviteLink: 'அழைப்பு இணைப்பு',
     scanToJoin: 'ஸ்கேன் செய்து சேரவும்',
     whatsapp: 'WhatsApp',
     shareAnotherWay: 'வேறு வழியில் பகிர்',
     copyLink: 'இணைப்பை நகலெடு',
     createLink: 'அழைப்பு இணைப்பை உருவாக்கு',
-    durableLinkBody:
-      'இந்த இணைப்பு அல்லது QR உள்ள யாரும் சேரலாம். இது எப்போதும் ஒரே மாதிரியாக இருக்கும் — அதிகம் பரவினால் மீட்டமை.',
-    resetLink: 'இணைப்பை மீட்டமை',
-    resetLinkBody:
-      'தற்போதைய இணைப்பும் QR-ம் வேலை செய்யாது. நீங்கள் ஏற்கனவே அழைத்தவர்கள் பாதிக்கப்பட மாட்டார்கள்.',
-    linkCopied: 'இணைப்பு நகலெடுக்கப்பட்டது',
     expires: '{when} க்கு காலாவதி',
     usesBadge: '{count} பயன்பாடுகள்',
     shareMessage:
       'செலவுகளைப் பிரிக்க Waves-ல் {group} குழுவில் சேரவும் — தொடங்க ஆப் அல்லது கணக்கு தேவையில்லை: {link}',
     emailSubject: 'Waves-ல் {group} குழுவில் சேரவும்',
-    mintMistakeNote:
-      'தவறுதலாக இணைப்பு உருவாக்கினீர்களா? புதிதாக ஒன்றை உருவாக்கவும் — பழைய இணைப்பு காலாவதியாகும் வரை வேலை செய்யும், எனவே நீங்கள் நினைத்த இணைப்புகளை மட்டும் பகிரவும்.',
     hideContacts: 'தொடர்புகளை மறை',
     browseContacts: 'என் தொடர்புகளைப் பார்',
     contacts: 'தொடர்புகள்',
@@ -8129,28 +8102,18 @@ const hi: UiStrings = {
     upiForGroupNote:
       'सिर्फ़ यहाँ आपके खाते की UPI ID की जगह लेता है — जब कोई समूह किसी दूसरे खाते में निपटता हो तो काम आता है।',
     inviteTitle: 'लोगों को बुलाएँ',
-    anyoneWithLink: 'जिसके पास लिंक हो वह जुड़ सकता है',
-    anyoneWithLinkBody:
-      'समूह देखने और खर्च जोड़ने के लिए उन्हें कुछ इंस्टॉल करने या खाता बनाने की ज़रूरत नहीं।',
+    anyoneWithLink: 'इस लिंक वाला कोई भी जुड़ सकता है।',
     inviteLink: 'निमंत्रण लिंक',
     scanToJoin: 'स्कैन करके जुड़ें',
     whatsapp: 'WhatsApp',
     shareAnotherWay: 'किसी और तरीके से साझा करें',
     copyLink: 'लिंक कॉपी करें',
     createLink: 'निमंत्रण लिंक बनाएँ',
-    durableLinkBody:
-      'इस लिंक या QR वाला कोई भी जुड़ सकता है। यह हर बार एक जैसा रहता है — ज़्यादा फैल जाए तो रीसेट करें।',
-    resetLink: 'लिंक रीसेट करें',
-    resetLinkBody:
-      'मौजूदा लिंक और QR काम करना बंद कर देंगे। जिन्हें आपने पहले बुलाया है वे प्रभावित नहीं होंगे।',
-    linkCopied: 'लिंक कॉपी हो गया',
     expires: '{when} को खत्म',
     usesBadge: '{count} उपयोग',
     shareMessage:
       'खर्च बाँटने के लिए Waves पर {group} में शामिल हों — शुरू करने के लिए कोई ऐप या खाता ज़रूरी नहीं: {link}',
     emailSubject: 'Waves पर {group} में शामिल हों',
-    mintMistakeNote:
-      'गलती से लिंक बना लिया? नया बनाएँ — पुराना लिंक खत्म होने तक चलता रहेगा, इसलिए वही लिंक साझा करें जो आप चाहते हैं।',
     hideContacts: 'संपर्क छिपाएँ',
     browseContacts: 'मेरे संपर्क देखें',
     contacts: 'संपर्क',
@@ -10364,26 +10327,18 @@ const ar: UiStrings = {
     upiForGroup: 'معرّف الدفع لهذه المجموعة',
     upiForGroupNote: 'يتجاوز معرّف حسابك هنا فقط — مفيد حين تُسوّى مجموعة إلى حساب مختلف.',
     inviteTitle: 'ادعُ أشخاصًا',
-    anyoneWithLink: 'يستطيع أي شخص لديه الرابط الانضمام',
-    anyoneWithLinkBody: 'لا يحتاجون إلى تثبيت شيء أو إنشاء حساب لرؤية المجموعة وإضافة المصروفات.',
+    anyoneWithLink: 'يمكن لأي شخص لديه هذا الرابط الانضمام.',
     inviteLink: 'رابط الدعوة',
     scanToJoin: 'امسح للانضمام',
     whatsapp: 'واتساب',
     shareAnotherWay: 'شارك بطريقة أخرى',
     copyLink: 'نسخ الرابط',
     createLink: 'أنشئ رابط دعوة',
-    durableLinkBody:
-      'يمكن لأي شخص لديه هذا الرابط أو رمز QR الانضمام. يبقى كما هو في كل مرة — أعِد تعيينه إذا انتشر كثيرًا.',
-    resetLink: 'إعادة تعيين الرابط',
-    resetLinkBody: 'يتوقف الرابط ورمز QR الحاليان عن العمل. لن يتأثر من دعوتهم من قبل.',
-    linkCopied: 'تم نسخ الرابط',
     expires: 'ينتهي {when}',
     usesBadge: '{count} استخدامات',
     shareMessage:
       'انضم إلى {group} على Waves لتقسيم المصروفات — لا حاجة إلى تطبيق أو حساب للبدء: {link}',
     emailSubject: 'انضم إلى {group} على Waves',
-    mintMistakeNote:
-      'أنشأت رابطًا بالخطأ؟ أنشئ رابطًا جديدًا — يظل الرابط القديم صالحًا حتى ينتهي، لذا شارك فقط الروابط التي تقصدها.',
     hideContacts: 'إخفاء جهات الاتصال',
     browseContacts: 'تصفّح جهات اتصالي',
     contacts: 'جهات الاتصال',


### PR DESCRIPTION
The group **Invite people** screen said the same thing three times over. It now says it once.

## What changed

**Header is the title alone.** The group's name sat under "Invite people" as a subtitle. The screen is only reachable from inside that group, so it told the reader what they already knew, and a long name pushed the header out of shape. The name is untouched everywhere it earns its place — the share message and the email subject still carry it.

**One sentence, not three blocks.** The intro `Card` — a subheading plus a paragraph explaining the durable link — is gone, replaced by a single muted line above the QR: *"Anyone with this link can join."* The `Made a link by mistake? …` footnote at the bottom is gone too.

**Copy link joined the share row.** It was a full-width secondary `Button` sitting under the row even though it does the same job as everything in it: hand out the same link by a different road. It is now the fifth peer on that row — WhatsApp, SMS, Email, Share, **Copy** — same circle, same caption, positioned last. The *Copied* feedback moved onto the item's own label and icon (`copy-outline` → `checkmark`, label → `Copied`), still for 2 s, and it is the `accessibilityLabel` too, so a screen reader hears the confirmation.

**Copy is a coloured peer, not the grey one.** Copy and the generic Share are the two items that are ours rather than a third party's, so both wear `theme.color.brand` — a pair at the end of the row, and the only two tiles that follow the theme into dark mode (Share was a hardcoded `#7C4DFF`). WhatsApp, SMS and Email keep their own brand colours.

Ordering is by flex position only — no absolute `left`/`right` — so RTL mirrors it for free. The circles now size off their own column (`width: '100%'`, `maxWidth: 56`, `aspectRatio: 1`) instead of a fixed 56pt, so five of them still fit, and stay round, on a narrow phone.

**Reset section removed.** The admin-only *Reset link* button and its confirm alert are off this screen, along with the `iAmAdmin` computation. `busy` now guards the *Create an invite link* retry button instead, so it keeps a busy-lock.

The **Invite link** card between the QR and the share row is deliberately left as it is.

## Removed strings

Deleted from the `people` type block and all four languages (en/ta/hi/ar):

| key | en value |
| --- | --- |
| `anyoneWithLinkBody` | "They do not need to install anything or make an account to see the group and add expenses." (already unreferenced) |
| `durableLinkBody` | "Anyone with this link or QR can join. It stays the same every time — reset it if it spreads too far." |
| `resetLink` | "Reset link" |
| `resetLinkBody` | "The current link and QR stop working. Everyone you already invited is unaffected." |
| `linkCopied` | "Link copied" |
| `mintMistakeNote` | "Made a link by mistake? Mint a new one — the old link keeps working until it expires, so only share links you mean to." |

`anyoneWithLink` was reused rather than replaced — its value tightened from "Anyone with the link can join" to "Anyone with this link can join." in all four languages. The copied state now reads `misc.copied` ("Copied"), which already existed. No key was added.

## Note on reset reachability

`resetGroupJoinToken` in `apps/mobile/src/data/api.ts` and the RPC behind it are untouched, but **reset is now unreachable from the UI** — this screen was its only caller. Candidate to surface in group settings; its strings would need to come back with it.

## Note on the reported gear button

A screenshot showed a floating round ⚙ overlapping the subline, read as an admin reset entry point. **There is no gear in this screen's source** — not on `main`, not on any branch (the only icon the reset ever had was a `refresh-outline` inside a full-width ghost button at the bottom, which this PR removes). The floating control is most likely the dev-client overlay on a development build rather than app UI; worth confirming on an `assembleRelease` APK. Either way every reset entry point this screen had is gone.

## Checks

`prettier --check`, `expo lint`, `tsc --noEmit` and `vitest run` (57 files, 750 tests) all pass. No Maestro flow in `e2e/` asserts on the removed text or on this screen, so none needed updating.

**Not device-tested.**
