### PR TITLE
fix: give the product and the console their own hosts

### DIFF
--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -10,7 +10,7 @@ name: Vercel deploy (manual)
 #   VERCEL_ORG_ID             — the Vercel team/org id (same for every project)
 #   VERCEL_PROJECT_ID_WEB     — project id of waves-web     (.vercel/project.json)
 #   VERCEL_PROJECT_ID_ADMIN   — project id of waves-admin   (.vercel/project.json)
-#   VERCEL_PROJECT_ID_WEBSITE — project id of waves-website (.vercel/project.json)
+#   VERCEL_PROJECT_ID_WEBSITE — project id of waves         (.vercel/project.json)
 
 on:
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ both before it claims a row, so a half-configured deployment strands nothing.
 ```bash
 supabase secrets set RESEND_WEBHOOK_SECRET=whsec_...
 supabase secrets set EMAIL_FROM='Waves <hello@mail.dmadan.com>'   # optional; this is the default
-supabase secrets set EMAIL_WEB_URL=https://wavs.co.in             # optional; this is the default
+supabase secrets set EMAIL_WEB_URL=https://app.wavs.co.in         # optional; this is the default
 pnpm edge:deploy
 ```
 
@@ -473,8 +473,9 @@ pnpm edge:deploy
 it invalidates every unsubscribe link already sitting in somebody's mailbox, so
 it is set once and left alone.
 
-`EMAIL_WEB_URL` is where the button in an email points — defaults to the site's
-real domain, `https://wavs.co.in`. A fork or a self-host pointing at a
+`EMAIL_WEB_URL` is where the button in an email points — defaults to the web
+app, `https://app.wavs.co.in`, because the button lands on a group page that
+only that deployment serves. A fork or a self-host pointing at a
 different domain (or nothing at all, deliberately) should set this explicitly;
 with it unset the button falls back to the `waves://` deep link,
 which works on a phone and does nothing in desktop webmail. That fallback is
@@ -510,14 +511,13 @@ lives in somebody's console rather than in this repository:
    URL Configuration → Redirect URLs**, and to the redirect URIs of the Google
    OAuth client (and Apple's Services ID, if that ever comes back). Until it is
    listed, Google sign-in completes at the provider and lands nowhere.
-2. **The admin domain.** The console, its CSRF check and its tests all name
-   `waves.dmadan.com`. Point that host at the admin Vercel project and put it in
-   `ADMIN_ALLOWED_ORIGIN`; the old host stops matching the moment this ships.
-3. **The Vercel projects.** The workflows and the admin README name
-   `waves-admin` and `waves-web`. Renaming a project in Vercel keeps its
-   project id, so the `VERCEL_PROJECT_ID_*` secrets stay valid — only the
-   `.vercel.app` hostname moves.
-4. **The edge functions.** They call `waves_*` now. A deployed function still
+2. **The three hosts.** The marketing site keeps the apex, `wavs.co.in`; the
+   product moved to `app.wavs.co.in` and the console to `admin.wavs.co.in`.
+   Point both subdomains at their Vercel projects, and put the console's host in
+   `ADMIN_ALLOWED_ORIGIN` — its CSRF check compares against exactly that name.
+   The app's invite links and the button in every email now resolve against
+   `app.wavs.co.in`, so a join link is dead until that host answers.
+3. **The edge functions.** They call `waves_*` now. A deployed function still
    calling the old names answers "function does not exist" on every write, so
    they redeploy with this.
 

--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -23,5 +23,5 @@ ADMIN_SESSION_SECRET=
 ADMIN_ORIGIN_SECRET=
 
 # Optional. Pins the origin the CSRF check compares against, e.g.
-# https://waves.dmadan.com. Leave blank to derive it from the request Host.
+# https://admin.wavs.co.in. Leave blank to derive it from the request Host.
 ADMIN_ALLOWED_ORIGIN=

--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -75,7 +75,7 @@ because most of it is not obvious from the app's own config.
      "The custom domain took that door away" below. **In production, if this is
      unset the proxy refuses every request** (fail-closed), so set it and the
      Cloudflare Transform Rule together.
-   - `ADMIN_ALLOWED_ORIGIN` — optional, e.g. `https://waves.dmadan.com`. Pins
+   - `ADMIN_ALLOWED_ORIGIN` — optional, e.g. `https://admin.wavs.co.in`. Pins
      the origin the CSRF check compares against; leave it unset to derive the
      expected origin from the request `Host`, which is correct for a normal
      single-domain deployment.
@@ -108,14 +108,14 @@ another door_, and a bad one on its own.
 ### The custom domain took that door away
 
 **Current state, and it is not the state above.** The console answers on
-`waves.dmadan.com`, and pointing a custom domain at a Vercel project removes it
+`admin.wavs.co.in`, and pointing a custom domain at a Vercel project removes it
 from Vercel Authentication's scope. Verified rather than assumed:
 
 ```
 waves-admin-dmadan.vercel.app            302 → vercel.com/sso-api   (protected)
 waves-admin-git-main-dmadan.vercel.app   302 → vercel.com/sso-api   (protected)
-waves-admin.vercel.app                   307 → waves.dmadan.com     (open)
-waves.dmadan.com                         307 → /login               (open)
+waves-admin.vercel.app                   307 → admin.wavs.co.in     (open)
+admin.wavs.co.in                         307 → /login               (open)
 ```
 
 The project is on the **Hobby** plan with
@@ -127,17 +127,17 @@ Advanced Deployment Protection add-on at $150/month with a 30-day minimum, and
 Trusted IPs is Enterprise-only.
 
 So the second door has to come from somewhere other than Vercel. `dmadan.com`
-runs on Cloudflare and `waves.dmadan.com` is currently DNS-only, which makes
+runs on Cloudflare and `admin.wavs.co.in` is currently DNS-only, which makes
 **Cloudflare Access** the cheap answer: free to 50 seats, and a real second
 factor by one-time PIN.
 
 Two things that must be true together, or neither is worth doing:
 
-1. `waves.dmadan.com` proxied (orange cloud), SSL/TLS **Full (strict)**, with a
+1. `admin.wavs.co.in` proxied (orange cloud), SSL/TLS **Full (strict)**, with a
    Zero Trust Access application in front of it.
 2. **The `.vercel.app` back door closed.** `waves-admin.vercel.app` still serves
    this console, and a request sent straight to Vercel's IP with
-   `Host: waves.dmadan.com` walks around Cloudflare entirely. Closing it means a
+   `Host: admin.wavs.co.in` walks around Cloudflare entirely. Closing it means a
    secret header injected by a Cloudflare Transform Rule that `src/proxy.ts`
    requires — a host check alone does not do it, because the host is exactly
    what an attacker sets.
@@ -151,9 +151,9 @@ attacker on the open origin could obtain or replay. The compare is constant-time
 Ops steps to make it hold, in Cloudflare's dashboard:
 
 1. **Zero Trust → Access → Applications**: add a self-hosted application for
-   `waves.dmadan.com` with a one-time-PIN (or stricter) policy for your email.
+   `admin.wavs.co.in` with a one-time-PIN (or stricter) policy for your email.
 2. **Rules → Transform Rules → Modify Request Header**: on requests to
-   `waves.dmadan.com`, _set_ `x-admin-origin-secret` to the same value you put
+   `admin.wavs.co.in`, _set_ `x-admin-origin-secret` to the same value you put
    in the `ADMIN_ORIGIN_SECRET` env var. Set (not add), so a value a client
    tried to send cannot survive.
 3. Set `ADMIN_ORIGIN_SECRET` in Vercel Production to that value and redeploy.

--- a/apps/admin/src/lib/session.ts
+++ b/apps/admin/src/lib/session.ts
@@ -107,7 +107,7 @@ export const SESSION_COOKIE = COOKIE;
 /**
  * The second door: proof the request arrived through the trusted proxy.
  *
- * The custom domain (`waves.dmadan.com`) is on Vercel Hobby, whose Deployment
+ * The custom domain (`admin.wavs.co.in`) is on Vercel Hobby, whose Deployment
  * Protection does not cover custom domains, and the `*.vercel.app` origin stays
  * reachable directly — so a valid session cookie alone does not prove a request
  * came through Cloudflare Access. Cloudflare injects a shared secret header (a

--- a/apps/admin/test/csrf.test.ts
+++ b/apps/admin/test/csrf.test.ts
@@ -20,7 +20,7 @@ vi.mock('next/headers', () => ({
 import { assertCsrfToken, assertSameOrigin, csrfToken, guardMutation } from '@/lib/csrf';
 import { SESSION_COOKIE, csrfTokenFor, issueToken } from '@/lib/session';
 
-const HOST = 'waves.dmadan.com';
+const HOST = 'admin.wavs.co.in';
 
 beforeEach(() => {
   headerStore.clear();

--- a/apps/admin/test/proxy.test.ts
+++ b/apps/admin/test/proxy.test.ts
@@ -9,7 +9,7 @@ const ORIGIN_SECRET = 'origin-secret-value';
 // The real vercel.app back door: an attacker sending a request straight to the
 // origin sets Host to the custom domain, but cannot forge the Cloudflare header.
 const VERCEL_ORIGIN = 'https://waves-admin.vercel.app';
-const SPOOFED_HOST = 'waves.dmadan.com';
+const SPOOFED_HOST = 'admin.wavs.co.in';
 
 beforeAll(() => {
   process.env.ADMIN_SESSION_SECRET = 'test-session-secret';
@@ -25,7 +25,7 @@ async function validCookie(): Promise<string> {
 function request(
   path: string,
   headers: Record<string, string>,
-  origin = 'https://waves.dmadan.com',
+  origin = 'https://admin.wavs.co.in',
 ): NextRequest {
   return new NextRequest(new URL(path, origin), { headers });
 }

--- a/apps/mobile/src/lib/webUrl.ts
+++ b/apps/mobile/src/lib/webUrl.ts
@@ -14,7 +14,7 @@
  * anything heavier along with it.
  */
 
-const DEFAULT_WEB_URL = 'https://wavs.co.in';
+const DEFAULT_WEB_URL = 'https://app.wavs.co.in';
 
 /**
  * Origin only — scheme + host, no path, query or fragment — however

--- a/apps/mobile/test/qrScan.test.ts
+++ b/apps/mobile/test/qrScan.test.ts
@@ -39,8 +39,8 @@ describe('cameraAvailable', () => {
 
 describe('tokenFromScan', () => {
   it('extracts tokens from the supported HTTPS and app deep-link invite URLs', () => {
-    expect(tokenFromScan(' https://wavs.co.in/join?token=abc123 ')).toBe('abc123');
-    expect(tokenFromScan('https://WAVS.CO.IN/join/?token=a%20b')).toBe('a b');
+    expect(tokenFromScan(' https://app.wavs.co.in/join?token=abc123 ')).toBe('abc123');
+    expect(tokenFromScan('https://APP.WAVS.CO.IN/join/?token=a%20b')).toBe('a b');
     expect(tokenFromScan('waves://join?token=wave-token')).toBe('wave-token');
     expect(tokenFromScan('waves:///join?token=triple-slash')).toBe('triple-slash');
   });
@@ -49,31 +49,31 @@ describe('tokenFromScan', () => {
     for (const data of [
       '',
       'not a url',
-      'http://wavs.co.in/join?token=abc',
+      'http://app.wavs.co.in/join?token=abc',
       'https://evil.example/join?token=abc',
-      'https://wavs.co.in/not-join?token=abc',
+      'https://app.wavs.co.in/not-join?token=abc',
       'waves://evil.example/join?token=abc',
       'mailto:test@example.com?token=abc',
-      'https://wavs.co.in/join?token=',
-      'https://wavs.co.in/join?token=%20%20',
+      'https://app.wavs.co.in/join?token=',
+      'https://app.wavs.co.in/join?token=%20%20',
     ]) {
       expect(tokenFromScan(data)).toBeNull();
     }
   });
 
   it('does not let fragments leak into the invite token', () => {
-    expect(tokenFromScan('https://wavs.co.in/join?token=abc#token=evil')).toBe('abc');
-    expect(tokenFromScan('https://wavs.co.in/join?other=1&token=abc#frag')).toBe('abc');
+    expect(tokenFromScan('https://app.wavs.co.in/join?token=abc#token=evil')).toBe('abc');
+    expect(tokenFromScan('https://app.wavs.co.in/join?other=1&token=abc#frag')).toBe('abc');
   });
 
   it('keeps malformed percent-encoding as the trimmed raw non-empty token', () => {
-    expect(tokenFromScan('https://wavs.co.in/join?token=%E0%A4%A')).toBe('%E0%A4%A');
-    expect(tokenFromScan('https://wavs.co.in/join?token=%E0%A4%A%20')).toBe('%E0%A4%A%20');
+    expect(tokenFromScan('https://app.wavs.co.in/join?token=%E0%A4%A')).toBe('%E0%A4%A');
+    expect(tokenFromScan('https://app.wavs.co.in/join?token=%E0%A4%A%20')).toBe('%E0%A4%A%20');
   });
 
   it('rejects non-invite QR payloads quickly even in a large scan batch', () => {
     const payloads = Array.from({ length: 1_000 }, (_, index) =>
-      index === 999 ? 'https://wavs.co.in/join?token=last' : `https://example.com/${index}`,
+      index === 999 ? 'https://app.wavs.co.in/join?token=last' : `https://example.com/${index}`,
     );
 
     const tokens = payloads.map(tokenFromScan).filter((token): token is string => token !== null);

--- a/apps/mobile/test/webUrl.test.ts
+++ b/apps/mobile/test/webUrl.test.ts
@@ -23,9 +23,9 @@ afterEach(() => {
 describe('WEB_URL', () => {
   it('defaults to the site’s real domain when unset', async () => {
     const mod = await loadWith(undefined);
-    expect(mod.WEB_URL).toBe('https://wavs.co.in');
-    expect(mod.INVITE_BASE).toBe('https://wavs.co.in/join');
-    expect(mod.INVITE_HOST).toBe('wavs.co.in');
+    expect(mod.WEB_URL).toBe('https://app.wavs.co.in');
+    expect(mod.INVITE_BASE).toBe('https://app.wavs.co.in/join');
+    expect(mod.INVITE_HOST).toBe('app.wavs.co.in');
   });
 
   it('takes a clean origin override as-is', async () => {
@@ -50,11 +50,11 @@ describe('WEB_URL', () => {
 
   it('falls back to the default rather than shipping a broken URL', async () => {
     const mod = await loadWith('not a url at all');
-    expect(mod.WEB_URL).toBe('https://wavs.co.in');
+    expect(mod.WEB_URL).toBe('https://app.wavs.co.in');
   });
 
   it('builds a join link with the token as the fragment', async () => {
     const mod = await loadWith(undefined);
-    expect(mod.groupJoinLink('abc123')).toBe('https://wavs.co.in/join#abc123');
+    expect(mod.groupJoinLink('abc123')).toBe('https://app.wavs.co.in/join#abc123');
   });
 });

--- a/supabase/functions/_shared/email.ts
+++ b/supabase/functions/_shared/email.ts
@@ -304,7 +304,7 @@ export function emailFrom(): string {
  * right choice for a self-host not yet pointing anywhere it can vouch for.
  */
 function emailWebUrl(): string | null {
-  return Deno.env.get('EMAIL_WEB_URL') ?? 'https://wavs.co.in';
+  return Deno.env.get('EMAIL_WEB_URL') ?? 'https://app.wavs.co.in';
 }
 
 /** Where an unsubscribe click lands. Same origin as every other function. */

--- a/website/README.md
+++ b/website/README.md
@@ -59,11 +59,18 @@ Vercel, as its own project, with **Root Directory** set to `website`.
 
 | Setting           | Value                          |
 | ----------------- | ------------------------------ |
+| Project name      | `waves`                        |
 | Framework         | Next.js (detected)             |
 | Root directory    | `website`                      |
 | Install command   | `pnpm install`                 |
 | Build command     | `pnpm build`                   |
 | Production domain | `wavs.co.in`, `www.wavs.co.in` |
+
+Nothing deploys on a push: `git.deploymentEnabled` is false, and the only way a
+deployment happens is the **Vercel deploy (manual)** workflow in the Actions tab
+— pick `website` and a target. It needs `VERCEL_TOKEN`, `VERCEL_ORG_ID` and
+`VERCEL_PROJECT_ID_WEBSITE` (the id in this directory's `.vercel/project.json`
+after a `vercel link`) as repository secrets.
 
 `vercel.json` carries an `ignoreCommand` so a push that did not touch this
 directory does not spend a deployment — the free tier rate-limits on a burst of
@@ -78,8 +85,7 @@ commits.
 
 Both have working defaults; set them only if a domain moves.
 
-> **Note on the apex domain.** `apps/web` (the product) already claims
-> `wavs.co.in`. Decide which one owns the apex: either the product moves to
-> `app.wavs.co.in` and this site takes the apex, or this site takes `www.` and
-> `NEXT_PUBLIC_APP_URL` stays pointing at the apex. The site works either way —
-> it is one environment variable.
+The apex question is settled: this site owns `wavs.co.in`, the product answers
+on `app.wavs.co.in` and the console on `admin.wavs.co.in`. The mobile app's
+invite links and the button in every email resolve against `app.wavs.co.in`,
+so nothing here should be pointed back at the apex.


### PR DESCRIPTION
Settles the apex question `website/README.md` had been holding open.

| host | serves |
|---|---|
| `wavs.co.in` | the marketing site (`website/`) — unchanged |
| `app.wavs.co.in` | the product (`apps/web`) |
| `admin.wavs.co.in` | the console (`apps/admin`), replacing `waves.dmadan.com` |

## What followed the product

Three things point at the *app*, not the site, because each lands on a route only `apps/web` serves:

- **`WEB_URL`** in `apps/mobile/src/lib/webUrl.ts`, and with it `INVITE_BASE` and the QR scanner's `INVITE_HOST` allowlist. A join link on the apex would have opened the marketing site and 404'd — and the scanner would have stopped trusting the app's own links.
- **`EMAIL_WEB_URL`**'s default in `supabase/functions/_shared/email.ts` — the button in an email goes to a group page.
- **The console's own host**, which its CSRF check compares against exactly, so `csrf.test.ts` and `proxy.test.ts` carry it too.

`mail.dmadan.com` is left alone — that is the Resend sending domain, a separate concern.

## Also

The manual Vercel workflow already covered the marketing site (`project: website`, `VERCEL_PROJECT_ID_WEBSITE`); its comment now names the project **`waves`**, and `website/README.md` spells out the deploy path — `git.deploymentEnabled` is false, so nothing deploys on a push and the Actions tab is the only route.

## Still needs a console

- Point `app.wavs.co.in` and `admin.wavs.co.in` at their Vercel projects, and set `ADMIN_ALLOWED_ORIGIN` to the console's host.
- Create the `waves` Vercel project for `website/` and set `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID_WEBSITE`.

Until `app.wavs.co.in` answers, every invite link and every email button is dead — worth pointing DNS before this ships to a device.

## Gates

`format` · `lint` · `typecheck` clean; mobile 58 files, admin 4, edge 6 all pass. One test caught a real gap while I was at it: `qrScan.test.ts` asserts the host match is case-insensitive with an uppercase URL, which had to move to `APP.WAVS.CO.IN` too.
