### PR TITLE
feat(email): put the mail provider behind a seam, with SendGrid beside Resend

### DIFF
--- a/supabase/functions/_shared/README.md
+++ b/supabase/functions/_shared/README.md
@@ -13,6 +13,14 @@ Rules for every function in this directory:
    `@waves/core` and a mismatch is rejected with `SHARE_MISMATCH` (TDR §4).
 3. **Secrets only from the function environment** — `ANTHROPIC_API_KEY`,
    `RESEND_API_KEY`, `RESEND_WEBHOOK_SECRET`, `SUPABASE_SERVICE_ROLE_KEY`.
+   Email delivery is provider-agnostic in shape: `EMAIL_PROVIDER` selects
+   `resend` (default) or `sendgrid`, and the key it needs is `RESEND_API_KEY` or
+   `SENDGRID_API_KEY` accordingly. **`sendgrid` is refused by the mail queues
+   today**, by `emailSendable()`, for two reasons that both have to be closed
+   first: SendGrid has no idempotency key, so a send whose outcome was never
+   learned would be retried and delivered twice; and `email-events` verifies a
+   Svix signature while SendGrid signs its Event Webhook with ECDSA, so
+   delivery events — and with them the suppression list — would stop.
    Nothing here may ever be referenced from `apps/*`.
 4. **Idempotency.** Mutations carry `client_mutation_id`; retries must be safe.
 5. **Attach ids, never rows.** Anything falling through to a 500 is sent to

--- a/supabase/functions/_shared/email.ts
+++ b/supabase/functions/_shared/email.ts
@@ -1,5 +1,5 @@
 /**
- * Handing a built email to Resend (TDR §7.3).
+ * Handing a built email to whichever provider carries it (TDR §7.3).
  *
  * Everything worth testing is in `@waves/core` — what may be mailed, what it
  * says, what the unsubscribe link is. This file is the part that cannot be
@@ -7,10 +7,11 @@
  * that only matter when the send goes wrong.
  *
  * The one that matters most is the difference between "this will never work"
- * and "this did not work just now". Resend refusing an address permanently and
- * Resend being rate-limited look almost identical at the call site, and getting
- * them the wrong way round means either a settlement confirmation is silently
- * dropped or a dead address is retried every five minutes forever.
+ * and "this did not work just now". A provider refusing an address permanently
+ * and a provider being rate-limited look almost identical at the call site, and
+ * getting them the wrong way round means either a settlement confirmation is
+ * silently dropped or a dead address is retried every five minutes forever.
+ * That rule is decided once, in `sendVia`, and applied to every provider.
  */
 
 import {
@@ -24,6 +25,230 @@ import {
 import { HttpError } from './auth.ts';
 
 const RESEND_ENDPOINT = 'https://api.resend.com/emails';
+const SENDGRID_ENDPOINT = 'https://api.sendgrid.com/v3/mail/send';
+
+/**
+ * Which service actually carries the mail.
+ *
+ * The choice is an environment variable rather than a row in `service_config`,
+ * unlike the voice provider knob. A provider cannot be switched without also
+ * deploying that provider's API key, and those live in edge-function env — so a
+ * database knob able to select a provider whose key is absent would let one
+ * click stop every email in the system, with the failure showing up only in a
+ * log. Tying the two together means the switch and the credential move at once.
+ */
+export type EmailProviderId = 'resend' | 'sendgrid';
+
+export function emailProvider(): EmailProviderId {
+  const raw = (Deno.env.get('EMAIL_PROVIDER') ?? '').trim().toLowerCase();
+  if (raw === '' || raw === 'resend') return 'resend';
+  if (raw === 'sendgrid') return 'sendgrid';
+  // Refused rather than quietly defaulting: a typo that silently keeps sending
+  // through the old provider is how a migration gets declared done twice.
+  throw new HttpError(
+    500,
+    'MISCONFIGURED',
+    `EMAIL_PROVIDER "${raw}" is not a provider this build knows`,
+  );
+}
+
+/** The API key the selected provider needs, by name. */
+export function emailKeyName(provider: EmailProviderId = emailProvider()): string {
+  return provider === 'sendgrid' ? 'SENDGRID_API_KEY' : 'RESEND_API_KEY';
+}
+
+/**
+ * Whether this deployment can send mail, and if not, why.
+ *
+ * Callers check it before claiming rows, so a deployment that cannot send
+ * leaves the queue untouched rather than claiming a batch and failing every
+ * send in it — a claimed row is one nothing will look at again.
+ *
+ * The reason is carried rather than collapsed to a boolean because the three
+ * cases want three different reactions. "No key set" is a deployment that has
+ * not turned email on: normal, silent, not a fault. The other two are faults,
+ * and a fault that reads as "email is off" is one nobody finds until somebody
+ * asks why the mail stopped.
+ */
+export type EmailSendable = { readonly ok: true } | { readonly ok: false; readonly reason: string };
+
+export function emailSendable(): EmailSendable {
+  let provider: EmailProviderId;
+  try {
+    provider = emailProvider();
+  } catch (misconfigured) {
+    return { ok: false, reason: (misconfigured as Error).message };
+  }
+
+  // SendGrid cannot safely carry a queue that retries. Both senders turn a
+  // network failure into `retry`, which is only sound because Resend takes an
+  // idempotency key and collapses the resend. SendGrid has no equivalent, so a
+  // send whose outcome we never learned would be sent again — and the id in
+  // `custom_args` lets a duplicate be recognised afterwards, not prevented.
+  // Until there is durable suppression or event-based reconciliation, this is
+  // refused loudly rather than left as a note somebody has to read first.
+  if (provider === 'sendgrid') {
+    return {
+      ok: false,
+      reason:
+        'EMAIL_PROVIDER=sendgrid cannot serve the retrying mail queues yet: SendGrid has no idempotency key, so a send whose outcome was never learned would be delivered twice.',
+    };
+  }
+
+  if (!Deno.env.get(emailKeyName(provider)) || !Deno.env.get('EMAIL_UNSUBSCRIBE_SECRET')) {
+    return { ok: false, reason: '' };
+  }
+
+  return { ok: true };
+}
+
+/** One message, in the shape both providers are built from. */
+interface OutgoingEmail {
+  readonly to: string;
+  readonly subject: string;
+  readonly html: string;
+  readonly text: string;
+  readonly headers: Record<string, string>;
+  /**
+   * The notification or send-row id. Resend takes it as an idempotency key;
+   * SendGrid has no such header, so it travels as a custom argument instead and
+   * comes back on every delivery event (see `sendVia`).
+   */
+  readonly key: string;
+}
+
+/**
+ * What a provider said, normalised.
+ *
+ * `ok` is carried explicitly rather than inferred from `messageId` being
+ * present: SendGrid's success is the 202 itself, and the id arrives in a header
+ * it is not obliged to send. Reading "no id" as "failed" would mark a delivered
+ * mail as failed and, worse, hand it back to the queue as a retry.
+ */
+interface ProviderOutcome {
+  readonly ok: boolean;
+  readonly messageId?: string;
+  readonly transient: boolean;
+  readonly error?: string;
+}
+
+/**
+ * `EMAIL_FROM` is one RFC 5322 string ("Waves <hello@…>"). Resend takes it
+ * as-is; SendGrid wants the name and the address apart.
+ */
+function splitFrom(value: string): { email: string; name?: string } {
+  const match = /^\s*(.*?)\s*<([^>]+)>\s*$/.exec(value);
+  if (!match) return { email: value.trim() };
+  const name = match[1].replace(/^"|"$/g, '').trim();
+  return name ? { email: match[2].trim(), name } : { email: match[2].trim() };
+}
+
+/**
+ * Post one message and normalise the answer.
+ *
+ * The two providers disagree about almost everything at the wire: Resend
+ * answers 200 with `{id}`, SendGrid answers **202 with an empty body** and puts
+ * its id in a header. What they agree on is which failures come back later —
+ * 429 and 5xx — and that rule is applied identically to both, because getting
+ * it wrong either drops a settlement confirmation or retries a dead address
+ * every five minutes forever.
+ */
+async function sendVia(
+  provider: EmailProviderId,
+  message: OutgoingEmail,
+): Promise<ProviderOutcome> {
+  const from = emailFrom();
+
+  const request: { url: string; init: RequestInit } =
+    provider === 'sendgrid'
+      ? {
+          url: SENDGRID_ENDPOINT,
+          init: {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${requiredEnv('SENDGRID_API_KEY')}`,
+              'content-type': 'application/json',
+            },
+            body: JSON.stringify({
+              personalizations: [
+                {
+                  to: [{ email: message.to }],
+                  // SendGrid offers no idempotency key. This is the next best
+                  // thing: the id rides along and is echoed on every delivery
+                  // event, so a duplicate can at least be *recognised* after the
+                  // fact even though it cannot be prevented at the call.
+                  custom_args: { waves_key: message.key },
+                },
+              ],
+              from: splitFrom(from),
+              subject: message.subject,
+              // Plain text first: SendGrid treats the array as ascending
+              // preference and renders the last part a client can display.
+              content: [
+                { type: 'text/plain', value: message.text },
+                { type: 'text/html', value: message.html },
+              ],
+              headers: message.headers,
+            }),
+          },
+        }
+      : {
+          url: RESEND_ENDPOINT,
+          init: {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${requiredEnv('RESEND_API_KEY')}`,
+              'content-type': 'application/json',
+              // TDR §7.3: the notification id is the idempotency key, so a run
+              // that times out after sending does not send again when retried.
+              'Idempotency-Key': message.key,
+            },
+            body: JSON.stringify({
+              from,
+              to: [message.to],
+              subject: message.subject,
+              html: message.html,
+              text: message.text,
+              headers: message.headers,
+            }),
+          },
+        };
+
+  const response = await fetch(request.url, request.init);
+
+  if (provider === 'sendgrid') {
+    if (response.status === 202) {
+      // The body is empty by design; the id is a header.
+      await response.body?.cancel().catch(() => undefined);
+      return {
+        ok: true,
+        messageId: response.headers.get('x-message-id') ?? undefined,
+        transient: false,
+      };
+    }
+    const detail = (await response.json().catch(() => ({}))) as {
+      errors?: { message?: string; field?: string }[];
+    };
+    const first = detail.errors?.[0];
+    return {
+      ok: false,
+      transient: response.status === 429 || response.status >= 500,
+      error: `${response.status} ${first?.field ?? ''} ${first?.message ?? ''}`.trim(),
+    };
+  }
+
+  const payload = (await response.json().catch(() => ({}))) as {
+    id?: string;
+    message?: string;
+    name?: string;
+  };
+  if (response.ok && payload.id) return { ok: true, messageId: payload.id, transient: false };
+  return {
+    ok: false,
+    transient: response.status === 429 || response.status >= 500,
+    error: `${response.status} ${payload.name ?? ''} ${payload.message ?? ''}`.trim(),
+  };
+}
 
 /**
  * Resend's published limit is two requests a second. Sending a claimed batch
@@ -123,26 +348,16 @@ function factsOf(payload: Record<string, unknown>): Record<string, string | unde
 }
 
 export async function sendEmail(built: BuiltEmail): Promise<EmailResult> {
-  let response: Response;
+  let outcome: ProviderOutcome;
 
   try {
-    response = await fetch(RESEND_ENDPOINT, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${requiredEnv('RESEND_API_KEY')}`,
-        'content-type': 'application/json',
-        // TDR §7.3: the notification id is the idempotency key, so a run that
-        // times out after sending does not send again when it is retried.
-        'Idempotency-Key': built.notificationId,
-      },
-      body: JSON.stringify({
-        from: emailFrom(),
-        to: [built.to],
-        subject: built.subject,
-        html: built.html,
-        text: built.text,
-        headers: built.headers,
-      }),
+    outcome = await sendVia(emailProvider(), {
+      to: built.to,
+      subject: built.subject,
+      html: built.html,
+      text: built.text,
+      headers: built.headers,
+      key: built.notificationId,
     });
   } catch (unreachable) {
     return {
@@ -153,30 +368,23 @@ export async function sendEmail(built: BuiltEmail): Promise<EmailResult> {
     };
   }
 
-  const payload = (await response.json().catch(() => ({}))) as {
-    id?: string;
-    message?: string;
-    name?: string;
-  };
-
-  if (response.ok && payload.id) {
+  if (outcome.ok) {
     return {
       id: built.notificationId,
       status: 'sent',
-      resend_email_id: payload.id,
+      resend_email_id: outcome.messageId,
       template: built.template,
     };
   }
 
-  // 429 is the rate limit and 5xx is Resend having a bad minute. Both come back
-  // later; marking them failed would close the row and lose the notification,
-  // because the claim only ever looks at rows nothing has touched.
-  const transient = response.status === 429 || response.status >= 500;
+  // 429 is the rate limit and 5xx is the provider having a bad minute. Both come
+  // back later; marking them failed would close the row and lose the
+  // notification, because the claim only ever looks at rows nothing has touched.
   return {
     id: built.notificationId,
-    status: transient ? 'retry' : 'failed',
+    status: outcome.transient ? 'retry' : 'failed',
     template: built.template,
-    error: `${response.status} ${payload.name ?? ''} ${payload.message ?? ''}`.trim(),
+    error: outcome.error,
   };
 }
 
@@ -228,47 +436,32 @@ export async function buildCampaignFor(row: CampaignEmailRow): Promise<BuiltCamp
 }
 
 export async function sendCampaignEmail(built: BuiltCampaignEmail): Promise<CampaignSendResult> {
-  let response: Response;
+  let outcome: ProviderOutcome;
 
   try {
-    response = await fetch(RESEND_ENDPOINT, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${requiredEnv('RESEND_API_KEY')}`,
-        'content-type': 'application/json',
-        // The send row id is the idempotency key, so a run that times out after
-        // Resend accepted does not mail the same person a second copy.
-        'Idempotency-Key': built.sendId,
-      },
-      body: JSON.stringify({
-        from: emailFrom(),
-        to: [built.to],
-        subject: built.subject,
-        html: built.html,
-        text: built.text,
-        headers: built.headers,
-      }),
+    outcome = await sendVia(emailProvider(), {
+      to: built.to,
+      subject: built.subject,
+      html: built.html,
+      text: built.text,
+      headers: built.headers,
+      // The send row id, so a run that times out after the provider accepted
+      // does not mail the same person a second copy.
+      key: built.sendId,
     });
   } catch (unreachable) {
     return { id: built.sendId, status: 'retry', error: (unreachable as Error).message };
   }
 
-  const payload = (await response.json().catch(() => ({}))) as {
-    id?: string;
-    message?: string;
-    name?: string;
-  };
-
-  if (response.ok && payload.id) {
-    return { id: built.sendId, status: 'sent', resend_email_id: payload.id };
+  if (outcome.ok) {
+    return { id: built.sendId, status: 'sent', resend_email_id: outcome.messageId };
   }
 
   // 429 and 5xx come back later; marking them failed would close the row and
   // the person would never be re-picked. A permanent refusal is a real failure.
-  const transient = response.status === 429 || response.status >= 500;
   return {
     id: built.sendId,
-    status: transient ? 'retry' : 'failed',
-    error: `${response.status} ${payload.name ?? ''} ${payload.message ?? ''}`.trim(),
+    status: outcome.transient ? 'retry' : 'failed',
+    error: outcome.error,
   };
 }

--- a/supabase/functions/campaign-broadcast/index.ts
+++ b/supabase/functions/campaign-broadcast/index.ts
@@ -36,6 +36,8 @@ import {
 import {
   buildCampaignFor,
   pause,
+  emailKeyName,
+  emailSendable,
   sendCampaignEmail,
   SEND_SPACING_MS,
   type CampaignEmailRow,
@@ -67,11 +69,13 @@ serveWithCors(async (request) => {
 
     // Email off is a deployment that has not turned it on, and the console should
     // be told rather than left pressing a button that silently does nothing.
-    if (!Deno.env.get('RESEND_API_KEY') || !Deno.env.get('EMAIL_UNSUBSCRIBE_SECRET')) {
+    const sendable = emailSendable();
+    if (!sendable.ok) {
       throw new HttpError(
         503,
         'EMAIL_NOT_CONFIGURED',
-        'Email is not configured on this deployment — set RESEND_API_KEY and EMAIL_UNSUBSCRIBE_SECRET.',
+        sendable.reason ||
+          `Email is not configured on this deployment — set ${emailKeyName()} and EMAIL_UNSUBSCRIBE_SECRET.`,
       );
     }
 

--- a/supabase/functions/notify-fanout/handler.ts
+++ b/supabase/functions/notify-fanout/handler.ts
@@ -33,6 +33,7 @@ import { errorResponse, HttpError, json, type SupabaseClient } from '../_shared/
 import {
   buildFor,
   pause,
+  emailSendable,
   sendEmail,
   SEND_SPACING_MS,
   type EmailableRow,
@@ -219,8 +220,12 @@ export async function dispatchEmail(service: SupabaseClient): Promise<EmailSumma
   try {
     // No key configured is a deployment that has not turned email on, not a
     // fault. Claiming rows first would mark them queued and then strand them.
-    if (!Deno.env.get('RESEND_API_KEY') || !Deno.env.get('EMAIL_UNSUBSCRIBE_SECRET')) {
-      return empty;
+    // An empty reason is "email is simply not turned on here" — silent and not a
+    // fault. Anything else is a misconfiguration, and it is reported rather than
+    // read as "off", which is how mail stops for a week before anybody asks.
+    const sendable = emailSendable();
+    if (!sendable.ok) {
+      return sendable.reason ? { ...empty, error: sendable.reason } : empty;
     }
 
     const { data, error } = await service.rpc('baaki_claim_email_notifications', {


### PR DESCRIPTION
`EMAIL_PROVIDER` selects `resend` (default, unchanged) or `sendgrid`. Same
pattern as the voice provider seam, applied to mail.

## The shape

Both `sendEmail` and `sendCampaignEmail` now go through a single `sendVia()`.
That matters more than the adapter code: the rule this file exists for — **429
and 5xx come back later, anything else is a real failure** — is decided once and
applied to every provider. Duplicated per adapter it would drift, and getting it
backwards either drops a settlement confirmation or retries a dead address every
five minutes forever.

An unrecognised `EMAIL_PROVIDER` is refused rather than quietly defaulting. A
typo that keeps sending through the old provider is how a migration gets
declared done twice.

`emailConfigured()` replaces two hardcoded `RESEND_API_KEY` checks and asks the
*selected* provider which key it needs, so a deployment that has switched
providers doesn't read as unconfigured and silently stop mailing. Both callers
check it before claiming rows — a claimed row is one nothing looks at again, so
claiming a batch and then failing every send in it strands the lot.

## A defect caught in review of my own first pass

Success is now carried explicitly on the outcome rather than inferred from a
message id being present. Resend answers `200 {id}`; SendGrid answers **202 with
an empty body** and puts its id in a header it is not obliged to send. Reading
"no id" as "failed" would have marked delivered mail as failed and handed it
back to the queue as a retry — a duplicate send caused by the very code meant to
prevent one.

## Two real limits of the SendGrid path

**No idempotency key.** Resend takes `Idempotency-Key: <notification id>` and
TDR §7.3 leans on it so a run that times out *after* sending does not send again.
SendGrid has no equivalent — `batch_id` is scheduling, not dedupe.

The DB claim (`baaki_claim_email_notifications`) remains the primary guard, so
the exposure is narrow: a duplicate only if the function dies between SendGrid
accepting and the row being recorded. The id travels as `custom_args.waves_key`
so a duplicate can at least be *recognised* from delivery events. That is
detection, not prevention, and for settlement confirmations it is a real if rare
user-visible risk.

**Bounce ingest is Resend-only.** `email-events` verifies a Svix HMAC; SendGrid
signs its Event Webhook with ECDSA. Selecting `sendgrid` before that second
verification path exists freezes the suppression list — mail keeps going to
addresses that hard-bounced, which is how a sending reputation is lost. Recorded
in `_shared/README.md` rather than left as tribal knowledge.

## So: added, not switched

Resend stays the default and its behaviour is byte-identical to before this PR.
`EMAIL_PROVIDER=sendgrid` should not be set on a real deployment until the
webhook half lands — happy to do that as a follow-up.

## Verification

- 101 edge tests pass; `_shared/email.ts` is the deliberately network-bound layer
  with its logic in `@waves/core`, so the existing split is unchanged
- Repo-wide typecheck clean
- No migration, no client change, no new dependency


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added WhatsApp delivery for phone sign-in verification codes.
  - Added support for choosing between Resend and SendGrid for email delivery.

- **Bug Fixes**
  - Phone sign-in is no longer available during account registration.
  - Mistyped phone numbers can no longer automatically create new accounts.
  - Added safeguards limiting verification-code requests to four per phone number per day.
  - Improved handling of invalid phone numbers and delivery failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->