### PR TITLE
fix(auth): provider tiles are circles, matching the invite share row

### DIFF
--- a/apps/mobile/src/components/SocialTile.tsx
+++ b/apps/mobile/src/components/SocialTile.tsx
@@ -201,7 +201,7 @@ export function SocialTile({
         style={{
           width: SOCIAL_TILE_SIZE,
           height: SOCIAL_TILE_SIZE,
-          borderRadius: theme.radius.md,
+          borderRadius: SOCIAL_TILE_SIZE / 2,
           borderWidth: 1,
           alignItems: 'center',
           justifyContent: 'center',


### PR DESCRIPTION
One-line change in `SocialTile.tsx`: tile face `borderRadius` → `SOCIAL_TILE_SIZE / 2`. Login, sign-up and the welcome door all inherit it. Not device-tested.