### PR TITLE
test(notify): cover exhausted group_added fallback without device

### DIFF
--- a/packages/db/test/m4-email.test.ts
+++ b/packages/db/test/m4-email.test.ts
@@ -367,6 +367,22 @@ describe('who does not get mailed', () => {
       expect(await claimFor(profileId)).toHaveLength(1);
     });
 
+    it('mails it once push has exhausted all attempts and the device is gone', async () => {
+      const { profileId, groupId } = await seedPerson({ tokens: 1 });
+      const id = await notify(profileId, groupId, 'group_added');
+      await client.query(
+        `UPDATE notifications SET push_status = 'failed', push_attempts = 3,
+                                   push_next_retry_at = NULL
+          WHERE id = $1`,
+        [id],
+      );
+      await client.query(`UPDATE push_tokens SET revoked_at = now() WHERE profile_id = $1`, [
+        profileId,
+      ]);
+
+      expect(await claimFor(profileId)).toHaveLength(1);
+    });
+
     it('suppresses it once push actually succeeds', async () => {
       const { profileId, groupId } = await seedPerson({ tokens: 1 });
       const id = await notify(profileId, groupId, 'group_added');


### PR DESCRIPTION
## Summary
- Adds a DB regression test for group_added email fallback after push retries are exhausted and the push token has since been revoked
- Complements the existing live-device exhausted-retry and successful-push suppression cases in m4-email.test.ts

## Validation
- pnpm exec prettier --check packages/db/test/m4-email.test.ts
- Attempted: pnpm --filter @waves/db exec vitest run test/m4-push-fanout.test.ts test/m4-email.test.ts (blocked locally: Postgres unavailable on localhost:54330; Docker daemon unavailable to start baaki-pg)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added regression coverage verifying that group-added email notifications are sent after push delivery attempts are exhausted and the associated device is revoked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->