### PR TITLE
fix(db): put pg_net back in the migrations, where a rebuild will find it

### DIFF
--- a/packages/db/prisma/migrations/20260904140000_pg_net/migration.sql
+++ b/packages/db/prisma/migrations/20260904140000_pg_net/migration.sql
@@ -1,0 +1,27 @@
+-- `pg_net`, which the fanout cannot do without.
+--
+-- Two things reach for `net.http_post`: the every-five-minutes cron job, and
+-- `waves_notify_fanout_trigger`, which asks the edge function to go now rather
+-- than wait for the next tick. The trigger swallows its own failures (an AFTER
+-- trigger that raises would take the INSERT down with it), so a missing
+-- extension does not break writing a notification — it just silently stops the
+-- immediate half of delivery, and leaves the cron job erroring
+-- `schema "net" does not exist` on every run.
+--
+-- It was left out of the baseline because a schema-only dump does not carry
+-- extensions the database happens to have, and on this project `pg_net` sits in
+-- `public` — so rebuilding that schema takes the extension with it. Recreating
+-- it belongs in the migrations, where a rebuild will run it again.
+--
+-- Guarded twice over: `pg_net` is a hosted-Postgres extension and is simply not
+-- available on the plain Postgres that CI and a laptop run, where the fanout is
+-- driven by calling the edge function directly rather than by a schedule.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'pg_net') THEN
+    CREATE EXTENSION IF NOT EXISTS pg_net;
+  ELSE
+    RAISE NOTICE 'pg_net is not available here; the scheduled fanout is hosted-only';
+  END IF;
+END
+$$;


### PR DESCRIPTION
Found by the error `schema "net" does not exist` on the hosted project after the rebuild in #646.

## What broke

`net.http_post` has two callers:

- the five-minute fanout **cron job**, and
- `waves_notify_fanout_trigger`, which asks `notify-fanout` to go *now* rather than wait for the next tick.

Neither could complain usefully. The trigger swallows its own failures — an AFTER trigger that raises takes the INSERT down with it — so writing a notification kept working and only the immediate half of delivery stopped, silently. The cron job had nothing to swallow it and errored on every run.

## Why it was missing

`pg_net` was never in the baseline. A schema-only dump does not carry the extensions a database happens to have, and on this project `pg_net` is installed **in `public`** — so `DROP SCHEMA public CASCADE` during the rebuild took the extension and its `net` schema with it. Every other extension survived (`pgcrypto`, `uuid-ossp` and `pg_stat_statements` live in `extensions`; `pg_cron` in `pg_catalog`; `supabase_vault` in `vault`).

## The fix

A new migration guarded on availability, because `pg_net` is a hosted-Postgres extension and is simply absent from the plain Postgres that CI and a laptop run — there the fanout is driven by calling the edge function directly, not by a schedule.

```sql
IF EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'pg_net') THEN
  CREATE EXTENSION IF NOT EXISTS pg_net;
```

It is a new migration rather than an edit to the baseline, so the checksum the hosted project already recorded stays intact.

## Prod

Already repaired by hand and verified end to end before this PR: extension recreated, then `net.http_post` → `notify-fanout` returned `200 {"claimed":0,"sent":0,"email":{...}}`. This is so the *next* rebuild carries it.

## Gates

Fresh local database dropped and rebuilt through both migrations: deploy clean (takes the skip path), `db:drift` no difference, db suite 718/718.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved database setup to conditionally enable the `pg_net` extension when available.
  - Added a clear notice when `pg_net` is unavailable, allowing setup to continue in environments that do not support it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->