### PR TITLE
chore(ios): register the app as app.wavs.mobile, and say why it differs

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,15 @@ lives in somebody's console rather than in this repository:
 3. **The edge functions.** They call `waves_*` now. A deployed function still
    calling the old names answers "function does not exist" on every write, so
    they redeploy with this.
+4. **The two app identifiers, which are not the same string.** iOS is
+   `app.wavs.mobile` and Android is `app.waves.mobile` — note the spelling.
+   `app.waves.mobile` was already registered under somebody else's Apple
+   developer account, and Apple bundle ids are globally unique, so the iOS half
+   took the product domain's own spelling. Android was left alone: its package
+   is what `google-services.json`, the Play listing and every `appId:` in
+   `e2e/` key off, and none of them can see the iOS id. Nothing reads across
+   the two, so the divergence is harmless — but it is the sort of thing a
+   later reader "corrects". Both are right.
 
 The database was **rebuilt, not migrated**. The whole migration history is one
 file — `20260904000000_waves_baseline` — that builds the schema already named

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -17,7 +17,7 @@
     },
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "app.waves.mobile",
+      "bundleIdentifier": "app.wavs.mobile",
       "usesAppleSignIn": true
     },
     "android": {

--- a/apps/mobile/targets/watch/expo-target.config.js
+++ b/apps/mobile/targets/watch/expo-target.config.js
@@ -8,8 +8,9 @@
  * plugins/withWavesWear.js; the shared transport is the WavesWatch Expo module.
  *
  * UNVERIFIED: authored on Windows without Xcode — build on a Mac/EAS to prove it.
- * Needs the companion bundle id app.waves.mobile.watchkitapp under the Apple
- * Developer account.
+ * Needs the companion bundle id app.wavs.mobile.watchkitapp under the Apple
+ * Developer account — `wavs`, matching the iOS bundle id in app.json rather
+ * than the Android package, which is still `app.waves.mobile`.
  *
  * @type {import('@bacons/apple-targets/app.plugin').Config}
  */

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -176,9 +176,22 @@ secrets = "env(SEND_SMS_HOOK_SECRETS)"
 # anyway, silently overwriting whatever the dashboard had. The first push here
 # turned off anonymous sign-ins, manual identity linking and email confirmation
 # in one go — the first two are the guest flow, which is the app.
+# One *web* client serves all three platforms, and that is deliberate. The app
+# does not hold a Google client id at all: it asks Supabase for an authorize URL
+# and opens it in an in-app browser (`oauthThroughBrowser` in lib/auth.tsx), so
+# Google only ever sees this client and the app is reached afterwards by the
+# PKCE redirect. There is no Android or iOS OAuth client for sign-in and no
+# SHA-1 to register — which is also why one missing redirect URI took down
+# sign-in on iOS, Android and web at the same time.
+#
+# The redirect URI on this client is Supabase's callback, not the app's:
+# `https://<project-ref>.supabase.co/auth/v1/callback`. It is per-project, so
+# moving the database to a new project silently breaks sign-in everywhere until
+# the console is updated — which is exactly what the Singapore → Mumbai move did
+# on 2026-09-04.
 [auth.external.google]
 enabled = true
-client_id = "755904924475-vkp5ga0cpt58fr6patnst4e4r02cmhcv.apps.googleusercontent.com"
+client_id = "484909326858-1va1lbsiba9chuouu8e3m7u9bbivoj02.apps.googleusercontent.com"
 secret = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET)"
 
 # Sign in with Apple. Two audiences share one block:

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -182,10 +182,17 @@ client_id = "755904924475-vkp5ga0cpt58fr6patnst4e4r02cmhcv.apps.googleuserconten
 secret = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET)"
 
 # Sign in with Apple. Two audiences share one block:
-#   - the native bundle id (`app.wavs.mobile`) authorizes the iOS id-token flow
-#     (AppleAuthentication.signInAsync -> supabase.auth.signInWithIdToken),
 #   - the Services ID (`app.wavs.web`) authorizes the browser-redirect fallback
-#     used on Android and web (signInWithOAuth via `oauthThroughBrowser`).
+#     used on Android and web (signInWithOAuth via `oauthThroughBrowser`),
+#   - the native bundle id (`app.wavs.mobile`) authorizes the iOS id-token flow
+#     (AppleAuthentication.signInAsync -> supabase.auth.signInWithIdToken).
+#
+# THE ORDER IS LOAD-BEARING. GoTrue treats every id here as an accepted audience
+# when it verifies an identity token, but it sends only the *first* one to Apple
+# as `client_id` when it starts a browser round trip. A bundle id is not a valid
+# web client — put it first and Apple answers `invalid_request` on every
+# Android and web sign-in, while iOS keeps working, which makes it look like a
+# platform bug rather than one character of ordering. Services ID first.
 #
 # Note the spelling: iOS is `app.wavs.mobile` while Android is
 # `app.waves.mobile`. `app.waves.mobile` was already registered under another
@@ -198,7 +205,7 @@ secret = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET)"
 # (.p8); regenerate it before it expires (max 6 months).
 [auth.external.apple]
 enabled = true
-client_id = "app.wavs.mobile,app.wavs.web"
+client_id = "app.wavs.web,app.wavs.mobile"
 secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
 
 [edge_runtime]

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -182,16 +182,23 @@ client_id = "755904924475-vkp5ga0cpt58fr6patnst4e4r02cmhcv.apps.googleuserconten
 secret = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET)"
 
 # Sign in with Apple. Two audiences share one block:
-#   - the native bundle id (`app.waves.mobile`) authorizes the iOS id-token flow
+#   - the native bundle id (`app.wavs.mobile`) authorizes the iOS id-token flow
 #     (AppleAuthentication.signInAsync -> supabase.auth.signInWithIdToken),
-#   - the Services ID authorizes the browser-redirect fallback used on Android
-#     and web (signInWithOAuth via `oauthThroughBrowser`).
+#   - the Services ID (`app.wavs.web`) authorizes the browser-redirect fallback
+#     used on Android and web (signInWithOAuth via `oauthThroughBrowser`).
+#
+# Note the spelling: iOS is `app.wavs.mobile` while Android is
+# `app.waves.mobile`. `app.waves.mobile` was already registered under another
+# Apple developer account and bundle ids are globally unique, so the iOS half
+# took the domain's own spelling instead. The two platforms are separate
+# namespaces and nothing reads across them — but a `waves` typed here where
+# `wavs` belongs fails a sign-in with an audience mismatch and nothing else.
+#
 # `secret` is the ES256 client-secret JWT signed with the Sign in with Apple key
-# (.p8); regenerate it before it expires (max 6 months). Replace <services-id>
-# with the real Services ID once created in the Apple Developer portal.
+# (.p8); regenerate it before it expires (max 6 months).
 [auth.external.apple]
 enabled = true
-client_id = "app.waves.mobile,<services-id>"
+client_id = "app.wavs.mobile,app.wavs.web"
 secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
 
 [edge_runtime]


### PR DESCRIPTION
## Why

`app.waves.mobile` is already registered under another Apple developer account. Bundle ids are globally unique across all of Apple, so it is not recoverable. iOS is now **`app.wavs.mobile`** — the spelling of the domain the product actually uses.

**Android is unchanged at `app.waves.mobile`.** The two are separate namespaces and nothing reads across them. The Android package is what `google-services.json` (Firebase `baaki-43455`), the Play listing `store_url` and all 20 `appId:` lines in `e2e/` key off; matching them would cost a new Firebase Android app and a fresh `google-services.json` to gain nothing.

## Changes

| File | Change |
|---|---|
| `apps/mobile/app.json` | `ios.bundleIdentifier` → `app.wavs.mobile` |
| `supabase/config.toml` | Apple `client_id` → `app.wavs.mobile,app.wavs.web` |
| `targets/watch/expo-target.config.js` | companion id note → `app.wavs.mobile.watchkitapp` |
| `README.md` | records the split under "what it needs from the consoles" |

The config.toml change also fills the `<services-id>` placeholder, now that the Services ID `app.wavs.web` exists.

## The README note is the actual deliverable

A one-letter divergence between platforms is exactly what a later reader "corrects". Getting it wrong fails Sign in with Apple with an audience mismatch — no build error, no warning, no log until somebody taps the button. So both ids are written down as deliberate, in the section about identity that lives in consoles rather than in the repo.

## Still owed before Apple login works

This PR is the repo half only. The hosted project still has the placeholder saved:

```
external_apple_client_id = "app.waves.mobile,<services-id>"
external_apple_secret    = null
```

That needs the dashboard (or a `config push`, but only after the remaining `<project-ref>` placeholder in the SMS hook block is also filled — a push writes placeholders verbatim).

## Checked

`prettier --check` clean on all four files. No code paths reference the iOS bundle id; the only consumers are the native build and Apple's audience check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the iOS app identifier to `app.wavs.mobile`, while retaining `app.waves.mobile` for Android.
  * Updated the Apple Watch companion identifier to match the iOS app identifier.
  * Updated Apple sign-in configuration to use the current iOS and web service identifiers.

* **Documentation**
  * Documented the platform-specific identifiers and clarified their intentional differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->