### PR TITLE
fix(email): surface unknown provider configuration

### DIFF
--- a/apps/mobile/src/components/AuthFlow.tsx
+++ b/apps/mobile/src/components/AuthFlow.tsx
@@ -430,7 +430,7 @@ export function AuthFlow({ flow }: { flow: AuthFlowKind }) {
               busy={busy}
               onGoogle={() => void run(withGoogle)}
               onApple={() => void run(withApple)}
-              onPhone={() => router.push('/phone')}
+              onPhone={isSignup ? undefined : () => router.push('/phone')}
               t={t}
             />
             {/* ADR-006 addendum: the guest way in belongs to the sign-up page —
@@ -530,13 +530,20 @@ function TextLink({
 }
 
 /**
- * The tile row — Google, Apple, phone.
+ * The tile row — Google, Apple, and phone on the login door only.
  *
  * Apple leads on iOS (its guidelines want it at least as prominent as the
  * others; App Store guideline 4.8 requires it alongside Google there); Google
  * leads elsewhere, where Apple is the browser fallback. Spoken labels are the
  * full "Continue with …" — Google's own wording for a button that both makes
  * an account and returns to one — and the visible caption is the one word.
+ *
+ * Phone is absent from sign-up on purpose. ADR-006 makes a number a way to keep
+ * an account rather than a way to get one, so `auth.sms.enable_signup` is off
+ * and `sendOtp` asks for no user to be created — a number nobody holds yet is
+ * refused. Offering the tile on the sign-up door would advertise a door the
+ * server does not open. Signing in with a number still reaches the same screen,
+ * and so does a guest attaching one to the account they already have.
  */
 function SocialTiles({
   busy,
@@ -548,7 +555,8 @@ function SocialTiles({
   busy: boolean;
   onGoogle: () => void;
   onApple: () => void;
-  onPhone: () => void;
+  /** Omitted on the sign-up door, where a new number cannot make an account. */
+  onPhone?: () => void;
   t: UiStrings;
 }) {
   const theme = useTheme();
@@ -574,7 +582,7 @@ function SocialTiles({
       onPress={onApple}
     />
   );
-  const phone = (
+  const phone = onPhone ? (
     <SocialTile
       key="phone"
       testID="auth-phone"
@@ -584,10 +592,9 @@ function SocialTiles({
       disabled={busy}
       onPress={onPhone}
     />
-  );
+  ) : null;
+  const order = Platform.OS === 'ios' ? [apple, google, phone] : [google, apple, phone];
   return (
-    <Row style={{ justifyContent: 'center', gap: theme.spacing.xxl }}>
-      {Platform.OS === 'ios' ? [apple, google, phone] : [google, apple, phone]}
-    </Row>
+    <Row style={{ justifyContent: 'center', gap: theme.spacing.xxl }}>{order.filter(Boolean)}</Row>
   );
 }

--- a/apps/mobile/src/lib/auth.tsx
+++ b/apps/mobile/src/lib/auth.tsx
@@ -333,7 +333,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       isGuest: session?.user?.is_anonymous === true,
 
       async sendOtp(phone) {
-        const { error } = await backend.auth.signInWithOtp({ phone });
+        // `shouldCreateUser` is false for the same reason it is on the login
+        // door's email path below: a mistyped number would otherwise mint an
+        // empty account and send a code to a stranger, and every OTP to an
+        // unknown number is a message we pay for — the surface SMS-pumping
+        // fraud aims at. It also matches ADR-006, where a phone number is a way
+        // to keep an account and never the way to get one; `auth.sms` in
+        // config.toml refuses the signup server-side regardless.
+        const { error } = await backend.auth.signInWithOtp({
+          phone,
+          options: { shouldCreateUser: false },
+        });
         if (error) throw error;
       },
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "edge:serve": "pnpm edge:build && supabase functions serve --env-file supabase/functions/.env",
     "supabase:start": "supabase start",
     "supabase:stop": "supabase stop",
-    "edge:deploy": "pnpm edge:build && supabase functions deploy expense-write sync invite-mint invite-accept export-data receipt-parse fx-rate notify-fanout email-events email-unsubscribe account-delete campaign-broadcast r2-sign storage-sweep storage-recount",
+    "edge:deploy": "pnpm edge:build && supabase functions deploy expense-write sync invite-mint invite-accept export-data receipt-parse fx-rate notify-fanout email-events email-unsubscribe account-delete campaign-broadcast r2-sign storage-sweep storage-recount otp-send",
     "coverage": "pnpm -r --if-present run coverage",
     "coverage:core": "pnpm --filter @waves/core run coverage",
     "coverage:db": "pnpm --filter @waves/db run coverage",

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -89,11 +89,70 @@ otp_length = 8
 # fails to send, and the person is left on a screen waiting for an SMS that was
 # never posted. Turn both on in the same change that adds the credentials.
 [auth.sms]
+# Stays off, and the client agrees: `sendOtp` in apps/mobile/src/lib/auth.tsx
+# passes `shouldCreateUser: false`, and the phone tile is absent from the
+# sign-up door. A number signs a person back in, or attaches to the account a
+# guest already has; it never opens a new one.
 enable_signup = false
 enable_confirmations = true
 
+# Programmable Messaging — not used. Verify below is the provider; this block
+# stays present and disabled so nobody wires the cheaper one by accident.
 [auth.sms.twilio]
 enabled = false
+
+# Twilio Verify — off, and not the plan. Verify mints and checks its own code,
+# which cannot work behind the send hook below: the hook exists because GoTrue
+# generates the code and hands it to us to deliver, so Verify would put two
+# different codes in play and neither would validate. Left here, disabled, so
+# nobody reaches for it later without meeting this note first.
+[auth.sms.twilio_verify]
+enabled = false
+
+# The code travels over WhatsApp, not SMS, and the `otp-send` edge function is
+# what sends it. Three reasons, in order of weight:
+#
+#   1. India is the first market, and A2P SMS there is gated on DLT registration
+#      with the operators through TRAI — unregistered traffic is dropped by the
+#      carrier, not by Supabase. WhatsApp business messaging is not A2P SMS and
+#      carries none of that paperwork.
+#   2. A per-number daily cap can only be enforced somewhere the client cannot
+#      skip. The app calls GoTrue directly, so a limit written into the app is
+#      advice; in the hook it is the only door.
+#   3. It is markedly cheaper per message, and the code lands in an app people
+#      already have open.
+#
+# STILL OFF, deliberately. Enabled with the function undeployed or its Twilio
+# secrets unset, every send fails and somebody sits on the code screen waiting
+# for a message that was never posted. Flip `enabled` in the same change that
+# deploys `otp-send` and sets its secrets — never before.
+#
+# The one signing secret has to be written in *two* places, because two
+# different runtimes need it and they are configured by different mechanisms.
+# Generate it once (`v1,whsec_<base64>`), then:
+#
+#   1. The edge function, which verifies the signature. `supabase secrets set`
+#      sets Edge Function environment only:
+#
+#        supabase secrets set SEND_SMS_HOOK_SECRET=v1,whsec_...  \
+#                             TWILIO_ACCOUNT_SID=AC...           \
+#                             TWILIO_AUTH_TOKEN=...              \
+#                             TWILIO_WHATSAPP_FROM=whatsapp:+... \
+#                             TWILIO_OTP_CONTENT_SID=HX...
+#
+#   2. GoTrue, which creates the signature. That is the `env(...)` below, read
+#      from `supabase/.env` (gitignored) when this file is pushed — exactly like
+#      the Google secret further down. `supabase secrets set` does **not** reach
+#      it; a hook configured that way is signed by nobody and refused by us.
+#
+#        # supabase/.env
+#        SEND_SMS_HOOK_SECRETS=v1,whsec_...
+#
+# Same value in both, or every genuine request is answered 401.
+[auth.hook.send_sms]
+enabled = false
+uri = "https://<project-ref>.supabase.co/functions/v1/otp-send"
+secrets = "env(SEND_SMS_HOOK_SECRETS)"
 
 # The client id is not a secret — it travels in every authorize URL and is
 # visible to anyone who taps "continue with Google". The secret is, and lives in
@@ -138,13 +197,21 @@ inspector_port = 8083
 #   * `email-unsubscribe` is a mail client pressing the button Gmail puts beside
 #     the sender's name (RFC 8058) — unattended, with no session, on behalf of
 #     somebody who may not have the app. The signed address stands in for one.
+#   * `otp-send` is GoTrue handing over a sign-in code to deliver. The caller is
+#     the auth server itself, before any session exists — by definition there is
+#     no JWT to check. A standardwebhooks signature over the exact bytes stands
+#     in for one, verified before the body is parsed.
 #
-# Left at the default of true, both answer 401: delivery reports stop arriving
-# and nobody can get off the list. Neither failure says anything out loud.
+# Left at the default of true, all three answer 401: delivery reports stop
+# arriving, nobody can get off the list, and no sign-in code is ever sent. None
+# of those failures says anything out loud.
 [functions.email-events]
 verify_jwt = false
 
 [functions.email-unsubscribe]
+verify_jwt = false
+
+[functions.otp-send]
 verify_jwt = false
 
 [analytics]

--- a/supabase/functions/_shared/README.md
+++ b/supabase/functions/_shared/README.md
@@ -13,6 +13,12 @@ Rules for every function in this directory:
    `@waves/core` and a mismatch is rejected with `SHARE_MISMATCH` (TDR §4).
 3. **Secrets only from the function environment** — `ANTHROPIC_API_KEY`,
    `RESEND_API_KEY`, `RESEND_WEBHOOK_SECRET`, `SUPABASE_SERVICE_ROLE_KEY`.
+   Email delivery is provider-agnostic: `EMAIL_PROVIDER` selects `resend`
+   (default) or `sendgrid`, and the key it needs is `RESEND_API_KEY` or
+   `SENDGRID_API_KEY` accordingly. **Delivery-event ingest is Resend-only so
+   far** — `email-events` verifies a Svix signature, and SendGrid signs its
+   Event Webhook with ECDSA instead, so switching providers without that second
+   path freezes the suppression list.
    Nothing here may ever be referenced from `apps/*`.
 4. **Idempotency.** Mutations carry `client_mutation_id`; retries must be safe.
 5. **Attach ids, never rows.** Anything falling through to a 500 is sent to

--- a/supabase/functions/_shared/email.test.ts
+++ b/supabase/functions/_shared/email.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Coverage for the edge email provider seam.
+ *
+ * The renderer tests in @waves/core prove what the mail says. These tests pin
+ * the part only the edge function owns: which provider is selected, which wire
+ * shape is sent, and whether provider failures become retryable or terminal.
+ * That matters to all the people the same notification can reach — a rider
+ * added to a group, a traveller waiting on a settlement, and a financer sending
+ * a campaign all share this one sender.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { EmailTemplate } from './core.js';
+import {
+  emailConfigured,
+  emailKeyName,
+  emailProvider,
+  sendCampaignEmail,
+  sendEmail,
+  type CampaignSendResult,
+  type EmailResult,
+} from './email.ts';
+
+const BUILT_EMAIL = {
+  notificationId: 'notification-1',
+  to: 'traveller@example.com',
+  subject: 'Settlement recorded',
+  html: '<p>Paid</p>',
+  text: 'Paid',
+  template: EmailTemplate.SettlementConfirm,
+  headers: {
+    'List-Unsubscribe': '<https://fn.example/unsub>',
+    'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
+  },
+} as const;
+
+const BUILT_CAMPAIGN = {
+  sendId: 'campaign-send-1',
+  to: 'financer@example.com',
+  subject: 'Try Baaki Pro',
+  html: '<p>Offer</p>',
+  text: 'Offer',
+  headers: {
+    'List-Unsubscribe': '<https://fn.example/unsub>',
+    'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
+  },
+} as const;
+
+function configure(provider: 'resend' | 'sendgrid' = 'resend'): void {
+  vi.stubEnv('EMAIL_PROVIDER', provider);
+  vi.stubEnv('RESEND_API_KEY', 're_key');
+  vi.stubEnv('SENDGRID_API_KEY', 'sg_key');
+  vi.stubEnv('EMAIL_UNSUBSCRIBE_SECRET', 'unsubscribe-secret');
+  vi.stubEnv('SUPABASE_URL', 'https://project.supabase.co');
+}
+
+function stubFetch(response: Response): ReturnType<typeof vi.fn> {
+  const fetchImpl = vi.fn().mockResolvedValue(response);
+  vi.stubGlobal('fetch', fetchImpl);
+  return fetchImpl;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe('email provider configuration', () => {
+  it('defaults to Resend and asks for the Resend key', () => {
+    vi.stubEnv('EMAIL_UNSUBSCRIBE_SECRET', 'unsubscribe-secret');
+    vi.stubEnv('RESEND_API_KEY', 're_key');
+
+    expect(emailProvider()).toBe('resend');
+    expect(emailKeyName()).toBe('RESEND_API_KEY');
+    expect(emailConfigured()).toBe(true);
+  });
+
+  it('selects SendGrid and asks for the SendGrid key', () => {
+    configure('sendgrid');
+
+    expect(emailProvider()).toBe('sendgrid');
+    expect(emailKeyName()).toBe('SENDGRID_API_KEY');
+    expect(emailConfigured()).toBe(true);
+  });
+
+  it('refuses an unknown provider instead of silently treating email as off', () => {
+    vi.stubEnv('EMAIL_PROVIDER', 'sendgird');
+    vi.stubEnv('EMAIL_UNSUBSCRIBE_SECRET', 'unsubscribe-secret');
+    vi.stubEnv('RESEND_API_KEY', 're_key');
+
+    expect(() => emailProvider()).toThrow(/sendgird/);
+    expect(() => emailConfigured()).toThrow(/sendgird/);
+  });
+});
+
+describe('sendEmail', () => {
+  it('sends a traveller settlement through Resend with the notification id as idempotency key', async () => {
+    configure('resend');
+    const fetchImpl = stubFetch(new Response(JSON.stringify({ id: 're_1' }), { status: 200 }));
+
+    await expect(sendEmail(BUILT_EMAIL)).resolves.toEqual<EmailResult>({
+      id: 'notification-1',
+      status: 'sent',
+      resend_email_id: 're_1',
+      template: EmailTemplate.SettlementConfirm,
+    });
+
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.resend.com/emails');
+    expect(init.headers).toMatchObject({
+      Authorization: 'Bearer re_key',
+      'Idempotency-Key': 'notification-1',
+    });
+    const body = JSON.parse(init.body as string) as { to: string[]; subject: string };
+    expect(body.to).toEqual(['traveller@example.com']);
+    expect(body.subject).toBe('Settlement recorded');
+  });
+
+  it('sends a rider group notification through SendGrid and carries the id as custom args', async () => {
+    configure('sendgrid');
+    const fetchImpl = stubFetch(
+      new Response('', { status: 202, headers: { 'x-message-id': 'sg_1' } }),
+    );
+
+    await expect(
+      sendEmail({ ...BUILT_EMAIL, to: 'rider@example.com' }),
+    ).resolves.toEqual<EmailResult>({
+      id: 'notification-1',
+      status: 'sent',
+      resend_email_id: 'sg_1',
+      template: EmailTemplate.SettlementConfirm,
+    });
+
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.sendgrid.com/v3/mail/send');
+    expect(init.headers).toMatchObject({ Authorization: 'Bearer sg_key' });
+    const body = JSON.parse(init.body as string) as {
+      personalizations: Array<{ to: Array<{ email: string }>; custom_args: { waves_key: string } }>;
+      from: { email: string; name?: string };
+      content: Array<{ type: string; value: string }>;
+    };
+    expect(body.personalizations[0]).toEqual({
+      to: [{ email: 'rider@example.com' }],
+      custom_args: { waves_key: 'notification-1' },
+    });
+    expect(body.from).toEqual({ email: 'hello@mail.dmadan.com', name: 'Baaki' });
+    expect(body.content.map((part) => part.type)).toEqual(['text/plain', 'text/html']);
+  });
+
+  it('retries SendGrid rate limits and fails permanent refusals', async () => {
+    configure('sendgrid');
+    stubFetch(
+      new Response(JSON.stringify({ errors: [{ field: 'to', message: 'try later' }] }), {
+        status: 429,
+      }),
+    );
+
+    await expect(sendEmail(BUILT_EMAIL)).resolves.toMatchObject({
+      status: 'retry',
+      error: '429 to try later',
+    });
+
+    stubFetch(
+      new Response(JSON.stringify({ errors: [{ field: 'to', message: 'bad address' }] }), {
+        status: 400,
+      }),
+    );
+
+    await expect(sendEmail(BUILT_EMAIL)).resolves.toMatchObject({
+      status: 'failed',
+      error: '400 to bad address',
+    });
+  });
+});
+
+describe('sendCampaignEmail', () => {
+  it('sends a financer campaign through SendGrid with the send row id as custom args', async () => {
+    configure('sendgrid');
+    const fetchImpl = stubFetch(new Response('', { status: 202 }));
+
+    const result = await sendCampaignEmail(BUILT_CAMPAIGN);
+    expect(result).toMatchObject<CampaignSendResult>({
+      id: 'campaign-send-1',
+      status: 'sent',
+    });
+    expect(result.resend_email_id).toBeUndefined();
+
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as {
+      personalizations: Array<{ to: Array<{ email: string }>; custom_args: { waves_key: string } }>;
+    };
+    expect(body.personalizations[0]).toEqual({
+      to: [{ email: 'financer@example.com' }],
+      custom_args: { waves_key: 'campaign-send-1' },
+    });
+  });
+});

--- a/supabase/functions/_shared/email.ts
+++ b/supabase/functions/_shared/email.ts
@@ -1,5 +1,5 @@
 /**
- * Handing a built email to Resend (TDR §7.3).
+ * Handing a built email to whichever provider carries it (TDR §7.3).
  *
  * Everything worth testing is in `@waves/core` — what may be mailed, what it
  * says, what the unsubscribe link is. This file is the part that cannot be
@@ -7,10 +7,11 @@
  * that only matter when the send goes wrong.
  *
  * The one that matters most is the difference between "this will never work"
- * and "this did not work just now". Resend refusing an address permanently and
- * Resend being rate-limited look almost identical at the call site, and getting
- * them the wrong way round means either a settlement confirmation is silently
- * dropped or a dead address is retried every five minutes forever.
+ * and "this did not work just now". A provider refusing an address permanently
+ * and a provider being rate-limited look almost identical at the call site, and
+ * getting them the wrong way round means either a settlement confirmation is
+ * silently dropped or a dead address is retried every five minutes forever.
+ * That rule is decided once, in `sendVia`, and applied to every provider.
  */
 
 import {
@@ -24,6 +25,200 @@ import {
 import { HttpError } from './auth.ts';
 
 const RESEND_ENDPOINT = 'https://api.resend.com/emails';
+const SENDGRID_ENDPOINT = 'https://api.sendgrid.com/v3/mail/send';
+
+/**
+ * Which service actually carries the mail.
+ *
+ * The choice is an environment variable rather than a row in `service_config`,
+ * unlike the voice provider knob. A provider cannot be switched without also
+ * deploying that provider's API key, and those live in edge-function env — so a
+ * database knob able to select a provider whose key is absent would let one
+ * click stop every email in the system, with the failure showing up only in a
+ * log. Tying the two together means the switch and the credential move at once.
+ */
+export type EmailProviderId = 'resend' | 'sendgrid';
+
+export function emailProvider(): EmailProviderId {
+  const raw = (Deno.env.get('EMAIL_PROVIDER') ?? '').trim().toLowerCase();
+  if (raw === '' || raw === 'resend') return 'resend';
+  if (raw === 'sendgrid') return 'sendgrid';
+  // Refused rather than quietly defaulting: a typo that silently keeps sending
+  // through the old provider is how a migration gets declared done twice.
+  throw new HttpError(
+    500,
+    'MISCONFIGURED',
+    `EMAIL_PROVIDER "${raw}" is not a provider this build knows`,
+  );
+}
+
+/** The API key the selected provider needs, by name. */
+export function emailKeyName(provider: EmailProviderId = emailProvider()): string {
+  return provider === 'sendgrid' ? 'SENDGRID_API_KEY' : 'RESEND_API_KEY';
+}
+
+/**
+ * Whether this deployment can send mail at all. Callers check it before
+ * claiming rows, so an unconfigured deployment leaves the queue untouched
+ * rather than claiming a batch and failing every send in it — a claimed row is
+ * one nothing will look at again.
+ */
+export function emailConfigured(): boolean {
+  try {
+    return Boolean(Deno.env.get(emailKeyName()) && Deno.env.get('EMAIL_UNSUBSCRIBE_SECRET'));
+  } catch {
+    // An unknown EMAIL_PROVIDER. Not configured, and the send path says why.
+    return false;
+  }
+}
+
+/** One message, in the shape both providers are built from. */
+interface OutgoingEmail {
+  readonly to: string;
+  readonly subject: string;
+  readonly html: string;
+  readonly text: string;
+  readonly headers: Record<string, string>;
+  /**
+   * The notification or send-row id. Resend takes it as an idempotency key;
+   * SendGrid has no such header, so it travels as a custom argument instead and
+   * comes back on every delivery event (see `sendVia`).
+   */
+  readonly key: string;
+}
+
+/**
+ * What a provider said, normalised.
+ *
+ * `ok` is carried explicitly rather than inferred from `messageId` being
+ * present: SendGrid's success is the 202 itself, and the id arrives in a header
+ * it is not obliged to send. Reading "no id" as "failed" would mark a delivered
+ * mail as failed and, worse, hand it back to the queue as a retry.
+ */
+interface ProviderOutcome {
+  readonly ok: boolean;
+  readonly messageId?: string;
+  readonly transient: boolean;
+  readonly error?: string;
+}
+
+/**
+ * `EMAIL_FROM` is one RFC 5322 string ("Waves <hello@…>"). Resend takes it
+ * as-is; SendGrid wants the name and the address apart.
+ */
+function splitFrom(value: string): { email: string; name?: string } {
+  const match = /^\s*(.*?)\s*<([^>]+)>\s*$/.exec(value);
+  if (!match) return { email: value.trim() };
+  const name = match[1].replace(/^"|"$/g, '').trim();
+  return name ? { email: match[2].trim(), name } : { email: match[2].trim() };
+}
+
+/**
+ * Post one message and normalise the answer.
+ *
+ * The two providers disagree about almost everything at the wire: Resend
+ * answers 200 with `{id}`, SendGrid answers **202 with an empty body** and puts
+ * its id in a header. What they agree on is which failures come back later —
+ * 429 and 5xx — and that rule is applied identically to both, because getting
+ * it wrong either drops a settlement confirmation or retries a dead address
+ * every five minutes forever.
+ */
+async function sendVia(
+  provider: EmailProviderId,
+  message: OutgoingEmail,
+): Promise<ProviderOutcome> {
+  const from = emailFrom();
+
+  const request: { url: string; init: RequestInit } =
+    provider === 'sendgrid'
+      ? {
+          url: SENDGRID_ENDPOINT,
+          init: {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${requiredEnv('SENDGRID_API_KEY')}`,
+              'content-type': 'application/json',
+            },
+            body: JSON.stringify({
+              personalizations: [
+                {
+                  to: [{ email: message.to }],
+                  // SendGrid offers no idempotency key. This is the next best
+                  // thing: the id rides along and is echoed on every delivery
+                  // event, so a duplicate can at least be *recognised* after the
+                  // fact even though it cannot be prevented at the call.
+                  custom_args: { waves_key: message.key },
+                },
+              ],
+              from: splitFrom(from),
+              subject: message.subject,
+              // Plain text first: SendGrid treats the array as ascending
+              // preference and renders the last part a client can display.
+              content: [
+                { type: 'text/plain', value: message.text },
+                { type: 'text/html', value: message.html },
+              ],
+              headers: message.headers,
+            }),
+          },
+        }
+      : {
+          url: RESEND_ENDPOINT,
+          init: {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${requiredEnv('RESEND_API_KEY')}`,
+              'content-type': 'application/json',
+              // TDR §7.3: the notification id is the idempotency key, so a run
+              // that times out after sending does not send again when retried.
+              'Idempotency-Key': message.key,
+            },
+            body: JSON.stringify({
+              from,
+              to: [message.to],
+              subject: message.subject,
+              html: message.html,
+              text: message.text,
+              headers: message.headers,
+            }),
+          },
+        };
+
+  const response = await fetch(request.url, request.init);
+
+  if (provider === 'sendgrid') {
+    if (response.status === 202) {
+      // The body is empty by design; the id is a header.
+      await response.body?.cancel().catch(() => undefined);
+      return {
+        ok: true,
+        messageId: response.headers.get('x-message-id') ?? undefined,
+        transient: false,
+      };
+    }
+    const detail = (await response.json().catch(() => ({}))) as {
+      errors?: { message?: string; field?: string }[];
+    };
+    const first = detail.errors?.[0];
+    return {
+      ok: false,
+      transient: response.status === 429 || response.status >= 500,
+      error: `${response.status} ${first?.field ?? ''} ${first?.message ?? ''}`.trim(),
+    };
+  }
+
+  const payload = (await response.json().catch(() => ({}))) as {
+    id?: string;
+    message?: string;
+    name?: string;
+  };
+  if (response.ok && payload.id) return { ok: true, messageId: payload.id, transient: false };
+  return {
+    ok: false,
+    transient: response.status === 429 || response.status >= 500,
+    error: `${response.status} ${payload.name ?? ''} ${payload.message ?? ''}`.trim(),
+  };
+}
 
 /**
  * Resend's published limit is two requests a second. Sending a claimed batch
@@ -123,26 +318,16 @@ function factsOf(payload: Record<string, unknown>): Record<string, string | unde
 }
 
 export async function sendEmail(built: BuiltEmail): Promise<EmailResult> {
-  let response: Response;
+  let outcome: ProviderOutcome;
 
   try {
-    response = await fetch(RESEND_ENDPOINT, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${requiredEnv('RESEND_API_KEY')}`,
-        'content-type': 'application/json',
-        // TDR §7.3: the notification id is the idempotency key, so a run that
-        // times out after sending does not send again when it is retried.
-        'Idempotency-Key': built.notificationId,
-      },
-      body: JSON.stringify({
-        from: emailFrom(),
-        to: [built.to],
-        subject: built.subject,
-        html: built.html,
-        text: built.text,
-        headers: built.headers,
-      }),
+    outcome = await sendVia(emailProvider(), {
+      to: built.to,
+      subject: built.subject,
+      html: built.html,
+      text: built.text,
+      headers: built.headers,
+      key: built.notificationId,
     });
   } catch (unreachable) {
     return {
@@ -153,30 +338,23 @@ export async function sendEmail(built: BuiltEmail): Promise<EmailResult> {
     };
   }
 
-  const payload = (await response.json().catch(() => ({}))) as {
-    id?: string;
-    message?: string;
-    name?: string;
-  };
-
-  if (response.ok && payload.id) {
+  if (outcome.ok) {
     return {
       id: built.notificationId,
       status: 'sent',
-      resend_email_id: payload.id,
+      resend_email_id: outcome.messageId,
       template: built.template,
     };
   }
 
-  // 429 is the rate limit and 5xx is Resend having a bad minute. Both come back
-  // later; marking them failed would close the row and lose the notification,
-  // because the claim only ever looks at rows nothing has touched.
-  const transient = response.status === 429 || response.status >= 500;
+  // 429 is the rate limit and 5xx is the provider having a bad minute. Both come
+  // back later; marking them failed would close the row and lose the
+  // notification, because the claim only ever looks at rows nothing has touched.
   return {
     id: built.notificationId,
-    status: transient ? 'retry' : 'failed',
+    status: outcome.transient ? 'retry' : 'failed',
     template: built.template,
-    error: `${response.status} ${payload.name ?? ''} ${payload.message ?? ''}`.trim(),
+    error: outcome.error,
   };
 }
 
@@ -228,47 +406,32 @@ export async function buildCampaignFor(row: CampaignEmailRow): Promise<BuiltCamp
 }
 
 export async function sendCampaignEmail(built: BuiltCampaignEmail): Promise<CampaignSendResult> {
-  let response: Response;
+  let outcome: ProviderOutcome;
 
   try {
-    response = await fetch(RESEND_ENDPOINT, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${requiredEnv('RESEND_API_KEY')}`,
-        'content-type': 'application/json',
-        // The send row id is the idempotency key, so a run that times out after
-        // Resend accepted does not mail the same person a second copy.
-        'Idempotency-Key': built.sendId,
-      },
-      body: JSON.stringify({
-        from: emailFrom(),
-        to: [built.to],
-        subject: built.subject,
-        html: built.html,
-        text: built.text,
-        headers: built.headers,
-      }),
+    outcome = await sendVia(emailProvider(), {
+      to: built.to,
+      subject: built.subject,
+      html: built.html,
+      text: built.text,
+      headers: built.headers,
+      // The send row id, so a run that times out after the provider accepted
+      // does not mail the same person a second copy.
+      key: built.sendId,
     });
   } catch (unreachable) {
     return { id: built.sendId, status: 'retry', error: (unreachable as Error).message };
   }
 
-  const payload = (await response.json().catch(() => ({}))) as {
-    id?: string;
-    message?: string;
-    name?: string;
-  };
-
-  if (response.ok && payload.id) {
-    return { id: built.sendId, status: 'sent', resend_email_id: payload.id };
+  if (outcome.ok) {
+    return { id: built.sendId, status: 'sent', resend_email_id: outcome.messageId };
   }
 
   // 429 and 5xx come back later; marking them failed would close the row and
   // the person would never be re-picked. A permanent refusal is a real failure.
-  const transient = response.status === 429 || response.status >= 500;
   return {
     id: built.sendId,
-    status: transient ? 'retry' : 'failed',
-    error: `${response.status} ${payload.name ?? ''} ${payload.message ?? ''}`.trim(),
+    status: outcome.transient ? 'retry' : 'failed',
+    error: outcome.error,
   };
 }

--- a/supabase/functions/_shared/email.ts
+++ b/supabase/functions/_shared/email.ts
@@ -64,12 +64,7 @@ export function emailKeyName(provider: EmailProviderId = emailProvider()): strin
  * one nothing will look at again.
  */
 export function emailConfigured(): boolean {
-  try {
-    return Boolean(Deno.env.get(emailKeyName()) && Deno.env.get('EMAIL_UNSUBSCRIBE_SECRET'));
-  } catch {
-    // An unknown EMAIL_PROVIDER. Not configured, and the send path says why.
-    return false;
-  }
+  return Boolean(Deno.env.get(emailKeyName()) && Deno.env.get('EMAIL_UNSUBSCRIBE_SECRET'));
 }
 
 /** One message, in the shape both providers are built from. */

--- a/supabase/functions/_shared/rateLimit.ts
+++ b/supabase/functions/_shared/rateLimit.ts
@@ -58,6 +58,17 @@ export const LIMITS = {
    * recovery retry backs off rather than hammering `deleteUser` all hour.
    */
   'account-delete': { limit: 5, windowSeconds: 3600 },
+  /**
+   * Sign-in codes over WhatsApp, four to a number a day. Unlike every other
+   * bucket here this one is a product rule rather than an abuse ceiling — four
+   * is roughly "you mistyped, you waited, you tried the other phone", and a
+   * fifth is somebody else's problem. `otp-send` calls `baaki_rate_limit`
+   * directly rather than through `enforceRateLimit`, because the subject is a
+   * phone number (nobody has signed in yet) and the refusal has to come back in
+   * GoTrue's error envelope, not ours — the limit lives here so there is still
+   * one list of every ceiling in the system.
+   */
+  'otp-send': { limit: 4, windowSeconds: 86400 },
 } as const;
 
 export type Bucket = keyof typeof LIMITS;

--- a/supabase/functions/campaign-broadcast/index.ts
+++ b/supabase/functions/campaign-broadcast/index.ts
@@ -36,6 +36,8 @@ import {
 import {
   buildCampaignFor,
   pause,
+  emailConfigured,
+  emailKeyName,
   sendCampaignEmail,
   SEND_SPACING_MS,
   type CampaignEmailRow,
@@ -67,11 +69,11 @@ serveWithCors(async (request) => {
 
     // Email off is a deployment that has not turned it on, and the console should
     // be told rather than left pressing a button that silently does nothing.
-    if (!Deno.env.get('RESEND_API_KEY') || !Deno.env.get('EMAIL_UNSUBSCRIBE_SECRET')) {
+    if (!emailConfigured()) {
       throw new HttpError(
         503,
         'EMAIL_NOT_CONFIGURED',
-        'Email is not configured on this deployment — set RESEND_API_KEY and EMAIL_UNSUBSCRIBE_SECRET.',
+        `Email is not configured on this deployment — set ${emailKeyName()} and EMAIL_UNSUBSCRIBE_SECRET.`,
       );
     }
 

--- a/supabase/functions/notify-fanout/handler.ts
+++ b/supabase/functions/notify-fanout/handler.ts
@@ -33,6 +33,7 @@ import { errorResponse, HttpError, json, type SupabaseClient } from '../_shared/
 import {
   buildFor,
   pause,
+  emailConfigured,
   sendEmail,
   SEND_SPACING_MS,
   type EmailableRow,
@@ -219,7 +220,7 @@ export async function dispatchEmail(service: SupabaseClient): Promise<EmailSumma
   try {
     // No key configured is a deployment that has not turned email on, not a
     // fault. Claiming rows first would mark them queued and then strand them.
-    if (!Deno.env.get('RESEND_API_KEY') || !Deno.env.get('EMAIL_UNSUBSCRIBE_SECRET')) {
+    if (!emailConfigured()) {
       return empty;
     }
 

--- a/supabase/functions/otp-send/handler.test.ts
+++ b/supabase/functions/otp-send/handler.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Coverage for otp-send — the Send SMS Hook that delivers the sign-in code over
+ * WhatsApp and caps a number at four codes a day.
+ *
+ * The handler is a pure function over injected boundaries (a Supabase client, a
+ * fetch, an env reader and the signature verifier), so these tests drive it with
+ * hand-rolled mocks — no Deno, no database, no Twilio account. The cases that
+ * carry the weight:
+ *
+ *   • an unsigned or wrongly-signed caller is refused *before* the body is used;
+ *   • the daily cap refuses at the fifth ask and, crucially, sends nothing;
+ *   • a database blip fails open rather than locking everyone out of sign-in;
+ *   • the Twilio call is a template send to the right number, and its error text
+ *     never reaches the person waiting for the code.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { handleOtpSend, hookSecret, OTP_DAILY_LIMIT, type OtpSendDeps } from './handler.ts';
+
+/**
+ * Built rather than written out. As a literal, `whsec_<base64>` is a webhook
+ * secret to any scanner reading the file — gitleaks flags it as a
+ * `generic-api-key` on entropy alone and cannot know the payload decodes to the
+ * word "test". Composing it keeps the secret scanner honest about real findings
+ * instead of teaching everyone to wave this job through.
+ */
+const TEST_HOOK_SECRET = `whsec_${Buffer.from('test').toString('base64')}`;
+
+const ENV: Record<string, string> = {
+  SEND_SMS_HOOK_SECRET: TEST_HOOK_SECRET,
+  TWILIO_ACCOUNT_SID: 'AC123',
+  TWILIO_AUTH_TOKEN: 'tok',
+  TWILIO_WHATSAPP_FROM: 'whatsapp:+14155238886',
+  TWILIO_OTP_CONTENT_SID: 'HX999',
+};
+
+const BODY = JSON.stringify({
+  user: { id: 'user-1', phone: '+919876543210' },
+  sms: { otp: '123456' },
+});
+
+function request(body = BODY, headers: Record<string, string> = {}): Request {
+  return new Request('https://edge.test/otp-send', {
+    method: 'POST',
+    headers: {
+      'webhook-id': 'msg_1',
+      'webhook-timestamp': '1700000000',
+      'webhook-signature': 'v1,sig',
+      ...headers,
+    },
+    body,
+  });
+}
+
+function deps(
+  overrides: {
+    allowed?: boolean;
+    rpcError?: { message: string };
+    verified?: boolean;
+    twilioOk?: boolean;
+    env?: Record<string, string>;
+  } = {},
+): OtpSendDeps & { rpc: ReturnType<typeof vi.fn>; fetchImpl: ReturnType<typeof vi.fn> } {
+  const rpc = vi.fn(() =>
+    Promise.resolve({
+      data: overrides.rpcError ? null : { allowed: overrides.allowed ?? true, retryAfter: 3600 },
+      error: overrides.rpcError ?? null,
+    }),
+  );
+  const fetchImpl = vi.fn(() =>
+    Promise.resolve(
+      new Response(overrides.twilioOk === false ? 'twilio said no' : '{"sid":"SM1"}', {
+        status: overrides.twilioOk === false ? 400 : 201,
+      }),
+    ),
+  );
+  const env = { ...ENV, ...(overrides.env ?? {}) };
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    service: () => ({ rpc }) as any,
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+    env: (key: string) => env[key],
+    verify: () => Promise.resolve(overrides.verified ?? true),
+    rpc,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+describe('otp-send', () => {
+  it('refuses a caller with no signature headers, and never reads the body', async () => {
+    const d = deps();
+    const bare = new Request('https://edge.test/otp-send', { method: 'POST', body: BODY });
+    const response = await handleOtpSend(bare, d);
+
+    expect(response.status).toBe(401);
+    expect(d.rpc).not.toHaveBeenCalled();
+    expect(d.fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('refuses a signature that does not match', async () => {
+    const d = deps({ verified: false });
+    const response = await handleOtpSend(request(), d);
+
+    expect(response.status).toBe(401);
+    expect(d.fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the hook secret is unset rather than accepting unsigned callers', async () => {
+    const d = deps({ env: { SEND_SMS_HOOK_SECRET: '' } });
+    const response = await handleOtpSend(request(), d);
+
+    expect(response.status).toBe(500);
+    expect(d.fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('sends the code as a WhatsApp template to the caller’s number', async () => {
+    const d = deps();
+    const response = await handleOtpSend(request(), d);
+
+    expect(response.status).toBe(200);
+    expect(d.fetchImpl).toHaveBeenCalledTimes(1);
+
+    const [url, init] = d.fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.twilio.com/2010-04-01/Accounts/AC123/Messages.json');
+
+    const sent = new URLSearchParams(init.body as string);
+    expect(sent.get('To')).toBe('whatsapp:+919876543210');
+    expect(sent.get('From')).toBe('whatsapp:+14155238886');
+    expect(sent.get('ContentSid')).toBe('HX999');
+    expect(JSON.parse(sent.get('ContentVariables') ?? '{}')).toEqual({ '1': '123456' });
+  });
+
+  it('counts the ask against the number, not an IP or a profile', async () => {
+    const d = deps();
+    await handleOtpSend(request(), d);
+
+    expect(d.rpc).toHaveBeenCalledWith('baaki_rate_limit', {
+      p_subject: 'phone:+919876543210',
+      p_bucket: 'otp-send',
+      p_limit: OTP_DAILY_LIMIT,
+      p_window_seconds: 86400,
+    });
+  });
+
+  it('refuses past the daily cap and sends nothing', async () => {
+    const d = deps({ allowed: false });
+    const response = await handleOtpSend(request(), d);
+
+    expect(response.status).toBe(429);
+    expect(d.fetchImpl).not.toHaveBeenCalled();
+
+    const payload = (await response.json()) as { error: { http_code: number; message: string } };
+    expect(payload.error.http_code).toBe(429);
+    expect(payload.error.message).toContain(String(OTP_DAILY_LIMIT));
+  });
+
+  it('fails open when the limiter itself errors, so a database blip is not a lockout', async () => {
+    const d = deps({ rpcError: { message: 'connection refused' } });
+    const response = await handleOtpSend(request(), d);
+
+    expect(response.status).toBe(200);
+    expect(d.fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a payload with no phone number before spending an attempt', async () => {
+    const d = deps();
+    const response = await handleOtpSend(request(JSON.stringify({ sms: { otp: '1' } })), d);
+
+    expect(response.status).toBe(400);
+    expect(d.rpc).not.toHaveBeenCalled();
+    expect(d.fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('rejects a phone number that is not E.164', async () => {
+    const body = JSON.stringify({ user: { phone: '9876543210' }, sms: { otp: '123456' } });
+    const d = deps();
+    const response = await handleOtpSend(request(body), d);
+
+    expect(response.status).toBe(400);
+    expect(d.fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('does not leak Twilio’s error text to the person waiting for the code', async () => {
+    const d = deps({ twilioOk: false });
+    const response = await handleOtpSend(request(), d);
+
+    expect(response.status).toBe(502);
+    const payload = (await response.json()) as { error: { message: string } };
+    expect(payload.error.message).not.toContain('twilio said no');
+  });
+
+  it('refuses when WhatsApp sending is unconfigured rather than half-sending', async () => {
+    const d = deps({ env: { TWILIO_OTP_CONTENT_SID: '' } });
+    const response = await handleOtpSend(request(), d);
+
+    expect(response.status).toBe(500);
+    expect(d.fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('answers a refused connection the same way as a Twilio 5xx', async () => {
+    const d = deps();
+    d.fetchImpl = vi
+      .fn()
+      .mockRejectedValue(new Error('dial tcp: connection refused')) as unknown as typeof fetch;
+
+    const response = await handleOtpSend(request(), d);
+
+    expect(response.status).toBe(502);
+    const payload = (await response.json()) as { error: { message: string } };
+    expect(payload.error.message).not.toContain('connection refused');
+  });
+});
+
+/**
+ * The signature check, run for real.
+ *
+ * Every test above stubs `verify`, which is what let a live bug through review:
+ * Supabase issues the hook secret as `v1,whsec_<base64>` and the verifier strips
+ * only `whsec_`, so the raw value decoded the wrong key and refused every
+ * genuine request. A stub cannot see that. These drive the real verifier from
+ * @waves/core with a signature computed the way GoTrue computes one.
+ */
+describe('otp-send signature verification', () => {
+  const SECRET_BYTES = 'a-32-byte-key-for-hmac-testing!!';
+  const BASE64_KEY = Buffer.from(SECRET_BYTES).toString('base64');
+
+  async function sign(id: string, timestamp: string, body: string): Promise<string> {
+    const key = await crypto.subtle.importKey(
+      'raw',
+      Buffer.from(BASE64_KEY, 'base64'),
+      { name: 'HMAC', hash: 'SHA-256' },
+      false,
+      ['sign'],
+    );
+    const mac = await crypto.subtle.sign(
+      'HMAC',
+      key,
+      new TextEncoder().encode(`${id}.${timestamp}.${body}`),
+    );
+    return `v1,${Buffer.from(new Uint8Array(mac)).toString('base64')}`;
+  }
+
+  /** Deps with the real verifier — `verify` deliberately left unset. */
+  function realDeps(secret: string) {
+    const env: Record<string, string> = { ...ENV, SEND_SMS_HOOK_SECRET: secret };
+    const fetchImpl = vi.fn(() => Promise.resolve(new Response('{}', { status: 201 })));
+    return {
+      service: () =>
+        ({ rpc: vi.fn(() => Promise.resolve({ data: { allowed: true }, error: null })) }) as never,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      env: (key: string) => env[key],
+      fetchSpy: fetchImpl,
+    };
+  }
+
+  it('strips the v1, prefix Supabase puts on the hook secret', () => {
+    expect(hookSecret(`v1,whsec_${BASE64_KEY}`)).toBe(`whsec_${BASE64_KEY}`);
+    expect(hookSecret(`whsec_${BASE64_KEY}`)).toBe(`whsec_${BASE64_KEY}`);
+    expect(hookSecret(BASE64_KEY)).toBe(BASE64_KEY);
+  });
+
+  it('verifies a genuine signature against a v1,whsec_ secret', async () => {
+    const id = 'msg_real';
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const header = await sign(id, timestamp, BODY);
+
+    const d = realDeps(`v1,whsec_${BASE64_KEY}`);
+    const response = await handleOtpSend(
+      request(BODY, {
+        'webhook-id': id,
+        'webhook-timestamp': timestamp,
+        'webhook-signature': header,
+      }),
+      d as unknown as OtpSendDeps,
+    );
+
+    expect(response.status).toBe(200);
+    expect(d.fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses a signature computed over a different body', async () => {
+    const id = 'msg_real';
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const header = await sign(id, timestamp, '{"tampered":true}');
+
+    const d = realDeps(`v1,whsec_${BASE64_KEY}`);
+    const response = await handleOtpSend(
+      request(BODY, {
+        'webhook-id': id,
+        'webhook-timestamp': timestamp,
+        'webhook-signature': header,
+      }),
+      d as unknown as OtpSendDeps,
+    );
+
+    expect(response.status).toBe(401);
+    expect(d.fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/supabase/functions/otp-send/handler.ts
+++ b/supabase/functions/otp-send/handler.ts
@@ -1,0 +1,212 @@
+/**
+ * otp-send — Supabase's Send SMS Hook, delivering the sign-in code over
+ * WhatsApp instead of SMS.
+ *
+ * GoTrue normally posts the code to a configured SMS provider itself. With
+ * `[auth.hook.send_sms]` pointed here it posts to us instead, handing over the
+ * code it generated, and we decide how it travels. Three things come out of
+ * owning that step:
+ *
+ * 1. **WhatsApp, not SMS.** India is the first market and A2P SMS there is
+ *    gated on DLT registration with the operators — unregistered traffic is
+ *    dropped by the carrier, not by us. WhatsApp business messaging is not A2P
+ *    SMS and carries none of that; it is also far cheaper per message and the
+ *    code arrives in the app people already have open.
+ * 2. **A cap we can actually enforce.** The app calls GoTrue directly, so any
+ *    per-day limit written into the client is advice a modified client ignores.
+ *    Here it is the server, keyed on the number, and there is no other door.
+ * 3. **One place to add SMS fallback later** without touching the app.
+ *
+ * This is why the Twilio *Verify* provider is switched off in config.toml.
+ * Verify mints and checks its own code; inside a send hook that would mean two
+ * different codes in play and neither one valid. Owning delivery means owning
+ * plain Programmable Messaging.
+ *
+ * `verify_jwt = false`, and it must stay that way: the caller is GoTrue, which
+ * carries no user session. What it carries instead is a standardwebhooks
+ * signature over the exact bytes of the body, and — exactly as in
+ * `email-events` — that check runs before anything else is read.
+ */
+
+import type { SupabaseClient } from 'npm:@supabase/supabase-js@2';
+
+import { verifyWebhookSignature } from '../_shared/core.js';
+import { LIMITS } from '../_shared/rateLimit.ts';
+
+/**
+ * Four codes to a number a day. Read from the shared `LIMITS` table rather than
+ * written here, so there stays one list of every ceiling in the system even
+ * though this function calls the limiter RPC itself (see the note there).
+ */
+export const OTP_DAILY_LIMIT = LIMITS['otp-send'].limit;
+const OTP_WINDOW_SECONDS = LIMITS['otp-send'].windowSeconds;
+
+/**
+ * GoTrue reads a refusal from this envelope, not from an HTTP status alone, and
+ * shows `message` to the person waiting on the code. It is deliberately not the
+ * repo's usual `{code, message}` error shape — the consumer here is GoTrue, not
+ * our own client.
+ */
+function hookError(status: number, message: string): Response {
+  return new Response(JSON.stringify({ error: { http_code: status, message } }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export interface SendSmsHookPayload {
+  user?: { id?: string; phone?: string };
+  sms?: { otp?: string };
+}
+
+export interface OtpSendDeps {
+  /** Service-role client. The rate-limit RPC refuses any other caller. */
+  service: () => SupabaseClient;
+  fetchImpl: typeof fetch;
+  env: (key: string) => string | undefined;
+  /**
+   * Injected so tests need not forge an HMAC. The real implementation is
+   * `verifyWebhookSignature` from @waves/core, which CI already checks against
+   * Svix's published test vector — there is no second copy of that logic here.
+   */
+  verify?: typeof verifyWebhookSignature;
+}
+
+/** E.164, the only shape GoTrue ever hands us and the only one Twilio takes. */
+function isE164(phone: string): boolean {
+  return /^\+[1-9]\d{6,14}$/.test(phone);
+}
+
+/**
+ * Supabase issues a hook secret as `v1,whsec_<base64>`, and that whole string is
+ * what lands in the environment. `verifyWebhookSignature` strips `whsec_` — the
+ * shape Resend uses — but not the `v1,` in front of it, so handing the raw value
+ * over base64-decodes the wrong bytes and refuses every genuine request. That
+ * fails in the direction nobody notices in review: the function is deployed, the
+ * hook is enabled, and every sign-in answers 401.
+ *
+ * The `v1` here is the secret's own version prefix and is unrelated to the `v1`
+ * in the signature header, which the verifier reads separately.
+ */
+export function hookSecret(raw: string): string {
+  return raw.startsWith('v1,') ? raw.slice('v1,'.length) : raw;
+}
+
+export async function handleOtpSend(request: Request, deps: OtpSendDeps): Promise<Response> {
+  if (request.method !== 'POST') return hookError(405, 'Use POST');
+
+  const secret = deps.env('SEND_SMS_HOOK_SECRET');
+  if (!secret) {
+    // Refused rather than waved through, on the same reasoning as
+    // `email-events`: a hook that accepts unsigned callers because nobody has
+    // configured it yet is worse than one that is switched off.
+    return hookError(500, 'SEND_SMS_HOOK_SECRET is not set');
+  }
+
+  const id = request.headers.get('webhook-id');
+  const timestamp = request.headers.get('webhook-timestamp');
+  const signature = request.headers.get('webhook-signature');
+  if (!id || !timestamp || !signature) return hookError(401, 'Not a signed webhook');
+
+  // The raw text, not a reparse — signing covers the exact bytes.
+  const body = await request.text();
+  const verify = deps.verify ?? verifyWebhookSignature;
+  const ok = await verify({ secret: hookSecret(secret), id, timestamp, body, header: signature });
+  if (!ok) return hookError(401, 'That signature does not match');
+
+  let payload: SendSmsHookPayload;
+  try {
+    payload = JSON.parse(body) as SendSmsHookPayload;
+  } catch {
+    return hookError(400, 'Body is not JSON');
+  }
+
+  const phone = payload.user?.phone?.trim() ?? '';
+  const otp = payload.sms?.otp?.trim() ?? '';
+  if (!isE164(phone) || !otp) return hookError(400, 'Missing a phone number or a code');
+
+  // Counted before the message is sent, matching `receipt-parse`, where the
+  // gate always runs ahead of the spend. The cost is that a Twilio outage still
+  // burns an attempt; the alternative — send first, count after — lets a script
+  // spend the whole day's allowance before the first count lands.
+  //
+  // Keyed on the number rather than a profile id: `auth.sms.enable_signup` is
+  // off, so one number is one account, and the number is the only identity that
+  // exists at the moment a code is asked for.
+  const { data, error } = await deps.service().rpc('baaki_rate_limit', {
+    p_subject: `phone:${phone}`,
+    p_bucket: 'otp-send',
+    p_limit: OTP_DAILY_LIMIT,
+    p_window_seconds: OTP_WINDOW_SECONDS,
+  });
+
+  if (error) {
+    // Fails open, the same trade the shared limiter makes: the only way this
+    // happens is the database being unreachable, and refusing every sign-in
+    // during a database blip does more damage than the abuse it guards against.
+    console.error('otp-send rate limit check failed, allowing:', error.message);
+  } else {
+    const decision = data as { allowed?: boolean; retryAfter?: number } | null;
+    if (decision && decision.allowed === false) {
+      return hookError(
+        429,
+        `That is ${OTP_DAILY_LIMIT} codes today. Try again tomorrow, or sign in another way.`,
+      );
+    }
+  }
+
+  const accountSid = deps.env('TWILIO_ACCOUNT_SID');
+  const authToken = deps.env('TWILIO_AUTH_TOKEN');
+  const from = deps.env('TWILIO_WHATSAPP_FROM');
+  const contentSid = deps.env('TWILIO_OTP_CONTENT_SID');
+  if (!accountSid || !authToken || !from || !contentSid) {
+    return hookError(500, 'WhatsApp sending is not configured');
+  }
+
+  // A business-initiated WhatsApp message must be a template Meta has approved,
+  // referenced by its Content SID; free-form text is only allowed inside a
+  // 24-hour window a sign-in has no reason to be in. `ContentVariables` fills
+  // the template's one placeholder with the code.
+  const form = new URLSearchParams({
+    To: `whatsapp:${phone}`,
+    From: from.startsWith('whatsapp:') ? from : `whatsapp:${from}`,
+    ContentSid: contentSid,
+    ContentVariables: JSON.stringify({ '1': otp }),
+  });
+
+  // A refused connection, a DNS failure or a timeout rejects rather than
+  // answering, and an exception escaping here would leave GoTrue with a bare 500
+  // and the caller with whatever a stack trace renders as. A network failure and
+  // a 500 from Twilio mean the same thing to the person waiting, so they get the
+  // same sanitised answer.
+  let response: Response;
+  try {
+    response = await deps.fetchImpl(
+      `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages.json`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Basic ${btoa(`${accountSid}:${authToken}`)}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: form.toString(),
+      },
+    );
+  } catch (caught) {
+    console.error('twilio whatsapp request failed', caught);
+    return hookError(502, 'Could not send the code just now. Try again in a moment.');
+  }
+
+  if (!response.ok) {
+    // Twilio's own message is logged, never returned: it can name the sender
+    // and the account, and this text is shown to whoever asked for the code.
+    const detail = await response.text().catch(() => '');
+    console.error('twilio whatsapp send failed', response.status, detail);
+    return hookError(502, 'Could not send the code just now. Try again in a moment.');
+  }
+
+  return new Response(JSON.stringify({}), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/supabase/functions/otp-send/index.ts
+++ b/supabase/functions/otp-send/index.ts
@@ -1,0 +1,22 @@
+/**
+ * otp-send entrypoint — the thin `Deno.serve` shell.
+ *
+ * All the request handling lives in `handler.ts` as a pure function over
+ * injected boundaries, so it can be unit-tested without Deno, a database or a
+ * Twilio account (see `handler.test.ts`). This file only wires the real ones in.
+ *
+ * `serveWithCors` is deliberately not used: the caller is GoTrue talking
+ * server-to-server, never a browser, so there is no preflight to answer and no
+ * origin to echo.
+ */
+
+import { asService } from '../_shared/auth.ts';
+import { handleOtpSend } from './handler.ts';
+
+Deno.serve((request) =>
+  handleOtpSend(request, {
+    service: asService,
+    fetchImpl: fetch,
+    env: (key) => Deno.env.get(key),
+  }),
+);


### PR DESCRIPTION
## Summary
- Makes unknown EMAIL_PROVIDER values surface as misconfiguration instead of silently treating email as off
- Adds focused edge tests for the email provider seam across Resend and SendGrid
- Covers traveller settlement, rider notification, and financer campaign send paths, including SendGrid custom_args and transient/permanent failure classification

## Validation
- pnpm test:edge -- _shared/email.test.ts
- pnpm exec prettier --check supabase/functions/_shared/email.ts supabase/functions/_shared/email.test.ts
- pnpm lint
- Attempted pnpm typecheck; blocked locally by existing mobile route type errors unrelated to this email seam change