### PR TITLE
fix(deploy): stop excluding apps/web from the archive both apps share

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,19 +1,29 @@
-# What Vercel does not need to build the admin console.
+# What Vercel does not need to build the two apps deployed from this root.
 #
 # The CLI uploads the whole repository so that pnpm can resolve the workspace
-# packages `@waves/admin` depends on — without this it also uploaded the Android
+# packages those apps depend on — without this it also uploaded the Android
 # build tree and a 165MB APK, and the transfer aborted at 2.9GB.
 #
-# Only `apps/admin` is built. `packages/*` is kept because the app imports
-# `@waves/core`, and the lockfile and workspace manifest are kept because
-# `pnpm install --frozen-lockfile` needs them.
+# **This file is shared.** It is read from the deployment source root, which is
+# the repository root for both `apps/admin` and `apps/web`, since each imports
+# workspace packages and so cannot be uploaded on its own. It once excluded
+# `apps/web` — written when only the console deployed this way — and a web
+# deploy then failed with "The specified Root Directory apps/web does not
+# exist", which was true: the archive did not contain it. Anything excluded here
+# is excluded from *every* deploy made from this root.
+#
+# `packages/*` is kept because both apps import `@waves/core`, and the lockfile
+# and workspace manifest are kept because `pnpm install --frozen-lockfile`
+# needs them.
 
 node_modules
 **/node_modules
 
-# Other apps. web and mobile are deployed elsewhere and are not imported.
+# The mobile app is not deployed here, and neither the e2e suite nor the edge
+# functions are imported by either web app. `website/` is absent from this list
+# on purpose: it has no workspace dependencies, so it deploys from its own
+# directory and never reads this file.
 apps/mobile
-apps/web
 e2e
 supabase
 


### PR DESCRIPTION
Found while redeploying everything onto Mumbai. A web deploy from the repository root failed with:

```
Error: The specified Root Directory "apps/web" does not exist.
```

That reads like a project-settings problem. It wasn't — the setting was correct. The archive genuinely did not contain the directory, because **`.vercelignore` excludes `apps/web`**.

The file says so in its own first line: *"What Vercel does not need to build the admin console."* Harmless while the console was the only thing deployed from the root. Not harmless now: `.vercelignore` is read from the **deployment source root**, and both apps deploy from there, since each imports workspace packages (`@waves/core`, `@waves/api-client`) and cannot be uploaded on its own.

`website/` is deliberately still absent from the list — it has no workspace dependencies, deploys from its own directory, and never reads this file.

## Verified by deploying all three

| Project | Status | |
|---|---|---|
| `waves-web` | ● Ready | `/login` 200 |
| `waves-admin` | ● Ready | `/` 200 |
| `waves` | ● Ready | **https://wavs.co.in** → `/en`, all locales + `/privacy` 200 |

## What else this chase turned up

Worth recording, because each one costs an hour to rediscover:

- **The prebuilt path does not work for any Next app in this pnpm workspace.** `vercel build` inside an app directory packages nothing above it, so tracing resolves dependencies into the root store and the upload fails on a file that exists. #659 already moved `website` to a remote build for this reason; `apps/web` and `apps/admin` hit it identically. They still work because they deploy from the root, where the workspace is present.
- **`--archive=tgz` is required from the root.** A plain deploy exceeds Vercel's limit: *"`files` should NOT have more than 15000 items, received 26727"*.
- **`rootDirectory` must not be double-applied.** Running the CLI from inside `apps/web` while the project sets `rootDirectory: apps/web` resolves to `apps/web/apps/web`. Deploy from the root and let the platform apply it.

Including `apps/web` grows the admin upload to ~97 MB. That is source only — `node_modules`, `.next` and the Android tree are all still excluded, and the 2.9 GB transfer the original comment warns about stays fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment packaging for the web and admin applications.
  * Prevented web deployments from failing due to missing application files.
  * Clarified deployment exclusions for mobile, end-to-end testing, and standalone website resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->