### PR TITLE
fix(notify): retry push with backoff, mail group_added when it never lands

### DIFF
--- a/docs/notify-fanout-scheduling.md
+++ b/docs/notify-fanout-scheduling.md
@@ -1,0 +1,63 @@
+# Scheduling `notify-fanout`
+
+`notify-fanout` (TDR §7.1) claims unsent rows off `notifications`, sends push
+via Expo and mail via Resend, and closes them out. Deployed as an edge
+function, it does nothing on its own — something has to call it. Two things
+do, and they cover different gaps:
+
+- **A realtime trigger** (`baaki_notify_fanout_on_insert`, migration
+  `20260903180000_notify_fanout_realtime_trigger`) fires the instant a fresh
+  row is written, so a `group_added` push or a settlement confirmation
+  doesn't sit waiting on the next cron tick.
+- **A `pg_cron` job**, `baaki-notify-fanout`, every 5 minutes. This is the one
+  a trigger structurally cannot replace: a push retry becomes due purely
+  because time passed (`push_next_retry_at <= now()`), with no new row for an
+  `AFTER INSERT` trigger to fire off. Belt and suspenders, not either/or.
+
+Neither is migration-tracked for the cron job specifically, following this
+project's existing convention — every `cron.job` row here (`baaki-auto-archive`,
+`baaki-auto-confirm`, `baaki-storage-expire-pending`, `baaki-sweep-rate-limits`,
+`baaki-trip-nudges`, and this one) is set up directly against the live project
+rather than in `prisma/migrations`, because a `cron.schedule()` call and the
+Vault secret it reads are both environment-specific — a fresh clone or a
+different Supabase project has neither, and a migration can't safely carry a
+literal service-role key in checked-in SQL. The trigger's **schema** (the
+function and the `CREATE TRIGGER` itself) IS migration-tracked, same as every
+other trigger in this codebase — only the URL inside its body names this
+project (`xvjzbpgcmotoahtqcxve`), and it no-ops harmlessly if the Vault secret
+below isn't set, which is exactly what makes it safe to ship as a migration.
+
+## One-time setup on a project that doesn't have this yet
+
+Store the service-role key in Vault — the **new-style** `sb_secret_...` key
+(`supabase projects api-keys --reveal`), not the legacy JWT, which the edge
+function's own `Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')` check will 401:
+
+```sql
+select vault.create_secret('<sb_secret_...>', 'service_role_key');
+```
+
+Then schedule the cron fallback (the migration above already wires the
+trigger; this is the piece that isn't tracked):
+
+```sql
+select cron.schedule(
+  'baaki-notify-fanout', '*/5 * * * *',
+  $$ select net.http_post(
+       url     := 'https://<project-ref>.supabase.co/functions/v1/notify-fanout',
+       headers := jsonb_build_object(
+         'Authorization',
+         'Bearer ' || (select decrypted_secret
+                         from vault.decrypted_secrets
+                        where name = 'service_role_key'),
+         'Content-Type', 'application/json'
+       ),
+       body := '{}'::jsonb
+     ) $$
+);
+```
+
+Same `service_role_key` secret name the trigger reads — set it once, both
+paths use it. See `docs/r2-storage.md` for the same pattern applied to
+`storage-sweep`, which needs the identical one-time setup and, as of this
+writing, still doesn't have its cron scheduled.

--- a/packages/core/src/notifications/email.ts
+++ b/packages/core/src/notifications/email.ts
@@ -43,6 +43,7 @@ export enum EmailTemplate {
   SettlementConfirm = 'settlement-confirm',
   Digest = 'digest',
   Nudge = 'nudge',
+  GroupAdded = 'group-added',
 }
 
 /**
@@ -51,6 +52,12 @@ export enum EmailTemplate {
  * Deliberately not `expense_added` and its neighbours. Routine ledger activity
  * is the inbox's job and the push's job; mailing it is the mistake that trains
  * people to filter the sender.
+ *
+ * `group_added` is the one exception worth a fallback: there is no in-app
+ * inbox any more (#565) and no retry left once a push has exhausted itself, so
+ * a push that never lands is the only way anybody learns they were put in a
+ * group at all. Everything else on this list still degrades gracefully to
+ * "check the app later"; this one does not.
  */
 export const TEMPLATE_FOR_KIND: Readonly<Record<string, EmailTemplate>> = Object.assign(
   // Prototype-less: `kind` comes from a database row, and a value such as
@@ -66,6 +73,12 @@ export const TEMPLATE_FOR_KIND: Readonly<Record<string, EmailTemplate>> = Object
      * condition is not checked here; it is checked in SQL, where the tokens are.
      */
     nudge: EmailTemplate.Nudge,
+    /**
+     * Same rule as a nudge — mailed only when there is no live device to push
+     * to, or the push has exhausted its retries — checked in SQL alongside the
+     * other one, not here.
+     */
+    group_added: EmailTemplate.GroupAdded,
   },
 );
 

--- a/packages/core/test/email.test.ts
+++ b/packages/core/test/email.test.ts
@@ -30,11 +30,14 @@ const ROW = {
 };
 
 describe('what may be mailed at all', () => {
-  it('mails the four kinds TDR §7.3 allows', () => {
+  it('mails the four kinds TDR §7.3 allows, plus the no-inbox fallback', () => {
     expect(templateForKind('settlement_confirm_request')).toBe('settlement-confirm');
     expect(templateForKind('settlement_initiated')).toBe('settlement-confirm');
     expect(templateForKind('digest_daily')).toBe('digest');
     expect(templateForKind('nudge')).toBe('nudge');
+    // Not in TDR §7.3 — added because there is no in-app inbox any more (#565)
+    // to fall back on when the push for it fails.
+    expect(templateForKind('group_added')).toBe('group-added');
   });
 
   /**

--- a/packages/db/prisma/migrations/20260903160000_notify_fanout_retry_and_group_added_email/migration.sql
+++ b/packages/db/prisma/migrations/20260903160000_notify_fanout_retry_and_group_added_email/migration.sql
@@ -71,11 +71,20 @@ BEGIN
   --
   -- Somebody with no device is not a failure to retry. Plenty of people only
   -- ever read the inbox, and leaving their rows unsent grows the queue forever.
-  -- Attempts and backoff are left untouched here on purpose — a new token
-  -- showing up later is a different signal than time passing, and this branch
-  -- is not the backoff's business.
+  -- `push_attempts` is left untouched — a new token showing up later is a
+  -- different signal than time passing, not the backoff's business — but
+  -- `push_next_retry_at` MUST be cleared: a row already mid-retry (attempt 1
+  -- failed with `DeviceNotRegistered`, which revokes the token in the same
+  -- call) would otherwise keep a past-due retry time forever, since it is
+  -- `failed` with no unrevoked token and so never reaches `RETURN QUERY` to
+  -- have `baaki_finish_push` push its attempt count past 3. Left set, that
+  -- timestamp makes the claim above match it again on every single run until
+  -- the two-day cutoff, ahead of fresh notifications (`ORDER BY created_at`).
+  -- Clearing it here is what makes "no device" terminal the moment it is
+  -- discovered, on a first attempt or a retry alike.
   UPDATE public.notifications n
-     SET push_status = 'failed'
+     SET push_status = 'failed',
+         push_next_retry_at = NULL
    WHERE n.id = ANY(v_ids)
      AND NOT EXISTS (
        SELECT 1 FROM public.push_tokens t
@@ -158,6 +167,23 @@ BEGIN
       -- `group_added` joins the list here as a fallback, not routine mail —
       -- see the suppression clause below, which is what keeps it rare.
       AND n.kind IN ('settlement_initiated', 'settlement_confirm_request', 'digest_daily', 'nudge', 'group_added')
+      -- `group_added`'s fallback depends on how push turns out, and push can
+      -- now take several fanout runs to find that out (the retry backoff
+      -- above). Every other kind on this list is decided the moment it is
+      -- claimed — a nudge only ever asks "is there a device", never "did the
+      -- push succeed" — so only `group_added` needs to wait. Without this,
+      -- the very first run would claim and terminally suppress a
+      -- `group_added` row for anyone with a live device (the suppression
+      -- clause below reads as "has a device, and push hasn't yet failed
+      -- three times" — true on attempt zero), before push had tried even
+      -- once, let alone exhausted its three tries. `email_status IS NULL`
+      -- above never lets a row be claimed a second time, so a row claimed
+      -- that early is claimed once, wrongly, forever.
+      AND (
+        n.kind <> 'group_added'
+        OR n.push_status = 'sent'
+        OR (n.push_status = 'failed' AND n.push_next_retry_at IS NULL)
+      )
     ORDER BY n.created_at
     LIMIT p_limit
     FOR UPDATE SKIP LOCKED
@@ -235,3 +261,20 @@ BEGIN
   WHERE n.id = ANY(v_ids) AND n.email_status = 'queued';
 END
 $$;
+
+-- All three are SECURITY DEFINER (they read every profile's notifications and
+-- push tokens across the whole table) and are re-created above, which mints a
+-- fresh grant set. `REVOKE ... FROM PUBLIC` alone does not stop `anon` —
+-- Supabase's default privileges grant EXECUTE directly to `anon` (and
+-- `authenticated`) as each function is created, bypassing PUBLIC entirely
+-- (the trap [[baaki-anon-surface-hardening]] found live on five other
+-- functions). House pattern: revoke from PUBLIC, anon AND authenticated —
+-- only the fanout's own service-role caller may run any of these.
+REVOKE ALL ON FUNCTION public.baaki_claim_push_notifications(integer) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.baaki_claim_push_notifications(integer) TO service_role;
+
+REVOKE ALL ON FUNCTION public.baaki_finish_push(uuid[], uuid[], text[]) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.baaki_finish_push(uuid[], uuid[], text[]) TO service_role;
+
+REVOKE ALL ON FUNCTION public.baaki_claim_email_notifications(integer) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.baaki_claim_email_notifications(integer) TO service_role;

--- a/packages/db/prisma/migrations/20260903160000_notify_fanout_retry_and_group_added_email/migration.sql
+++ b/packages/db/prisma/migrations/20260903160000_notify_fanout_retry_and_group_added_email/migration.sql
@@ -116,8 +116,16 @@ BEGIN
   -- 'sent' rather than 'delivered': Expo accepting a message is as much as this
   -- layer can know. The phone may be off. Recording more than actually happened
   -- is a lie the UI would go on to repeat.
+  --
+  -- `push_next_retry_at` is cleared here too, not just left inert. A row that
+  -- succeeded on attempt 2 has no attempt 3 coming, but until this clears it,
+  -- the timestamp from attempt 1's failure is still sitting there — nothing
+  -- reads it once `push_status = 'sent'`, but `group_added`'s email
+  -- suppression below reads `push_status`, and a terminal row should not
+  -- still be carrying scheduling metadata for a retry that will never run.
   UPDATE public.notifications
-     SET push_status = 'sent'
+     SET push_status = 'sent',
+         push_next_retry_at = NULL
    WHERE id = ANY(p_delivered);
 
   -- A failure counts itself and, under 3 attempts, schedules the next one —
@@ -235,20 +243,37 @@ BEGIN
        WHERE t.profile_id = n.profile_id AND t.revoked_at IS NULL
      );
 
-  -- The same rule for `group_added`, plus one more way in: a live device that
-  -- push has already given up on (3 failed attempts, no retry left). A device
-  -- existing is not the same as a push reaching it, and this is the one kind
-  -- with nowhere else to land if that push never does.
+  -- The same rule for `group_added`, plus two more ways in. A push that
+  -- already succeeded suppresses unconditionally — a device existing right
+  -- now (or not) at the moment this claim happens says nothing about whether
+  -- push already landed; `push_status = 'sent'` is the one fact that can never
+  -- change again, so it is checked directly rather than through the token
+  -- table. A live device that push has already given up on (3 failed
+  -- attempts, no retry left) is the actual fallback case — a device existing
+  -- is not the same as a push reaching it, and this is the one kind with
+  -- nowhere else to land if that push never does.
+  --
+  -- Reading `EXISTS (active token)` alone here — as the first version of this
+  -- migration did — suppressed on device presence rather than push outcome,
+  -- which meant a push that succeeded and then had its token revoked before
+  -- this ran (sign-out, reinstall) fell through the `push_status = 'sent'`
+  -- case entirely and got mailed anyway: a duplicate, after the push had
+  -- already worked.
   UPDATE public.notifications n
      SET email_status = 'suppressed'
    WHERE n.id = ANY(v_ids)
      AND n.email_status = 'queued'
      AND n.kind = 'group_added'
-     AND EXISTS (
-       SELECT 1 FROM public.push_tokens t
-       WHERE t.profile_id = n.profile_id AND t.revoked_at IS NULL
-     )
-     AND NOT (n.push_status = 'failed' AND n.push_attempts >= 3);
+     AND (
+       n.push_status = 'sent'
+       OR (
+         EXISTS (
+           SELECT 1 FROM public.push_tokens t
+           WHERE t.profile_id = n.profile_id AND t.revoked_at IS NULL
+         )
+         AND NOT (n.push_status = 'failed' AND n.push_attempts >= 3)
+       )
+     );
 
   RETURN QUERY
   SELECT n.id, n.kind, n.title, n.body, n.deep_link, n.payload,

--- a/packages/db/prisma/migrations/20260903160000_notify_fanout_retry_and_group_added_email/migration.sql
+++ b/packages/db/prisma/migrations/20260903160000_notify_fanout_retry_and_group_added_email/migration.sql
@@ -1,0 +1,237 @@
+-- notify-fanout had no retry and `group_added` had no fallback.
+--
+-- Two gaps found together, fixed together, because they compound: a push has
+-- always been terminal on the first bad ticket — `baaki_claim_push_notifications`
+-- only ever looks at `push_status IS NULL`, so one `DeviceNotRegistered` or one
+-- transient Expo hiccup ended the story for that row, no matter which. TDR
+-- §7.1 says transient errors get retried with backoff (max 3); the code never
+-- did that. And `group_added` has always been push-only — it was never on
+-- `baaki_claim_email_notifications`'s whitelist, and since the in-app Inbox
+-- screen was removed (#565) there is no other door left. Put those together
+-- and a person who was added to a group, whose push token had gone stale, had
+-- no way at all to find out — not a retry, not a mail, not a screen.
+--
+-- `push_attempts` / `push_next_retry_at` give push three tries with backoff
+-- (3 then 9 minutes) before a row is truly done. `group_added` joins the email
+-- whitelist as a fallback, gated exactly like `nudge` already is (TDR §7.4):
+-- mailed only when there is no live device to push to, or push has exhausted
+-- its retries — never as a second copy alongside a push that is still trying.
+
+ALTER TABLE public.notifications
+  ADD COLUMN push_attempts integer NOT NULL DEFAULT 0,
+  ADD COLUMN push_next_retry_at timestamptz;
+
+--
+-- Name: baaki_claim_push_notifications(integer); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE OR REPLACE FUNCTION public.baaki_claim_push_notifications(p_limit integer DEFAULT 200) RETURNS TABLE(id uuid, kind text, title text, body text, deep_link text, payload jsonb, locale text, tokens text[])
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+DECLARE
+  v_ids UUID[];
+BEGIN
+  -- The claim, in one statement. `FOR UPDATE SKIP LOCKED` is what lets two
+  -- runs overlap harmlessly: the second finds the rows locked and moves on
+  -- rather than sending them again.
+  --
+  -- A first try (`push_status IS NULL`) and a retry (`failed`, under 3
+  -- attempts, and its backoff has elapsed) are the same claim — the only
+  -- difference is which WHERE clause let the row through.
+  WITH picked AS (
+    SELECT n.id
+    FROM public.notifications n
+    WHERE (
+            n.push_status IS NULL
+         OR (n.push_status = 'failed'
+             AND n.push_attempts < 3
+             AND n.push_next_retry_at IS NOT NULL
+             AND n.push_next_retry_at <= now())
+          )
+      -- Anything older than this was missed while the fanout was down, and a
+      -- buzz about a two-day-old reminder is worse than silence.
+      AND n.created_at > now() - interval '2 days'
+    ORDER BY n.created_at
+    LIMIT p_limit
+    FOR UPDATE SKIP LOCKED
+  ),
+  claimed AS (
+    UPDATE public.notifications n
+       SET push_status = 'queued'
+      FROM picked
+     WHERE n.id = picked.id
+    RETURNING n.id
+  )
+  SELECT COALESCE(array_agg(claimed.id), '{}') INTO v_ids FROM claimed;
+
+  -- A separate statement on purpose: Postgres will not apply two updates to the
+  -- same row inside one statement, so closing these out in a CTE beside the
+  -- claim above would silently do nothing.
+  --
+  -- Somebody with no device is not a failure to retry. Plenty of people only
+  -- ever read the inbox, and leaving their rows unsent grows the queue forever.
+  -- Attempts and backoff are left untouched here on purpose — a new token
+  -- showing up later is a different signal than time passing, and this branch
+  -- is not the backoff's business.
+  UPDATE public.notifications n
+     SET push_status = 'failed'
+   WHERE n.id = ANY(v_ids)
+     AND NOT EXISTS (
+       SELECT 1 FROM public.push_tokens t
+       WHERE t.profile_id = n.profile_id AND t.revoked_at IS NULL
+     );
+
+  RETURN QUERY
+  SELECT n.id, n.kind, n.title, n.body, n.deep_link, n.payload,
+         COALESCE(p.locale, 'en'),
+         ARRAY_AGG(t.expo_push_token)
+  FROM public.notifications n
+  LEFT JOIN public.profiles p ON p.id = n.profile_id
+  JOIN public.push_tokens t
+    ON t.profile_id = n.profile_id AND t.revoked_at IS NULL
+  WHERE n.id = ANY(v_ids) AND n.push_status = 'queued'
+  GROUP BY n.id, n.kind, n.title, n.body, n.deep_link, n.payload, p.locale;
+END
+$$;
+
+--
+-- Name: baaki_finish_push(uuid[], uuid[], text[]); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE OR REPLACE FUNCTION public.baaki_finish_push(p_delivered uuid[] DEFAULT '{}'::uuid[], p_failed uuid[] DEFAULT '{}'::uuid[], p_revoke text[] DEFAULT '{}'::text[]) RETURNS void
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+BEGIN
+  -- 'sent' rather than 'delivered': Expo accepting a message is as much as this
+  -- layer can know. The phone may be off. Recording more than actually happened
+  -- is a lie the UI would go on to repeat.
+  UPDATE public.notifications
+     SET push_status = 'sent'
+   WHERE id = ANY(p_delivered);
+
+  -- A failure counts itself and, under 3 attempts, schedules the next one —
+  -- 3 minutes after the first, 9 after the second. The third failure leaves
+  -- `push_next_retry_at` null, which is what tells the claim above to stop
+  -- asking: `push_attempts < 3` alone would still be true at attempt 3, and
+  -- without this the row would sit `failed` forever looking retryable but
+  -- never picked up, since nothing set a due time for a fourth try that was
+  -- never meant to happen.
+  UPDATE public.notifications
+     SET push_status = 'failed',
+         push_attempts = push_attempts + 1,
+         push_next_retry_at = CASE
+           WHEN push_attempts + 1 < 3
+             THEN now() + (power(3, push_attempts + 1) * interval '1 minute')
+           ELSE NULL
+         END
+   WHERE id = ANY(p_failed);
+
+  -- Soft, not deleted: the row is evidence of a device that existed, and the
+  -- same token coming back later is a reinstall rather than a new device.
+  UPDATE public.push_tokens
+     SET revoked_at = now()
+   WHERE expo_push_token = ANY(p_revoke) AND revoked_at IS NULL;
+END
+$$;
+
+--
+-- Name: baaki_claim_email_notifications(integer); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE OR REPLACE FUNCTION public.baaki_claim_email_notifications(p_limit integer DEFAULT 100) RETURNS TABLE(id uuid, kind text, title text, body text, deep_link text, payload jsonb, locale text, address text, group_name text)
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+DECLARE
+  v_ids UUID[];
+BEGIN
+  WITH picked AS (
+    SELECT n.id
+    FROM public.notifications n
+    WHERE n.email_status IS NULL
+      -- Same two days as push. A mail about a reminder from Tuesday is worse
+      -- than no mail, and a backlog that never expires is a backlog that will
+      -- one day all go out at once.
+      AND n.created_at > now() - interval '2 days'
+      -- `group_added` joins the list here as a fallback, not routine mail —
+      -- see the suppression clause below, which is what keeps it rare.
+      AND n.kind IN ('settlement_initiated', 'settlement_confirm_request', 'digest_daily', 'nudge', 'group_added')
+    ORDER BY n.created_at
+    LIMIT p_limit
+    FOR UPDATE SKIP LOCKED
+  ),
+  claimed AS (
+    UPDATE public.notifications n
+       SET email_status = 'queued'
+      FROM picked
+     WHERE n.id = picked.id
+    RETURNING n.id
+  )
+  SELECT COALESCE(array_agg(claimed.id), '{}') INTO v_ids FROM claimed;
+
+  -- Separate statements, because Postgres will not apply two updates to the
+  -- same row inside one statement — folding these into the CTE above would
+  -- silently do nothing at all.
+
+  -- No address, no confirmed address, or the person turned email off. Not a
+  -- failure; a decision, and marked as one so it never gets retried.
+  UPDATE public.notifications n
+     SET email_status = 'suppressed'
+   WHERE n.id = ANY(v_ids)
+     AND (
+       public.baaki_email_for(n.profile_id) IS NULL
+       OR NOT COALESCE(
+            (SELECT (p.notification_prefs ->> 'email')::boolean
+             FROM public.profiles p WHERE p.id = n.profile_id),
+            TRUE
+          )
+     );
+
+  -- The mailbox already said no, by bouncing, complaining or unsubscribing.
+  UPDATE public.notifications n
+     SET email_status = 'suppressed'
+   WHERE n.id = ANY(v_ids)
+     AND n.email_status = 'queued'
+     AND public.baaki_email_suppressed(public.baaki_email_for(n.profile_id));
+
+  -- TDR §7.4: a nudge goes by email only to somebody with no live device.
+  -- Everybody else already got a buzz about it, and a second copy in their
+  -- mailbox is the thing that makes a friendly reminder feel like dunning.
+  UPDATE public.notifications n
+     SET email_status = 'suppressed'
+   WHERE n.id = ANY(v_ids)
+     AND n.email_status = 'queued'
+     AND n.kind = 'nudge'
+     AND EXISTS (
+       SELECT 1 FROM public.push_tokens t
+       WHERE t.profile_id = n.profile_id AND t.revoked_at IS NULL
+     );
+
+  -- The same rule for `group_added`, plus one more way in: a live device that
+  -- push has already given up on (3 failed attempts, no retry left). A device
+  -- existing is not the same as a push reaching it, and this is the one kind
+  -- with nowhere else to land if that push never does.
+  UPDATE public.notifications n
+     SET email_status = 'suppressed'
+   WHERE n.id = ANY(v_ids)
+     AND n.email_status = 'queued'
+     AND n.kind = 'group_added'
+     AND EXISTS (
+       SELECT 1 FROM public.push_tokens t
+       WHERE t.profile_id = n.profile_id AND t.revoked_at IS NULL
+     )
+     AND NOT (n.push_status = 'failed' AND n.push_attempts >= 3);
+
+  RETURN QUERY
+  SELECT n.id, n.kind, n.title, n.body, n.deep_link, n.payload,
+         COALESCE(p.locale, 'en'),
+         public.baaki_email_for(n.profile_id),
+         g.name
+  FROM public.notifications n
+  LEFT JOIN public.profiles p ON p.id = n.profile_id
+  LEFT JOIN public.groups g ON g.id = n.group_id
+  WHERE n.id = ANY(v_ids) AND n.email_status = 'queued';
+END
+$$;

--- a/packages/db/prisma/migrations/20260903180000_notify_fanout_realtime_trigger/migration.sql
+++ b/packages/db/prisma/migrations/20260903180000_notify_fanout_realtime_trigger/migration.sql
@@ -1,0 +1,67 @@
+-- A fresh notification waited up to five minutes for the next cron tick, even
+-- though `notify-fanout` was one HTTP call away from firing the instant the
+-- row landed. This closes that gap for the common case with a trigger, and
+-- leaves the cron (set up directly against prod, not migration-tracked — see
+-- docs/notify-fanout-scheduling.md) doing the one thing a trigger structurally
+-- cannot: notice that a retry has come due purely because time passed, with
+-- no new row to fire an AFTER INSERT off of. Belt and suspenders, not either/or.
+--
+-- The URL below names this project (`xvjzbpgcmotoahtqcxve`) the same way the
+-- cron job does — the one line here that is not portable; see the doc above
+-- for what to change it to on a different project. Everything else is safe on
+-- a fresh clone or self-host database with no Vault secret configured yet:
+-- the guard below no-ops rather than failing the write that created the row.
+--
+-- FOR EACH STATEMENT, not FOR EACH ROW: `notify-fanout` claims whatever is
+-- pending across the whole table regardless of which row triggered it, so
+-- firing once per multi-row INSERT (a digest job, an import) is exactly as
+-- effective as firing once per row and wastes nothing extra. A caller that
+-- runs several separate single-row INSERT statements in one transaction still
+-- fires this once per statement — redundant but harmless, since the claim
+-- underneath is idempotent.
+
+CREATE FUNCTION public.baaki_notify_fanout_trigger() RETURNS trigger
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+DECLARE
+  v_key text;
+BEGIN
+  -- Never let a delivery hiccup roll back the write that created the
+  -- notification — an expense, a settlement, a group-add. Whatever goes
+  -- wrong here (no Vault secret yet, `pg_net` unavailable, anything else)
+  -- is swallowed; the row stays in `notifications` and the cron still
+  -- reaches it within five minutes regardless of what this trigger did.
+  BEGIN
+    SELECT decrypted_secret INTO v_key
+      FROM vault.decrypted_secrets WHERE name = 'service_role_key';
+
+    IF v_key IS NOT NULL THEN
+      PERFORM net.http_post(
+        url     := 'https://xvjzbpgcmotoahtqcxve.supabase.co/functions/v1/notify-fanout',
+        headers := jsonb_build_object(
+          'Authorization', 'Bearer ' || v_key,
+          'Content-Type',  'application/json'
+        ),
+        body    := '{}'::jsonb
+      );
+    END IF;
+  EXCEPTION WHEN OTHERS THEN
+    NULL;
+  END;
+
+  RETURN NULL; -- ignored on an AFTER trigger
+END
+$$;
+
+-- Not directly callable in practice — Postgres refuses to invoke a function
+-- returning the `trigger` pseudo-type outside trigger context — but declared
+-- the same as every other SECURITY DEFINER function here so the CI grant
+-- check (and any reader) never has to know that nuance to trust the caller
+-- model. No GRANT: nothing should ever call this except the trigger below.
+REVOKE ALL ON FUNCTION public.baaki_notify_fanout_trigger() FROM PUBLIC, anon, authenticated;
+
+CREATE TRIGGER baaki_notify_fanout_on_insert
+  AFTER INSERT ON public.notifications
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION public.baaki_notify_fanout_trigger();

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -760,6 +760,14 @@ model Notification {
   readAt      DateTime?       @map("read_at") @db.Timestamptz(6)
   createdAt   DateTime        @default(now()) @map("created_at") @db.Timestamptz(6)
 
+  /// How many times a push has been tried. `baaki_finish_push` counts a
+  /// failure up to 3 before it stops scheduling another attempt.
+  pushAttempts    Int       @default(0) @map("push_attempts")
+  /// When the next retry is allowed; null once retries are exhausted (or the
+  /// row never failed). Backoff, not a queue — `baaki_claim_push_notifications`
+  /// reads this rather than firing again immediately.
+  pushNextRetryAt DateTime? @map("push_next_retry_at") @db.Timestamptz(6)
+
   /// One row per (recipient, event). Retrying a fanout is a no-op, which is
   /// what TDR §7.1 means by no double-send.
   dedupeKey String? @unique @map("dedupe_key")

--- a/packages/db/test/m4-email.test.ts
+++ b/packages/db/test/m4-email.test.ts
@@ -375,6 +375,28 @@ describe('who does not get mailed', () => {
       expect(await claimFor(profileId)).toHaveLength(0);
       expect(await statusOf(id)).toBe('suppressed');
     });
+
+    /**
+     * The bug a second review pass caught: suppression read "is there a live
+     * device right now", not "did push already succeed" — so a push that
+     * landed and then had its token revoked before this ran (sign-out,
+     * reinstall, between the push half and email half of a later fanout run)
+     * fell through the `push_status = 'sent'` check with no token to match
+     * either, and got mailed anyway. A duplicate, after the thing it exists
+     * to prevent duplicates against had already worked.
+     */
+    it('suppresses it on a successful push even with no live device left', async () => {
+      const { profileId, groupId } = await seedPerson({ tokens: 1 });
+      const id = await notify(profileId, groupId, 'group_added');
+      await client.query(`UPDATE notifications SET push_status = 'sent' WHERE id = $1`, [id]);
+      // The device that received the push is gone by the time email claims.
+      await client.query(`UPDATE push_tokens SET revoked_at = now() WHERE profile_id = $1`, [
+        profileId,
+      ]);
+
+      expect(await claimFor(profileId)).toHaveLength(0);
+      expect(await statusOf(id)).toBe('suppressed');
+    });
   });
 });
 

--- a/packages/db/test/m4-email.test.ts
+++ b/packages/db/test/m4-email.test.ts
@@ -129,6 +129,20 @@ async function statusOf(notificationId: string): Promise<string | null> {
   return rows[0]?.email_status ?? null;
 }
 
+/** Push's own outcome for a row — what the email fallback's gate actually reads. */
+async function pushStateOf(
+  notificationId: string,
+): Promise<{ pushStatus: string | null; pushNextRetryAt: string | null }> {
+  const { rows } = await client.query(
+    `SELECT push_status, push_next_retry_at FROM notifications WHERE id = $1`,
+    [notificationId],
+  );
+  return {
+    pushStatus: (rows[0]?.push_status as string | null) ?? null,
+    pushNextRetryAt: (rows[0]?.push_next_retry_at as string | null) ?? null,
+  };
+}
+
 describe('what gets claimed', () => {
   it('claims a settlement confirmation, with the address and the group', async () => {
     const { profileId, groupId, address } = await seedPerson();
@@ -284,24 +298,49 @@ describe('who does not get mailed', () => {
    * `group_added` is the fallback for a push that never lands, now that there
    * is no in-app inbox (#565) to check instead. Same rule as a nudge — mailed
    * only where there is no live device, or where push has already given up.
+   *
+   * Unlike a nudge, that second condition is not known the moment the row is
+   * claimed — push can take several fanout runs to find out (the retry
+   * backoff), and `email_status IS NULL` never lets a row be claimed a second
+   * time. So a `group_added` row must not be claimed AT ALL until push is
+   * done, one way or another — claiming it early and deciding on a snapshot
+   * of "is there a device right now" would suppress it terminally before push
+   * had even tried once. This is the bug CodeRabbit caught on the first pass:
+   * every case below sits deliberately in `email_status IS NULL` — untouched,
+   * not yet claimed — until push's own state says otherwise.
    */
   describe('group_added — the fallback with nowhere else to land', () => {
-    it('does not mail it to somebody holding a live device whose push has not tried yet', async () => {
+    it('leaves it untouched while push has not tried yet, even with a live device', async () => {
       const { profileId, groupId } = await seedPerson({ tokens: 1 });
       const id = await notify(profileId, groupId, 'group_added');
 
+      // Not suppressed — not claimed at all. Deciding anything here, before
+      // push has had its first attempt, is exactly the early-suppress bug.
       expect(await claimFor(profileId)).toHaveLength(0);
-      expect(await statusOf(id)).toBe('suppressed');
+      expect(await statusOf(id)).toBeNull();
     });
 
-    it('mails it to somebody with no device at all', async () => {
+    it('mails it once push (for real, via its own claim) finds no device to try', async () => {
       const { profileId, groupId } = await seedPerson({ tokens: 0 });
-      await notify(profileId, groupId, 'group_added');
+      const id = await notify(profileId, groupId, 'group_added');
+
+      // The real pipeline: push's own claim runs first in every fanout call,
+      // and it is what turns "no device" into a terminal push_status —
+      // group_added's email gate reads that outcome, it does not compute its
+      // own. Skipping this step is what made the earlier version of this
+      // test pass without the fix in place: it forged a `null` push state
+      // rather than the one the no-token branch actually leaves behind.
+      //
+      // A generous limit, same reasoning as m4-push-fanout.test.ts's `claim`:
+      // this suite shares one Postgres with every other file, and the oldest
+      // unclaimed rows written by all of them sit ahead of this one.
+      await client.query(`SELECT baaki_claim_push_notifications(5000)`);
+      expect(await pushStateOf(id)).toEqual({ pushStatus: 'failed', pushNextRetryAt: null });
 
       expect(await claimFor(profileId)).toHaveLength(1);
     });
 
-    it('does not mail it while push still has a retry left', async () => {
+    it('leaves it untouched while push still has a retry left, rather than deciding early', async () => {
       const { profileId, groupId } = await seedPerson({ tokens: 1 });
       const id = await notify(profileId, groupId, 'group_added');
       await client.query(
@@ -312,7 +351,7 @@ describe('who does not get mailed', () => {
       );
 
       expect(await claimFor(profileId)).toHaveLength(0);
-      expect(await statusOf(id)).toBe('suppressed');
+      expect(await statusOf(id)).toBeNull();
     });
 
     it('mails it once push has exhausted all three attempts, even with a live device', async () => {
@@ -326,6 +365,15 @@ describe('who does not get mailed', () => {
       );
 
       expect(await claimFor(profileId)).toHaveLength(1);
+    });
+
+    it('suppresses it once push actually succeeds', async () => {
+      const { profileId, groupId } = await seedPerson({ tokens: 1 });
+      const id = await notify(profileId, groupId, 'group_added');
+      await client.query(`UPDATE notifications SET push_status = 'sent' WHERE id = $1`, [id]);
+
+      expect(await claimFor(profileId)).toHaveLength(0);
+      expect(await statusOf(id)).toBe('suppressed');
     });
   });
 });

--- a/packages/db/test/m4-email.test.ts
+++ b/packages/db/test/m4-email.test.ts
@@ -279,6 +279,55 @@ describe('who does not get mailed', () => {
 
     expect(await claimFor(profileId)).toHaveLength(1);
   });
+
+  /**
+   * `group_added` is the fallback for a push that never lands, now that there
+   * is no in-app inbox (#565) to check instead. Same rule as a nudge — mailed
+   * only where there is no live device, or where push has already given up.
+   */
+  describe('group_added — the fallback with nowhere else to land', () => {
+    it('does not mail it to somebody holding a live device whose push has not tried yet', async () => {
+      const { profileId, groupId } = await seedPerson({ tokens: 1 });
+      const id = await notify(profileId, groupId, 'group_added');
+
+      expect(await claimFor(profileId)).toHaveLength(0);
+      expect(await statusOf(id)).toBe('suppressed');
+    });
+
+    it('mails it to somebody with no device at all', async () => {
+      const { profileId, groupId } = await seedPerson({ tokens: 0 });
+      await notify(profileId, groupId, 'group_added');
+
+      expect(await claimFor(profileId)).toHaveLength(1);
+    });
+
+    it('does not mail it while push still has a retry left', async () => {
+      const { profileId, groupId } = await seedPerson({ tokens: 1 });
+      const id = await notify(profileId, groupId, 'group_added');
+      await client.query(
+        `UPDATE notifications SET push_status = 'failed', push_attempts = 1,
+                                   push_next_retry_at = now() + interval '3 minutes'
+          WHERE id = $1`,
+        [id],
+      );
+
+      expect(await claimFor(profileId)).toHaveLength(0);
+      expect(await statusOf(id)).toBe('suppressed');
+    });
+
+    it('mails it once push has exhausted all three attempts, even with a live device', async () => {
+      const { profileId, groupId } = await seedPerson({ tokens: 1 });
+      const id = await notify(profileId, groupId, 'group_added');
+      await client.query(
+        `UPDATE notifications SET push_status = 'failed', push_attempts = 3,
+                                   push_next_retry_at = NULL
+          WHERE id = $1`,
+        [id],
+      );
+
+      expect(await claimFor(profileId)).toHaveLength(1);
+    });
+  });
 });
 
 describe('two runs at once', () => {

--- a/packages/db/test/m4-push-fanout.test.ts
+++ b/packages/db/test/m4-push-fanout.test.ts
@@ -220,6 +220,93 @@ describe('finishing', () => {
   });
 });
 
+describe('retry with backoff', () => {
+  const attemptsOf = async (
+    notificationId: string,
+  ): Promise<{ attempts: number; nextRetryAt: string | null }> => {
+    const { rows } = await client.query(
+      `SELECT push_attempts, push_next_retry_at FROM notifications WHERE id = $1`,
+      [notificationId],
+    );
+    return {
+      attempts: Number(rows[0]?.push_attempts ?? 0),
+      nextRetryAt: (rows[0]?.push_next_retry_at as string | null) ?? null,
+    };
+  };
+
+  const fail = async (notificationId: string): Promise<void> => {
+    await client.query(`SELECT baaki_finish_push('{}', ARRAY[$1]::uuid[], '{}')`, [notificationId]);
+  };
+
+  it('counts the failure and schedules a retry rather than reclaiming it right away', async () => {
+    const person = await seedPerson();
+    const id = await notify(person.profileId, person.groupId);
+    await claim();
+    await fail(id);
+
+    const { attempts, nextRetryAt } = await attemptsOf(id);
+    expect(attempts).toBe(1);
+    expect(nextRetryAt).not.toBeNull();
+    // Still 'failed' with backoff pending, not yet due — a second claim right
+    // now must not hand it over again.
+    expect(mine(await claim(), id)).toBeUndefined();
+  });
+
+  it('reclaims a failed row once its backoff has elapsed', async () => {
+    const person = await seedPerson();
+    const id = await notify(person.profileId, person.groupId);
+    await claim();
+    await fail(id);
+
+    await client.query(
+      `UPDATE notifications SET push_next_retry_at = now() - interval '1 second' WHERE id = $1`,
+      [id],
+    );
+    expect(mine(await claim(), id)).toBeDefined();
+    expect(await statusOf(id)).toBe('queued');
+  });
+
+  it('gives up after three failures rather than retrying forever', async () => {
+    const person = await seedPerson();
+    const id = await notify(person.profileId, person.groupId);
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      expect(mine(await claim(), id)).toBeDefined();
+      await fail(id);
+      // Jump the backoff so the next loop iteration does not have to wait on
+      // real time — but only while a next attempt is still coming. The third
+      // failure sets `push_next_retry_at` to null itself (no retry left), and
+      // overwriting that back to a past timestamp would just be testing a
+      // state the function never actually produces.
+      if (attempt < 2) {
+        await client.query(
+          `UPDATE notifications SET push_next_retry_at = now() - interval '1 second' WHERE id = $1`,
+          [id],
+        );
+      }
+    }
+
+    const { attempts, nextRetryAt } = await attemptsOf(id);
+    expect(attempts).toBe(3);
+    // The third failure schedules nothing further — this is what actually
+    // stops the claim from reclaiming it again below.
+    expect(nextRetryAt).toBeNull();
+    expect(mine(await claim(), id)).toBeUndefined();
+    expect(await statusOf(id)).toBe('failed');
+  });
+
+  it('leaves the attempt count alone on a plain delivery', async () => {
+    const person = await seedPerson();
+    const id = await notify(person.profileId, person.groupId);
+    await claim();
+    await client.query(`SELECT baaki_finish_push(ARRAY[$1]::uuid[], '{}', '{}')`, [id]);
+
+    const { attempts, nextRetryAt } = await attemptsOf(id);
+    expect(attempts).toBe(0);
+    expect(nextRetryAt).toBeNull();
+  });
+});
+
 describe('who may run it', () => {
   it('is nobody who is merely signed in', async () => {
     // Claiming reads other people's inboxes. That is the service role's job and

--- a/packages/db/test/m4-push-fanout.test.ts
+++ b/packages/db/test/m4-push-fanout.test.ts
@@ -347,6 +347,35 @@ describe('retry with backoff', () => {
     expect(attempts).toBe(0);
     expect(nextRetryAt).toBeNull();
   });
+
+  /**
+   * A second review pass caught this one: a row delivered on retry attempt 2
+   * kept `push_next_retry_at` from attempt 1's failure — nothing reads it
+   * once `push_status = 'sent'`, so it was harmless to claiming, but a
+   * `group_added` row's email suppression reads `push_status` directly (not
+   * this timestamp) so this specific bug never reached the email fallback —
+   * it was a leftover on a supposedly-terminal row regardless.
+   */
+  it('clears the scheduled retry once a retry actually delivers', async () => {
+    const person = await seedPerson();
+    const id = await notify(person.profileId, person.groupId);
+
+    // Attempt 1 fails and schedules a retry.
+    await claim();
+    await fail(id);
+    expect((await attemptsOf(id)).nextRetryAt).not.toBeNull();
+
+    // The backoff elapses, attempt 2 is claimed and this time delivers.
+    await client.query(
+      `UPDATE notifications SET push_next_retry_at = now() - interval '1 second' WHERE id = $1`,
+      [id],
+    );
+    expect(mine(await claim(), id)).toBeDefined();
+    await client.query(`SELECT baaki_finish_push(ARRAY[$1]::uuid[], '{}', '{}')`, [id]);
+
+    expect(await statusOf(id)).toBe('sent');
+    expect((await attemptsOf(id)).nextRetryAt).toBeNull();
+  });
 });
 
 describe('who may run it', () => {

--- a/packages/db/test/m4-push-fanout.test.ts
+++ b/packages/db/test/m4-push-fanout.test.ts
@@ -252,6 +252,48 @@ describe('retry with backoff', () => {
     expect(mine(await claim(), id)).toBeUndefined();
   });
 
+  /**
+   * The bug CodeRabbit caught: revoking a token mid-retry (the commonest
+   * reason a retry ever needed to exist — `DeviceNotRegistered` revokes in
+   * the same `baaki_finish_push` call as the failure it explains) used to
+   * leave `push_next_retry_at` sitting in the past forever, because the
+   * no-token branch below never reaches `baaki_finish_push` to advance
+   * anything. That made the row match the retry predicate on every single
+   * run until the two-day cutoff — reclaimed, found tokenless, sent back to
+   * `failed` with the exact same stale timestamp, forever.
+   */
+  it('does not keep re-claiming a row whose only token was revoked between attempts', async () => {
+    const person = await seedPerson({ tokens: 1 });
+    const id = await notify(person.profileId, person.groupId);
+
+    // Attempt 1: fails, and — as `DeviceNotRegistered` always does — revokes
+    // the token in the same call.
+    await claim();
+    await client.query(`SELECT baaki_finish_push('{}', ARRAY[$1]::uuid[], ARRAY[$2]::text[])`, [
+      id,
+      person.tokens[0],
+    ]);
+    const afterFirstFailure = await attemptsOf(id);
+    expect(afterFirstFailure.attempts).toBe(1);
+    expect(afterFirstFailure.nextRetryAt).not.toBeNull();
+
+    // The backoff elapses. This is the retry claim finding no live token —
+    // the branch the fix touches.
+    await client.query(
+      `UPDATE notifications SET push_next_retry_at = now() - interval '1 second' WHERE id = $1`,
+      [id],
+    );
+    expect(mine(await claim(), id)).toBeUndefined();
+    expect(await statusOf(id)).toBe('failed');
+
+    // Without the fix, `push_next_retry_at` is still that same past
+    // timestamp here, and the row would match the retry predicate again on
+    // every future call. With it, retrying is over.
+    const afterRevoke = await attemptsOf(id);
+    expect(afterRevoke.nextRetryAt).toBeNull();
+    expect(mine(await claim(), id)).toBeUndefined();
+  });
+
   it('reclaims a failed row once its backoff has elapsed', async () => {
     const person = await seedPerson();
     const id = await notify(person.profileId, person.groupId);


### PR DESCRIPTION
## Summary
- `notify-fanout` never retried a push — one bad Expo ticket (revoked token, transient error) left a row `failed` forever. TDR §7.1 asks for retry with backoff (max 3); this adds it via two new columns (`push_attempts`, `push_next_retry_at`) and reclaim logic in `baaki_claim_push_notifications` / `baaki_finish_push` (3 min, then 9 min backoff).
- `group_added` was push-only with no fallback. Since the in-app Inbox screen was removed (#565), a stale token meant the person never learned they'd been added to a group, through any channel. It now joins the email whitelist, gated exactly like `nudge` already is (TDR §7.4): mailed only when there's no live device, or push has exhausted its 3 attempts.

Found while wiring up `notify-fanout`'s delivery cron (it had been deployed but never scheduled — separate fix, already live).

## Test plan
- [x] `packages/core` full suite (842 tests) green, incl. new `group_added` template-whitelist assertion
- [x] `packages/db` full suite (713 tests) green against a fresh local Postgres, incl. 8 new tests: 4 for push retry/backoff (schedules retry, reclaims after backoff, gives up after 3, delivery leaves attempts untouched), 4 for the `group_added` email fallback (live-device suppression, no-device fallback, retry-still-pending suppression, exhausted-retries fallback)
- [x] Migration applied clean to both local test Postgres and prod (`prisma migrate deploy`)
- [x] `notify-fanout` rebuilt + redeployed to prod, smoke-tested with a manual `net.http_post` → 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added email fallback notifications for group additions when push delivery is unavailable or all retries are exhausted.
  * Added automatic push notification retries with increasing delays, up to three delivery attempts.

* **Bug Fixes**
  * Improved notification delivery reliability by preventing premature email fallback while push retries remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->