### PR TITLE
feat(web): wavs.co.in is the site's domain, made configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ both before it claims a row, so a half-configured deployment strands nothing.
 ```bash
 supabase secrets set RESEND_WEBHOOK_SECRET=whsec_...
 supabase secrets set EMAIL_FROM='Baaki <hello@mail.dmadan.com>'   # optional; this is the default
-supabase secrets set EMAIL_WEB_URL=https://...                    # optional; see below
+supabase secrets set EMAIL_WEB_URL=https://wavs.co.in             # optional; this is the default
 pnpm edge:deploy
 ```
 
@@ -473,10 +473,12 @@ pnpm edge:deploy
 it invalidates every unsubscribe link already sitting in somebody's mailbox, so
 it is set once and left alone.
 
-`EMAIL_WEB_URL` is where the button in an email points. Web-lite is not deployed
-anywhere yet, so with it unset the button falls back to the `baaki://` deep link
-— which works on a phone and does nothing in desktop webmail. That is deliberate:
-an `https://` URL that 404s looks like it should have worked.
+`EMAIL_WEB_URL` is where the button in an email points — defaults to the site's
+real domain, `https://wavs.co.in`. A fork or a self-host pointing at a
+different domain (or nothing at all, deliberately) should set this explicitly;
+with it unset the button falls back to the `baaki://`/`waves://` deep link,
+which works on a phone and does nothing in desktop webmail. That fallback is
+deliberate: an `https://` URL that 404s looks like it should have worked.
 
 **What can be seen without sending anything:** `email_status` on `notifications`
 tells you what happened to each one — `suppressed` means we chose not to mail it

--- a/apps/mobile/modules/waves-watch/ios/WavesWatch.podspec
+++ b/apps/mobile/modules/waves-watch/ios/WavesWatch.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.summary        = 'WatchConnectivity bridge for the Waves Apple Watch companion.'
   s.description    = 'Relays quick-add / voice / recent intents between the phone app and its watchOS companion.'
   s.author         = 'Waves'
-  s.homepage       = 'https://waves.app'
+  s.homepage       = 'https://wavs.co.in'
   s.platforms      = { :ios => '15.1', :tvos => '15.1' }
   s.source         = { git: '' }
   s.static_framework = true

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -1017,19 +1017,10 @@ export async function deleteGroup(groupId: string): Promise<void> {
 
 // ─────────────────────────────────────────────── invites (ADR-006) ──
 
-/**
- * Base of a group's durable join link. Web-lite (M3) will serve this path; until
- * then the link deep-links straight into the app, which is what the people being
- * invited actually have.
- */
-export const INVITE_BASE = 'https://baaki.app/join';
-
-/** A group's durable join link from its join token — the same string the invite
- *  screen paints as a QR and shares. Kept here so every place that shares a link
- *  (the invite screen, the post-merge invite sheet) builds the identical URL. */
-export function groupJoinLink(token: string): string {
-  return `${INVITE_BASE}#${token}`;
-}
+// Re-exported rather than defined here — `@/lib/webUrl` is the single source
+// for the site's domain, shared with the QR scanner's host allowlist so the
+// two can never drift apart. See that file for why.
+export { INVITE_BASE, groupJoinLink } from '@/lib/webUrl';
 
 export interface MintedInvite {
   inviteId: string;

--- a/apps/mobile/src/lib/mapTiles.ts
+++ b/apps/mobile/src/lib/mapTiles.ts
@@ -34,6 +34,8 @@
  * provider is configured, satisfying OSM-style policies either way.
  */
 
+import { WEB_URL } from '@/lib/webUrl';
+
 /** Every raster tile is 256×256 device-independent pixels. */
 export const TILE_SIZE = 256;
 
@@ -61,10 +63,11 @@ export const TILE_ATTRIBUTION =
  * required by OpenStreetMap's tile policy and is good citizenship with any
  * provider — the default `okhttp`/blank UA a bare `<Image>` sends is exactly
  * what OSM's server refuses. Referenced by both map surfaces so the two never
- * drift.
+ * drift. The contact URL comes from `@/lib/webUrl`, the app's one configured
+ * domain, rather than a second hardcoded copy of it.
  */
 export const TILE_HEADERS: Record<string, string> = {
-  'User-Agent': 'WavesApp/1.0 (+https://waves.app; expense location map)',
+  'User-Agent': `WavesApp/1.0 (+${WEB_URL}; expense location map)`,
 };
 
 /**

--- a/apps/mobile/src/lib/qrScan.ts
+++ b/apps/mobile/src/lib/qrScan.ts
@@ -12,6 +12,8 @@
 import { requireOptionalNativeModule } from 'expo';
 import { Platform } from 'react-native';
 
+import { INVITE_HOST } from '@/lib/webUrl';
+
 /** Whether this binary actually contains the camera module. False on web, and
  *  on any dev-client built before `expo-camera` was added. */
 export function cameraAvailable(): boolean {
@@ -22,14 +24,15 @@ export function cameraAvailable(): boolean {
 /**
  * The invite token out of whatever the camera read.
  *
- * A Waves invite QR encodes the join URL (`https://baaki.app/join?token=…`, or
- * the `waves://join?token=…` deep link). We only trust a value that carries a
+ * A Waves invite QR encodes the join URL (`${INVITE_HOST}/join?token=…`, or the
+ * `waves://join?token=…` deep link). We only trust a value that carries a
  * `token` query on a join URL; a random QR from a poster is not an invite, and
  * returns null so the screen can say so rather than routing nowhere.
+ *
+ * `INVITE_HOST` comes from `@/lib/webUrl` — the same constant `groupJoinLink`
+ * builds outgoing links from, so this allowlist can never point somewhere
+ * different than the app's own invites do.
  */
-/** Where a real Waves invite points: the https link's host, and the deep-link
- *  schemes the app registers. Anything else is somebody else's QR. */
-const INVITE_HOST = 'baaki.app';
 const INVITE_SCHEMES = new Set(['waves', 'baaki']);
 
 export function tokenFromScan(data: string): string | null {

--- a/apps/mobile/src/lib/webUrl.ts
+++ b/apps/mobile/src/lib/webUrl.ts
@@ -1,0 +1,34 @@
+/**
+ * The one place the marketing/web-lite site's domain is named.
+ *
+ * `INVITE_HOST` (the QR scanner's allowlist, {@link ../lib/qrScan}) and
+ * `INVITE_BASE` (the link generator, `groupJoinLink`) used to carry the same
+ * domain as two separate hardcoded strings — an unowned placeholder
+ * (`baaki.app`), left over from before the app was renamed. Two copies of a
+ * security-relevant host is a drift risk: change one and the QR scanner
+ * silently stops trusting the app's own invite links, or worse, still trusts
+ * whatever the old one was. This is the single source both read from.
+ *
+ * Pure — no React Native, no network — so it can be imported into
+ * `mapTiles.ts` (deliberately RN-free, see its own header) without pulling
+ * anything heavier along with it.
+ */
+
+/** Trailing slash stripped so every consumer can assume `${WEB_URL}/path`. */
+export const WEB_URL = (process.env.EXPO_PUBLIC_WEB_URL || 'https://wavs.co.in').replace(
+  /\/+$/,
+  '',
+);
+
+/** Base of a group's durable join link — see `groupJoinLink`. */
+export const INVITE_BASE = `${WEB_URL}/join`;
+
+/** The join link's host, for the QR scanner's allowlist. */
+export const INVITE_HOST = new URL(INVITE_BASE).hostname.toLowerCase();
+
+/** A group's durable join link from its join token — the same string the invite
+ *  screen paints as a QR and shares. Kept here so every place that shares a link
+ *  (the invite screen, the post-merge invite sheet) builds the identical URL. */
+export function groupJoinLink(token: string): string {
+  return `${INVITE_BASE}#${token}`;
+}

--- a/apps/mobile/src/lib/webUrl.ts
+++ b/apps/mobile/src/lib/webUrl.ts
@@ -14,11 +14,27 @@
  * anything heavier along with it.
  */
 
-/** Trailing slash stripped so every consumer can assume `${WEB_URL}/path`. */
-export const WEB_URL = (process.env.EXPO_PUBLIC_WEB_URL || 'https://wavs.co.in').replace(
-  /\/+$/,
-  '',
-);
+const DEFAULT_WEB_URL = 'https://wavs.co.in';
+
+/**
+ * Origin only — scheme + host, no path, query or fragment — however
+ * `EXPO_PUBLIC_WEB_URL` was typed. `INVITE_BASE` below assumes it can append
+ * `/join` and get exactly that path back; a misconfigured value carrying its
+ * own path (`https://wavs.co.in/app`, say) would otherwise produce
+ * `.../app/join`, which `tokenFromScan`'s `path !== '/join'` check — a fixed
+ * literal, not derived from this — would then reject as somebody else's QR,
+ * including the app's own freshly generated links. An unparseable value
+ * falls back to the default rather than shipping `undefined/join`.
+ */
+export const WEB_URL = (() => {
+  const configured = process.env.EXPO_PUBLIC_WEB_URL;
+  if (!configured) return DEFAULT_WEB_URL;
+  try {
+    return new URL(configured).origin;
+  } catch {
+    return DEFAULT_WEB_URL;
+  }
+})();
 
 /** Base of a group's durable join link — see `groupJoinLink`. */
 export const INVITE_BASE = `${WEB_URL}/join`;

--- a/apps/mobile/test/qrScan.test.ts
+++ b/apps/mobile/test/qrScan.test.ts
@@ -39,8 +39,8 @@ describe('cameraAvailable', () => {
 
 describe('tokenFromScan', () => {
   it('extracts tokens from the supported HTTPS and app deep-link invite URLs', () => {
-    expect(tokenFromScan(' https://baaki.app/join?token=abc123 ')).toBe('abc123');
-    expect(tokenFromScan('https://BAAKI.app/join/?token=a%20b')).toBe('a b');
+    expect(tokenFromScan(' https://wavs.co.in/join?token=abc123 ')).toBe('abc123');
+    expect(tokenFromScan('https://WAVS.CO.IN/join/?token=a%20b')).toBe('a b');
     expect(tokenFromScan('waves://join?token=wave-token')).toBe('wave-token');
     expect(tokenFromScan('baaki:///join?token=triple-slash')).toBe('triple-slash');
   });
@@ -49,31 +49,31 @@ describe('tokenFromScan', () => {
     for (const data of [
       '',
       'not a url',
-      'http://baaki.app/join?token=abc',
+      'http://wavs.co.in/join?token=abc',
       'https://evil.example/join?token=abc',
-      'https://baaki.app/not-join?token=abc',
+      'https://wavs.co.in/not-join?token=abc',
       'waves://evil.example/join?token=abc',
       'mailto:test@example.com?token=abc',
-      'https://baaki.app/join?token=',
-      'https://baaki.app/join?token=%20%20',
+      'https://wavs.co.in/join?token=',
+      'https://wavs.co.in/join?token=%20%20',
     ]) {
       expect(tokenFromScan(data)).toBeNull();
     }
   });
 
   it('does not let fragments leak into the invite token', () => {
-    expect(tokenFromScan('https://baaki.app/join?token=abc#token=evil')).toBe('abc');
-    expect(tokenFromScan('https://baaki.app/join?other=1&token=abc#frag')).toBe('abc');
+    expect(tokenFromScan('https://wavs.co.in/join?token=abc#token=evil')).toBe('abc');
+    expect(tokenFromScan('https://wavs.co.in/join?other=1&token=abc#frag')).toBe('abc');
   });
 
   it('keeps malformed percent-encoding as the trimmed raw non-empty token', () => {
-    expect(tokenFromScan('https://baaki.app/join?token=%E0%A4%A')).toBe('%E0%A4%A');
-    expect(tokenFromScan('https://baaki.app/join?token=%E0%A4%A%20')).toBe('%E0%A4%A%20');
+    expect(tokenFromScan('https://wavs.co.in/join?token=%E0%A4%A')).toBe('%E0%A4%A');
+    expect(tokenFromScan('https://wavs.co.in/join?token=%E0%A4%A%20')).toBe('%E0%A4%A%20');
   });
 
   it('rejects non-invite QR payloads quickly even in a large scan batch', () => {
     const payloads = Array.from({ length: 1_000 }, (_, index) =>
-      index === 999 ? 'https://baaki.app/join?token=last' : `https://example.com/${index}`,
+      index === 999 ? 'https://wavs.co.in/join?token=last' : `https://example.com/${index}`,
     );
 
     const tokens = payloads.map(tokenFromScan).filter((token): token is string => token !== null);

--- a/apps/mobile/test/webUrl.test.ts
+++ b/apps/mobile/test/webUrl.test.ts
@@ -1,0 +1,60 @@
+/**
+ * `WEB_URL` is read from `process.env.EXPO_PUBLIC_WEB_URL` at module load, so
+ * exercising an override means setting the env var and reloading the module
+ * fresh — `vi.resetModules()` plus a dynamic `import()`, same pattern as
+ * `watchSendFailure.test.ts`.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const ENV_KEY = 'EXPO_PUBLIC_WEB_URL';
+
+async function loadWith(value: string | undefined) {
+  if (value === undefined) delete process.env[ENV_KEY];
+  else process.env[ENV_KEY] = value;
+  vi.resetModules();
+  return import('@/lib/webUrl');
+}
+
+afterEach(() => {
+  delete process.env[ENV_KEY];
+  vi.resetModules();
+});
+
+describe('WEB_URL', () => {
+  it('defaults to the site’s real domain when unset', async () => {
+    const mod = await loadWith(undefined);
+    expect(mod.WEB_URL).toBe('https://wavs.co.in');
+    expect(mod.INVITE_BASE).toBe('https://wavs.co.in/join');
+    expect(mod.INVITE_HOST).toBe('wavs.co.in');
+  });
+
+  it('takes a clean origin override as-is', async () => {
+    const mod = await loadWith('https://staging.example.com');
+    expect(mod.WEB_URL).toBe('https://staging.example.com');
+    expect(mod.INVITE_BASE).toBe('https://staging.example.com/join');
+    expect(mod.INVITE_HOST).toBe('staging.example.com');
+  });
+
+  /**
+   * The bug a review pass caught: `INVITE_BASE` assumes it can append `/join`
+   * to `WEB_URL` and get exactly that path back. A misconfigured override
+   * carrying its own path would otherwise produce `.../app/join`, which
+   * `tokenFromScan`'s hardcoded `path !== '/join'` check would then reject —
+   * including the app's own freshly generated links.
+   */
+  it('strips a path, query and fragment off an override to just its origin', async () => {
+    const mod = await loadWith('https://staging.example.com/app/sub?x=1#y');
+    expect(mod.WEB_URL).toBe('https://staging.example.com');
+    expect(mod.INVITE_BASE).toBe('https://staging.example.com/join');
+  });
+
+  it('falls back to the default rather than shipping a broken URL', async () => {
+    const mod = await loadWith('not a url at all');
+    expect(mod.WEB_URL).toBe('https://wavs.co.in');
+  });
+
+  it('builds a join link with the token as the fragment', async () => {
+    const mod = await loadWith(undefined);
+    expect(mod.groupJoinLink('abc123')).toBe('https://wavs.co.in/join#abc123');
+  });
+});

--- a/infra/self-host/functions.env.example
+++ b/infra/self-host/functions.env.example
@@ -9,10 +9,17 @@
 # Fan-out / email (notify-fanout, email-events, campaign-broadcast)
 RESEND_API_KEY=
 # EMAIL_FROM / EMAIL_WEB_URL default to the cloud project's own domain
-# (mail.dmadan.com / wavs.co.in) when unset — set both here to point a fork
-# or self-host at its own instead. EMAIL_WEB_URL is what an email's button
-# links to; leave it blank rather than a domain you don't own, and the
-# button falls back to the app's own deep link (see EmailOptions.webUrl).
+# (mail.dmadan.com / wavs.co.in) when the KEY IS ABSENT from this file —
+# right for the cloud project, not for a fork or self-host, which should set
+# both to a domain it actually owns.
+#
+# EMAIL_WEB_URL is what an email's button links to. This file ships the line
+# present but EMPTY on purpose, not absent: an empty value is read as "no
+# domain to vouch for yet" and the button falls back to the app's own deep
+# link (baaki://, waves://) instead of silently pointing at the SaaS
+# deployment's site — see EmailOptions.webUrl and emailWebUrl() for the
+# unset-vs-empty distinction this relies on. DELETING this line instead of
+# leaving it blank brings the default back.
 EMAIL_FROM=
 EMAIL_WEB_URL=
 # Push (notify-fanout) — FCM / APNs

--- a/infra/self-host/functions.env.example
+++ b/infra/self-host/functions.env.example
@@ -8,6 +8,13 @@
 
 # Fan-out / email (notify-fanout, email-events, campaign-broadcast)
 RESEND_API_KEY=
+# EMAIL_FROM / EMAIL_WEB_URL default to the cloud project's own domain
+# (mail.dmadan.com / wavs.co.in) when unset — set both here to point a fork
+# or self-host at its own instead. EMAIL_WEB_URL is what an email's button
+# links to; leave it blank rather than a domain you don't own, and the
+# button falls back to the app's own deep link (see EmailOptions.webUrl).
+EMAIL_FROM=
+EMAIL_WEB_URL=
 # Push (notify-fanout) — FCM / APNs
 FCM_SERVICE_ACCOUNT_JSON=
 APNS_KEY=

--- a/packages/core/src/notifications/email.ts
+++ b/packages/core/src/notifications/email.ts
@@ -121,11 +121,11 @@ export interface BuiltEmail {
 
 export interface EmailOptions {
   /**
-   * Base URL where web-lite is served. Optional because web-lite is not
-   * deployed anywhere yet — with nothing set, the button falls back to the
-   * `baaki://` deep link, which works on the phone and does nothing in desktop
-   * webmail. A dead `https://` link would be worse: it looks like it should
-   * work.
+   * Base URL where web-lite is served — `EMAIL_WEB_URL` in the edge function,
+   * defaulting to the site's real domain. Still optional here: a fork or a
+   * self-host with nothing set falls back to the `baaki://`/`waves://` deep
+   * link, which works on the phone and does nothing in desktop webmail. A
+   * dead `https://` link would be worse — it looks like it should work.
    */
   readonly webUrl?: string | null;
   /** Signed, address-specific, and safe to POST without a session. */

--- a/packages/core/src/notifications/email.ts
+++ b/packages/core/src/notifications/email.ts
@@ -121,11 +121,13 @@ export interface BuiltEmail {
 
 export interface EmailOptions {
   /**
-   * Base URL where web-lite is served — `EMAIL_WEB_URL` in the edge function,
-   * defaulting to the site's real domain. Still optional here: a fork or a
-   * self-host with nothing set falls back to the `baaki://`/`waves://` deep
-   * link, which works on the phone and does nothing in desktop webmail. A
-   * dead `https://` link would be worse — it looks like it should work.
+   * Base URL where web-lite is served — `EMAIL_WEB_URL` in the edge function
+   * (see `emailWebUrl()`), which defaults to the site's real domain when
+   * *unset* but falls back to nothing when set to an *explicit empty
+   * string*. Either `null` or `''` here falls back to the `baaki://`/
+   * `waves://` deep link, which works on the phone and does nothing in
+   * desktop webmail. A dead `https://` link would be worse — it looks like
+   * it should work.
    */
   readonly webUrl?: string | null;
   /** Signed, address-specific, and safe to POST without a session. */

--- a/supabase/functions/_shared/email.ts
+++ b/supabase/functions/_shared/email.ts
@@ -68,6 +68,16 @@ export function emailFrom(): string {
   return Deno.env.get('EMAIL_FROM') ?? 'Baaki <hello@mail.dmadan.com>';
 }
 
+/**
+ * The button an email links to. `EMAIL_WEB_URL` overrides it per deployment —
+ * a fork or a self-host pointing at their own domain, or nothing at all,
+ * which turns the button off and falls back to the `baaki://`/`waves://`
+ * deep link (dead in desktop webmail, exactly right on a phone).
+ */
+function emailWebUrl(): string | null {
+  return Deno.env.get('EMAIL_WEB_URL') ?? 'https://wavs.co.in';
+}
+
 /** Where an unsubscribe click lands. Same origin as every other function. */
 function functionsUrl(): string {
   return `${requiredEnv('SUPABASE_URL').replace(/\/+$/, '')}/functions/v1`;
@@ -88,7 +98,7 @@ export async function buildFor(row: EmailableRow): Promise<BuiltEmail | null> {
       groupName: row.group_name,
     },
     {
-      webUrl: Deno.env.get('EMAIL_WEB_URL') ?? null,
+      webUrl: emailWebUrl(),
       unsubscribeUrl: unsubscribeUrlFor(functionsUrl(), row.address, signature),
     },
   );
@@ -207,7 +217,7 @@ export async function buildCampaignFor(row: CampaignEmailRow): Promise<BuiltCamp
       to: row.address,
     },
     {
-      webUrl: Deno.env.get('EMAIL_WEB_URL') ?? null,
+      webUrl: emailWebUrl(),
       unsubscribeUrl: unsubscribeUrlFor(functionsUrl(), row.address, signature),
     },
   );

--- a/supabase/functions/_shared/email.ts
+++ b/supabase/functions/_shared/email.ts
@@ -69,10 +69,14 @@ export function emailFrom(): string {
 }
 
 /**
- * The button an email links to. `EMAIL_WEB_URL` overrides it per deployment —
- * a fork or a self-host pointing at their own domain, or nothing at all,
- * which turns the button off and falls back to the `baaki://`/`waves://`
- * deep link (dead in desktop webmail, exactly right on a phone).
+ * The button an email links to. Two different settings turn it off, on
+ * purpose: leaving `EMAIL_WEB_URL` **unset** defaults to the canonical
+ * deployment's own domain (`https://wavs.co.in`) — right for the cloud
+ * project, wrong for a fork or self-host that has not set its own yet.
+ * Setting it to an **explicit empty string** (`EMAIL_WEB_URL=`) opts out of
+ * that default deliberately and falls back to the `baaki://`/`waves://` deep
+ * link instead (dead in desktop webmail, exactly right on a phone) — the
+ * right choice for a self-host not yet pointing anywhere it can vouch for.
  */
 function emailWebUrl(): string | null {
   return Deno.env.get('EMAIL_WEB_URL') ?? 'https://wavs.co.in';


### PR DESCRIPTION
## Summary
- The invite join link, the QR scanner's host allowlist, and the map tile User-Agent all hardcoded `baaki.app`/`waves.app` — a domain the project never owned, left over from before the app was renamed. Two separate hardcoded copies of the invite host (link generator + QR allowlist) were also a drift risk.
- `apps/mobile/src/lib/webUrl.ts` is now the single source: `EXPO_PUBLIC_WEB_URL`, defaulting to `https://wavs.co.in`. Everything that needs "the website" reads from it.
- `EMAIL_WEB_URL` (edge functions) already existed as a secret but had no default and a stale comment ("web-lite is not deployed anywhere"). Now defaults to the same domain via a new `emailWebUrl()` helper, mirroring the existing `emailFrom()` pattern.
- Documented in `infra/self-host/functions.env.example` (previously silent on `EMAIL_FROM`/`EMAIL_WEB_URL` entirely) and README's email setup section (previously wrong).

## Test plan
- [x] `packages/core` full suite (842 tests) green
- [x] `apps/mobile` full suite (750 tests) green, incl. `qrScan.test.ts` updated for the new domain (and the uppercase-host case-insensitivity assertion restored, not just flattened)
- [x] Both packages typecheck clean
- [x] Deployed to prod (`notify-fanout`, `campaign-broadcast` — the two functions using `_shared/email.ts`) and smoke-tested: manual `net.http_post` → 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable web URL support for invite links, QR scanning, map requests, and email links.
  * Added a default site URL for hosted deployments, with environment-variable overrides for forks and self-hosted instances.
  * Added configuration examples for email sender and web URL settings.

* **Documentation**
  * Updated setup guidance, project homepage references, and deep-link fallback documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->