### PR TITLE
chore: move the Vercel functions to Mumbai, beside the database

### DIFF
--- a/apps/admin/vercel.json
+++ b/apps/admin/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
-  "regions": ["sin1"],
+  "regions": ["bom1"],
   "git": { "deploymentEnabled": false },
   "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ':/apps/admin' ':/packages' ':/pnpm-lock.yaml' ':/package.json'"
 }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
-  "regions": ["sin1"],
+  "regions": ["bom1"],
   "git": { "deploymentEnabled": false },
   "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ':/apps/web' ':/packages' ':/pnpm-lock.yaml' ':/package.json'"
 }

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
-  "regions": ["sin1"],
+  "regions": ["bom1"],
   "git": { "deploymentEnabled": false },
   "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ':/website' ':/pnpm-lock.yaml'"
 }


### PR DESCRIPTION
All three Vercel projects pinned `"regions": ["sin1"]` — chosen when the database was in ap-southeast-1. It isn't any more: it's ap-south-1, and the Singapore project is being deleted. Every server render currently crosses a region to reach its own data.

`bom1` is the same city as the database.

| Project | Why it matters |
|---|---|
| `apps/admin` | Server-rendered against the service role on **every** request — the most round-trips per page |
| `apps/web` | Server components querying Supabase on load |
| `website` | Prerendered and cached, so the region only decides where an occasional miss is served from |

I changed the marketing site too, which is what was actually asked, but the reasoning applies far more strongly to the other two — and leaving one project in a different region from the others is a difference nobody would remember the reason for later.

**Region is applied at deploy time**, so this takes effect on each project's next deploy rather than on merge. `apps/web` and `apps/admin` also still need a redeploy to pick up the Supabase env vars I repointed at Mumbai earlier, so those two want a deploy regardless.