### PR TITLE
fix(auth): do not burn OTP quota when WhatsApp is unconfigured

### DIFF
--- a/supabase/functions/otp-send/handler.test.ts
+++ b/supabase/functions/otp-send/handler.test.ts
@@ -143,6 +143,24 @@ describe('otp-send', () => {
     });
   });
 
+  it.each([
+    ['Indian rider', '+919876543210'],
+    ['traveller on a UK SIM', '+447700900123'],
+    ['long international number', '+123456789012345'],
+  ])('accepts a valid E.164 number for an %s', async (_persona, phone) => {
+    const body = JSON.stringify({ user: { id: 'user-1', phone }, sms: { otp: '123456' } });
+    const d = deps();
+    const response = await handleOtpSend(request(body), d);
+
+    expect(response.status).toBe(200);
+    const [, init] = d.fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(new URLSearchParams(init.body as string).get('To')).toBe(`whatsapp:${phone}`);
+    expect(d.rpc).toHaveBeenCalledWith(
+      'baaki_rate_limit',
+      expect.objectContaining({ p_subject: `phone:${phone}` }),
+    );
+  });
+
   it('refuses past the daily cap and sends nothing', async () => {
     const d = deps({ allowed: false });
     const response = await handleOtpSend(request(), d);
@@ -190,12 +208,15 @@ describe('otp-send', () => {
     expect(payload.error.message).not.toContain('twilio said no');
   });
 
-  it('refuses when WhatsApp sending is unconfigured rather than half-sending', async () => {
+  it('refuses an unconfigured deployment without burning a daily code', async () => {
     const d = deps({ env: { TWILIO_OTP_CONTENT_SID: '' } });
     const response = await handleOtpSend(request(), d);
 
     expect(response.status).toBe(500);
     expect(d.fetchImpl).not.toHaveBeenCalled();
+    // The point of the check's position: a deploy missing its Twilio secrets
+    // must not spend somebody's four codes on sends it could never make.
+    expect(d.rpc).not.toHaveBeenCalled();
   });
 
   it('answers a refused connection the same way as a Twilio 5xx', async () => {

--- a/supabase/functions/otp-send/handler.ts
+++ b/supabase/functions/otp-send/handler.ts
@@ -125,6 +125,19 @@ export async function handleOtpSend(request: Request, deps: OtpSendDeps): Promis
   const otp = payload.sms?.otp?.trim() ?? '';
   if (!isE164(phone) || !otp) return hookError(400, 'Missing a phone number or a code');
 
+  // Configuration is checked before the quota is spent. A provider outage still
+  // burns an attempt below — the gate deliberately runs ahead of the spend — but
+  // a deploy that is simply missing its Twilio secrets should not consume all
+  // four of somebody's daily codes for a send this function was never capable of
+  // making.
+  const accountSid = deps.env('TWILIO_ACCOUNT_SID');
+  const authToken = deps.env('TWILIO_AUTH_TOKEN');
+  const from = deps.env('TWILIO_WHATSAPP_FROM');
+  const contentSid = deps.env('TWILIO_OTP_CONTENT_SID');
+  if (!accountSid || !authToken || !from || !contentSid) {
+    return hookError(500, 'WhatsApp sending is not configured');
+  }
+
   // Counted before the message is sent, matching `receipt-parse`, where the
   // gate always runs ahead of the spend. The cost is that a Twilio outage still
   // burns an attempt; the alternative — send first, count after — lets a script
@@ -153,14 +166,6 @@ export async function handleOtpSend(request: Request, deps: OtpSendDeps): Promis
         `That is ${OTP_DAILY_LIMIT} codes today. Try again tomorrow, or sign in another way.`,
       );
     }
-  }
-
-  const accountSid = deps.env('TWILIO_ACCOUNT_SID');
-  const authToken = deps.env('TWILIO_AUTH_TOKEN');
-  const from = deps.env('TWILIO_WHATSAPP_FROM');
-  const contentSid = deps.env('TWILIO_OTP_CONTENT_SID');
-  if (!accountSid || !authToken || !from || !contentSid) {
-    return hookError(500, 'WhatsApp sending is not configured');
   }
 
   // A business-initiated WhatsApp message must be a template Meta has approved,


### PR DESCRIPTION
## Summary
- Checks Twilio/WhatsApp configuration before spending the phone OTP daily quota
- Adds persona-style E.164 coverage for Indian rider, travelling UK SIM, and long international financer numbers
- Strengthens the unconfigured-send test to assert no rate-limit RPC is called

## Validation
- pnpm test:edge -- supabase/functions/otp-send/handler.test.ts
- pnpm exec prettier --check supabase/functions/otp-send/handler.ts supabase/functions/otp-send/handler.test.ts
- pnpm lint
- Attempted pnpm typecheck; blocked by existing mobile route type errors in src/app/(tabs)/me.tsx, src/app/personal/*.tsx, src/app/voice.tsx, src/components/AppTabBar.tsx unrelated to this OTP change