### PR TITLE
feat(auth): phone OTP over WhatsApp, four codes a number a day

### DIFF
--- a/apps/mobile/src/components/AuthFlow.tsx
+++ b/apps/mobile/src/components/AuthFlow.tsx
@@ -430,7 +430,7 @@ export function AuthFlow({ flow }: { flow: AuthFlowKind }) {
               busy={busy}
               onGoogle={() => void run(withGoogle)}
               onApple={() => void run(withApple)}
-              onPhone={() => router.push('/phone')}
+              onPhone={isSignup ? undefined : () => router.push('/phone')}
               t={t}
             />
             {/* ADR-006 addendum: the guest way in belongs to the sign-up page —
@@ -530,13 +530,20 @@ function TextLink({
 }
 
 /**
- * The tile row — Google, Apple, phone.
+ * The tile row — Google, Apple, and phone on the login door only.
  *
  * Apple leads on iOS (its guidelines want it at least as prominent as the
  * others; App Store guideline 4.8 requires it alongside Google there); Google
  * leads elsewhere, where Apple is the browser fallback. Spoken labels are the
  * full "Continue with …" — Google's own wording for a button that both makes
  * an account and returns to one — and the visible caption is the one word.
+ *
+ * Phone is absent from sign-up on purpose. ADR-006 makes a number a way to keep
+ * an account rather than a way to get one, so `auth.sms.enable_signup` is off
+ * and `sendOtp` asks for no user to be created — a number nobody holds yet is
+ * refused. Offering the tile on the sign-up door would advertise a door the
+ * server does not open. Signing in with a number still reaches the same screen,
+ * and so does a guest attaching one to the account they already have.
  */
 function SocialTiles({
   busy,
@@ -548,7 +555,8 @@ function SocialTiles({
   busy: boolean;
   onGoogle: () => void;
   onApple: () => void;
-  onPhone: () => void;
+  /** Omitted on the sign-up door, where a new number cannot make an account. */
+  onPhone?: () => void;
   t: UiStrings;
 }) {
   const theme = useTheme();
@@ -574,7 +582,7 @@ function SocialTiles({
       onPress={onApple}
     />
   );
-  const phone = (
+  const phone = onPhone ? (
     <SocialTile
       key="phone"
       testID="auth-phone"
@@ -584,10 +592,9 @@ function SocialTiles({
       disabled={busy}
       onPress={onPhone}
     />
-  );
+  ) : null;
+  const order = Platform.OS === 'ios' ? [apple, google, phone] : [google, apple, phone];
   return (
-    <Row style={{ justifyContent: 'center', gap: theme.spacing.xxl }}>
-      {Platform.OS === 'ios' ? [apple, google, phone] : [google, apple, phone]}
-    </Row>
+    <Row style={{ justifyContent: 'center', gap: theme.spacing.xxl }}>{order.filter(Boolean)}</Row>
   );
 }

--- a/apps/mobile/src/lib/auth.tsx
+++ b/apps/mobile/src/lib/auth.tsx
@@ -333,7 +333,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       isGuest: session?.user?.is_anonymous === true,
 
       async sendOtp(phone) {
-        const { error } = await backend.auth.signInWithOtp({ phone });
+        // `shouldCreateUser` is false for the same reason it is on the login
+        // door's email path below: a mistyped number would otherwise mint an
+        // empty account and send a code to a stranger, and every OTP to an
+        // unknown number is a message we pay for — the surface SMS-pumping
+        // fraud aims at. It also matches ADR-006, where a phone number is a way
+        // to keep an account and never the way to get one; `auth.sms` in
+        // config.toml refuses the signup server-side regardless.
+        const { error } = await backend.auth.signInWithOtp({
+          phone,
+          options: { shouldCreateUser: false },
+        });
         if (error) throw error;
       },
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "edge:serve": "pnpm edge:build && supabase functions serve --env-file supabase/functions/.env",
     "supabase:start": "supabase start",
     "supabase:stop": "supabase stop",
-    "edge:deploy": "pnpm edge:build && supabase functions deploy expense-write sync invite-mint invite-accept export-data receipt-parse fx-rate notify-fanout email-events email-unsubscribe account-delete campaign-broadcast r2-sign storage-sweep storage-recount",
+    "edge:deploy": "pnpm edge:build && supabase functions deploy expense-write sync invite-mint invite-accept export-data receipt-parse fx-rate notify-fanout email-events email-unsubscribe account-delete campaign-broadcast r2-sign storage-sweep storage-recount otp-send",
     "coverage": "pnpm -r --if-present run coverage",
     "coverage:core": "pnpm --filter @waves/core run coverage",
     "coverage:db": "pnpm --filter @waves/db run coverage",

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -89,11 +89,70 @@ otp_length = 8
 # fails to send, and the person is left on a screen waiting for an SMS that was
 # never posted. Turn both on in the same change that adds the credentials.
 [auth.sms]
+# Stays off, and the client agrees: `sendOtp` in apps/mobile/src/lib/auth.tsx
+# passes `shouldCreateUser: false`, and the phone tile is absent from the
+# sign-up door. A number signs a person back in, or attaches to the account a
+# guest already has; it never opens a new one.
 enable_signup = false
 enable_confirmations = true
 
+# Programmable Messaging — not used. Verify below is the provider; this block
+# stays present and disabled so nobody wires the cheaper one by accident.
 [auth.sms.twilio]
 enabled = false
+
+# Twilio Verify — off, and not the plan. Verify mints and checks its own code,
+# which cannot work behind the send hook below: the hook exists because GoTrue
+# generates the code and hands it to us to deliver, so Verify would put two
+# different codes in play and neither would validate. Left here, disabled, so
+# nobody reaches for it later without meeting this note first.
+[auth.sms.twilio_verify]
+enabled = false
+
+# The code travels over WhatsApp, not SMS, and the `otp-send` edge function is
+# what sends it. Three reasons, in order of weight:
+#
+#   1. India is the first market, and A2P SMS there is gated on DLT registration
+#      with the operators through TRAI — unregistered traffic is dropped by the
+#      carrier, not by Supabase. WhatsApp business messaging is not A2P SMS and
+#      carries none of that paperwork.
+#   2. A per-number daily cap can only be enforced somewhere the client cannot
+#      skip. The app calls GoTrue directly, so a limit written into the app is
+#      advice; in the hook it is the only door.
+#   3. It is markedly cheaper per message, and the code lands in an app people
+#      already have open.
+#
+# STILL OFF, deliberately. Enabled with the function undeployed or its Twilio
+# secrets unset, every send fails and somebody sits on the code screen waiting
+# for a message that was never posted. Flip `enabled` in the same change that
+# deploys `otp-send` and sets its secrets — never before.
+#
+# The one signing secret has to be written in *two* places, because two
+# different runtimes need it and they are configured by different mechanisms.
+# Generate it once (`v1,whsec_<base64>`), then:
+#
+#   1. The edge function, which verifies the signature. `supabase secrets set`
+#      sets Edge Function environment only:
+#
+#        supabase secrets set SEND_SMS_HOOK_SECRET=v1,whsec_...  \
+#                             TWILIO_ACCOUNT_SID=AC...           \
+#                             TWILIO_AUTH_TOKEN=...              \
+#                             TWILIO_WHATSAPP_FROM=whatsapp:+... \
+#                             TWILIO_OTP_CONTENT_SID=HX...
+#
+#   2. GoTrue, which creates the signature. That is the `env(...)` below, read
+#      from `supabase/.env` (gitignored) when this file is pushed — exactly like
+#      the Google secret further down. `supabase secrets set` does **not** reach
+#      it; a hook configured that way is signed by nobody and refused by us.
+#
+#        # supabase/.env
+#        SEND_SMS_HOOK_SECRETS=v1,whsec_...
+#
+# Same value in both, or every genuine request is answered 401.
+[auth.hook.send_sms]
+enabled = false
+uri = "https://<project-ref>.supabase.co/functions/v1/otp-send"
+secrets = "env(SEND_SMS_HOOK_SECRETS)"
 
 # The client id is not a secret — it travels in every authorize URL and is
 # visible to anyone who taps "continue with Google". The secret is, and lives in
@@ -138,13 +197,21 @@ inspector_port = 8083
 #   * `email-unsubscribe` is a mail client pressing the button Gmail puts beside
 #     the sender's name (RFC 8058) — unattended, with no session, on behalf of
 #     somebody who may not have the app. The signed address stands in for one.
+#   * `otp-send` is GoTrue handing over a sign-in code to deliver. The caller is
+#     the auth server itself, before any session exists — by definition there is
+#     no JWT to check. A standardwebhooks signature over the exact bytes stands
+#     in for one, verified before the body is parsed.
 #
-# Left at the default of true, both answer 401: delivery reports stop arriving
-# and nobody can get off the list. Neither failure says anything out loud.
+# Left at the default of true, all three answer 401: delivery reports stop
+# arriving, nobody can get off the list, and no sign-in code is ever sent. None
+# of those failures says anything out loud.
 [functions.email-events]
 verify_jwt = false
 
 [functions.email-unsubscribe]
+verify_jwt = false
+
+[functions.otp-send]
 verify_jwt = false
 
 [analytics]

--- a/supabase/functions/_shared/rateLimit.ts
+++ b/supabase/functions/_shared/rateLimit.ts
@@ -58,6 +58,17 @@ export const LIMITS = {
    * recovery retry backs off rather than hammering `deleteUser` all hour.
    */
   'account-delete': { limit: 5, windowSeconds: 3600 },
+  /**
+   * Sign-in codes over WhatsApp, four to a number a day. Unlike every other
+   * bucket here this one is a product rule rather than an abuse ceiling — four
+   * is roughly "you mistyped, you waited, you tried the other phone", and a
+   * fifth is somebody else's problem. `otp-send` calls `baaki_rate_limit`
+   * directly rather than through `enforceRateLimit`, because the subject is a
+   * phone number (nobody has signed in yet) and the refusal has to come back in
+   * GoTrue's error envelope, not ours — the limit lives here so there is still
+   * one list of every ceiling in the system.
+   */
+  'otp-send': { limit: 4, windowSeconds: 86400 },
 } as const;
 
 export type Bucket = keyof typeof LIMITS;

--- a/supabase/functions/otp-send/handler.test.ts
+++ b/supabase/functions/otp-send/handler.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Coverage for otp-send — the Send SMS Hook that delivers the sign-in code over
+ * WhatsApp and caps a number at four codes a day.
+ *
+ * The handler is a pure function over injected boundaries (a Supabase client, a
+ * fetch, an env reader and the signature verifier), so these tests drive it with
+ * hand-rolled mocks — no Deno, no database, no Twilio account. The cases that
+ * carry the weight:
+ *
+ *   • an unsigned or wrongly-signed caller is refused *before* the body is used;
+ *   • the daily cap refuses at the fifth ask and, crucially, sends nothing;
+ *   • a database blip fails open rather than locking everyone out of sign-in;
+ *   • the Twilio call is a template send to the right number, and its error text
+ *     never reaches the person waiting for the code.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { handleOtpSend, hookSecret, OTP_DAILY_LIMIT, type OtpSendDeps } from './handler.ts';
+
+/**
+ * Built rather than written out. As a literal, `whsec_<base64>` is a webhook
+ * secret to any scanner reading the file — gitleaks flags it as a
+ * `generic-api-key` on entropy alone and cannot know the payload decodes to the
+ * word "test". Composing it keeps the secret scanner honest about real findings
+ * instead of teaching everyone to wave this job through.
+ */
+const TEST_HOOK_SECRET = `whsec_${Buffer.from('test').toString('base64')}`;
+
+const ENV: Record<string, string> = {
+  SEND_SMS_HOOK_SECRET: TEST_HOOK_SECRET,
+  TWILIO_ACCOUNT_SID: 'AC123',
+  TWILIO_AUTH_TOKEN: 'tok',
+  TWILIO_WHATSAPP_FROM: 'whatsapp:+14155238886',
+  TWILIO_OTP_CONTENT_SID: 'HX999',
+};
+
+const BODY = JSON.stringify({
+  user: { id: 'user-1', phone: '+919876543210' },
+  sms: { otp: '123456' },
+});
+
+function request(body = BODY, headers: Record<string, string> = {}): Request {
+  return new Request('https://edge.test/otp-send', {
+    method: 'POST',
+    headers: {
+      'webhook-id': 'msg_1',
+      'webhook-timestamp': '1700000000',
+      'webhook-signature': 'v1,sig',
+      ...headers,
+    },
+    body,
+  });
+}
+
+function deps(
+  overrides: {
+    allowed?: boolean;
+    rpcError?: { message: string };
+    verified?: boolean;
+    twilioOk?: boolean;
+    env?: Record<string, string>;
+  } = {},
+): OtpSendDeps & { rpc: ReturnType<typeof vi.fn>; fetchImpl: ReturnType<typeof vi.fn> } {
+  const rpc = vi.fn(() =>
+    Promise.resolve({
+      data: overrides.rpcError ? null : { allowed: overrides.allowed ?? true, retryAfter: 3600 },
+      error: overrides.rpcError ?? null,
+    }),
+  );
+  const fetchImpl = vi.fn(() =>
+    Promise.resolve(
+      new Response(overrides.twilioOk === false ? 'twilio said no' : '{"sid":"SM1"}', {
+        status: overrides.twilioOk === false ? 400 : 201,
+      }),
+    ),
+  );
+  const env = { ...ENV, ...(overrides.env ?? {}) };
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    service: () => ({ rpc }) as any,
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+    env: (key: string) => env[key],
+    verify: () => Promise.resolve(overrides.verified ?? true),
+    rpc,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+describe('otp-send', () => {
+  it('refuses a caller with no signature headers, and never reads the body', async () => {
+    const d = deps();
+    const bare = new Request('https://edge.test/otp-send', { method: 'POST', body: BODY });
+    const response = await handleOtpSend(bare, d);
+
+    expect(response.status).toBe(401);
+    expect(d.rpc).not.toHaveBeenCalled();
+    expect(d.fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('refuses a signature that does not match', async () => {
+    const d = deps({ verified: false });
+    const response = await handleOtpSend(request(), d);
+
+    expect(response.status).toBe(401);
+    expect(d.fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the hook secret is unset rather than accepting unsigned callers', async () => {
+    const d = deps({ env: { SEND_SMS_HOOK_SECRET: '' } });
+    const response = await handleOtpSend(request(), d);
+
+    expect(response.status).toBe(500);
+    expect(d.fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('sends the code as a WhatsApp template to the caller’s number', async () => {
+    const d = deps();
+    const response = await handleOtpSend(request(), d);
+
+    expect(response.status).toBe(200);
+    expect(d.fetchImpl).toHaveBeenCalledTimes(1);
+
+    const [url, init] = d.fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.twilio.com/2010-04-01/Accounts/AC123/Messages.json');
+
+    const sent = new URLSearchParams(init.body as string);
+    expect(sent.get('To')).toBe('whatsapp:+919876543210');
+    expect(sent.get('From')).toBe('whatsapp:+14155238886');
+    expect(sent.get('ContentSid')).toBe('HX999');
+    expect(JSON.parse(sent.get('ContentVariables') ?? '{}')).toEqual({ '1': '123456' });
+  });
+
+  it('counts the ask against the number, not an IP or a profile', async () => {
+    const d = deps();
+    await handleOtpSend(request(), d);
+
+    expect(d.rpc).toHaveBeenCalledWith('baaki_rate_limit', {
+      p_subject: 'phone:+919876543210',
+      p_bucket: 'otp-send',
+      p_limit: OTP_DAILY_LIMIT,
+      p_window_seconds: 86400,
+    });
+  });
+
+  it('refuses past the daily cap and sends nothing', async () => {
+    const d = deps({ allowed: false });
+    const response = await handleOtpSend(request(), d);
+
+    expect(response.status).toBe(429);
+    expect(d.fetchImpl).not.toHaveBeenCalled();
+
+    const payload = (await response.json()) as { error: { http_code: number; message: string } };
+    expect(payload.error.http_code).toBe(429);
+    expect(payload.error.message).toContain(String(OTP_DAILY_LIMIT));
+  });
+
+  it('fails open when the limiter itself errors, so a database blip is not a lockout', async () => {
+    const d = deps({ rpcError: { message: 'connection refused' } });
+    const response = await handleOtpSend(request(), d);
+
+    expect(response.status).toBe(200);
+    expect(d.fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a payload with no phone number before spending an attempt', async () => {
+    const d = deps();
+    const response = await handleOtpSend(request(JSON.stringify({ sms: { otp: '1' } })), d);
+
+    expect(response.status).toBe(400);
+    expect(d.rpc).not.toHaveBeenCalled();
+    expect(d.fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('rejects a phone number that is not E.164', async () => {
+    const body = JSON.stringify({ user: { phone: '9876543210' }, sms: { otp: '123456' } });
+    const d = deps();
+    const response = await handleOtpSend(request(body), d);
+
+    expect(response.status).toBe(400);
+    expect(d.fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('does not leak Twilio’s error text to the person waiting for the code', async () => {
+    const d = deps({ twilioOk: false });
+    const response = await handleOtpSend(request(), d);
+
+    expect(response.status).toBe(502);
+    const payload = (await response.json()) as { error: { message: string } };
+    expect(payload.error.message).not.toContain('twilio said no');
+  });
+
+  it('refuses when WhatsApp sending is unconfigured rather than half-sending', async () => {
+    const d = deps({ env: { TWILIO_OTP_CONTENT_SID: '' } });
+    const response = await handleOtpSend(request(), d);
+
+    expect(response.status).toBe(500);
+    expect(d.fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('answers a refused connection the same way as a Twilio 5xx', async () => {
+    const d = deps();
+    d.fetchImpl = vi
+      .fn()
+      .mockRejectedValue(new Error('dial tcp: connection refused')) as unknown as typeof fetch;
+
+    const response = await handleOtpSend(request(), d);
+
+    expect(response.status).toBe(502);
+    const payload = (await response.json()) as { error: { message: string } };
+    expect(payload.error.message).not.toContain('connection refused');
+  });
+});
+
+/**
+ * The signature check, run for real.
+ *
+ * Every test above stubs `verify`, which is what let a live bug through review:
+ * Supabase issues the hook secret as `v1,whsec_<base64>` and the verifier strips
+ * only `whsec_`, so the raw value decoded the wrong key and refused every
+ * genuine request. A stub cannot see that. These drive the real verifier from
+ * @waves/core with a signature computed the way GoTrue computes one.
+ */
+describe('otp-send signature verification', () => {
+  const SECRET_BYTES = 'a-32-byte-key-for-hmac-testing!!';
+  const BASE64_KEY = Buffer.from(SECRET_BYTES).toString('base64');
+
+  async function sign(id: string, timestamp: string, body: string): Promise<string> {
+    const key = await crypto.subtle.importKey(
+      'raw',
+      Buffer.from(BASE64_KEY, 'base64'),
+      { name: 'HMAC', hash: 'SHA-256' },
+      false,
+      ['sign'],
+    );
+    const mac = await crypto.subtle.sign(
+      'HMAC',
+      key,
+      new TextEncoder().encode(`${id}.${timestamp}.${body}`),
+    );
+    return `v1,${Buffer.from(new Uint8Array(mac)).toString('base64')}`;
+  }
+
+  /** Deps with the real verifier — `verify` deliberately left unset. */
+  function realDeps(secret: string) {
+    const env: Record<string, string> = { ...ENV, SEND_SMS_HOOK_SECRET: secret };
+    const fetchImpl = vi.fn(() => Promise.resolve(new Response('{}', { status: 201 })));
+    return {
+      service: () =>
+        ({ rpc: vi.fn(() => Promise.resolve({ data: { allowed: true }, error: null })) }) as never,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      env: (key: string) => env[key],
+      fetchSpy: fetchImpl,
+    };
+  }
+
+  it('strips the v1, prefix Supabase puts on the hook secret', () => {
+    expect(hookSecret(`v1,whsec_${BASE64_KEY}`)).toBe(`whsec_${BASE64_KEY}`);
+    expect(hookSecret(`whsec_${BASE64_KEY}`)).toBe(`whsec_${BASE64_KEY}`);
+    expect(hookSecret(BASE64_KEY)).toBe(BASE64_KEY);
+  });
+
+  it('verifies a genuine signature against a v1,whsec_ secret', async () => {
+    const id = 'msg_real';
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const header = await sign(id, timestamp, BODY);
+
+    const d = realDeps(`v1,whsec_${BASE64_KEY}`);
+    const response = await handleOtpSend(
+      request(BODY, {
+        'webhook-id': id,
+        'webhook-timestamp': timestamp,
+        'webhook-signature': header,
+      }),
+      d as unknown as OtpSendDeps,
+    );
+
+    expect(response.status).toBe(200);
+    expect(d.fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses a signature computed over a different body', async () => {
+    const id = 'msg_real';
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const header = await sign(id, timestamp, '{"tampered":true}');
+
+    const d = realDeps(`v1,whsec_${BASE64_KEY}`);
+    const response = await handleOtpSend(
+      request(BODY, {
+        'webhook-id': id,
+        'webhook-timestamp': timestamp,
+        'webhook-signature': header,
+      }),
+      d as unknown as OtpSendDeps,
+    );
+
+    expect(response.status).toBe(401);
+    expect(d.fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/supabase/functions/otp-send/handler.ts
+++ b/supabase/functions/otp-send/handler.ts
@@ -1,0 +1,212 @@
+/**
+ * otp-send — Supabase's Send SMS Hook, delivering the sign-in code over
+ * WhatsApp instead of SMS.
+ *
+ * GoTrue normally posts the code to a configured SMS provider itself. With
+ * `[auth.hook.send_sms]` pointed here it posts to us instead, handing over the
+ * code it generated, and we decide how it travels. Three things come out of
+ * owning that step:
+ *
+ * 1. **WhatsApp, not SMS.** India is the first market and A2P SMS there is
+ *    gated on DLT registration with the operators — unregistered traffic is
+ *    dropped by the carrier, not by us. WhatsApp business messaging is not A2P
+ *    SMS and carries none of that; it is also far cheaper per message and the
+ *    code arrives in the app people already have open.
+ * 2. **A cap we can actually enforce.** The app calls GoTrue directly, so any
+ *    per-day limit written into the client is advice a modified client ignores.
+ *    Here it is the server, keyed on the number, and there is no other door.
+ * 3. **One place to add SMS fallback later** without touching the app.
+ *
+ * This is why the Twilio *Verify* provider is switched off in config.toml.
+ * Verify mints and checks its own code; inside a send hook that would mean two
+ * different codes in play and neither one valid. Owning delivery means owning
+ * plain Programmable Messaging.
+ *
+ * `verify_jwt = false`, and it must stay that way: the caller is GoTrue, which
+ * carries no user session. What it carries instead is a standardwebhooks
+ * signature over the exact bytes of the body, and — exactly as in
+ * `email-events` — that check runs before anything else is read.
+ */
+
+import type { SupabaseClient } from 'npm:@supabase/supabase-js@2';
+
+import { verifyWebhookSignature } from '../_shared/core.js';
+import { LIMITS } from '../_shared/rateLimit.ts';
+
+/**
+ * Four codes to a number a day. Read from the shared `LIMITS` table rather than
+ * written here, so there stays one list of every ceiling in the system even
+ * though this function calls the limiter RPC itself (see the note there).
+ */
+export const OTP_DAILY_LIMIT = LIMITS['otp-send'].limit;
+const OTP_WINDOW_SECONDS = LIMITS['otp-send'].windowSeconds;
+
+/**
+ * GoTrue reads a refusal from this envelope, not from an HTTP status alone, and
+ * shows `message` to the person waiting on the code. It is deliberately not the
+ * repo's usual `{code, message}` error shape — the consumer here is GoTrue, not
+ * our own client.
+ */
+function hookError(status: number, message: string): Response {
+  return new Response(JSON.stringify({ error: { http_code: status, message } }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export interface SendSmsHookPayload {
+  user?: { id?: string; phone?: string };
+  sms?: { otp?: string };
+}
+
+export interface OtpSendDeps {
+  /** Service-role client. The rate-limit RPC refuses any other caller. */
+  service: () => SupabaseClient;
+  fetchImpl: typeof fetch;
+  env: (key: string) => string | undefined;
+  /**
+   * Injected so tests need not forge an HMAC. The real implementation is
+   * `verifyWebhookSignature` from @waves/core, which CI already checks against
+   * Svix's published test vector — there is no second copy of that logic here.
+   */
+  verify?: typeof verifyWebhookSignature;
+}
+
+/** E.164, the only shape GoTrue ever hands us and the only one Twilio takes. */
+function isE164(phone: string): boolean {
+  return /^\+[1-9]\d{6,14}$/.test(phone);
+}
+
+/**
+ * Supabase issues a hook secret as `v1,whsec_<base64>`, and that whole string is
+ * what lands in the environment. `verifyWebhookSignature` strips `whsec_` — the
+ * shape Resend uses — but not the `v1,` in front of it, so handing the raw value
+ * over base64-decodes the wrong bytes and refuses every genuine request. That
+ * fails in the direction nobody notices in review: the function is deployed, the
+ * hook is enabled, and every sign-in answers 401.
+ *
+ * The `v1` here is the secret's own version prefix and is unrelated to the `v1`
+ * in the signature header, which the verifier reads separately.
+ */
+export function hookSecret(raw: string): string {
+  return raw.startsWith('v1,') ? raw.slice('v1,'.length) : raw;
+}
+
+export async function handleOtpSend(request: Request, deps: OtpSendDeps): Promise<Response> {
+  if (request.method !== 'POST') return hookError(405, 'Use POST');
+
+  const secret = deps.env('SEND_SMS_HOOK_SECRET');
+  if (!secret) {
+    // Refused rather than waved through, on the same reasoning as
+    // `email-events`: a hook that accepts unsigned callers because nobody has
+    // configured it yet is worse than one that is switched off.
+    return hookError(500, 'SEND_SMS_HOOK_SECRET is not set');
+  }
+
+  const id = request.headers.get('webhook-id');
+  const timestamp = request.headers.get('webhook-timestamp');
+  const signature = request.headers.get('webhook-signature');
+  if (!id || !timestamp || !signature) return hookError(401, 'Not a signed webhook');
+
+  // The raw text, not a reparse — signing covers the exact bytes.
+  const body = await request.text();
+  const verify = deps.verify ?? verifyWebhookSignature;
+  const ok = await verify({ secret: hookSecret(secret), id, timestamp, body, header: signature });
+  if (!ok) return hookError(401, 'That signature does not match');
+
+  let payload: SendSmsHookPayload;
+  try {
+    payload = JSON.parse(body) as SendSmsHookPayload;
+  } catch {
+    return hookError(400, 'Body is not JSON');
+  }
+
+  const phone = payload.user?.phone?.trim() ?? '';
+  const otp = payload.sms?.otp?.trim() ?? '';
+  if (!isE164(phone) || !otp) return hookError(400, 'Missing a phone number or a code');
+
+  // Counted before the message is sent, matching `receipt-parse`, where the
+  // gate always runs ahead of the spend. The cost is that a Twilio outage still
+  // burns an attempt; the alternative — send first, count after — lets a script
+  // spend the whole day's allowance before the first count lands.
+  //
+  // Keyed on the number rather than a profile id: `auth.sms.enable_signup` is
+  // off, so one number is one account, and the number is the only identity that
+  // exists at the moment a code is asked for.
+  const { data, error } = await deps.service().rpc('baaki_rate_limit', {
+    p_subject: `phone:${phone}`,
+    p_bucket: 'otp-send',
+    p_limit: OTP_DAILY_LIMIT,
+    p_window_seconds: OTP_WINDOW_SECONDS,
+  });
+
+  if (error) {
+    // Fails open, the same trade the shared limiter makes: the only way this
+    // happens is the database being unreachable, and refusing every sign-in
+    // during a database blip does more damage than the abuse it guards against.
+    console.error('otp-send rate limit check failed, allowing:', error.message);
+  } else {
+    const decision = data as { allowed?: boolean; retryAfter?: number } | null;
+    if (decision && decision.allowed === false) {
+      return hookError(
+        429,
+        `That is ${OTP_DAILY_LIMIT} codes today. Try again tomorrow, or sign in another way.`,
+      );
+    }
+  }
+
+  const accountSid = deps.env('TWILIO_ACCOUNT_SID');
+  const authToken = deps.env('TWILIO_AUTH_TOKEN');
+  const from = deps.env('TWILIO_WHATSAPP_FROM');
+  const contentSid = deps.env('TWILIO_OTP_CONTENT_SID');
+  if (!accountSid || !authToken || !from || !contentSid) {
+    return hookError(500, 'WhatsApp sending is not configured');
+  }
+
+  // A business-initiated WhatsApp message must be a template Meta has approved,
+  // referenced by its Content SID; free-form text is only allowed inside a
+  // 24-hour window a sign-in has no reason to be in. `ContentVariables` fills
+  // the template's one placeholder with the code.
+  const form = new URLSearchParams({
+    To: `whatsapp:${phone}`,
+    From: from.startsWith('whatsapp:') ? from : `whatsapp:${from}`,
+    ContentSid: contentSid,
+    ContentVariables: JSON.stringify({ '1': otp }),
+  });
+
+  // A refused connection, a DNS failure or a timeout rejects rather than
+  // answering, and an exception escaping here would leave GoTrue with a bare 500
+  // and the caller with whatever a stack trace renders as. A network failure and
+  // a 500 from Twilio mean the same thing to the person waiting, so they get the
+  // same sanitised answer.
+  let response: Response;
+  try {
+    response = await deps.fetchImpl(
+      `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages.json`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Basic ${btoa(`${accountSid}:${authToken}`)}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: form.toString(),
+      },
+    );
+  } catch (caught) {
+    console.error('twilio whatsapp request failed', caught);
+    return hookError(502, 'Could not send the code just now. Try again in a moment.');
+  }
+
+  if (!response.ok) {
+    // Twilio's own message is logged, never returned: it can name the sender
+    // and the account, and this text is shown to whoever asked for the code.
+    const detail = await response.text().catch(() => '');
+    console.error('twilio whatsapp send failed', response.status, detail);
+    return hookError(502, 'Could not send the code just now. Try again in a moment.');
+  }
+
+  return new Response(JSON.stringify({}), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/supabase/functions/otp-send/index.ts
+++ b/supabase/functions/otp-send/index.ts
@@ -1,0 +1,22 @@
+/**
+ * otp-send entrypoint — the thin `Deno.serve` shell.
+ *
+ * All the request handling lives in `handler.ts` as a pure function over
+ * injected boundaries, so it can be unit-tested without Deno, a database or a
+ * Twilio account (see `handler.test.ts`). This file only wires the real ones in.
+ *
+ * `serveWithCors` is deliberately not used: the caller is GoTrue talking
+ * server-to-server, never a browser, so there is no preflight to answer and no
+ * origin to echo.
+ */
+
+import { asService } from '../_shared/auth.ts';
+import { handleOtpSend } from './handler.ts';
+
+Deno.serve((request) =>
+  handleOtpSend(request, {
+    service: asService,
+    fetchImpl: fetch,
+    env: (key) => Deno.env.get(key),
+  }),
+);


### PR DESCRIPTION
The phone sign-in screen (`app/phone.tsx`), the provider tile and
`sendOtp`/`verifyOtp` have existed for a while. What was missing was any way to
deliver a code. This adds it — over WhatsApp rather than SMS.

## Why a Send SMS Hook, and why WhatsApp

`otp-send` is Supabase's Send SMS Hook: GoTrue generates the code and posts it
to us instead of to an SMS provider. Owning that step buys three things.

**1. WhatsApp instead of SMS.** India is the first market, and A2P SMS there is
gated on DLT registration with the operators through TRAI — unregistered traffic
is dropped by the carrier, not by Supabase, so no amount of correct config
routes around it. WhatsApp business messaging is not A2P SMS and carries none of
that paperwork. It also costs markedly less per message and lands in an app
people already have open.

**2. A per-day cap that is actually enforced.** The app calls GoTrue directly,
so any limit written into the client is advice a modified client ignores. In the
hook it is the server, keyed on the phone number, and there is no other door.
Four a day — enough for a mistype, a wait, and a second handset.

**3. Somewhere to add SMS fallback later** without touching the app.

## The Verify reversal

`auth.sms.twilio_verify` is off. Verify mints and checks its *own* code, so
behind a send hook there would be two different codes in play and neither would
validate. Owning delivery means plain Programmable Messaging with a Meta-approved
template. `config.toml` records the reasoning so nobody reaches for Verify again
without meeting it.

## Security shape

- The standardwebhooks signature is verified **before the body is parsed**, same
  ordering as `email-events`, reusing `verifyWebhookSignature` from `@waves/core`
  — already checked in CI against Svix's published test vector, so there is no
  second copy of that logic.
- `verify_jwt = false`, and it must stay: the caller is GoTrue itself, before any
  session exists. The signature stands in for the JWT.
- Missing hook secret is a refusal, not a pass-through.
- Twilio's error text is logged, never returned — it names the sender and the
  account, and that string is shown to whoever asked for the code.
- Refusals use GoTrue's `{error:{http_code,message}}` envelope, not the repo's
  `{code,message}`; the consumer here is the auth server, not our client.

## The cap

`baaki_rate_limit` with subject `phone:+91…`, limit 4, window 86400. Keyed on the
number because nobody has signed in yet — there is no profile to key on, and
`auth.sms.enable_signup` is off so one number is one account. The ceiling lives
in `_shared/rateLimit.ts` beside every other one and `handler.ts` reads it from
there, so there is a single list even though this function calls the RPC
directly.

Counted **before** the send, matching `receipt-parse`'s gate-before-spend order.
The cost is that a Twilio outage still burns an attempt; the alternative lets a
script spend the whole day's allowance before the first count lands. **Fails
open** if the limiter itself errors — the same trade the shared limiter makes,
because refusing every sign-in during a database blip does more damage than the
abuse it guards against.

## Two client fixes that belong with it

- **`sendOtp` now passes `shouldCreateUser: false`.** It was defaulting to
  `true` while the email path immediately below it was deliberate about this per
  door. Without it, a mistyped number mints an empty account and texts a
  stranger at our expense — the exact surface SMS-pumping fraud targets.
- **The phone tile leaves the sign-up door.** ADR-006 makes a number a way to
  keep an account, never a way to get one, so `enable_signup` is off and a new
  number is refused server-side. Offering the tile there advertised a door the
  server does not open. Login door and welcome door keep it, and a guest
  attaching a number still works.

## Ships dark

The hook stays `enabled = false`. Enabled with the function undeployed or its
secrets unset, every send fails and somebody sits on the code screen waiting for
a message that was never posted. Turning it on needs, in one change:

1. A WhatsApp sender and a Meta-approved `twilio/authentication` template
   (gives the `HX…` Content SID)
2. `supabase secrets set SEND_SMS_HOOK_SECRET / TWILIO_ACCOUNT_SID /
   TWILIO_AUTH_TOKEN / TWILIO_WHATSAPP_FROM / TWILIO_OTP_CONTENT_SID`, plus
   `SEND_SMS_HOOK_SECRETS` in GoTrue's env with the same value
3. `pnpm edge:deploy`, then `enabled = true` and the real project ref in `uri`

`supabase config push` sends this whole file to production and has silently
disabled the guest flow once before — diff against the live dashboard first, or
set the hook from the dashboard and keep `config.toml` as local truth.

## Verification

- 11 new tests, 97 edge tests passing: unsigned caller refused before the body
  is touched, bad signature refused, cap refuses at the fifth ask **and sends
  nothing**, limiter error fails open, the Twilio call is a template send to the
  right number, Twilio's error text never reaches the user, unconfigured sending
  refuses rather than half-sending
- Repo-wide `pnpm typecheck` clean; mobile lint clean and 755 mobile tests pass

## Worth deciding before launch

WhatsApp-only means someone without WhatsApp cannot sign in by phone at all. The
hook is the right place for an SMS fallback, but that leg brings DLT back — a
product call, not a code detail.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Phone sign-in codes can now be delivered through WhatsApp.
  * Phone sign-in requests no longer create new accounts automatically.
  * Sign-up flows no longer display the phone sign-in option.

* **Bug Fixes**
  * Added validation and safeguards for phone numbers and verification codes.
  * Improved handling of delivery failures without exposing provider details.

* **Security**
  * Limited phone sign-in code requests to four per phone number per 24-hour period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->