### PR TITLE
fix(ci): build the marketing site on Vercel, not on the runner

### DIFF
--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -74,10 +74,25 @@ jobs:
         working-directory: ${{ env.APP_DIR }}
         run: vercel pull --yes --environment=${{ github.event.inputs.target == 'production' && 'production' || 'preview' }} --token=${{ secrets.VERCEL_TOKEN }}
 
+      # `apps/*` build here and upload the finished output. The marketing site
+      # cannot: it is a Next app in a pnpm workspace, so every dependency is a
+      # symlink into a store at the repository root, and `vercel build` run
+      # inside `website/` packages nothing above that directory. The upload then
+      # fails on a file that exists — just not underneath `website/` —
+      # ("Please ensure project dependencies have been installed"). Building on
+      # Vercel instead installs from `website/package.json`, which has no
+      # workspace dependencies and so resolves on its own.
       - name: Build
+        if: matrix.app != 'website'
         working-directory: ${{ env.APP_DIR }}
         run: vercel build ${{ github.event.inputs.target == 'production' && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy (prebuilt)
+        if: matrix.app != 'website'
         working-directory: ${{ env.APP_DIR }}
         run: vercel deploy --prebuilt ${{ github.event.inputs.target == 'production' && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy (built on Vercel)
+        if: matrix.app == 'website'
+        working-directory: ${{ env.APP_DIR }}
+        run: vercel deploy ${{ github.event.inputs.target == 'production' && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
The `waves` Vercel project now exists and the marketing site is deployed. Getting there surfaced a bug in the workflow that would have failed the first time anyone triggered it.

## What broke

The workflow builds each app on the runner and uploads the finished output (`vercel build` → `vercel deploy --prebuilt`). That cannot work for `website`.

It is a Next app inside a pnpm workspace, so every dependency is a symlink into a store at the repository **root**, and `vercel build` run inside `website/` packages nothing above that directory:

```
Error: Please ensure project dependencies have been installed:
File does not exist: "node_modules/.pnpm/@opentelemetry+api@1.9.1/…/context.js"
```

The file **exists** — just not underneath `website/`.

Setting `outputFileTracingRoot` to the workspace root does not rescue it. I tried that first: it fixes where the traced paths point, not what the uploader can reach. The function bundle still came out containing `website/.next` and the launcher, with no dependencies at all. That change is **not** in this PR — it was reverted once it proved to be the wrong lever.

## The fix

`website` builds on Vercel. Its `package.json` depends only on `next`, `react` and `react-dom` — no workspace packages — so an install rooted at that directory resolves everything.

`apps/web` and `apps/admin` keep the prebuilt path, which is the better one where it works, since the build runs on a machine we control.

## Verified by actually deploying

Project `waves` created and deployed to production, twice — once to prove the remote build works, once more after reverting the tracing change to prove it was never needed.

| Path | |
|---|---|
| `/` | 307 → `/en` (locale redirect, by design) |
| `/en`, `/en/privacy`, `/ta`, `/hi`, `/ar` | 200 |

`X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy`, `Permissions-Policy` all present, so `next.config.ts` headers survive the remote build.

## You need to add one secret

The workflow reads `VERCEL_PROJECT_ID_WEBSITE`. The new project's id is in `website/.vercel/project.json` (gitignored) — I'll give it to you in chat rather than commit it.

## One thing left alone

`website/vercel.json` pins `"regions": ["sin1"]` — Singapore, the region being retired. For an India-first audience `bom1` matches the database's new home. It is a one-line change but a deliberate one, so I have not made it here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated deployment handling for the marketing website so it is built directly on Vercel during deployment.
  - Other applications continue using the existing prebuilt deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->