### PR TITLE
feat(mobile): back the personal ledger up to the user's own Google Drive

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,60 @@ allocations. None of the three changes what anybody owes, and the screen says so
 in those words before the import runs. `packages/db/test/m5-import-export.test.ts`
 proves the round trip against a real database rather than in the abstract.
 
+## Backing the personal ledger up to Drive
+
+The "Me" tab — solo expenses, income, recurring rules, loans, budgets — can be
+copied to the person's **own** Google Drive, WhatsApp-style: back up now, an
+Off/Daily/Weekly/Monthly schedule, Wi‑Fi-only or Wi‑Fi-and-data, a "last backup"
+line, and a restore for the new phone. `apps/mobile/src/app/settings/backup.tsx`
+is the screen; `apps/mobile/src/lib/backup` is the machinery and
+`apps/mobile/src/lib/cloud` is the provider seam it sits on.
+
+Three decisions worth knowing:
+
+- **The narrowest scope Google offers.** `drive.appdata`, not `drive.file` and
+  never full `drive`. The backup lives in the hidden per-application folder: the
+  app cannot see, list or read anything else in the user's Drive, because the
+  token was never issued for it. The file does not appear in their Drive either
+  — Drive's storage settings are where they can see and delete it.
+
+- **The key is the user's, and only the user's.** The file is sealed with
+  XChaCha20-Poly1305 under a 256-bit key the app generates and shows once as 64
+  hexadecimal characters, the same `seal`/`open` the offline mirror uses. It is
+  kept in this device's keystore for convenience and typed in on a new phone.
+  Waves never sees it and Google holds only ciphertext, so **a lost key is a
+  lost backup** — the screen says that before it makes one. The reasoning, and
+  the two options rejected, are in the header of
+  `apps/mobile/src/lib/backup/recoveryKey.ts`.
+
+- **A restore only adds.** Records carry client-chosen ids that are already the
+  idempotency key for `personal.upsert`, so a restore re-queues what this device
+  is missing and touches nothing it already has — including things it has
+  deleted on purpose. Running it twice does nothing the second time.
+
+Drive needs **its own OAuth clients**, which the app does not otherwise have:
+sign-in goes through Supabase's hosted Google flow and holds no Google client id
+of its own. In the Google Cloud console, on a project with the Drive API
+enabled: create an OAuth client per platform (Android bound to
+`app.waves.mobile` plus the signing SHA-1 — one for debug, one for release; iOS
+bound to the bundle id), add `.../auth/drive.appdata` to the consent screen, and
+set:
+
+| Variable                                     | Where              | What it does                   |
+| -------------------------------------------- | ------------------ | ------------------------------ |
+| `EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_ANDROID` | `apps/mobile/.env` | the Android OAuth client       |
+| `EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_IOS`     | `apps/mobile/.env` | the iOS OAuth client           |
+| `EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_WEB`     | `apps/mobile/.env` | the fallback for anything else |
+
+These are not secrets — a native OAuth client has none, which is why the flow is
+PKCE — but they name a Google project, so they are read from the environment
+rather than committed. With none set the app builds and runs; the backup screen
+says the destination is unavailable in this build rather than opening a consent
+page Google would reject.
+
+A `drive.appdata` app stays in testing until the consent screen is verified;
+until then only accounts added as test users can link one.
+
 ## Turning on push
 
 Everything between the inbox row and the phone is built and tested — the claim,

--- a/README.md
+++ b/README.md
@@ -389,6 +389,14 @@ Three decisions worth knowing:
   is missing and touches nothing it already has — including things it has
   deleted on purpose. Running it twice does nothing the second time.
 
+- **Everything is per-account, on a phone that is not always one person's.** The
+  keystore slots for the Drive tokens and the recovery key, the schedule and
+  last-backup preferences, and the remote filename all carry the owner id, and
+  signing out wipes the departing account's set (`clearBackupState`, called from
+  `clearLocalPrivateData`). The Drive file itself is left alone: it is the
+  user's, it is unreadable without their key, and outliving the app's state is
+  the whole point of it.
+
 Drive needs **its own OAuth clients**, which the app does not otherwise have:
 sign-in goes through Supabase's hosted Google flow and holds no Google client id
 of its own. In the Google Cloud console, on a project with the Drive API

--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -495,6 +495,12 @@ function ProfileForm() {
               route: '/settings/sync',
             },
             {
+              icon: 'cloud-done-outline',
+              label: t.backup.title,
+              hint: t.backup.row,
+              route: '/settings/backup',
+            },
+            {
               icon: 'shield-checkmark-outline',
               label: t.privacy.row,
               route: '/settings/privacy',

--- a/apps/mobile/src/app/+native-intent.ts
+++ b/apps/mobile/src/app/+native-intent.ts
@@ -31,6 +31,18 @@ export function redirectSystemPath({ path }: { path: string; initial: boolean })
     if (url.hostname === 'auth' || firstSegment === 'auth') {
       return '/';
     }
+    // The Drive-backup consent redirects to `waves://oauthredirect`, and the
+    // same double delivery happens: `promptAsync` has already taken the code
+    // and swapped it, so the intent carries nothing left to do — but there is
+    // no `/oauthredirect` screen either, and letting the router match it lands
+    // on "Unmatched Route" the moment somebody links their Drive. Unlike
+    // sign-in, sending this one to the root would be wrong: the person is
+    // standing on the backup screen and expects to still be there, so it goes
+    // back to the screen that started the flow. A `navigate` to a route already
+    // in the stack returns to it rather than pushing a second copy.
+    if (url.hostname === 'oauthredirect' || firstSegment === 'oauthredirect') {
+      return '/settings/backup';
+    }
     // The scan-receipt home-screen widget carries a fixed `?scan=1` — its link
     // is baked at build time and cannot mint a fresh value per tap. The capture
     // screen's consume-once guard keys off the nonce *value*, so a constant one

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -42,6 +42,7 @@ import { TourOverlay } from '@/components/TourOverlay';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { UpdateBanner, UpdateGate } from '@/components/UpdateGate';
 import { AuthProvider, useAuth } from '@/lib/auth';
+import { AutoBackup } from '@/lib/backup/AutoBackup';
 import { backendConfigured } from '@/lib/backend';
 import { DeviceSessionProvider } from '@/lib/deviceSession';
 import { useFlagEnabled } from '@/lib/flags';
@@ -233,6 +234,11 @@ function RootLayout() {
                                 while the app is locked or on a build we have
                                 stopped trusting. */}
                                         <WatchBridgeProvider />
+                                        {/* Same reasoning, one step further: an
+                                automatic backup must not run on a build we
+                                have stopped trusting, and must not decrypt a
+                                ledger while the app is still locked. */}
+                                        <AutoBackup />
                                         {/* Inside the lock so the two-device gate never
                                 paints over the lock screen, and past auth so it
                                 only ever asks a signed-in account. */}
@@ -649,6 +655,7 @@ function AuthGate() {
           <Stack.Screen name="settings/shortcut" />
           <Stack.Screen name="settings/recent" />
           <Stack.Screen name="settings/sync" />
+          <Stack.Screen name="settings/backup" />
           <Stack.Screen name="settings/theme" />
           <Stack.Screen name="settings/categories" />
           <Stack.Screen name="settings/language" />

--- a/apps/mobile/src/app/settings/backup.tsx
+++ b/apps/mobile/src/app/settings/backup.tsx
@@ -1,0 +1,640 @@
+/**
+ * Backing the private "Me" ledger up to the person's own Google Drive.
+ *
+ * The shape is WhatsApp's chat-backup screen, because that screen is the mental
+ * model people already have for this and inventing a different one would only
+ * cost them: back up now with a live line saying what is happening, how often
+ * to do it automatically, which account it goes to, over which networks, and
+ * when the last one landed. What WhatsApp puts behind "End-to-end encrypted
+ * backup" is here up front instead — the key is the thing that decides whether
+ * a backup is worth anything on a new phone, so it is a section, not a
+ * disclosure.
+ *
+ * Two ordering decisions worth naming. The key section sits *above* the
+ * schedule, because a schedule with no key backs nothing up and the screen
+ * should not let somebody set one and walk away believing otherwise. And
+ * Restore is last: it is the half people need once, at the worst moment, and
+ * burying it would be cruel — but putting it near "Back up now" invites the
+ * wrong tap.
+ *
+ * The one promise this screen makes, and must keep: nothing legible leaves the
+ * phone. What goes to Drive is a sealed blob; the key that opens it is shown to
+ * the person and never sent anywhere.
+ */
+
+import { useCallback, useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import * as Clipboard from 'expo-clipboard';
+import { router } from 'expo-router';
+import { ActivityIndicator, ScrollView, TextInput, View } from 'react-native';
+
+import {
+  Button,
+  Callout,
+  Card,
+  directionalIcon,
+  Divider,
+  IconButton,
+  iconSize,
+  ListRow,
+  Popup,
+  Row,
+  Screen,
+  SectionHeader,
+  Sheet,
+  Text,
+  useTabBarClearance,
+  useTheme,
+} from '@waves/ui';
+
+import { plural, useStrings } from '@/i18n';
+import { formatBytes } from '@/lib/bytes';
+import { useBackup, type BackupOutcome } from '@/lib/backup/useBackup';
+import { BackupFrequency } from '@/lib/backup/schedule';
+import { formatRecoveryKey } from '@/lib/backup/recoveryKey';
+import type { RestoreScan } from '@/lib/backup/engine';
+import { friendlyError } from '@/lib/errors';
+import { SyncNetworkPreference } from '@/lib/syncNetwork';
+
+/** A found backup, held while the person decides whether to take it. */
+type FoundBackup = Extract<RestoreScan, { ok: true }>;
+
+/** A brand name, not copy — the same word in every locale, so not translated. */
+const PROVIDER_LABEL = 'Google Drive';
+
+export default function BackupSettingsScreen() {
+  const theme = useTheme();
+  const clearance = useTabBarClearance();
+  const { t, locale } = useStrings();
+  const backup = useBackup();
+
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [shownKey, setShownKey] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [entering, setEntering] = useState(false);
+  const [typedKey, setTypedKey] = useState('');
+  const [typedInvalid, setTypedInvalid] = useState(false);
+  const [unlinking, setUnlinking] = useState(false);
+  const [found, setFound] = useState<FoundBackup | null>(null);
+  const [restored, setRestored] = useState<number | null>(null);
+
+  const dateTime = useCallback(
+    (at: number): string =>
+      new Intl.DateTimeFormat(locale, { dateStyle: 'medium', timeStyle: 'short' }).format(
+        new Date(at),
+      ),
+    [locale],
+  );
+
+  /** The one sentence for a refusal — each has a different way out. */
+  const refusalLine = (outcome: BackupOutcome): string => {
+    if (outcome.kind === 'ok') return plural(locale, outcome.records, t.backup.backedUp);
+    switch (outcome.refusal) {
+      case 'not-configured':
+        return t.backup.unavailable;
+      case 'not-connected':
+        return t.backup.refusedNotConnected;
+      case 'no-key':
+        return t.backup.refusedNoKey;
+      case 'offline':
+        return t.backup.refusedOffline;
+      case 'network-policy':
+        return t.backup.refusedNetwork;
+      case 'auth':
+        return t.backup.refusedAuth;
+      case 'no-backup':
+        return t.backup.refusedNoBackup;
+      default:
+        return t.backup.refusedBusy;
+    }
+  };
+
+  const phaseLine =
+    backup.phase === 'collecting'
+      ? t.backup.phaseCollecting
+      : backup.phase === 'sealing'
+        ? t.backup.phaseSealing
+        : backup.phase === 'uploading'
+          ? t.backup.phaseUploading
+          : null;
+
+  const onConnect = async (): Promise<void> => {
+    setBusy(true);
+    setError(null);
+    try {
+      await backup.connect();
+    } catch (caught) {
+      setError(friendlyError(caught, t.backup.connectFailed, 'backup.connect'));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onBackUpNow = async (): Promise<void> => {
+    setBusy(true);
+    setError(null);
+    try {
+      await backup.backupNow();
+    } catch (caught) {
+      setError(friendlyError(caught, t.backup.backupFailed, 'backup.run'));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onCreateKey = async (): Promise<void> => {
+    setBusy(true);
+    setError(null);
+    try {
+      setCopied(false);
+      setShownKey(await backup.createKey());
+    } catch (caught) {
+      setError(friendlyError(caught, t.backup.backupFailed, 'backup.createKey'));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onShowKey = async (): Promise<void> => {
+    setCopied(false);
+    setShownKey(await backup.revealKey());
+  };
+
+  const onAcceptKey = async (): Promise<void> => {
+    if (!(await backup.acceptKey(typedKey))) {
+      setTypedInvalid(true);
+      return;
+    }
+    setEntering(false);
+    setTypedKey('');
+    setTypedInvalid(false);
+  };
+
+  const onCheckForBackup = async (): Promise<void> => {
+    setBusy(true);
+    setError(null);
+    setRestored(null);
+    try {
+      const result = await backup.scan();
+      if (result.ok) setFound(result);
+      else setError(refusalLine({ kind: 'refused', refusal: result.refusal }));
+    } catch (caught) {
+      // A key that does not open the file throws out of the AEAD. That is the
+      // whole diagnosis and it is worth saying precisely; anything else is a
+      // transport failure whose text must not reach the screen.
+      const wrongKey =
+        caught instanceof Error && /Poly1305|invalid tag|decrypt/i.test(caught.message);
+      setError(
+        wrongKey
+          ? t.backup.restoreWrongKey
+          : friendlyError(caught, t.backup.restoreFailed, 'backup.scan'),
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onRestore = async (): Promise<void> => {
+    if (!found) return;
+    setBusy(true);
+    try {
+      setRestored(await backup.applyRestore(found));
+      setFound(null);
+    } catch (caught) {
+      setFound(null);
+      setError(friendlyError(caught, t.backup.restoreFailed, 'backup.restore'));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onUnlink = async (): Promise<void> => {
+    setUnlinking(false);
+    setBusy(true);
+    try {
+      await backup.disconnect();
+    } catch (caught) {
+      setError(friendlyError(caught, t.backup.connectFailed, 'backup.disconnect'));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const frequencies: { value: BackupFrequency; label: string }[] = [
+    { value: BackupFrequency.Off, label: t.backup.freqOff },
+    { value: BackupFrequency.Daily, label: t.backup.freqDaily },
+    { value: BackupFrequency.Weekly, label: t.backup.freqWeekly },
+    { value: BackupFrequency.Monthly, label: t.backup.freqMonthly },
+  ];
+
+  const networks: { value: SyncNetworkPreference; label: string }[] = [
+    { value: SyncNetworkPreference.Wifi, label: t.backup.networkWifi },
+    { value: SyncNetworkPreference.Both, label: t.backup.networkAny },
+  ];
+
+  const running = backup.phase !== null;
+  // A backup needs a linked account and a key the person has confirmed they
+  // kept. Anything less and the button would produce a file nobody can open.
+  const canBackUp =
+    backup.configured && backup.connected && backup.hasKey && backup.settings.keySeen;
+
+  return (
+    <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.backup.title}</Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
+      <ScrollView
+        style={{ flex: 1 }}
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: clearance,
+          paddingTop: theme.spacing.lg,
+          gap: theme.spacing.xl,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        <Text variant="body" tone="muted">
+          {t.backup.intro}
+        </Text>
+
+        {!backup.configured ? <Callout tone="warning">{t.backup.unavailable}</Callout> : null}
+        {error ? <Callout tone="negative">{error}</Callout> : null}
+
+        {/* Back up now, and the last one. The button and the record it produces
+            belong together — a result line under a button somewhere else is a
+            result nobody connects to what they just pressed. */}
+        <Card style={{ gap: theme.spacing.md }}>
+          <Button
+            label={t.backup.backUpNow}
+            onPress={() => void onBackUpNow()}
+            disabled={!canBackUp || busy || running}
+            fullWidth
+            icon={
+              running ? (
+                <ActivityIndicator size="small" color={theme.color.onBrand} />
+              ) : (
+                <Ionicons
+                  name="cloud-upload-outline"
+                  size={iconSize.md}
+                  color={theme.color.onBrand}
+                />
+              )
+            }
+          />
+          {phaseLine ? (
+            <Text variant="micro" tone="muted" align="center">
+              {phaseLine}
+            </Text>
+          ) : backup.outcome ? (
+            <Text
+              variant="micro"
+              tone={backup.outcome.kind === 'ok' ? 'muted' : 'faint'}
+              align="center"
+            >
+              {refusalLine(backup.outcome)}
+            </Text>
+          ) : null}
+
+          <Divider />
+          <Row style={{ justifyContent: 'space-between' }}>
+            <Text variant="micro" tone="faint">
+              {t.backup.lastSection}
+            </Text>
+            <Text variant="micro" tone="muted">
+              {backup.settings.last
+                ? `${dateTime(backup.settings.last.at)} · ${formatBytes(
+                    backup.settings.last.size,
+                    locale,
+                  )}`
+                : t.backup.never}
+            </Text>
+          </Row>
+        </Card>
+
+        {/* Which Google account. */}
+        <View style={{ gap: theme.spacing.sm }}>
+          <SectionHeader title={t.backup.accountSection} />
+          <Card style={{ gap: theme.spacing.md }}>
+            <Row style={{ gap: theme.spacing.md }}>
+              <Ionicons
+                name={backup.connected ? 'logo-google' : 'cloud-offline-outline'}
+                size={iconSize.xl}
+                color={backup.connected ? theme.color.brand : theme.color.textFaint}
+              />
+              {/* The linked address when Drive will say who it is, and the
+                  destination's own name when it will not — never a guess, and
+                  never a blank row that reads as "not connected". */}
+              <Text variant="body" style={{ flex: 1 }}>
+                {backup.connected ? (backup.account ?? PROVIDER_LABEL) : t.backup.notConnected}
+              </Text>
+            </Row>
+            <Button
+              label={backup.connected ? t.backup.disconnect : t.backup.connect}
+              variant={backup.connected ? 'ghostDanger' : 'secondary'}
+              onPress={() => (backup.connected ? setUnlinking(true) : void onConnect())}
+              disabled={!backup.configured || busy}
+              fullWidth
+            />
+          </Card>
+        </View>
+
+        {/* The key. Above the schedule on purpose — see the file header. */}
+        <View style={{ gap: theme.spacing.sm }}>
+          <SectionHeader title={t.backup.keySection} />
+          <Card style={{ gap: theme.spacing.md }}>
+            <Text variant="micro" tone="muted">
+              {t.backup.keyIntro}
+            </Text>
+            <Row style={{ gap: theme.spacing.sm }}>
+              <Ionicons
+                name={backup.hasKey ? 'key' : 'key-outline'}
+                size={iconSize.md}
+                color={backup.hasKey ? theme.color.brand : theme.color.textFaint}
+              />
+              <Text variant="body">{backup.hasKey ? t.backup.keyPresent : t.backup.keyAbsent}</Text>
+            </Row>
+            {/* A key made and then dismissed without confirming leaves "Back up
+                now" disabled with nothing on screen explaining why. Say it, and
+                point at the button that fixes it. */}
+            {backup.hasKey && !backup.settings.keySeen ? (
+              <Callout tone="warning">{t.backup.keyWarning}</Callout>
+            ) : null}
+            <Row style={{ gap: theme.spacing.sm }}>
+              <View style={{ flex: 1 }}>
+                <Button
+                  label={backup.hasKey ? t.backup.keyShow : t.backup.keyCreate}
+                  variant="secondary"
+                  size="sm"
+                  onPress={() => void (backup.hasKey ? onShowKey() : onCreateKey())}
+                  disabled={busy}
+                  fullWidth
+                />
+              </View>
+              <View style={{ flex: 1 }}>
+                <Button
+                  label={t.backup.keyEnter}
+                  variant="ghost"
+                  size="sm"
+                  onPress={() => {
+                    setTypedKey('');
+                    setTypedInvalid(false);
+                    setEntering(true);
+                  }}
+                  disabled={busy}
+                  fullWidth
+                />
+              </View>
+            </Row>
+          </Card>
+        </View>
+
+        {/* How often. */}
+        <View style={{ gap: theme.spacing.sm }}>
+          <SectionHeader title={t.backup.frequencySection} />
+          <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+            {frequencies.map((option, index) => {
+              const chosen = backup.settings.frequency === option.value;
+              return (
+                <View key={option.value}>
+                  <ListRow
+                    title={option.label}
+                    onPress={() => void backup.setFrequency(option.value)}
+                    accessibilityRole="radio"
+                    accessibilityState={{ selected: chosen }}
+                    accessibilityLabel={`${option.label}${chosen ? `, ${t.backup.selected}` : ''}`}
+                    trailing={
+                      chosen ? (
+                        <Ionicons name="checkmark" size={iconSize.lg} color={theme.color.brand} />
+                      ) : null
+                    }
+                  />
+                  {index < frequencies.length - 1 ? (
+                    <View style={{ height: 1, backgroundColor: theme.color.border }} />
+                  ) : null}
+                </View>
+              );
+            })}
+          </Card>
+          <Text variant="micro" tone="faint">
+            {t.backup.frequencyNote}
+          </Text>
+        </View>
+
+        {/* Over which networks. The same vocabulary the sync setting uses. */}
+        <View style={{ gap: theme.spacing.sm }}>
+          <SectionHeader title={t.backup.networkSection} />
+          <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+            {networks.map((option, index) => {
+              const chosen = backup.settings.network === option.value;
+              return (
+                <View key={option.value}>
+                  <ListRow
+                    title={option.label}
+                    onPress={() => void backup.setNetwork(option.value)}
+                    accessibilityRole="radio"
+                    accessibilityState={{ selected: chosen }}
+                    accessibilityLabel={`${option.label}${chosen ? `, ${t.backup.selected}` : ''}`}
+                    leading={
+                      <Ionicons
+                        name={
+                          option.value === SyncNetworkPreference.Wifi
+                            ? 'wifi-outline'
+                            : 'globe-outline'
+                        }
+                        size={iconSize.xl}
+                        color={theme.color.text}
+                      />
+                    }
+                    trailing={
+                      chosen ? (
+                        <Ionicons name="checkmark" size={iconSize.lg} color={theme.color.brand} />
+                      ) : null
+                    }
+                  />
+                  {index < networks.length - 1 ? (
+                    <View style={{ height: 1, backgroundColor: theme.color.border }} />
+                  ) : null}
+                </View>
+              );
+            })}
+          </Card>
+        </View>
+
+        {/* Getting it back. Last, and deliberately not beside "Back up now". */}
+        <View style={{ gap: theme.spacing.sm }}>
+          <SectionHeader title={t.backup.restoreSection} />
+          <Card style={{ gap: theme.spacing.md }}>
+            <Text variant="micro" tone="muted">
+              {t.backup.restoreIntro}
+            </Text>
+            {restored !== null ? (
+              <Text variant="body" tone="muted">
+                {plural(locale, restored, t.backup.restoreDone)}
+              </Text>
+            ) : null}
+            <Button
+              label={t.backup.restoreCheck}
+              variant="secondary"
+              onPress={() => void onCheckForBackup()}
+              disabled={!backup.configured || !backup.connected || !backup.hasKey || busy}
+              fullWidth
+            />
+          </Card>
+        </View>
+      </ScrollView>
+
+      {/* The key, shown once — or again, on request. */}
+      <Sheet
+        visible={shownKey !== null}
+        onClose={() => setShownKey(null)}
+        closeLabel={t.common.close}
+      >
+        <View style={{ gap: theme.spacing.md }}>
+          <Text variant="heading">{t.backup.keyTitle}</Text>
+          <Card flat style={{ backgroundColor: theme.color.surfaceMuted }}>
+            <Text
+              variant="body"
+              // Monospace so the groups line up and a mistyped character is
+              // visible; selectable so it can be dragged out as well as copied.
+              selectable
+              style={{ fontFamily: 'monospace', letterSpacing: 1, lineHeight: 24 }}
+            >
+              {shownKey ? formatRecoveryKey(shownKey) : ''}
+            </Text>
+          </Card>
+          <Callout tone="warning">{t.backup.keyWarning}</Callout>
+          <Row style={{ gap: theme.spacing.sm }}>
+            <View style={{ flex: 1 }}>
+              <Button
+                label={copied ? t.backup.keyCopied : t.backup.keyCopy}
+                variant="secondary"
+                onPress={() => {
+                  if (!shownKey) return;
+                  void Clipboard.setStringAsync(formatRecoveryKey(shownKey));
+                  setCopied(true);
+                }}
+                fullWidth
+              />
+            </View>
+            <View style={{ flex: 1 }}>
+              <Button
+                label={t.backup.keyConfirm}
+                onPress={() => {
+                  void backup.confirmKeySeen();
+                  setShownKey(null);
+                }}
+                fullWidth
+              />
+            </View>
+          </Row>
+        </View>
+      </Sheet>
+
+      {/* A key brought over from the phone that made the backup. */}
+      <Sheet visible={entering} onClose={() => setEntering(false)} closeLabel={t.common.close}>
+        <View style={{ gap: theme.spacing.md }}>
+          <Text variant="heading">{t.backup.keyEnterTitle}</Text>
+          <Text variant="micro" tone="muted">
+            {t.backup.keyEnterBody}
+          </Text>
+          <Card flat style={{ backgroundColor: theme.color.surfaceMuted }}>
+            <TextInput
+              value={typedKey}
+              onChangeText={(value) => {
+                setTypedKey(value);
+                setTypedInvalid(false);
+              }}
+              placeholder={t.backup.keyEnterPlaceholder}
+              placeholderTextColor={theme.color.textFaint}
+              accessibilityLabel={t.backup.keyEnterTitle}
+              autoCapitalize="none"
+              autoCorrect={false}
+              multiline
+              style={{
+                minHeight: 72,
+                fontSize: 16,
+                fontFamily: 'monospace',
+                color: theme.color.text,
+                textAlignVertical: 'top',
+                // A key is hexadecimal in either direction; forcing LTR keeps it
+                // readable, and typed correctly, in an Arabic layout.
+                writingDirection: 'ltr',
+              }}
+            />
+          </Card>
+          {typedInvalid ? <Callout tone="negative">{t.backup.keyEnterInvalid}</Callout> : null}
+          <Button label={t.backup.keyEnterSave} onPress={() => void onAcceptKey()} fullWidth />
+        </View>
+      </Sheet>
+
+      {/* What a restore would bring back, before it brings anything back. */}
+      <Sheet visible={found !== null} onClose={() => setFound(null)} closeLabel={t.common.close}>
+        <View style={{ gap: theme.spacing.md }}>
+          <Text variant="heading">{t.backup.restoreSection}</Text>
+          {found ? (
+            <>
+              <Text variant="micro" tone="muted">
+                {t.backup.restoreFrom.replace(
+                  '{date}',
+                  found.body.createdAt ? dateTime(Date.parse(found.body.createdAt)) : '—',
+                )}
+              </Text>
+              <Text variant="body">
+                {found.plan.restore.length === 0
+                  ? t.backup.restoreNothingNew
+                  : plural(locale, found.plan.restore.length, t.backup.restoreFound)}
+              </Text>
+              {found.plan.restore.length > 0 ? (
+                <Button
+                  label={t.backup.restoreConfirm}
+                  onPress={() => void onRestore()}
+                  disabled={busy}
+                  fullWidth
+                />
+              ) : null}
+            </>
+          ) : null}
+        </View>
+      </Sheet>
+
+      <Popup visible={unlinking} onClose={() => setUnlinking(false)} closeLabel={t.common.close}>
+        <View style={{ gap: theme.spacing.md }}>
+          <Text variant="heading">{t.backup.disconnectTitle}</Text>
+          <Text variant="body" tone="muted">
+            {t.backup.disconnectBody}
+          </Text>
+          <Row style={{ gap: theme.spacing.sm }}>
+            <View style={{ flex: 1 }}>
+              <Button
+                label={t.common.cancel}
+                variant="ghost"
+                onPress={() => setUnlinking(false)}
+                fullWidth
+              />
+            </View>
+            <View style={{ flex: 1 }}>
+              <Button
+                label={t.backup.disconnect}
+                variant="danger"
+                onPress={() => void onUnlink()}
+                fullWidth
+              />
+            </View>
+          </Row>
+        </View>
+      </Popup>
+    </Screen>
+  );
+}

--- a/apps/mobile/src/app/settings/storage.tsx
+++ b/apps/mobile/src/app/settings/storage.tsx
@@ -30,18 +30,10 @@ import {
 } from '@waves/ui';
 
 import { canUploadGroupPhoto, myStorageUsage } from '@/data/api';
+import { formatBytes } from '@/lib/bytes';
 import { useStrings } from '@/i18n';
 import { SkeletonList } from '@/components/Skeletons';
 import { r2Enabled } from '@/lib/storage';
-
-/** "3.2 MB", "512 KB", "0 MB" — a size a person reads, localised. */
-function formatBytes(bytes: number, locale: string): string {
-  const number = (value: number, fractionDigits: number): string =>
-    new Intl.NumberFormat(locale, { maximumFractionDigits: fractionDigits }).format(value);
-  if (bytes > 0 && bytes < 1024 * 1024) return `${number(bytes / 1024, 0)} KB`;
-  const mb = bytes / (1024 * 1024);
-  return `${number(mb, mb < 10 ? 1 : 0)} MB`;
-}
 
 export default function StorageUsageScreen() {
   const theme = useTheme();

--- a/apps/mobile/src/data/personal.ts
+++ b/apps/mobile/src/data/personal.ts
@@ -24,6 +24,7 @@ import {
   personalScope,
   recurringCatchUp,
   recurringOccurrenceId,
+  type MirrorPersonalRecord,
   type PersonalBudget,
   type PersonalLoan,
   type PersonalRecordKind,
@@ -59,19 +60,55 @@ export interface PersonalLedger {
 }
 
 const EMPTY: PersonalLedger = { txns: [], recurrings: [], loans: [], budgets: [] };
+const NO_RECORDS: readonly MirrorPersonalRecord[] = [];
+
+/**
+ * The ledger's raw rows — the mirror's `personal_records` for this owner with
+ * the offline queue replayed on top, before anything is decoded into a txn or
+ * a loan.
+ *
+ * The decoded shapes below are one interpretation of the `data` blob, and a
+ * lossy one: a field a future build adds does not survive today's decode. The
+ * cloud backup (`lib/backup`) has to keep what it does not understand, so it
+ * reads the rows instead. Empty when signed out.
+ */
+export function usePersonalRecords(): readonly MirrorPersonalRecord[] {
+  const { mirror, queue } = useSync();
+  const { session } = useAuth();
+  const ownerId = session?.user?.id ?? '';
+  return useMemo(
+    () => (ownerId ? materialisePersonalRecords(mirror, queue, { ownerId }) : NO_RECORDS),
+    [mirror, queue, ownerId],
+  );
+}
+
+/**
+ * Every personal record id this device knows about, **tombstones included**.
+ *
+ * Only a restore wants this. A record the person deleted here must not come
+ * back because an older backup still has it, and the live rows alone cannot say
+ * "deleted on purpose" apart from "never seen".
+ */
+export function usePersonalRecordIds(): ReadonlySet<string> {
+  const { mirror, queue } = useSync();
+  const { session } = useAuth();
+  const ownerId = session?.user?.id ?? '';
+  return useMemo(() => {
+    if (!ownerId) return new Set<string>();
+    const rows = materialisePersonalRecords(mirror, queue, { ownerId, includeDeleted: true });
+    return new Set(rows.map((row) => row.id));
+  }, [mirror, queue, ownerId]);
+}
 
 /**
  * The whole ledger, decoded by kind and read local-first. Txns come back newest
  * first. Empty (not an error) when signed out — personal finance is per-account.
  */
 export function usePersonalLedger(): PersonalLedger {
-  const { mirror, queue } = useSync();
-  const { session } = useAuth();
-  const ownerId = session?.user?.id ?? '';
+  const records = usePersonalRecords();
 
   return useMemo(() => {
-    if (!ownerId) return EMPTY;
-    const records = materialisePersonalRecords(mirror, queue, { ownerId });
+    if (records.length === 0) return EMPTY;
     const txns: PersonalTxn[] = [];
     const recurrings: PersonalRecurring[] = [];
     const loans: PersonalLoan[] = [];
@@ -96,7 +133,7 @@ export function usePersonalLedger(): PersonalLedger {
     }
     txns.sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
     return { txns, recurrings, loans, budgets };
-  }, [mirror, queue, ownerId]);
+  }, [records]);
 }
 
 export interface UpsertPersonalInput {

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1448,39 +1448,93 @@ export interface UiStrings {
     full: string;
     upgrade: string;
   };
+  /**
+   * Copying the private "Me" ledger to the person's own Google Drive, and
+   * getting it back on a new phone. WhatsApp's chat-backup screen applied to a
+   * ledger: back up now, how often, which account, over which network — and the
+   * 64-character key without which none of it opens again.
+   */
   backup: {
-    connectFailed: string;
     title: string;
-    subtitle: string;
-    primaryTitle: string;
-    primaryBody: string;
-    off: string;
+    /** The settings-row label. */
+    row: string;
+    /** The promise the screen leads with. */
+    intro: string;
+    /** Shown when this build carries no Drive OAuth client id. */
+    unavailable: string;
+
+    accountSection: string;
+    notConnected: string;
     connect: string;
+    connectFailed: string;
     disconnect: string;
-    connected: string;
-    notConfigured: string;
-    /** The status line under the Waves destination when it is available. */
-    wavesHint: string;
-    /** Badge on the Waves row for a free account: it is a paid destination. */
-    plus: string;
-    /** Button on the Waves row for a free account, routing to the upgrade screen. */
-    upgrade: string;
-    networkTitle: string;
-    wifiOnly: string;
-    wifiAndData: string;
-    pending: PluralForms;
-    allBackedUp: string;
-    /** Heading of the card shown when receipts failed to upload. */
-    troubleTitle: string;
-    troubleOffline: string;
-    troublePolicy: string;
-    troubleReconnect: string;
-    troubleGeneric: string;
-    /** Reassurance under the trouble card: nothing is lost while stuck. */
-    troubleSafe: string;
-    /** Button on the trouble card: reset the backoff and try the upload again. */
-    retry: string;
-    privacyNote: string;
+    disconnectTitle: string;
+    disconnectBody: string;
+
+    backUpNow: string;
+    phaseCollecting: string;
+    phaseSealing: string;
+    phaseUploading: string;
+    backedUp: PluralForms;
+    backupFailed: string;
+
+    lastSection: string;
+    never: string;
+    /** "{date} · {size}" — when the last backup landed, and how big it was. */
+    lastLine: string;
+
+    frequencySection: string;
+    freqOff: string;
+    freqDaily: string;
+    freqWeekly: string;
+    freqMonthly: string;
+    /** Why "daily" means "daily, when you open the app". */
+    frequencyNote: string;
+
+    networkSection: string;
+    networkWifi: string;
+    networkAny: string;
+
+    keySection: string;
+    keyIntro: string;
+    keyPresent: string;
+    keyAbsent: string;
+    keyCreate: string;
+    keyShow: string;
+    keyEnter: string;
+    keyTitle: string;
+    keyWarning: string;
+    keyCopy: string;
+    keyCopied: string;
+    keyConfirm: string;
+    keyEnterTitle: string;
+    keyEnterBody: string;
+    keyEnterPlaceholder: string;
+    keyEnterInvalid: string;
+    keyEnterSave: string;
+
+    restoreSection: string;
+    restoreIntro: string;
+    restoreCheck: string;
+    restoreFound: PluralForms;
+    /** "Backed up {date}" — the found backup's own date. */
+    restoreFrom: string;
+    restoreNothingNew: string;
+    restoreConfirm: string;
+    restoreDone: PluralForms;
+    restoreFailed: string;
+    restoreWrongKey: string;
+
+    /** Why a run did nothing. Each one is a different way out. */
+    refusedNotConnected: string;
+    refusedNoKey: string;
+    refusedOffline: string;
+    refusedNetwork: string;
+    refusedAuth: string;
+    refusedNoBackup: string;
+    refusedBusy: string;
+    /** Screen-reader suffix on a chosen option row. */
+    selected: string;
   };
   /** A group: its screen, its settings, and the ways out of it. */
   group: {
@@ -3610,38 +3664,91 @@ const en: UiStrings = {
     upgrade: 'Upgrade for unlimited',
   },
   backup: {
-    connectFailed: 'Could not connect. Please try again.',
-    title: 'Storage',
-    subtitle: 'Where scanned receipts are kept',
-    primaryTitle: 'Back up receipts to',
-    primaryBody:
-      'Scanned receipts always stay on this device. Copy them to a cloud you own, or — on Plus — to Waves’ own encrypted storage.',
-    off: 'Off',
-    connect: 'Connect',
-    disconnect: 'Disconnect',
-    connected: 'Connected',
-    notConfigured: 'Not set up in this build',
-    wavesHint: 'Encrypted on Waves — a Plus feature',
-    plus: 'Plus',
-    upgrade: 'Upgrade',
-    networkTitle: 'Upload over',
-    wifiOnly: 'Wi‑Fi only',
-    wifiAndData: 'Wi‑Fi & mobile data',
-    pending: {
-      one: '{n} receipt waiting to back up',
-      other: '{n} receipts waiting to back up',
+    title: 'Backup',
+    row: 'Back up to Google Drive',
+    intro:
+      'Your private Me ledger, copied to your own Google Drive and locked with a key only you hold. Neither Waves nor Google can read it.',
+    unavailable: 'Backup is not available in this build.',
+
+    accountSection: 'Google account',
+    notConnected: 'No account linked yet',
+    connect: 'Link Google Drive',
+    connectFailed: 'Could not link that account. Try again.',
+    disconnect: 'Unlink',
+    disconnectTitle: 'Unlink Google Drive?',
+    disconnectBody:
+      'Automatic backups stop and this phone forgets its key. The backup already on Drive stays there, and the key you wrote down still opens it.',
+
+    backUpNow: 'Back up now',
+    phaseCollecting: 'Gathering your records…',
+    phaseSealing: 'Locking the backup…',
+    phaseUploading: 'Uploading to Drive…',
+    backedUp: {
+      one: '{n} record backed up',
+      other: '{n} records backed up',
     },
-    allBackedUp: 'All receipts backed up',
-    troubleTitle: 'Some receipts didn’t upload',
-    troubleOffline: 'You’re offline. They’ll upload on their own once you’re back on a network.',
-    troublePolicy: 'Uploads are set to Wi‑Fi only. Connect to Wi‑Fi, or allow mobile data above.',
-    troubleReconnect:
-      'The destination stopped accepting the upload — its sign-in may have expired, or a Plus plan ended. Reconnect it above, or pick another.',
-    troubleGeneric: 'The last attempt failed. Fix the cause, then try again.',
-    troubleSafe: 'Your receipts are safe on this device the whole time — nothing is lost.',
-    retry: 'Try again',
-    privacyNote:
-      'A personal cloud keeps the photo off Waves entirely. Waves storage is a Plus feature, encrypted at rest.',
+    backupFailed: 'The backup did not finish. Try again in a moment.',
+
+    lastSection: 'Last backup',
+    never: 'Never backed up',
+    lastLine: '{date} · {size}',
+
+    frequencySection: 'Automatic backup',
+    freqOff: 'Off',
+    freqDaily: 'Daily',
+    freqWeekly: 'Weekly',
+    freqMonthly: 'Monthly',
+    frequencyNote: 'Automatic backups run when you open the app, not while it is closed.',
+
+    networkSection: 'Back up over',
+    networkWifi: 'Wi‑Fi only',
+    networkAny: 'Wi‑Fi or mobile data',
+
+    keySection: 'Your key',
+    keyIntro:
+      'The backup is locked with a 64-character key. Write it down: it is the only way to open the backup on a new phone, and nobody can give it back to you — not Waves, not Google.',
+    keyPresent: 'This phone has your key',
+    keyAbsent: 'No key on this phone yet',
+    keyCreate: 'Create a key',
+    keyShow: 'Show my key',
+    keyEnter: 'I already have a key',
+    keyTitle: 'Your backup key',
+    keyWarning: 'Save this somewhere safe. Lose it and the backup can never be opened.',
+    keyCopy: 'Copy',
+    keyCopied: 'Copied',
+    keyConfirm: 'I have saved it',
+    keyEnterTitle: 'Enter your backup key',
+    keyEnterBody: 'The 64 characters from the phone that made the backup.',
+    keyEnterPlaceholder: '64 characters',
+    keyEnterInvalid: 'That is not a backup key. A key is 64 letters and digits.',
+    keyEnterSave: 'Use this key',
+
+    restoreSection: 'Restore',
+    restoreIntro:
+      'Bring records back from the Drive backup. Nothing already on this phone is changed or removed.',
+    restoreCheck: 'Check for a backup',
+    restoreFound: {
+      one: '{n} record to bring back',
+      other: '{n} records to bring back',
+    },
+    restoreFrom: 'Backed up {date}',
+    restoreNothingNew: 'That backup holds nothing this phone is missing.',
+    restoreConfirm: 'Restore',
+    restoreDone: {
+      one: '{n} record restored',
+      other: '{n} records restored',
+    },
+    restoreFailed: 'Could not read that backup. Try again in a moment.',
+    restoreWrongKey: 'That key does not open this backup.',
+
+    refusedNotConnected: 'Link a Google account first.',
+    refusedNoKey: 'Create your backup key first.',
+    refusedOffline: 'No connection. The backup will run when you are back online.',
+    refusedNetwork: 'Waiting for Wi‑Fi. Change Back up over to use mobile data.',
+    refusedAuth: 'Google asked for the link again. Reconnect the account.',
+    refusedNoBackup: 'There is no backup on this Drive account yet.',
+    refusedBusy: 'A backup is already running.',
+    selected: 'selected',
   },
   group: {
     notFound: 'Group not found',
@@ -5795,41 +5902,92 @@ const ta: UiStrings = {
       '\u0bb5\u0bb0\u0bae\u0bcd\u0baa\u0bbf\u0bb2\u0bcd\u0bb2\u0bbe\u0ba4\u0ba4\u0bb1\u0bcd\u0b95\u0bc1 \u0bae\u0bc7\u0bae\u0bcd\u0baa\u0b9f\u0bc1\u0ba4\u0bcd\u0ba4\u0bc1',
   },
   backup: {
-    connectFailed: 'இணைக்க முடியவில்லை. மீண்டும் முயற்சிக்கவும்.',
-    title: 'சேமிப்பு',
-    subtitle: 'ஸ்கேன் செய்த ரசீதுகள் எங்கே வைக்கப்படும்',
-    primaryTitle: 'ரசீதுகளை காப்புப்பிடி',
-    primaryBody:
-      'ஸ்கேன் செய்த ரசீதுகள் எப்போதும் இந்தச் சாதனத்தில் இருக்கும். உங்கள் சொந்த கிளவுடுக்கு நகலெடுங்கள் — அல்லது Plus-இல் Waves-இன் சொந்த குறியாக்க சேமிப்புக்கு.',
-    off: 'அணை',
-    connect: 'இணை',
-    disconnect: 'துண்டி',
-    connected: 'இணைக்கப்பட்டது',
-    notConfigured: 'இந்த பதிப்பில் அமைக்கப்படவில்லை',
-    wavesHint: 'Waves-இல் குறியாக்கம் — Plus வசதி',
-    plus: 'Plus',
-    upgrade: 'மேம்படுத்து',
-    networkTitle: 'இதன் மூலம் பதிவேற்று',
-    wifiOnly: 'வைஃபை மட்டும்',
-    wifiAndData: 'வைஃபை & மொபைல் டேட்டா',
-    pending: {
-      one: '{n} ரசீது காப்புப்படிக்கக் காத்திருக்கிறது',
-      other: '{n} ரசீதுகள் காப்புப்படிக்கக் காத்திருக்கின்றன',
+    title: 'காப்புப்பிரதி',
+    row: 'Google Drive-இல் காப்பு',
+    intro:
+      'உங்கள் தனிப்பட்ட "நான்" கணக்கு, உங்கள் சொந்த Google Drive-க்கு நகலெடுக்கப்பட்டு, உங்களிடம் மட்டுமே உள்ள சாவியால் பூட்டப்படுகிறது. Waves-ஆலும் Google-ஆலும் அதைப் படிக்க முடியாது.',
+    unavailable: 'இந்தப் பதிப்பில் காப்புப்பிரதி கிடைக்கவில்லை.',
+
+    accountSection: 'Google கணக்கு',
+    notConnected: 'எந்தக் கணக்கும் இணைக்கப்படவில்லை',
+    connect: 'Google Drive-ஐ இணை',
+    connectFailed: 'அந்தக் கணக்கை இணைக்க முடியவில்லை. மீண்டும் முயலுங்கள்.',
+    disconnect: 'இணைப்பை நீக்கு',
+    disconnectTitle: 'Google Drive இணைப்பை நீக்கவா?',
+    disconnectBody:
+      'தானியங்கி காப்புப்பிரதிகள் நிற்கும், இந்த ஃபோன் தன் சாவியை மறக்கும். Drive-இல் உள்ள காப்புப்பிரதி அப்படியே இருக்கும் — நீங்கள் எழுதி வைத்த சாவி இன்னும் அதைத் திறக்கும்.',
+
+    backUpNow: 'இப்போது காப்பு எடு',
+    phaseCollecting: 'உங்கள் பதிவுகளைச் சேகரிக்கிறது…',
+    phaseSealing: 'காப்புப்பிரதியைப் பூட்டுகிறது…',
+    phaseUploading: 'Drive-க்கு பதிவேற்றுகிறது…',
+    backedUp: {
+      one: '{n} பதிவு காப்பு செய்யப்பட்டது',
+      other: '{n} பதிவுகள் காப்பு செய்யப்பட்டன',
     },
-    allBackedUp: 'அனைத்து ரசீதுகளும் காப்புப்படி எடுக்கப்பட்டன',
-    troubleTitle: 'சில ரசீதுகள் பதிவேற்றப்படவில்லை',
-    troubleOffline:
-      'நீங்கள் ஆஃப்லைனில் உள்ளீர்கள். மீண்டும் நெட்வொர்க்கில் வந்ததும் தானாகப் பதிவேறும்.',
-    troublePolicy:
-      'பதிவேற்றம் வைஃபை மட்டும் என அமைக்கப்பட்டுள்ளது. வைஃபையில் இணையுங்கள், அல்லது மேலே மொபைல் டேட்டாவை அனுமதியுங்கள்.',
-    troubleReconnect:
-      'இலக்கு பதிவேற்றத்தை ஏற்க நிறுத்தியது — அதன் உள்நுழைவு காலாவதியாகியிருக்கலாம், அல்லது Plus திட்டம் முடிந்திருக்கலாம். மேலே மீண்டும் இணையுங்கள், அல்லது வேறொன்றைத் தேர்ந்தெடுங்கள்.',
-    troubleGeneric: 'கடைசி முயற்சி தோல்வியடைந்தது. காரணத்தைச் சரிசெய்து மீண்டும் முயற்சிக்கவும்.',
-    troubleSafe:
-      'உங்கள் ரசீதுகள் இந்தச் சாதனத்தில் எப்போதும் பாதுகாப்பாக உள்ளன — எதுவும் இழக்கப்படவில்லை.',
-    retry: 'மீண்டும் முயற்சி',
-    privacyNote:
-      'சொந்த கிளவுட் புகைப்படத்தை Waves-இலிருந்து முழுவதுமாக விலக்கி வைக்கும். Waves சேமிப்பு ஒரு Plus வசதி, ஓய்வில் குறியாக்கம் செய்யப்படும்.',
+    backupFailed: 'காப்புப்பிரதி முடியவில்லை. சிறிது நேரம் கழித்து முயலுங்கள்.',
+
+    lastSection: 'கடைசி காப்புப்பிரதி',
+    never: 'இதுவரை காப்பு எடுக்கவில்லை',
+    lastLine: '{date} · {size}',
+
+    frequencySection: 'தானியங்கி காப்பு',
+    freqOff: 'இல்லை',
+    freqDaily: 'தினமும்',
+    freqWeekly: 'வாரம் ஒருமுறை',
+    freqMonthly: 'மாதம் ஒருமுறை',
+    frequencyNote: 'செயலியைத் திறக்கும்போது தானியங்கி காப்பு இயங்கும்; மூடியிருக்கும்போது அல்ல.',
+
+    networkSection: 'எதன் வழியாகக் காப்பு எடுக்க',
+    networkWifi: 'Wi‑Fi மட்டும்',
+    networkAny: 'Wi‑Fi அல்லது மொபைல் டேட்டா',
+
+    keySection: 'உங்கள் சாவி',
+    keyIntro:
+      'காப்புப்பிரதி 64 எழுத்துச் சாவியால் பூட்டப்படுகிறது. அதை எழுதி வையுங்கள்: புதிய ஃபோனில் அதைத் திறக்க அதுவே ஒரே வழி. Waves-ஆலும் Google-ஆலும் அதைத் திரும்பத் தர முடியாது.',
+    keyPresent: 'இந்த ஃபோனில் உங்கள் சாவி உள்ளது',
+    keyAbsent: 'இந்த ஃபோனில் இன்னும் சாவி இல்லை',
+    keyCreate: 'சாவியை உருவாக்கு',
+    keyShow: 'என் சாவியைக் காட்டு',
+    keyEnter: 'என்னிடம் ஏற்கனவே சாவி உள்ளது',
+    keyTitle: 'உங்கள் காப்புச் சாவி',
+    keyWarning: 'இதைப் பத்திரமாக வையுங்கள். தொலைந்தால் காப்புப்பிரதியை ஒருபோதும் திறக்க முடியாது.',
+    keyCopy: 'நகலெடு',
+    keyCopied: 'நகலெடுக்கப்பட்டது',
+    keyConfirm: 'சேமித்துவிட்டேன்',
+    keyEnterTitle: 'உங்கள் காப்புச் சாவியை உள்ளிடுங்கள்',
+    keyEnterBody: 'காப்பு எடுத்த ஃபோனில் இருந்த 64 எழுத்துகள்.',
+    keyEnterPlaceholder: '64 எழுத்துகள்',
+    keyEnterInvalid: 'இது காப்புச் சாவி அல்ல. சாவி 64 எழுத்துகளும் இலக்கங்களும் கொண்டது.',
+    keyEnterSave: 'இந்தச் சாவியைப் பயன்படுத்து',
+
+    restoreSection: 'மீட்டெடு',
+    restoreIntro:
+      'Drive காப்புப்பிரதியிலிருந்து பதிவுகளைத் திரும்பக் கொண்டுவாருங்கள். இந்த ஃபோனில் ஏற்கனவே உள்ளது எதுவும் மாறாது, நீக்கப்படாது.',
+    restoreCheck: 'காப்புப்பிரதி உள்ளதா எனப் பார்',
+    restoreFound: {
+      one: '{n} பதிவைத் திரும்பக் கொண்டுவரலாம்',
+      other: '{n} பதிவுகளைத் திரும்பக் கொண்டுவரலாம்',
+    },
+    restoreFrom: '{date} அன்று எடுக்கப்பட்ட காப்பு',
+    restoreNothingNew: 'இந்த ஃபோனில் இல்லாதது எதுவும் அந்தக் காப்பில் இல்லை.',
+    restoreConfirm: 'மீட்டெடு',
+    restoreDone: {
+      one: '{n} பதிவு மீட்கப்பட்டது',
+      other: '{n} பதிவுகள் மீட்கப்பட்டன',
+    },
+    restoreFailed: 'அந்தக் காப்பைப் படிக்க முடியவில்லை. சிறிது நேரம் கழித்து முயலுங்கள்.',
+    restoreWrongKey: 'அந்தச் சாவி இந்தக் காப்பைத் திறக்காது.',
+
+    refusedNotConnected: 'முதலில் ஒரு Google கணக்கை இணையுங்கள்.',
+    refusedNoKey: 'முதலில் உங்கள் காப்புச் சாவியை உருவாக்குங்கள்.',
+    refusedOffline: 'இணைப்பு இல்லை. மீண்டும் ஆன்லைனுக்கு வரும்போது காப்பு எடுக்கப்படும்.',
+    refusedNetwork:
+      'Wi‑Fi-க்காகக் காத்திருக்கிறது. மொபைல் டேட்டாவைப் பயன்படுத்த அமைப்பை மாற்றுங்கள்.',
+    refusedAuth: 'Google மீண்டும் அனுமதி கேட்கிறது. கணக்கை மீண்டும் இணையுங்கள்.',
+    refusedNoBackup: 'இந்த Drive கணக்கில் இன்னும் காப்புப்பிரதி இல்லை.',
+    refusedBusy: 'ஒரு காப்பு ஏற்கனவே இயங்குகிறது.',
+    selected: 'தேர்ந்தெடுக்கப்பட்டது',
   },
   group: {
     notFound: 'குழு கிடைக்கவில்லை',
@@ -7993,39 +8151,91 @@ const hi: UiStrings = {
       '\u0905\u0938\u0940\u092e\u093f\u0924 \u0915\u0947 \u0932\u093f\u090f \u0905\u092a\u0917\u094d\u0930\u0947\u0921 \u0915\u0930\u0947\u0902',
   },
   backup: {
-    connectFailed: 'कनेक्ट नहीं हो सका। कृपया फिर कोशिश करें।',
-    title: 'स्टोरेज',
-    subtitle: 'स्कैन की गई रसीदें कहाँ रखी जाती हैं',
-    primaryTitle: 'रसीदें यहाँ बैकअप करें',
-    primaryBody:
-      'स्कैन की गई रसीदें हमेशा इसी डिवाइस पर रहती हैं। इन्हें अपने किसी क्लाउड पर कॉपी करें — या Plus पर Waves के अपने एन्क्रिप्टेड स्टोरेज पर।',
-    off: 'बंद',
-    connect: 'कनेक्ट करें',
-    disconnect: 'डिसकनेक्ट करें',
-    connected: 'कनेक्टेड',
-    notConfigured: 'इस बिल्ड में सेट नहीं है',
-    wavesHint: 'Waves पर एन्क्रिप्टेड — एक Plus सुविधा',
-    plus: 'Plus',
-    upgrade: 'अपग्रेड',
-    networkTitle: 'इसके ज़रिए अपलोड करें',
-    wifiOnly: 'केवल वाई‑फाई',
-    wifiAndData: 'वाई‑फाई और मोबाइल डेटा',
-    pending: {
-      one: '{n} रसीद बैकअप के लिए प्रतीक्षारत',
-      other: '{n} रसीदें बैकअप के लिए प्रतीक्षारत',
+    title: 'बैकअप',
+    row: 'Google Drive पर बैकअप',
+    intro:
+      'आपका निजी "मैं" खाता, आपकी अपनी Google Drive पर कॉपी होता है और सिर्फ़ आपके पास मौजूद चाबी से बंद रहता है। इसे न Waves पढ़ सकता है, न Google।',
+    unavailable: 'इस बिल्ड में बैकअप उपलब्ध नहीं है।',
+
+    accountSection: 'Google खाता',
+    notConnected: 'अभी कोई खाता जुड़ा नहीं है',
+    connect: 'Google Drive जोड़ें',
+    connectFailed: 'वह खाता नहीं जुड़ सका। फिर कोशिश करें।',
+    disconnect: 'हटाएँ',
+    disconnectTitle: 'Google Drive हटाएँ?',
+    disconnectBody:
+      'अपने आप होने वाले बैकअप रुक जाएँगे और यह फ़ोन अपनी चाबी भूल जाएगा। Drive पर मौजूद बैकअप वहीं रहेगा — आपकी लिखी हुई चाबी उसे अब भी खोल देगी।',
+
+    backUpNow: 'अभी बैकअप लें',
+    phaseCollecting: 'आपके रिकॉर्ड जुटाए जा रहे हैं…',
+    phaseSealing: 'बैकअप बंद किया जा रहा है…',
+    phaseUploading: 'Drive पर भेजा जा रहा है…',
+    backedUp: {
+      one: '{n} रिकॉर्ड का बैकअप हो गया',
+      other: '{n} रिकॉर्ड का बैकअप हो गया',
     },
-    allBackedUp: 'सभी रसीदें बैकअप हो गईं',
-    troubleTitle: 'कुछ रसीदें अपलोड नहीं हुईं',
-    troubleOffline: 'आप ऑफ़लाइन हैं। नेटवर्क वापस आते ही ये अपने आप अपलोड हो जाएँगी।',
-    troublePolicy:
-      'अपलोड केवल वाई‑फाई पर सेट है। वाई‑फाई से कनेक्ट करें, या ऊपर मोबाइल डेटा की अनुमति दें।',
-    troubleReconnect:
-      'गंतव्य ने अपलोड लेना बंद कर दिया — उसका साइन-इन समाप्त हो गया होगा, या Plus प्लान खत्म हो गया होगा। ऊपर दोबारा कनेक्ट करें, या कोई और चुनें।',
-    troubleGeneric: 'पिछली कोशिश विफल रही। कारण ठीक करें, फिर दोबारा कोशिश करें।',
-    troubleSafe: 'आपकी रसीदें इस दौरान इसी डिवाइस पर सुरक्षित रहती हैं — कुछ भी नहीं खोता।',
-    retry: 'दोबारा कोशिश करें',
-    privacyNote:
-      'निजी क्लाउड रखने पर फ़ोटो Waves तक पहुँचती ही नहीं। Waves स्टोरेज एक Plus सुविधा है, जो स्थिर अवस्था में एन्क्रिप्टेड रहती है।',
+    backupFailed: 'बैकअप पूरा नहीं हुआ। थोड़ी देर में फिर कोशिश करें।',
+
+    lastSection: 'पिछला बैकअप',
+    never: 'अभी तक कोई बैकअप नहीं',
+    lastLine: '{date} · {size}',
+
+    frequencySection: 'अपने आप बैकअप',
+    freqOff: 'बंद',
+    freqDaily: 'रोज़',
+    freqWeekly: 'हफ़्ते में एक बार',
+    freqMonthly: 'महीने में एक बार',
+    frequencyNote: 'अपने आप बैकअप तब चलता है जब आप ऐप खोलते हैं, बंद रहने पर नहीं।',
+
+    networkSection: 'किस पर बैकअप लें',
+    networkWifi: 'सिर्फ़ Wi‑Fi',
+    networkAny: 'Wi‑Fi या मोबाइल डेटा',
+
+    keySection: 'आपकी चाबी',
+    keyIntro:
+      'बैकअप 64 अक्षरों की एक चाबी से बंद रहता है। उसे लिख लीजिए: नए फ़ोन पर बैकअप खोलने का यही एक रास्ता है, और उसे कोई लौटा नहीं सकता — न Waves, न Google।',
+    keyPresent: 'इस फ़ोन पर आपकी चाबी है',
+    keyAbsent: 'इस फ़ोन पर अभी कोई चाबी नहीं',
+    keyCreate: 'चाबी बनाएँ',
+    keyShow: 'मेरी चाबी दिखाएँ',
+    keyEnter: 'मेरे पास पहले से चाबी है',
+    keyTitle: 'आपकी बैकअप चाबी',
+    keyWarning: 'इसे कहीं सुरक्षित रखें। खो गई तो बैकअप कभी नहीं खुलेगा।',
+    keyCopy: 'कॉपी करें',
+    keyCopied: 'कॉपी हो गया',
+    keyConfirm: 'मैंने सहेज लिया',
+    keyEnterTitle: 'अपनी बैकअप चाबी डालें',
+    keyEnterBody: 'उस फ़ोन के 64 अक्षर जिसने बैकअप लिया था।',
+    keyEnterPlaceholder: '64 अक्षर',
+    keyEnterInvalid: 'यह बैकअप चाबी नहीं है। चाबी में 64 अक्षर और अंक होते हैं।',
+    keyEnterSave: 'यही चाबी इस्तेमाल करें',
+
+    restoreSection: 'वापस लाएँ',
+    restoreIntro:
+      'Drive बैकअप से रिकॉर्ड वापस लाएँ। इस फ़ोन पर जो पहले से है, वह न बदलेगा न हटेगा।',
+    restoreCheck: 'बैकअप ढूँढें',
+    restoreFound: {
+      one: '{n} रिकॉर्ड वापस आ सकता है',
+      other: '{n} रिकॉर्ड वापस आ सकते हैं',
+    },
+    restoreFrom: '{date} को लिया गया बैकअप',
+    restoreNothingNew: 'उस बैकअप में ऐसा कुछ नहीं जो इस फ़ोन पर न हो।',
+    restoreConfirm: 'वापस लाएँ',
+    restoreDone: {
+      one: '{n} रिकॉर्ड वापस आ गया',
+      other: '{n} रिकॉर्ड वापस आ गए',
+    },
+    restoreFailed: 'वह बैकअप पढ़ा नहीं जा सका। थोड़ी देर में फिर कोशिश करें।',
+    restoreWrongKey: 'यह चाबी इस बैकअप को नहीं खोलती।',
+
+    refusedNotConnected: 'पहले एक Google खाता जोड़ें।',
+    refusedNoKey: 'पहले अपनी बैकअप चाबी बनाएँ।',
+    refusedOffline: 'कोई कनेक्शन नहीं। ऑनलाइन आते ही बैकअप चल जाएगा।',
+    refusedNetwork: 'Wi‑Fi का इंतज़ार है। मोबाइल डेटा इस्तेमाल करने के लिए सेटिंग बदलें।',
+    refusedAuth: 'Google ने फिर से अनुमति माँगी है। खाता दोबारा जोड़ें।',
+    refusedNoBackup: 'इस Drive खाते पर अभी कोई बैकअप नहीं है।',
+    refusedBusy: 'एक बैकअप पहले से चल रहा है।',
+    selected: 'चुना गया',
   },
   group: {
     notFound: 'समूह नहीं मिला',
@@ -10199,42 +10409,102 @@ const ar: UiStrings = {
       '\u0627\u0644\u062a\u0631\u0642\u064a\u0629 \u0644\u063a\u064a\u0631 \u0645\u062d\u062f\u0648\u062f',
   },
   backup: {
-    connectFailed: 'تعذّر الاتصال. حاول مرة أخرى.',
-    title: 'التخزين',
-    subtitle: 'أين تُحفظ الإيصالات الممسوحة',
-    primaryTitle: 'انسخ الإيصالات احتياطيًا إلى',
-    primaryBody:
-      'تبقى الإيصالات الممسوحة دائمًا على هذا الجهاز. انسخها إلى سحابة تملكها — أو، مع Plus، إلى تخزين Waves المشفّر الخاص.',
-    off: 'إيقاف',
-    connect: 'اتصال',
-    disconnect: 'قطع الاتصال',
-    connected: 'متصل',
-    notConfigured: 'غير مُهيّأ في هذه النسخة',
-    wavesHint: 'مشفّر على Waves — ميزة Plus',
-    plus: 'Plus',
-    upgrade: 'ترقية',
-    networkTitle: 'الرفع عبر',
-    wifiOnly: 'واي‑فاي فقط',
-    wifiAndData: 'واي‑فاي وبيانات الجوال',
-    pending: {
-      zero: 'لا إيصالات بانتظار النسخ',
-      one: 'إيصال واحد بانتظار النسخ الاحتياطي',
-      two: 'إيصالان بانتظار النسخ',
-      few: '{n} إيصالات بانتظار النسخ',
-      many: '{n} إيصالًا بانتظار النسخ',
-      other: '{n} إيصال بانتظار النسخ',
+    title: 'النسخ الاحتياطي',
+    row: 'نسخ احتياطي إلى Google Drive',
+    intro:
+      'دفترك الخاص في تبويب "أنا"، يُنسخ إلى Google Drive الخاص بك ويُقفل بمفتاح لا يملكه سواك. لا يستطيع Waves ولا Google قراءته.',
+    unavailable: 'النسخ الاحتياطي غير متاح في هذه النسخة.',
+
+    accountSection: 'حساب Google',
+    notConnected: 'لم يُربط أي حساب بعد',
+    connect: 'اربط Google Drive',
+    connectFailed: 'تعذّر ربط هذا الحساب. حاول مرة أخرى.',
+    disconnect: 'إلغاء الربط',
+    disconnectTitle: 'إلغاء ربط Google Drive؟',
+    disconnectBody:
+      'يتوقف النسخ التلقائي وينسى هذا الهاتف مفتاحه. تبقى النسخة الموجودة على Drive كما هي، والمفتاح الذي كتبته ما زال يفتحها.',
+
+    backUpNow: 'انسخ الآن',
+    phaseCollecting: 'يجمع سجلاتك…',
+    phaseSealing: 'يقفل النسخة…',
+    phaseUploading: 'يرفع إلى Drive…',
+    backedUp: {
+      zero: 'لا سجلات لنسخها',
+      one: 'نُسخ سجل واحد',
+      two: 'نُسخ سجلان',
+      few: 'نُسخت {n} سجلات',
+      many: 'نُسخ {n} سجلًا',
+      other: 'نُسخ {n} سجل',
     },
-    allBackedUp: 'تم نسخ جميع الإيصالات احتياطيًا',
-    troubleTitle: 'لم تُرفع بعض الإيصالات',
-    troubleOffline: 'أنت غير متصل. ستُرفع تلقائيًا بمجرد عودتك إلى الشبكة.',
-    troublePolicy: 'الرفع مضبوط على واي‑فاي فقط. اتصل بواي‑فاي، أو اسمح ببيانات الجوال أعلاه.',
-    troubleReconnect:
-      'توقّفت الوجهة عن قبول الرفع — قد تكون صلاحية تسجيل دخولها انتهت، أو انتهت خطة Plus. أعد الاتصال أعلاه، أو اختر وجهة أخرى.',
-    troubleGeneric: 'فشلت المحاولة الأخيرة. عالج السبب ثم أعد المحاولة.',
-    troubleSafe: 'تبقى إيصالاتك آمنة على هذا الجهاز طوال الوقت — لا شيء يُفقد.',
-    retry: 'أعد المحاولة',
-    privacyNote:
-      'السحابة الخاصة تُبقي الصورة بعيدة عن Waves تمامًا. تخزين Waves ميزة Plus، مشفّر أثناء التخزين.',
+    backupFailed: 'لم يكتمل النسخ. حاول بعد قليل.',
+
+    lastSection: 'آخر نسخة احتياطية',
+    never: 'لم يحدث نسخ بعد',
+    lastLine: '{date} · {size}',
+
+    frequencySection: 'النسخ التلقائي',
+    freqOff: 'إيقاف',
+    freqDaily: 'يوميًا',
+    freqWeekly: 'أسبوعيًا',
+    freqMonthly: 'شهريًا',
+    frequencyNote: 'يعمل النسخ التلقائي عند فتحك للتطبيق، لا وهو مغلق.',
+
+    networkSection: 'النسخ عبر',
+    networkWifi: 'Wi‑Fi فقط',
+    networkAny: 'Wi‑Fi أو بيانات الجوال',
+
+    keySection: 'مفتاحك',
+    keyIntro:
+      'تُقفل النسخة بمفتاح من 64 حرفًا. اكتبه في مكان آمن: هو الطريق الوحيد لفتح النسخة على هاتف جديد، ولا أحد يستطيع إعادته لك — لا Waves ولا Google.',
+    keyPresent: 'هذا الهاتف يحمل مفتاحك',
+    keyAbsent: 'لا مفتاح على هذا الهاتف بعد',
+    keyCreate: 'أنشئ مفتاحًا',
+    keyShow: 'أظهر مفتاحي',
+    keyEnter: 'لديّ مفتاح بالفعل',
+    keyTitle: 'مفتاح النسخة الاحتياطية',
+    keyWarning: 'احفظه في مكان آمن. إن ضاع لن تُفتح النسخة أبدًا.',
+    keyCopy: 'نسخ',
+    keyCopied: 'تم النسخ',
+    keyConfirm: 'حفظته',
+    keyEnterTitle: 'أدخل مفتاح النسخة',
+    keyEnterBody: 'الأحرف الـ64 من الهاتف الذي أنشأ النسخة.',
+    keyEnterPlaceholder: '64 حرفًا',
+    keyEnterInvalid: 'هذا ليس مفتاح نسخة. المفتاح 64 حرفًا ورقمًا.',
+    keyEnterSave: 'استخدم هذا المفتاح',
+
+    restoreSection: 'الاستعادة',
+    restoreIntro: 'أعد السجلات من نسخة Drive. لا يتغيّر ولا يُحذف شيء موجود على هذا الهاتف.',
+    restoreCheck: 'ابحث عن نسخة',
+    restoreFound: {
+      zero: 'لا شيء لاستعادته',
+      one: 'سجل واحد يمكن استعادته',
+      two: 'سجلان يمكن استعادتهما',
+      few: '{n} سجلات يمكن استعادتها',
+      many: '{n} سجلًا يمكن استعادته',
+      other: '{n} سجل يمكن استعادته',
+    },
+    restoreFrom: 'نُسخت في {date}',
+    restoreNothingNew: 'لا تحوي تلك النسخة شيئًا ينقص هذا الهاتف.',
+    restoreConfirm: 'استعادة',
+    restoreDone: {
+      zero: 'لم يُستعَد شيء',
+      one: 'استُعيد سجل واحد',
+      two: 'استُعيد سجلان',
+      few: 'استُعيدت {n} سجلات',
+      many: 'استُعيد {n} سجلًا',
+      other: 'استُعيد {n} سجل',
+    },
+    restoreFailed: 'تعذّرت قراءة تلك النسخة. حاول بعد قليل.',
+    restoreWrongKey: 'هذا المفتاح لا يفتح هذه النسخة.',
+
+    refusedNotConnected: 'اربط حساب Google أولًا.',
+    refusedNoKey: 'أنشئ مفتاح النسخة أولًا.',
+    refusedOffline: 'لا اتصال. سيجري النسخ عند عودتك للاتصال.',
+    refusedNetwork: 'في انتظار Wi‑Fi. غيّر الإعداد لاستخدام بيانات الجوال.',
+    refusedAuth: 'طلب Google الإذن من جديد. أعد ربط الحساب.',
+    refusedNoBackup: 'لا توجد نسخة على حساب Drive هذا بعد.',
+    refusedBusy: 'هناك نسخ جارٍ بالفعل.',
+    selected: 'محدد',
   },
   group: {
     notFound: 'المجموعة غير موجودة',

--- a/apps/mobile/src/lib/backup/AutoBackup.tsx
+++ b/apps/mobile/src/lib/backup/AutoBackup.tsx
@@ -58,12 +58,12 @@ export function AutoBackup() {
       if (now - lastCheckRef.current < CHECK_THROTTLE_MS) return;
       lastCheckRef.current = now;
 
-      const settings = await loadBackupSettings();
+      const settings = await loadBackupSettings(ownerId);
       if (!isDue(settings.last?.at ?? null, settings.frequency, now)) return;
       // Nothing goes out until the person has been shown the recovery key and
       // said they have it — a backup they cannot open is worse than none.
       if (!settings.keySeen) return;
-      const key = await loadRecoveryKey();
+      const key = await loadRecoveryKey(ownerId);
       if (!key) return;
 
       const result = await runBackup({
@@ -75,7 +75,7 @@ export function AutoBackup() {
         manual: false,
       });
       if (!alive || !result.ok) return;
-      await saveLastBackup(result.last);
+      await saveLastBackup(ownerId, result.last);
     };
 
     // Everything in here is best effort and silent. An automatic backup that

--- a/apps/mobile/src/lib/backup/AutoBackup.tsx
+++ b/apps/mobile/src/lib/backup/AutoBackup.tsx
@@ -1,0 +1,100 @@
+/**
+ * The automatic half of "Automatic backup: Daily / Weekly / Monthly".
+ *
+ * A headless component, mounted once inside the lock and auth gates. It renders
+ * nothing; it exists because the only honest source for the ledger is a hook,
+ * and a hook needs somewhere to live.
+ *
+ * What it deliberately is *not* is a background task. There is no OS alarm here
+ * — no `expo-background-task`, no `WorkManager`, no BGTaskScheduler. A phone
+ * that has not been opened in a week has not backed up in a week, and the screen
+ * says when the last one was rather than implying a schedule the OS never
+ * promised to keep. (Both platforms treat background work as discretionary:
+ * iOS decides when, or whether, a refresh task runs, and Android's Doze defers
+ * everything on an idle device. An app that says "daily" and means it needs a
+ * native module and a battery conversation, and that is a separate decision.)
+ *
+ * So: check when the app comes to the foreground, and once on mount. That is
+ * enough to make a daily backup happen daily for anyone who opens the app
+ * daily, which is the population the setting is for.
+ */
+
+import { useEffect, useRef } from 'react';
+import { AppState } from 'react-native';
+
+import { usePersonalRecords } from '@/data/personal';
+import { useAuth } from '@/lib/auth';
+import { reportHandled } from '@/lib/observability';
+
+import { runBackup } from './engine';
+import { loadRecoveryKey } from './recoveryKey';
+import { isDue } from './schedule';
+import { loadBackupSettings, saveLastBackup } from './settings';
+
+/** Don't re-ask the question more than this often, however often we foreground. */
+const CHECK_THROTTLE_MS = 5 * 60 * 1000;
+
+export function AutoBackup() {
+  const { session } = useAuth();
+  const ownerId = session?.user?.id ?? '';
+  const records = usePersonalRecords();
+
+  // The newest ledger, read at the moment a check fires rather than captured
+  // when the effect was set up — the effect must not re-subscribe to AppState
+  // every time somebody adds an expense.
+  const recordsRef = useRef(records);
+  useEffect(() => {
+    recordsRef.current = records;
+  }, [records]);
+
+  const lastCheckRef = useRef(0);
+
+  useEffect(() => {
+    if (!ownerId) return;
+    let alive = true;
+
+    const check = async (): Promise<void> => {
+      const now = Date.now();
+      if (now - lastCheckRef.current < CHECK_THROTTLE_MS) return;
+      lastCheckRef.current = now;
+
+      const settings = await loadBackupSettings();
+      if (!isDue(settings.last?.at ?? null, settings.frequency, now)) return;
+      // Nothing goes out until the person has been shown the recovery key and
+      // said they have it — a backup they cannot open is worse than none.
+      if (!settings.keySeen) return;
+      const key = await loadRecoveryKey();
+      if (!key) return;
+
+      const result = await runBackup({
+        ownerId,
+        records: recordsRef.current,
+        key,
+        network: settings.network,
+        // The whole point of the network preference is to gate *this* run.
+        manual: false,
+      });
+      if (!alive || !result.ok) return;
+      await saveLastBackup(result.last);
+    };
+
+    // Everything in here is best effort and silent. An automatic backup that
+    // failed is visible where it belongs — the "Last backup" line on the
+    // settings screen, which will still be showing the older date — not as an
+    // alert over whatever the person was actually doing.
+    const run = (): void => {
+      void check().catch((error: unknown) => reportHandled(error, 'backup.auto'));
+    };
+
+    run();
+    const subscription = AppState.addEventListener('change', (state) => {
+      if (state === 'active') run();
+    });
+    return () => {
+      alive = false;
+      subscription.remove();
+    };
+  }, [ownerId]);
+
+  return null;
+}

--- a/apps/mobile/src/lib/backup/engine.ts
+++ b/apps/mobile/src/lib/backup/engine.ts
@@ -21,7 +21,7 @@ import { networkAllows, type SyncNetworkPreference } from '../syncNetwork';
 import { isAuthFailure } from '../cloud/http';
 import { providerFor } from '../cloud/providers';
 import { clearTokens, loadTokens, saveTokens } from '../cloud/tokens';
-import type { CloudProviderId } from '../cloud/types';
+import type { CloudProviderId, CloudTokens } from '../cloud/types';
 import {
   backupAad,
   buildBody,
@@ -33,11 +33,27 @@ import {
   type RestorePlan,
   type SourceRecord,
 } from './payload';
-import { backupNonce, openBackup, sealBackup } from './recoveryKey';
-import type { LastBackup } from './settings';
+import { backupNonce, clearRecoveryKey, openBackup, sealBackup } from './recoveryKey';
+import { clearBackupSettings, type LastBackup } from './settings';
 
-/** The one file in the provider's app-private storage. Overwritten in place. */
-export const BACKUP_FILE_NAME = 'waves-personal-backup.json';
+/**
+ * The one file in the provider's app-private storage, per account. Overwritten
+ * in place, so the appDataFolder never accumulates.
+ *
+ * The owner id is in the name because scoping the *local* keys is not enough:
+ * two different Waves accounts that link the same Google account share one
+ * appDataFolder, and a fixed filename would have the second silently overwrite
+ * the first's backup — sealed under a key whose AAD no longer matches, so the
+ * first person could never open what was left of theirs. Nothing has ever run
+ * against Google (this build has no OAuth client ids), so there is no old
+ * fixed-name file anywhere to migrate; a shipped build would have needed one.
+ */
+export function backupFileName(ownerId: string): string {
+  // The id is a UUID from Supabase, but the name goes into a Drive query, so it
+  // is narrowed here rather than trusted to stay one.
+  const safe = ownerId.toLowerCase().replace(/[^a-z0-9-]/g, '');
+  return `waves-personal-backup-${safe}.json`;
+}
 
 /** Only Drive today; named so the rest of the module never hardcodes it. */
 export const PRIMARY_PROVIDER: CloudProviderId = 'gdrive';
@@ -111,17 +127,66 @@ async function connection(): Promise<{ online: boolean; type: Network.NetworkSta
 }
 
 /**
- * Tokens good to use now, refreshed if stale and written back so the next run
- * starts from the fresh pair. Null when there is nothing linked; throws only if
- * the refresh itself fails in a way worth reporting.
+ * The three answers to "can we talk to the provider right now", kept apart.
+ *
+ * `none` and `auth` used to be the same answer, because the refresh was wrapped
+ * in a `.catch(() => null)`: a refresh token the user had revoked came back as
+ * "nothing is linked", the dead tokens stayed on disk, and the screen offered
+ * connect-from-scratch as the remedy for a link that needed re-authorising.
+ * Two different states with two different ways out, so: two values.
  */
-async function freshTokens(id: CloudProviderId) {
-  const stored = await loadTokens(id);
-  if (!stored) return null;
-  const provider = providerFor(id);
-  const tokens = await provider.ensureValid(stored);
-  if (tokens !== stored) await saveTokens(id, tokens);
-  return tokens;
+type TokenLookup =
+  | { readonly kind: 'ok'; readonly tokens: CloudTokens }
+  | { readonly kind: 'none' }
+  | { readonly kind: 'auth' };
+
+/**
+ * Tokens good to use now, refreshed if stale and written back so the next run
+ * starts from the fresh pair.
+ *
+ * Throws for a transport failure — a token endpoint that timed out is not a
+ * dead link, and the caller launders the message before anybody sees it.
+ */
+async function freshTokens(id: CloudProviderId, ownerId: string): Promise<TokenLookup> {
+  const stored = await loadTokens(id, ownerId);
+  if (!stored) return { kind: 'none' };
+  try {
+    const tokens = await providerFor(id).ensureValid(stored);
+    if (tokens !== stored) await saveTokens(id, ownerId, tokens);
+    return { kind: 'ok', tokens };
+  } catch (error) {
+    if (!isAuthFailure(error)) throw error;
+    // The grant is gone for good. Drop the tokens so the screen stops offering
+    // a retry that cannot work, and say which of the two states this is.
+    await clearTokens(id, ownerId).catch(() => undefined);
+    return { kind: 'auth' };
+  }
+}
+
+/**
+ * Everything this device remembers about one account's backups: the provider
+ * tokens, the recovery key, and the schedule / last-backup / key-seen
+ * preferences.
+ *
+ * Called on unlink and — the case that matters — from the sign-out wipe in
+ * `sync/provider.tsx`. Until this existed, B signing in after A on a shared
+ * phone found A's Google account linked, held A's recovery key, and inherited
+ * A's schedule; worse, B's first backup would have found A's file and
+ * overwritten it. Every piece is attempted even after one fails and the first
+ * failure is rethrown, matching `clearLocalPrivateData`: a credential left
+ * behind by a half-finished wipe is a privacy problem, not a cosmetic one.
+ *
+ * The file on Drive is deliberately untouched. It is the user's, it is
+ * unreadable without the key they wrote down, and the point of it is to outlive
+ * this app's state.
+ */
+export async function clearBackupState(ownerId: string): Promise<void> {
+  if (!ownerId) return;
+  const failures: unknown[] = [];
+  await clearTokens(PRIMARY_PROVIDER, ownerId).catch((error: unknown) => failures.push(error));
+  await clearRecoveryKey(ownerId).catch((error: unknown) => failures.push(error));
+  await clearBackupSettings(ownerId).catch((error: unknown) => failures.push(error));
+  if (failures.length > 0) throw failures[0];
 }
 
 /**
@@ -144,8 +209,11 @@ export async function runBackup(input: BackupRunInput): Promise<BackupResult> {
       return { ok: false, refusal: 'network-policy' };
     }
 
-    const tokens = await freshTokens(PRIMARY_PROVIDER).catch(() => null);
-    if (!tokens) return { ok: false, refusal: 'not-connected' };
+    const lookup = await freshTokens(PRIMARY_PROVIDER, input.ownerId);
+    if (lookup.kind !== 'ok') {
+      return { ok: false, refusal: lookup.kind === 'auth' ? 'auth' : 'not-connected' };
+    }
+    const tokens = lookup.tokens;
 
     input.onPhase?.('collecting');
     const body = buildBody(input.ownerId, input.records, new Date());
@@ -160,14 +228,10 @@ export async function runBackup(input: BackupRunInput): Promise<BackupResult> {
     const content = JSON.stringify(buildFile(sealed, body.createdAt));
 
     input.onPhase?.('uploading');
+    const fileName = backupFileName(input.ownerId);
     try {
-      const existing = await provider.find(tokens, BACKUP_FILE_NAME);
-      const stored = await provider.put(
-        tokens,
-        BACKUP_FILE_NAME,
-        content,
-        existing?.remoteId ?? null,
-      );
+      const existing = await provider.find(tokens, fileName);
+      const stored = await provider.put(tokens, fileName, content, existing?.remoteId ?? null);
       return {
         ok: true,
         last: {
@@ -183,7 +247,7 @@ export async function runBackup(input: BackupRunInput): Promise<BackupResult> {
       // as a 401/403 forever. Drop the dead tokens so the screen offers
       // "Connect" rather than retrying a link that no longer exists.
       if (isAuthFailure(error)) {
-        await clearTokens(PRIMARY_PROVIDER);
+        await clearTokens(PRIMARY_PROVIDER, input.ownerId).catch(() => undefined);
         return { ok: false, refusal: 'auth' };
       }
       throw error;
@@ -228,11 +292,14 @@ export async function scanBackup(input: RestoreScanInput): Promise<RestoreScan> 
   const net = await connection();
   if (!net.online) return { ok: false, refusal: 'offline' };
 
-  const tokens = await freshTokens(PRIMARY_PROVIDER).catch(() => null);
-  if (!tokens) return { ok: false, refusal: 'not-connected' };
+  const lookup = await freshTokens(PRIMARY_PROVIDER, input.ownerId);
+  if (lookup.kind !== 'ok') {
+    return { ok: false, refusal: lookup.kind === 'auth' ? 'auth' : 'not-connected' };
+  }
+  const tokens = lookup.tokens;
 
   try {
-    const file = await provider.find(tokens, BACKUP_FILE_NAME);
+    const file = await provider.find(tokens, backupFileName(input.ownerId));
     if (!file) return { ok: false, refusal: 'no-backup' };
 
     const envelope = parseFile(await provider.read(tokens, file.remoteId));
@@ -248,7 +315,7 @@ export async function scanBackup(input: RestoreScanInput): Promise<RestoreScan> 
     };
   } catch (error) {
     if (isAuthFailure(error)) {
-      await clearTokens(PRIMARY_PROVIDER);
+      await clearTokens(PRIMARY_PROVIDER, input.ownerId).catch(() => undefined);
       return { ok: false, refusal: 'auth' };
     }
     throw error;

--- a/apps/mobile/src/lib/backup/engine.ts
+++ b/apps/mobile/src/lib/backup/engine.ts
@@ -1,0 +1,256 @@
+/**
+ * The pump: take the personal ledger, seal it, put it in the user's Drive — and
+ * on the way back, fetch it, open it, and say what a restore would write.
+ *
+ * No React and no hooks, so the whole flow can be reasoned about (and most of
+ * it tested) without a renderer. What it does not own is *what* to back up: the
+ * records come in from the caller, because the only honest source for them is
+ * the mirror with the offline queue replayed on top, and that is a hook.
+ *
+ * Two kinds of "did not happen" are kept apart on purpose. A **refusal** is a
+ * state the person can act on — no Drive connected, no key, holding for Wi‑Fi —
+ * and is returned as a value so the screen can say which one in their own
+ * words. A **failure** is a thrown error carrying a provider message that must
+ * never reach a screen; it goes through `friendlyError` at the call site, which
+ * reports the original and returns a sentence.
+ */
+
+import * as Network from 'expo-network';
+
+import { networkAllows, type SyncNetworkPreference } from '../syncNetwork';
+import { isAuthFailure } from '../cloud/http';
+import { providerFor } from '../cloud/providers';
+import { clearTokens, loadTokens, saveTokens } from '../cloud/tokens';
+import type { CloudProviderId } from '../cloud/types';
+import {
+  backupAad,
+  buildBody,
+  buildFile,
+  parseBody,
+  parseFile,
+  planRestore,
+  type BackupBody,
+  type RestorePlan,
+  type SourceRecord,
+} from './payload';
+import { backupNonce, openBackup, sealBackup } from './recoveryKey';
+import type { LastBackup } from './settings';
+
+/** The one file in the provider's app-private storage. Overwritten in place. */
+export const BACKUP_FILE_NAME = 'waves-personal-backup.json';
+
+/** Only Drive today; named so the rest of the module never hardcodes it. */
+export const PRIMARY_PROVIDER: CloudProviderId = 'gdrive';
+
+/** Where a run has got to, for the progress line under "Back up now". */
+export type BackupPhase = 'collecting' | 'sealing' | 'uploading';
+
+/** A run that did not happen, and why — each one has a different way out. */
+export type BackupRefusal =
+  /** Another run is already going. */
+  | 'busy'
+  /** This build has no OAuth client id for the provider. */
+  | 'not-configured'
+  /** No Drive account linked. */
+  | 'not-connected'
+  /** No recovery key on this device — nothing to seal (or open) with. */
+  | 'no-key'
+  /** No usable connection at all. */
+  | 'offline'
+  /** Connected, but not over a network the person allows backups on. */
+  | 'network-policy'
+  /** The stored tokens were rejected; the link has to be made again. */
+  | 'auth'
+  /** Nothing on Drive to restore from. */
+  | 'no-backup';
+
+export type BackupResult =
+  | { readonly ok: true; readonly last: LastBackup }
+  | { readonly ok: false; readonly refusal: BackupRefusal };
+
+export interface BackupRunInput {
+  readonly ownerId: string;
+  readonly records: readonly SourceRecord[];
+  /** The 32-byte recovery key. See `recoveryKey.ts` for why it is user-held. */
+  readonly key: Uint8Array;
+  readonly network: SyncNetworkPreference;
+  /**
+   * True for "Back up now". A person tapping the button has made the data-plan
+   * decision themselves, so the Wi‑Fi gate is not applied to them — it exists to
+   * stop the *automatic* schedule spending mobile data unasked. Being offline
+   * still stops both: there is nowhere for the bytes to go.
+   */
+  readonly manual: boolean;
+  readonly onPhase?: (phase: BackupPhase) => void;
+}
+
+// One run at a time, process-wide. The automatic check and a button press can
+// land together (the app foregrounds, the person taps immediately), and two
+// concurrent writes to one Drive file is a lost update at best.
+let running = false;
+
+/** Whether a run is in flight — the screen disables the button on it. */
+export function isRunning(): boolean {
+  return running;
+}
+
+async function connection(): Promise<{ online: boolean; type: Network.NetworkStateType | null }> {
+  try {
+    const state = await Network.getNetworkStateAsync();
+    return {
+      // `isInternetReachable` is undefined on some platforms; a connected
+      // interface is the best signal there, and a dead request fails anyway.
+      online: state.isInternetReachable ?? state.isConnected ?? true,
+      type: state.type ?? null,
+    };
+  } catch {
+    // Fail open, like the sync engine: better an attempt that fails than a
+    // backup silently never running because the network module would not say.
+    return { online: true, type: null };
+  }
+}
+
+/**
+ * Tokens good to use now, refreshed if stale and written back so the next run
+ * starts from the fresh pair. Null when there is nothing linked; throws only if
+ * the refresh itself fails in a way worth reporting.
+ */
+async function freshTokens(id: CloudProviderId) {
+  const stored = await loadTokens(id);
+  if (!stored) return null;
+  const provider = providerFor(id);
+  const tokens = await provider.ensureValid(stored);
+  if (tokens !== stored) await saveTokens(id, tokens);
+  return tokens;
+}
+
+/**
+ * Back the personal ledger up. Resolves with a refusal rather than throwing for
+ * anything the person can fix; throws for a genuine transport or provider
+ * failure, whose message the caller must launder before showing it.
+ */
+export async function runBackup(input: BackupRunInput): Promise<BackupResult> {
+  if (running) return { ok: false, refusal: 'busy' };
+  // Claimed before the first await, so two triggers cannot both pass the check.
+  running = true;
+  try {
+    const provider = providerFor(PRIMARY_PROVIDER);
+    if (!provider.isConfigured()) return { ok: false, refusal: 'not-configured' };
+    if (input.key.length === 0) return { ok: false, refusal: 'no-key' };
+
+    const net = await connection();
+    if (!net.online) return { ok: false, refusal: 'offline' };
+    if (!input.manual && !networkAllows(input.network, net.type)) {
+      return { ok: false, refusal: 'network-policy' };
+    }
+
+    const tokens = await freshTokens(PRIMARY_PROVIDER).catch(() => null);
+    if (!tokens) return { ok: false, refusal: 'not-connected' };
+
+    input.onPhase?.('collecting');
+    const body = buildBody(input.ownerId, input.records, new Date());
+
+    input.onPhase?.('sealing');
+    const sealed = sealBackup(
+      input.key,
+      backupNonce(),
+      JSON.stringify(body),
+      backupAad(input.ownerId),
+    );
+    const content = JSON.stringify(buildFile(sealed, body.createdAt));
+
+    input.onPhase?.('uploading');
+    try {
+      const existing = await provider.find(tokens, BACKUP_FILE_NAME);
+      const stored = await provider.put(
+        tokens,
+        BACKUP_FILE_NAME,
+        content,
+        existing?.remoteId ?? null,
+      );
+      return {
+        ok: true,
+        last: {
+          at: Date.now(),
+          // Drive echoes the stored size; fall back to what we sent, which is
+          // the same number in bytes for an ASCII-only sealed envelope.
+          size: stored.size > 0 ? stored.size : content.length,
+          records: body.records.length,
+        },
+      };
+    } catch (error) {
+      // A grant that has been revoked from the Google account side comes back
+      // as a 401/403 forever. Drop the dead tokens so the screen offers
+      // "Connect" rather than retrying a link that no longer exists.
+      if (isAuthFailure(error)) {
+        await clearTokens(PRIMARY_PROVIDER);
+        return { ok: false, refusal: 'auth' };
+      }
+      throw error;
+    }
+  } finally {
+    running = false;
+  }
+}
+
+export type RestoreScan =
+  | {
+      readonly ok: true;
+      readonly body: BackupBody;
+      readonly plan: RestorePlan;
+      /** Bytes of the file as stored, for the confirmation line. */
+      readonly size: number;
+    }
+  | { readonly ok: false; readonly refusal: BackupRefusal };
+
+export interface RestoreScanInput {
+  readonly ownerId: string;
+  readonly key: Uint8Array;
+  /** Every personal record id this device knows, tombstones included. */
+  readonly localIds: ReadonlySet<string>;
+}
+
+/**
+ * Fetch and open the backup, and work out what restoring it would write —
+ * without writing anything. The screen shows the person that number and the
+ * date before they commit, because "restore" is the word people are most afraid
+ * of pressing.
+ *
+ * The network policy is deliberately not applied: a restore is always somebody
+ * standing there having asked for it, usually on a phone that has just been set
+ * up and may well not be on Wi‑Fi yet.
+ */
+export async function scanBackup(input: RestoreScanInput): Promise<RestoreScan> {
+  const provider = providerFor(PRIMARY_PROVIDER);
+  if (!provider.isConfigured()) return { ok: false, refusal: 'not-configured' };
+  if (input.key.length === 0) return { ok: false, refusal: 'no-key' };
+
+  const net = await connection();
+  if (!net.online) return { ok: false, refusal: 'offline' };
+
+  const tokens = await freshTokens(PRIMARY_PROVIDER).catch(() => null);
+  if (!tokens) return { ok: false, refusal: 'not-connected' };
+
+  try {
+    const file = await provider.find(tokens, BACKUP_FILE_NAME);
+    if (!file) return { ok: false, refusal: 'no-backup' };
+
+    const envelope = parseFile(await provider.read(tokens, file.remoteId));
+    // Throws on the wrong key (the AEAD tag fails) — the screen turns that into
+    // "that key does not open this backup", which is the whole diagnosis.
+    const plain = openBackup(input.key, envelope.sealed, backupAad(input.ownerId));
+    const body = parseBody(plain, input.ownerId);
+    return {
+      ok: true,
+      body,
+      plan: planRestore(input.localIds, body),
+      size: file.size > 0 ? file.size : 0,
+    };
+  } catch (error) {
+    if (isAuthFailure(error)) {
+      await clearTokens(PRIMARY_PROVIDER);
+      return { ok: false, refusal: 'auth' };
+    }
+    throw error;
+  }
+}

--- a/apps/mobile/src/lib/backup/payload.ts
+++ b/apps/mobile/src/lib/backup/payload.ts
@@ -1,0 +1,238 @@
+/**
+ * What a personal-ledger backup actually *is*, and how a restore folds one back
+ * in. Pure — no keystore, no network, no React — so every decision in here is
+ * unit-testable, and the parts that are not pure (the key, the upload) have
+ * nothing left in them worth arguing about.
+ *
+ * The backed-up thing is the raw `personal_records` rows for the signed-in
+ * owner, exactly as the mirror materialises them (server rows plus the offline
+ * queue replayed on top, per ADR-005). Not the decoded `PersonalTxn`/`Loan`
+ * shapes the screens use: those are one lossy interpretation of the blob, and a
+ * backup that only understands today's fields cannot restore tomorrow's. The
+ * `data` blob is opaque here for the same reason it is opaque to the server.
+ *
+ * A restore is deliberately additive. Every record carries a client-chosen id
+ * that is already the idempotency key for `personal.upsert`, so a record the
+ * device already has is skipped and a record it is missing is re-queued — no
+ * merge, no field-level resolution, no clobbering something newer with an older
+ * copy. That makes the two cases people actually hit correct: a fresh install
+ * (nothing local, everything comes back) and a partial loss (only the missing
+ * rows return). It also means a restore can be run twice with no second effect.
+ *
+ * Tombstones ride along but are never re-applied. A backup that could delete
+ * records on restore is a backup that can lose data, and the whole point of the
+ * file is that it cannot.
+ */
+
+/** Marks a file as ours before anything is decrypted. */
+export const BACKUP_FORMAT = 'waves.personal.backup';
+/** The envelope version. Bumped only when the *outer* shape changes. */
+export const BACKUP_VERSION = 1;
+/** The AEAD the body is sealed with — see `recoveryKey.ts`. */
+export const BACKUP_ALG = 'xchacha20poly1305';
+
+/** One personal-finance record, as stored. `data` is opaque on purpose. */
+export interface BackupRecord {
+  readonly id: string;
+  readonly kind: string;
+  readonly data: Record<string, unknown>;
+  readonly createdAt: string;
+  readonly deletedAt: string | null;
+}
+
+/** The part that is encrypted: everything that says anything about anybody. */
+export interface BackupBody {
+  readonly ownerId: string;
+  readonly createdAt: string;
+  readonly records: readonly BackupRecord[];
+}
+
+/**
+ * The part Google can read. Deliberately almost nothing: enough to recognise
+ * the file and pick the right opener, and not one field more. The record count
+ * and the dates of somebody's spending live inside the sealed body — "how many
+ * transactions does this person have" is not a question a backup should answer
+ * to whoever holds the drive.
+ */
+export interface BackupFile {
+  readonly format: typeof BACKUP_FORMAT;
+  readonly version: number;
+  readonly alg: string;
+  /** When the backup was taken. Drive knows the file's mtime anyway. */
+  readonly createdAt: string;
+  /** The sealed body, in the `v1:`-tagged form `rowCipher.seal` produces. */
+  readonly sealed: string;
+}
+
+/** A file that is not ours, or is from a future version we cannot read. */
+export class BackupFormatError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BackupFormatError';
+  }
+}
+
+/** The wrong key, a corrupted file, or a file belonging to another account. */
+export class BackupOpenError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BackupOpenError';
+  }
+}
+
+/**
+ * The associated data the body is sealed against: the format, the version and
+ * the owner. It is authenticated, not encrypted, so it costs nothing to carry —
+ * and it means a sealed body lifted out of one account's file and dropped into
+ * another's fails to open rather than silently restoring one person's ledger
+ * into someone else's.
+ */
+export function backupAad(ownerId: string): string {
+  return `${BACKUP_FORMAT}:v${BACKUP_VERSION}:${ownerId}`;
+}
+
+/** The rows to back up, narrowed to what the envelope keeps. */
+export interface SourceRecord {
+  readonly id: string;
+  readonly record_kind: string;
+  readonly data: Record<string, unknown>;
+  readonly created_at: string;
+  readonly deleted_at: string | null;
+}
+
+/** Build the body for `ownerId` from the mirror's rows, in a stable order. */
+export function buildBody(
+  ownerId: string,
+  records: readonly SourceRecord[],
+  now: Date,
+): BackupBody {
+  return {
+    ownerId,
+    createdAt: now.toISOString(),
+    // Sorted by id so two backups of an unchanged ledger produce byte-identical
+    // bodies. Not an optimisation the uploader uses today, but it makes the
+    // file diffable and the tests independent of mirror ordering.
+    records: [...records]
+      .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+      .map((row) => ({
+        id: row.id,
+        kind: row.record_kind,
+        data: row.data,
+        createdAt: row.created_at,
+        deletedAt: row.deleted_at,
+      })),
+  };
+}
+
+/** Wrap a sealed body in the envelope that goes to the cloud. */
+export function buildFile(sealed: string, createdAt: string): BackupFile {
+  return {
+    format: BACKUP_FORMAT,
+    version: BACKUP_VERSION,
+    alg: BACKUP_ALG,
+    createdAt,
+    sealed,
+  };
+}
+
+/** Read an envelope back, or say which way it is wrong. */
+export function parseFile(text: string): BackupFile {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch {
+    throw new BackupFormatError('backup file is not JSON');
+  }
+  const file = raw as Partial<BackupFile>;
+  if (file?.format !== BACKUP_FORMAT) throw new BackupFormatError('not a Waves backup');
+  // A newer app may write a version this build cannot read. Refusing is the
+  // honest answer; guessing at an unknown shape is how a restore loses rows.
+  if (typeof file.version !== 'number' || file.version > BACKUP_VERSION) {
+    throw new BackupFormatError(`backup version ${String(file.version)} is newer than this app`);
+  }
+  if (file.alg !== BACKUP_ALG) throw new BackupFormatError(`unknown algorithm ${String(file.alg)}`);
+  if (typeof file.sealed !== 'string' || file.sealed.length === 0) {
+    throw new BackupFormatError('backup file has no body');
+  }
+  return {
+    format: BACKUP_FORMAT,
+    version: file.version,
+    alg: file.alg,
+    createdAt: typeof file.createdAt === 'string' ? file.createdAt : '',
+    sealed: file.sealed,
+  };
+}
+
+/**
+ * Read an opened (decrypted) body. Defensive in the same spirit as the record
+ * decoders in core: a row missing its id or kind is dropped rather than allowed
+ * to become an upsert with an empty key.
+ */
+export function parseBody(plain: string, expectOwnerId: string): BackupBody {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(plain);
+  } catch {
+    throw new BackupOpenError('backup body is not JSON');
+  }
+  const body = raw as Partial<BackupBody>;
+  if (typeof body?.ownerId !== 'string' || body.ownerId.length === 0) {
+    throw new BackupOpenError('backup body has no owner');
+  }
+  // The AEAD already binds the body to the owner, so this can only fail on a
+  // file we sealed ourselves — but a mismatch here would restore one account's
+  // records under another's id, so it is checked rather than assumed.
+  if (body.ownerId !== expectOwnerId) {
+    throw new BackupOpenError('backup belongs to a different account');
+  }
+  const records = Array.isArray(body.records) ? body.records : [];
+  return {
+    ownerId: body.ownerId,
+    createdAt: typeof body.createdAt === 'string' ? body.createdAt : '',
+    records: records.filter(
+      (record): record is BackupRecord =>
+        typeof record?.id === 'string' &&
+        record.id.length > 0 &&
+        typeof record.kind === 'string' &&
+        record.kind.length > 0 &&
+        typeof record.data === 'object' &&
+        record.data !== null,
+    ),
+  };
+}
+
+export interface RestorePlan {
+  /** The records to re-queue as upserts, in the order they should be sent. */
+  readonly restore: readonly BackupRecord[];
+  /** How many were already on this device — reported, not acted on. */
+  readonly alreadyHere: number;
+  /** How many were tombstones in the backup and deliberately left alone. */
+  readonly deleted: number;
+}
+
+/**
+ * Decide what a restore should actually write. `localIds` is every personal
+ * record id the device already knows about, deleted ones included: a record
+ * this device has already deleted must not come back, or "restore" would undo
+ * a deletion the person made on purpose.
+ */
+export function planRestore(
+  localIds: ReadonlySet<string>,
+  body: Pick<BackupBody, 'records'>,
+): RestorePlan {
+  const restore: BackupRecord[] = [];
+  let alreadyHere = 0;
+  let deleted = 0;
+  for (const record of body.records) {
+    if (record.deletedAt !== null && record.deletedAt !== undefined) {
+      deleted += 1;
+      continue;
+    }
+    if (localIds.has(record.id)) {
+      alreadyHere += 1;
+      continue;
+    }
+    restore.push(record);
+  }
+  return { restore, alreadyHere, deleted };
+}

--- a/apps/mobile/src/lib/backup/recoveryKey.ts
+++ b/apps/mobile/src/lib/backup/recoveryKey.ts
@@ -1,0 +1,155 @@
+/**
+ * The key model for a backup that has to survive the phone it was made on.
+ *
+ * THE TENSION. The offline mirror is already encrypted at rest (`sync/
+ * rowCipher.ts`) with a 256-bit key minted on the device and kept in the OS
+ * keystore under `AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY`. That flag is not an
+ * accident: it stops the key travelling in an iCloud or Android backup, so a
+ * restored copy of the SQLite file is unreadable on a new phone. Which is
+ * exactly right for a local cache — and exactly wrong for a backup, whose only
+ * job is to be readable on a new phone. Sealing the Drive file with the mirror
+ * DEK would produce a file nobody, including its owner, could ever open again.
+ *
+ * THE THREE OPTIONS, and why this one.
+ *
+ * 1. *Upload it in the clear.* Then the personal ledger — every solo expense,
+ *    every loan, every income line — is readable by anyone who reaches the
+ *    Google account, and by Google. The whole premise of the "Me" tab is that
+ *    it is private; a backup that quietly undoes that is worse than no backup.
+ *    Rejected.
+ *
+ * 2. *A password the user picks.* Nicest to use, and what most people expect.
+ *    But a human-chosen password has maybe 30 bits of entropy against a file an
+ *    attacker can copy and grind offline forever, so it is only safe behind a
+ *    memory-hard KDF — Argon2id or scrypt with real parameters. That is a new
+ *    crypto dependency and a tuning decision (a KDF slow enough to matter on a
+ *    laptop is slow on a five-year-old Android), and getting either wrong
+ *    produces something that *looks* encrypted. Deliberately not done here.
+ *
+ * 3. *A key the app generates.* 32 random bytes, shown to the person once as 64
+ *    hexadecimal characters, kept in this device's keystore for convenience,
+ *    and typed in on any new device that wants to restore. Full 256-bit
+ *    entropy, so there is nothing to grind and no KDF to get wrong: the key is
+ *    used directly as the XChaCha20-Poly1305 key, through the same `seal`/`open`
+ *    the mirror uses. This is WhatsApp's "64-digit encryption key" option,
+ *    minus the password option beside it.
+ *
+ * THE COST, said plainly: **lose the key and the backup is gone.** Nobody can
+ * recover it — not Waves, which never sees it, and not Google, which holds only
+ * ciphertext. The screen says this before it makes one, and refuses to make a
+ * backup until the person has been shown the key.
+ *
+ * A future password option can be added beside this without changing the file
+ * format: the envelope already names its algorithm, and a password variant
+ * would add a `kdf` block rather than replace anything.
+ */
+
+import * as Crypto from 'expo-crypto';
+import * as SecureStore from 'expo-secure-store';
+
+import { open, seal, type MirrorKey } from '@/sync/rowCipher';
+
+/** XChaCha20-Poly1305 key length, and so the recovery key's length. */
+const KEY_BYTES = 32;
+/** XChaCha20 takes a 192-bit nonce; a random one per file never collides. */
+const NONCE_BYTES = 24;
+/** 32 bytes as hex. What the person copies down. */
+export const RECOVERY_KEY_LENGTH = KEY_BYTES * 2;
+/** Shown in blocks of this many characters, so it can be read off a screen. */
+const GROUP = 4;
+
+/** The keystore slot this device's copy of the key lives in. */
+const KEY_STORE_SLOT = 'waves.backup.recovery_key.v1';
+
+// ─────────────────────────────────────────────────────────────── pure ──
+
+const HEX = '0123456789abcdef';
+
+export function bytesToHex(bytes: Uint8Array): string {
+  let out = '';
+  for (let i = 0; i < bytes.length; i += 1) {
+    const byte = bytes[i] as number;
+    out += HEX[(byte >> 4) & 15];
+    out += HEX[byte & 15];
+  }
+  return out;
+}
+
+/**
+ * The key as somebody reads it off a screen: 16 groups of 4, upper case. Hex is
+ * ambiguous read aloud (b/d, 0/o), so the screen never asks anybody to only read
+ * it aloud — it is selectable and there is a Copy button. The groups are for
+ * checking a transcription, not for making one.
+ */
+export function formatRecoveryKey(hex: string): string {
+  const groups: string[] = [];
+  for (let i = 0; i < hex.length; i += GROUP) groups.push(hex.slice(i, i + GROUP));
+  return groups.join(' ').toUpperCase();
+}
+
+/**
+ * Read a typed or pasted key back. Spaces, dashes and case are all forgiven —
+ * people paste from anywhere — but a string that is not exactly 64 hex
+ * characters is rejected rather than padded, because a key that is nearly right
+ * decrypts nothing and "almost" is not a state worth carrying forward.
+ */
+export function parseRecoveryKey(input: string): Uint8Array | null {
+  const hex = input.trim().toLowerCase().replace(/[\s-]/g, '');
+  if (hex.length !== RECOVERY_KEY_LENGTH) return null;
+  if (!/^[0-9a-f]+$/.test(hex)) return null;
+  const bytes = new Uint8Array(KEY_BYTES);
+  for (let i = 0; i < KEY_BYTES; i += 1) {
+    bytes[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+/**
+ * Seal a backup body. Same AEAD, same tagged format as the mirror's rows — the
+ * crypto is not re-implemented here, only pointed at a different key and a
+ * different associated-data string.
+ */
+export function sealBackup(key: MirrorKey, nonce: Uint8Array, plain: string, aad: string): string {
+  return seal(key, nonce, plain, aad);
+}
+
+/** Open a sealed backup body. Throws when the key or the `aad` is wrong. */
+export function openBackup(key: MirrorKey, sealed: string, aad: string): string {
+  return open(key, sealed, aad);
+}
+
+// ───────────────────────────────────────────────────────────── native ──
+
+/** A fresh 256-bit key. Not stored — the caller decides when it is committed. */
+export function mintRecoveryKey(): Uint8Array {
+  return Crypto.getRandomBytes(KEY_BYTES);
+}
+
+/** A fresh nonce for one sealed file. */
+export function backupNonce(): Uint8Array {
+  return Crypto.getRandomBytes(NONCE_BYTES);
+}
+
+/**
+ * This device's copy of the key, or null when there is none — a fresh install
+ * has none, which is precisely the case where the person has to type theirs in.
+ */
+export async function loadRecoveryKey(): Promise<Uint8Array | null> {
+  const hex = await SecureStore.getItemAsync(KEY_STORE_SLOT).catch(() => null);
+  return hex ? parseRecoveryKey(hex) : null;
+}
+
+export async function saveRecoveryKey(key: Uint8Array): Promise<void> {
+  await SecureStore.setItemAsync(KEY_STORE_SLOT, bytesToHex(key), {
+    // Same posture as the mirror's own key: readable after the first unlock
+    // since a foreground backup can run without the person having just
+    // authenticated, and never migrated to another device by an OS backup —
+    // the point of the printed key is that it, and not iCloud, is what moves.
+    keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY,
+  });
+}
+
+/** Forget this device's copy. The backup stays readable to whoever has the key. */
+export async function clearRecoveryKey(): Promise<void> {
+  await SecureStore.deleteItemAsync(KEY_STORE_SLOT).catch(() => undefined);
+}

--- a/apps/mobile/src/lib/backup/recoveryKey.ts
+++ b/apps/mobile/src/lib/backup/recoveryKey.ts
@@ -58,8 +58,14 @@ export const RECOVERY_KEY_LENGTH = KEY_BYTES * 2;
 /** Shown in blocks of this many characters, so it can be read off a screen. */
 const GROUP = 4;
 
-/** The keystore slot this device's copy of the key lives in. */
-const KEY_STORE_SLOT = 'waves.backup.recovery_key.v1';
+/**
+ * The keystore slot this device's copy of the key lives in, per account.
+ *
+ * The owner id is load-bearing on a shared phone: a key is what opens one
+ * account's backup, and an unscoped slot would hand B the key to A's file
+ * (and, with the tokens beside it, the ability to overwrite it).
+ */
+const keySlot = (ownerId: string): string => `waves.backup.recovery_key.v1.${ownerId}`;
 
 // ─────────────────────────────────────────────────────────────── pure ──
 
@@ -131,16 +137,19 @@ export function backupNonce(): Uint8Array {
 }
 
 /**
- * This device's copy of the key, or null when there is none — a fresh install
- * has none, which is precisely the case where the person has to type theirs in.
+ * This device's copy of `ownerId`'s key, or null when there is none — a fresh
+ * install has none, which is precisely the case where the person has to type
+ * theirs in.
  */
-export async function loadRecoveryKey(): Promise<Uint8Array | null> {
-  const hex = await SecureStore.getItemAsync(KEY_STORE_SLOT).catch(() => null);
+export async function loadRecoveryKey(ownerId: string): Promise<Uint8Array | null> {
+  if (!ownerId) return null;
+  const hex = await SecureStore.getItemAsync(keySlot(ownerId)).catch(() => null);
   return hex ? parseRecoveryKey(hex) : null;
 }
 
-export async function saveRecoveryKey(key: Uint8Array): Promise<void> {
-  await SecureStore.setItemAsync(KEY_STORE_SLOT, bytesToHex(key), {
+export async function saveRecoveryKey(ownerId: string, key: Uint8Array): Promise<void> {
+  if (!ownerId) return;
+  await SecureStore.setItemAsync(keySlot(ownerId), bytesToHex(key), {
     // Same posture as the mirror's own key: readable after the first unlock
     // since a foreground backup can run without the person having just
     // authenticated, and never migrated to another device by an OS backup —
@@ -149,7 +158,13 @@ export async function saveRecoveryKey(key: Uint8Array): Promise<void> {
   });
 }
 
-/** Forget this device's copy. The backup stays readable to whoever has the key. */
-export async function clearRecoveryKey(): Promise<void> {
-  await SecureStore.deleteItemAsync(KEY_STORE_SLOT).catch(() => undefined);
+/**
+ * Forget this device's copy. The backup stays readable to whoever has the key.
+ *
+ * Does not swallow: an unlink should say when it failed, and on sign-out a key
+ * left in the keystore is a privacy problem rather than a cosmetic one.
+ */
+export async function clearRecoveryKey(ownerId: string): Promise<void> {
+  if (!ownerId) return;
+  await SecureStore.deleteItemAsync(keySlot(ownerId));
 }

--- a/apps/mobile/src/lib/backup/schedule.ts
+++ b/apps/mobile/src/lib/backup/schedule.ts
@@ -1,0 +1,94 @@
+/**
+ * "Automatic backup: Off / Daily / Weekly / Monthly", and the one question that
+ * setting has to answer — is a backup owed right now?
+ *
+ * Pure date arithmetic, kept away from the engine so it can be tested at the
+ * month boundaries where it is actually wrong. Two things it deliberately does
+ * not do:
+ *
+ * - It does not schedule. There is no background task waking the phone at 2am;
+ *   the app checks whether one is owed when it comes to the foreground and runs
+ *   it then. A phone that has not been opened in a week has not backed up in a
+ *   week, and the screen says so honestly rather than claiming a schedule the
+ *   OS never promised to keep. (iOS background execution is discretionary and
+ *   Android's Doze defers alarms; an app that says "daily" and means it needs a
+ *   native background worker, which is a native build and its own decision.)
+ *
+ * - It does not drift-correct. Each period is measured from the *last backup*,
+ *   not from a fixed clock, so a run that happens late does not immediately make
+ *   the next one due.
+ *
+ * Monthly is calendar months, not 30 days, and clamps: a backup on the 31st is
+ * next due on the 28th/29th of February, not the 2nd or 3rd of March.
+ */
+
+export enum BackupFrequency {
+  Off = 'off',
+  Daily = 'daily',
+  Weekly = 'weekly',
+  Monthly = 'monthly',
+}
+
+export const BACKUP_FREQUENCIES: readonly BackupFrequency[] = [
+  BackupFrequency.Off,
+  BackupFrequency.Daily,
+  BackupFrequency.Weekly,
+  BackupFrequency.Monthly,
+];
+
+/** Off by default: nothing leaves the phone until somebody asks it to. */
+export const DEFAULT_FREQUENCY = BackupFrequency.Off;
+
+export function parseFrequency(raw: string | null): BackupFrequency {
+  return BACKUP_FREQUENCIES.includes(raw as BackupFrequency)
+    ? (raw as BackupFrequency)
+    : DEFAULT_FREQUENCY;
+}
+
+/** Add `months` calendar months, clamping the day to the target month's length. */
+function addMonths(from: Date, months: number): Date {
+  const day = from.getDate();
+  const shifted = new Date(from.getTime());
+  // Move to the 1st before shifting the month, so the browser/Hermes rollover
+  // (31 Jan + 1 month = 2 Mar) never happens, then clamp the day back on.
+  shifted.setDate(1);
+  shifted.setMonth(shifted.getMonth() + months);
+  const lastDay = new Date(shifted.getFullYear(), shifted.getMonth() + 1, 0).getDate();
+  shifted.setDate(Math.min(day, lastDay));
+  return shifted;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * When the next automatic backup falls due, given when the last one succeeded.
+ *
+ * Null when the schedule is off. When nothing has ever been backed up the
+ * answer is "now" — turning the schedule on should produce a backup rather than
+ * wait a day for the first one, which is the difference between a feature that
+ * works and one somebody has to be told about.
+ */
+export function nextDueAt(lastBackupAt: number | null, frequency: BackupFrequency): number | null {
+  if (frequency === BackupFrequency.Off) return null;
+  if (lastBackupAt === null) return 0;
+  switch (frequency) {
+    case BackupFrequency.Daily:
+      return lastBackupAt + DAY_MS;
+    case BackupFrequency.Weekly:
+      return lastBackupAt + 7 * DAY_MS;
+    case BackupFrequency.Monthly:
+      return addMonths(new Date(lastBackupAt), 1).getTime();
+    default:
+      return null;
+  }
+}
+
+/** Whether an automatic backup is owed at `now`. */
+export function isDue(
+  lastBackupAt: number | null,
+  frequency: BackupFrequency,
+  now: number,
+): boolean {
+  const due = nextDueAt(lastBackupAt, frequency);
+  return due !== null && now >= due;
+}

--- a/apps/mobile/src/lib/backup/settings.ts
+++ b/apps/mobile/src/lib/backup/settings.ts
@@ -9,6 +9,11 @@
  * Waves' servers how often they back up, and when they last did, would put a
  * shadow of the thing on the server anyway.
  *
+ * Every key carries the owner id. These are device-wide preferences on a device
+ * that is not always one person's, and "when did you last back up, and how
+ * often do you" is a shape of somebody's life that the next person to sign in
+ * on the same phone has no business inheriting.
+ *
  * The network choice reuses `SyncNetworkPreference` rather than inventing a
  * second vocabulary for the same idea — same enum, same `networkAllows`
  * predicate, so the two can never disagree about what "Wi‑Fi only" means. It is
@@ -28,6 +33,11 @@ const NETWORK_KEY = 'waves.backup.network';
 const LAST_KEY = 'waves.backup.last';
 /** Set once the person has been shown their recovery key and confirmed it. */
 const KEY_SEEN_KEY = 'waves.backup.key_seen';
+
+/** Every stored key, for the sign-out wipe. */
+const ALL_KEYS = [FREQUENCY_KEY, NETWORK_KEY, LAST_KEY, KEY_SEEN_KEY] as const;
+
+const scoped = (base: string, ownerId: string): string => `${base}.${ownerId}`;
 
 /**
  * A backup is bigger and less urgent than a sync flush, so it holds for Wi‑Fi
@@ -75,12 +85,21 @@ function parseLast(raw: string | null): LastBackup | null {
   }
 }
 
-export async function loadBackupSettings(): Promise<BackupSettings> {
+/** The defaults, for a signed-out caller or an account that has set nothing. */
+export const NO_BACKUP_SETTINGS: BackupSettings = {
+  frequency: DEFAULT_FREQUENCY,
+  network: DEFAULT_BACKUP_NETWORK,
+  last: null,
+  keySeen: false,
+};
+
+export async function loadBackupSettings(ownerId: string): Promise<BackupSettings> {
+  if (!ownerId) return NO_BACKUP_SETTINGS;
   const [frequency, network, last, keySeen] = await Promise.all([
-    AsyncStorage.getItem(FREQUENCY_KEY).catch(() => null),
-    AsyncStorage.getItem(NETWORK_KEY).catch(() => null),
-    AsyncStorage.getItem(LAST_KEY).catch(() => null),
-    AsyncStorage.getItem(KEY_SEEN_KEY).catch(() => null),
+    AsyncStorage.getItem(scoped(FREQUENCY_KEY, ownerId)).catch(() => null),
+    AsyncStorage.getItem(scoped(NETWORK_KEY, ownerId)).catch(() => null),
+    AsyncStorage.getItem(scoped(LAST_KEY, ownerId)).catch(() => null),
+    AsyncStorage.getItem(scoped(KEY_SEEN_KEY, ownerId)).catch(() => null),
   ]);
   return {
     frequency: parseFrequency(frequency),
@@ -90,35 +109,51 @@ export async function loadBackupSettings(): Promise<BackupSettings> {
   };
 }
 
-export async function saveFrequency(frequency: BackupFrequency): Promise<void> {
+export async function saveFrequency(ownerId: string, frequency: BackupFrequency): Promise<void> {
+  if (!ownerId) return;
+  const key = scoped(FREQUENCY_KEY, ownerId);
   // Storing the default is the same as storing nothing, so a reset-to-default
   // and a fresh install look identical — the same rule `syncNetwork` follows.
-  if (frequency === DEFAULT_FREQUENCY) await AsyncStorage.removeItem(FREQUENCY_KEY);
-  else await AsyncStorage.setItem(FREQUENCY_KEY, frequency);
+  if (frequency === DEFAULT_FREQUENCY) await AsyncStorage.removeItem(key);
+  else await AsyncStorage.setItem(key, frequency);
 }
 
-export async function saveNetwork(network: SyncNetworkPreference): Promise<void> {
-  if (network === DEFAULT_BACKUP_NETWORK) await AsyncStorage.removeItem(NETWORK_KEY);
-  else await AsyncStorage.setItem(NETWORK_KEY, network);
+export async function saveNetwork(ownerId: string, network: SyncNetworkPreference): Promise<void> {
+  if (!ownerId) return;
+  const key = scoped(NETWORK_KEY, ownerId);
+  if (network === DEFAULT_BACKUP_NETWORK) await AsyncStorage.removeItem(key);
+  else await AsyncStorage.setItem(key, network);
 }
 
-export async function saveLastBackup(last: LastBackup): Promise<void> {
-  await AsyncStorage.setItem(LAST_KEY, JSON.stringify(last));
+export async function saveLastBackup(ownerId: string, last: LastBackup): Promise<void> {
+  if (!ownerId) return;
+  await AsyncStorage.setItem(scoped(LAST_KEY, ownerId), JSON.stringify(last));
 }
 
-export async function markKeySeen(): Promise<void> {
-  await AsyncStorage.setItem(KEY_SEEN_KEY, '1');
+export async function markKeySeen(ownerId: string): Promise<void> {
+  if (!ownerId) return;
+  await AsyncStorage.setItem(scoped(KEY_SEEN_KEY, ownerId), '1');
 }
 
 /**
- * Forget everything this device remembered about backing up. Called on unlink
- * alongside the token and key wipes — the Drive file is untouched, since it is
- * the user's and the point of it is to outlive the app's state.
+ * Forget everything this device remembered about `ownerId` backing up. Called
+ * on unlink and on sign-out, alongside the token and key wipes — the Drive file
+ * is untouched, since it is the user's and the point of it is to outlive the
+ * app's state.
+ *
+ * Every key is attempted even after one fails, and the first failure is then
+ * rethrown: a wipe that stopped halfway is worse than one that reports.
  */
-export async function clearBackupSettings(): Promise<void> {
-  await Promise.all(
-    [FREQUENCY_KEY, NETWORK_KEY, LAST_KEY, KEY_SEEN_KEY].map((key) =>
-      AsyncStorage.removeItem(key).catch(() => undefined),
+export async function clearBackupSettings(ownerId: string): Promise<void> {
+  if (!ownerId) return;
+  const failures = await Promise.all(
+    ALL_KEYS.map((base) =>
+      AsyncStorage.removeItem(scoped(base, ownerId)).then(
+        () => null,
+        (error: unknown) => error,
+      ),
     ),
   );
+  const first = failures.find((error) => error !== null);
+  if (first !== undefined) throw first;
 }

--- a/apps/mobile/src/lib/backup/settings.ts
+++ b/apps/mobile/src/lib/backup/settings.ts
@@ -1,0 +1,124 @@
+/**
+ * What the phone remembers about backing up: how often, over which networks,
+ * and when the last one landed.
+ *
+ * Device-local, in AsyncStorage, like theme and motion and the sync-network
+ * choice — not on the server. ADR-005 keeps this kind of preference on the
+ * phone, and there is a sharper reason here: the whole point of the feature is
+ * that the backup is between the person and their own Drive. Recording on
+ * Waves' servers how often they back up, and when they last did, would put a
+ * shadow of the thing on the server anyway.
+ *
+ * The network choice reuses `SyncNetworkPreference` rather than inventing a
+ * second vocabulary for the same idea — same enum, same `networkAllows`
+ * predicate, so the two can never disagree about what "Wi‑Fi only" means. It is
+ * stored separately because it is a genuinely different decision: syncing a
+ * shared ledger is a few hundred bytes on a change somebody is waiting to see,
+ * and a backup is the whole ledger on a timer nobody is watching. Sync defaults
+ * to any connection; backup defaults to Wi‑Fi.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { SyncNetworkPreference } from '../syncNetwork';
+import { BackupFrequency, DEFAULT_FREQUENCY, parseFrequency } from './schedule';
+
+const FREQUENCY_KEY = 'waves.backup.frequency';
+const NETWORK_KEY = 'waves.backup.network';
+const LAST_KEY = 'waves.backup.last';
+/** Set once the person has been shown their recovery key and confirmed it. */
+const KEY_SEEN_KEY = 'waves.backup.key_seen';
+
+/**
+ * A backup is bigger and less urgent than a sync flush, so it holds for Wi‑Fi
+ * unless somebody says otherwise. Only Wi‑Fi and Both are offered on the screen
+ * — "mobile data only" is a coherent sync choice and an incoherent backup one.
+ */
+export const DEFAULT_BACKUP_NETWORK = SyncNetworkPreference.Wifi;
+
+/** What the last successful backup was, for the "Last backup" line. */
+export interface LastBackup {
+  /** Epoch ms. */
+  readonly at: number;
+  /** Bytes actually uploaded — the sealed file, not the ledger in memory. */
+  readonly size: number;
+  /** How many records it held. */
+  readonly records: number;
+}
+
+export interface BackupSettings {
+  readonly frequency: BackupFrequency;
+  readonly network: SyncNetworkPreference;
+  readonly last: LastBackup | null;
+  /** False until the recovery key has been shown and acknowledged. */
+  readonly keySeen: boolean;
+}
+
+function parseNetwork(raw: string | null): SyncNetworkPreference {
+  return raw === SyncNetworkPreference.Wifi || raw === SyncNetworkPreference.Both
+    ? raw
+    : DEFAULT_BACKUP_NETWORK;
+}
+
+function parseLast(raw: string | null): LastBackup | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<LastBackup>;
+    if (typeof parsed?.at !== 'number' || !Number.isFinite(parsed.at)) return null;
+    return {
+      at: parsed.at,
+      size: typeof parsed.size === 'number' && parsed.size >= 0 ? parsed.size : 0,
+      records: typeof parsed.records === 'number' && parsed.records >= 0 ? parsed.records : 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function loadBackupSettings(): Promise<BackupSettings> {
+  const [frequency, network, last, keySeen] = await Promise.all([
+    AsyncStorage.getItem(FREQUENCY_KEY).catch(() => null),
+    AsyncStorage.getItem(NETWORK_KEY).catch(() => null),
+    AsyncStorage.getItem(LAST_KEY).catch(() => null),
+    AsyncStorage.getItem(KEY_SEEN_KEY).catch(() => null),
+  ]);
+  return {
+    frequency: parseFrequency(frequency),
+    network: parseNetwork(network),
+    last: parseLast(last),
+    keySeen: keySeen === '1',
+  };
+}
+
+export async function saveFrequency(frequency: BackupFrequency): Promise<void> {
+  // Storing the default is the same as storing nothing, so a reset-to-default
+  // and a fresh install look identical — the same rule `syncNetwork` follows.
+  if (frequency === DEFAULT_FREQUENCY) await AsyncStorage.removeItem(FREQUENCY_KEY);
+  else await AsyncStorage.setItem(FREQUENCY_KEY, frequency);
+}
+
+export async function saveNetwork(network: SyncNetworkPreference): Promise<void> {
+  if (network === DEFAULT_BACKUP_NETWORK) await AsyncStorage.removeItem(NETWORK_KEY);
+  else await AsyncStorage.setItem(NETWORK_KEY, network);
+}
+
+export async function saveLastBackup(last: LastBackup): Promise<void> {
+  await AsyncStorage.setItem(LAST_KEY, JSON.stringify(last));
+}
+
+export async function markKeySeen(): Promise<void> {
+  await AsyncStorage.setItem(KEY_SEEN_KEY, '1');
+}
+
+/**
+ * Forget everything this device remembered about backing up. Called on unlink
+ * alongside the token and key wipes — the Drive file is untouched, since it is
+ * the user's and the point of it is to outlive the app's state.
+ */
+export async function clearBackupSettings(): Promise<void> {
+  await Promise.all(
+    [FREQUENCY_KEY, NETWORK_KEY, LAST_KEY, KEY_SEEN_KEY].map((key) =>
+      AsyncStorage.removeItem(key).catch(() => undefined),
+    ),
+  );
+}

--- a/apps/mobile/src/lib/backup/useBackup.ts
+++ b/apps/mobile/src/lib/backup/useBackup.ts
@@ -1,0 +1,309 @@
+/**
+ * The backup screen's whole state, in one hook.
+ *
+ * A React seam over three things that are not React — the settings on disk, the
+ * OAuth tokens in the keystore, and the engine — plus the one thing that is: the
+ * ledger itself, which only the mirror can produce. Kept out of the provider
+ * tree on purpose. A backup is a settings screen and a once-a-day check, not
+ * something every screen in the app needs a context for, and the app's provider
+ * stack is already fifteen deep.
+ *
+ * A restore writes through the ordinary offline queue (`personal.upsert`), not
+ * around it: the record ids in the backup are the same client-chosen ids that
+ * are already the idempotency key, so restored rows converge with whatever the
+ * server has exactly as a row typed on another phone would. That also means a
+ * restore works with no connection at all — the rows land locally and leave when
+ * the queue next drains, which is the ADR-005 promise applied to the one moment
+ * people are least likely to have signal: setting up a new phone.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { MutationKind, personalScope } from '@waves/core';
+
+import { usePersonalRecordIds, usePersonalRecords } from '@/data/personal';
+import { useAuth } from '@/lib/auth';
+import { useSync } from '@/sync';
+
+import { providerFor } from '../cloud/providers';
+import { clearTokens, loadTokens, saveTokens } from '../cloud/tokens';
+import type { SyncNetworkPreference } from '../syncNetwork';
+import {
+  PRIMARY_PROVIDER,
+  runBackup,
+  scanBackup,
+  type BackupPhase,
+  type BackupRefusal,
+  type RestoreScan,
+} from './engine';
+import {
+  bytesToHex,
+  clearRecoveryKey,
+  loadRecoveryKey,
+  mintRecoveryKey,
+  parseRecoveryKey,
+  saveRecoveryKey,
+} from './recoveryKey';
+import { BackupFrequency } from './schedule';
+import {
+  clearBackupSettings,
+  DEFAULT_BACKUP_NETWORK,
+  loadBackupSettings,
+  markKeySeen,
+  saveFrequency,
+  saveLastBackup,
+  saveNetwork,
+  type BackupSettings,
+} from './settings';
+
+/** What the screen says after a run: nothing yet, done, or a named refusal. */
+export type BackupOutcome =
+  | { readonly kind: 'ok'; readonly records: number }
+  | { readonly kind: 'refused'; readonly refusal: BackupRefusal };
+
+const NO_SETTINGS: BackupSettings = {
+  frequency: BackupFrequency.Off,
+  network: DEFAULT_BACKUP_NETWORK,
+  last: null,
+  keySeen: false,
+};
+
+export interface BackupState {
+  /** False while the stored settings and tokens are still being read. */
+  readonly loading: boolean;
+  readonly settings: BackupSettings;
+  /** False when this build has no OAuth client id — everything else is inert. */
+  readonly configured: boolean;
+  /** True when a Drive account is linked. */
+  readonly connected: boolean;
+  /** The linked account's address, or null when Drive would not say. */
+  readonly account: string | null;
+  /** True when this device holds the recovery key. */
+  readonly hasKey: boolean;
+  /** How many personal records a backup would carry right now. */
+  readonly recordCount: number;
+  /** Non-null while a backup is running. */
+  readonly phase: BackupPhase | null;
+  /** The result of the last run this session. */
+  readonly outcome: BackupOutcome | null;
+}
+
+export interface BackupActions {
+  connect: () => Promise<boolean>;
+  disconnect: () => Promise<void>;
+  backupNow: () => Promise<BackupOutcome>;
+  setFrequency: (frequency: BackupFrequency) => Promise<void>;
+  setNetwork: (network: SyncNetworkPreference) => Promise<void>;
+  /** Mint a key for this device and hand back its hex, for showing once. */
+  createKey: () => Promise<string>;
+  /** The key this device holds, as hex, or null. For "show it to me again". */
+  revealKey: () => Promise<string | null>;
+  /** Accept a key typed in from another device. False when it is not a key. */
+  acceptKey: (input: string) => Promise<boolean>;
+  /** Confirm the key has been written down. Backups refuse until this is set. */
+  confirmKeySeen: () => Promise<void>;
+  /** Read the Drive backup and say what restoring it would write. */
+  scan: () => Promise<RestoreScan>;
+  /** Queue the planned upserts. Returns how many were written. */
+  applyRestore: (scan: Extract<RestoreScan, { ok: true }>) => Promise<number>;
+}
+
+export function useBackup(): BackupState & BackupActions {
+  const { session } = useAuth();
+  const { mutate, flush } = useSync();
+  const ownerId = session?.user?.id ?? '';
+  const records = usePersonalRecords();
+  const localIds = usePersonalRecordIds();
+
+  const [loading, setLoading] = useState(true);
+  const [settings, setSettings] = useState<BackupSettings>(NO_SETTINGS);
+  const [connected, setConnected] = useState(false);
+  const [account, setAccount] = useState<string | null>(null);
+  const [hasKey, setHasKey] = useState(false);
+  const [phase, setPhase] = useState<BackupPhase | null>(null);
+  const [outcome, setOutcome] = useState<BackupOutcome | null>(null);
+
+  const provider = providerFor(PRIMARY_PROVIDER);
+  const configured = provider.isConfigured();
+
+  const refreshAccount = useCallback(async (): Promise<void> => {
+    const tokens = await loadTokens(PRIMARY_PROVIDER);
+    setConnected(tokens !== null);
+    if (!tokens) {
+      setAccount(null);
+      return;
+    }
+    // Best effort, and quietly: the address is a nicety, and a failed lookup
+    // must not make a working link look broken.
+    setAccount(
+      await providerFor(PRIMARY_PROVIDER)
+        .account(tokens)
+        .catch(() => null),
+    );
+  }, []);
+
+  useEffect(() => {
+    let alive = true;
+    void (async () => {
+      const [stored, key] = await Promise.all([loadBackupSettings(), loadRecoveryKey()]);
+      if (!alive) return;
+      setSettings(stored);
+      setHasKey(key !== null);
+      await refreshAccount();
+      if (alive) setLoading(false);
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [refreshAccount]);
+
+  const connect = useCallback(async (): Promise<boolean> => {
+    const tokens = await provider.connect();
+    // Null is a cancel — the person closed the consent page. Not an error, and
+    // the caller must not dress it as one.
+    if (!tokens) return false;
+    await saveTokens(PRIMARY_PROVIDER, tokens);
+    await refreshAccount();
+    return true;
+  }, [provider, refreshAccount]);
+
+  const disconnect = useCallback(async (): Promise<void> => {
+    const tokens = await loadTokens(PRIMARY_PROVIDER);
+    // Hand the grant back to Google as well as forgetting it here, so "not
+    // connected" is true in their account settings too. Best effort: a failed
+    // revoke must not leave the app still claiming a link it has dropped.
+    if (tokens) await provider.revoke?.(tokens).catch(() => undefined);
+    await clearTokens(PRIMARY_PROVIDER);
+    // The recovery key goes with the link. Keeping it would leave a key on the
+    // phone for a file the app can no longer reach, and the person still has
+    // their written copy, which is the only one that was ever load-bearing.
+    await clearRecoveryKey();
+    await clearBackupSettings();
+    setSettings(NO_SETTINGS);
+    setHasKey(false);
+    setOutcome(null);
+    await refreshAccount();
+  }, [provider, refreshAccount]);
+
+  const backupNow = useCallback(async (): Promise<BackupOutcome> => {
+    const key = await loadRecoveryKey();
+    if (!key) {
+      const refused: BackupOutcome = { kind: 'refused', refusal: 'no-key' };
+      setOutcome(refused);
+      return refused;
+    }
+    setOutcome(null);
+    try {
+      const result = await runBackup({
+        ownerId,
+        records,
+        key,
+        network: settings.network,
+        manual: true,
+        onPhase: setPhase,
+      });
+      if (!result.ok) {
+        const refused: BackupOutcome = { kind: 'refused', refusal: result.refusal };
+        setOutcome(refused);
+        // A dead grant clears the tokens inside the engine; reflect that here so
+        // the screen swaps to "Connect" instead of offering a retry that cannot
+        // work.
+        if (result.refusal === 'auth') await refreshAccount();
+        return refused;
+      }
+      await saveLastBackup(result.last);
+      setSettings((current) => ({ ...current, last: result.last }));
+      const done: BackupOutcome = { kind: 'ok', records: result.last.records };
+      setOutcome(done);
+      return done;
+    } finally {
+      setPhase(null);
+    }
+  }, [ownerId, records, settings.network, refreshAccount]);
+
+  const setFrequencyAction = useCallback(async (frequency: BackupFrequency): Promise<void> => {
+    setSettings((current) => ({ ...current, frequency }));
+    await saveFrequency(frequency);
+  }, []);
+
+  const setNetworkAction = useCallback(async (network: SyncNetworkPreference): Promise<void> => {
+    setSettings((current) => ({ ...current, network }));
+    await saveNetwork(network);
+  }, []);
+
+  const createKey = useCallback(async (): Promise<string> => {
+    const key = mintRecoveryKey();
+    await saveRecoveryKey(key);
+    setHasKey(true);
+    return bytesToHex(key);
+  }, []);
+
+  const revealKey = useCallback(async (): Promise<string | null> => {
+    const key = await loadRecoveryKey();
+    return key ? bytesToHex(key) : null;
+  }, []);
+
+  const acceptKey = useCallback(async (input: string): Promise<boolean> => {
+    const key = parseRecoveryKey(input);
+    if (!key) return false;
+    await saveRecoveryKey(key);
+    setHasKey(true);
+    // A key typed in from elsewhere has self-evidently been kept somewhere, so
+    // there is nothing left to warn this person about.
+    await markKeySeen();
+    setSettings((current) => ({ ...current, keySeen: true }));
+    return true;
+  }, []);
+
+  const confirmKeySeen = useCallback(async (): Promise<void> => {
+    setSettings((current) => ({ ...current, keySeen: true }));
+    await markKeySeen();
+  }, []);
+
+  const scan = useCallback(async (): Promise<RestoreScan> => {
+    const key = await loadRecoveryKey();
+    if (!key) return { ok: false, refusal: 'no-key' };
+    return scanBackup({ ownerId, key, localIds });
+  }, [ownerId, localIds]);
+
+  const applyRestore = useCallback(
+    async (result: Extract<RestoreScan, { ok: true }>): Promise<number> => {
+      if (!ownerId) return 0;
+      const scope = personalScope(ownerId);
+      for (const record of result.plan.restore) {
+        await mutate(MutationKind.PersonalUpsert, scope, {
+          recordId: record.id,
+          recordKind: record.kind,
+          data: record.data,
+        });
+      }
+      // Durable on disk already; this only asks the queue to leave sooner.
+      void flush([scope]);
+      return result.plan.restore.length;
+    },
+    [ownerId, mutate, flush],
+  );
+
+  return {
+    loading,
+    settings,
+    configured,
+    connected,
+    account,
+    hasKey,
+    recordCount: records.length,
+    phase,
+    outcome,
+    connect,
+    disconnect,
+    backupNow,
+    setFrequency: setFrequencyAction,
+    setNetwork: setNetworkAction,
+    createKey,
+    revealKey,
+    acceptKey,
+    confirmKeySeen,
+    scan,
+    applyRestore,
+  };
+}

--- a/apps/mobile/src/lib/backup/useBackup.ts
+++ b/apps/mobile/src/lib/backup/useBackup.ts
@@ -26,9 +26,10 @@ import { useAuth } from '@/lib/auth';
 import { useSync } from '@/sync';
 
 import { providerFor } from '../cloud/providers';
-import { clearTokens, loadTokens, saveTokens } from '../cloud/tokens';
+import { loadTokens, saveTokens } from '../cloud/tokens';
 import type { SyncNetworkPreference } from '../syncNetwork';
 import {
+  clearBackupState,
   PRIMARY_PROVIDER,
   runBackup,
   scanBackup,
@@ -38,7 +39,6 @@ import {
 } from './engine';
 import {
   bytesToHex,
-  clearRecoveryKey,
   loadRecoveryKey,
   mintRecoveryKey,
   parseRecoveryKey,
@@ -46,10 +46,9 @@ import {
 } from './recoveryKey';
 import { BackupFrequency } from './schedule';
 import {
-  clearBackupSettings,
-  DEFAULT_BACKUP_NETWORK,
   loadBackupSettings,
   markKeySeen,
+  NO_BACKUP_SETTINGS,
   saveFrequency,
   saveLastBackup,
   saveNetwork,
@@ -60,13 +59,6 @@ import {
 export type BackupOutcome =
   | { readonly kind: 'ok'; readonly records: number }
   | { readonly kind: 'refused'; readonly refusal: BackupRefusal };
-
-const NO_SETTINGS: BackupSettings = {
-  frequency: BackupFrequency.Off,
-  network: DEFAULT_BACKUP_NETWORK,
-  last: null,
-  keySeen: false,
-};
 
 export interface BackupState {
   /** False while the stored settings and tokens are still being read. */
@@ -116,7 +108,7 @@ export function useBackup(): BackupState & BackupActions {
   const localIds = usePersonalRecordIds();
 
   const [loading, setLoading] = useState(true);
-  const [settings, setSettings] = useState<BackupSettings>(NO_SETTINGS);
+  const [settings, setSettings] = useState<BackupSettings>(NO_BACKUP_SETTINGS);
   const [connected, setConnected] = useState(false);
   const [account, setAccount] = useState<string | null>(null);
   const [hasKey, setHasKey] = useState(false);
@@ -127,7 +119,7 @@ export function useBackup(): BackupState & BackupActions {
   const configured = provider.isConfigured();
 
   const refreshAccount = useCallback(async (): Promise<void> => {
-    const tokens = await loadTokens(PRIMARY_PROVIDER);
+    const tokens = ownerId ? await loadTokens(PRIMARY_PROVIDER, ownerId) : null;
     setConnected(tokens !== null);
     if (!tokens) {
       setAccount(null);
@@ -140,12 +132,18 @@ export function useBackup(): BackupState & BackupActions {
         .account(tokens)
         .catch(() => null),
     );
-  }, []);
+  }, [ownerId]);
 
+  // Everything below is keyed by the signed-in account, so a sign-out or a
+  // switch has to re-read rather than keep showing what the previous person
+  // had linked. `ownerId` in the dependency list is what makes that happen.
   useEffect(() => {
     let alive = true;
     void (async () => {
-      const [stored, key] = await Promise.all([loadBackupSettings(), loadRecoveryKey()]);
+      const [stored, key] = await Promise.all([
+        loadBackupSettings(ownerId),
+        ownerId ? loadRecoveryKey(ownerId) : Promise.resolve(null),
+      ]);
       if (!alive) return;
       setSettings(stored);
       setHasKey(key !== null);
@@ -155,38 +153,39 @@ export function useBackup(): BackupState & BackupActions {
     return () => {
       alive = false;
     };
-  }, [refreshAccount]);
+  }, [ownerId, refreshAccount]);
 
   const connect = useCallback(async (): Promise<boolean> => {
+    if (!ownerId) return false;
     const tokens = await provider.connect();
     // Null is a cancel — the person closed the consent page. Not an error, and
     // the caller must not dress it as one.
     if (!tokens) return false;
-    await saveTokens(PRIMARY_PROVIDER, tokens);
+    await saveTokens(PRIMARY_PROVIDER, ownerId, tokens);
     await refreshAccount();
     return true;
-  }, [provider, refreshAccount]);
+  }, [ownerId, provider, refreshAccount]);
 
   const disconnect = useCallback(async (): Promise<void> => {
-    const tokens = await loadTokens(PRIMARY_PROVIDER);
+    if (!ownerId) return;
+    const tokens = await loadTokens(PRIMARY_PROVIDER, ownerId);
     // Hand the grant back to Google as well as forgetting it here, so "not
     // connected" is true in their account settings too. Best effort: a failed
     // revoke must not leave the app still claiming a link it has dropped.
     if (tokens) await provider.revoke?.(tokens).catch(() => undefined);
-    await clearTokens(PRIMARY_PROVIDER);
-    // The recovery key goes with the link. Keeping it would leave a key on the
+    // Tokens, key and preferences together — the same wipe sign-out runs. The
+    // recovery key goes with the link: keeping it would leave a key on the
     // phone for a file the app can no longer reach, and the person still has
     // their written copy, which is the only one that was ever load-bearing.
-    await clearRecoveryKey();
-    await clearBackupSettings();
-    setSettings(NO_SETTINGS);
+    await clearBackupState(ownerId);
+    setSettings(NO_BACKUP_SETTINGS);
     setHasKey(false);
     setOutcome(null);
     await refreshAccount();
-  }, [provider, refreshAccount]);
+  }, [ownerId, provider, refreshAccount]);
 
   const backupNow = useCallback(async (): Promise<BackupOutcome> => {
-    const key = await loadRecoveryKey();
+    const key = ownerId ? await loadRecoveryKey(ownerId) : null;
     if (!key) {
       const refused: BackupOutcome = { kind: 'refused', refusal: 'no-key' };
       setOutcome(refused);
@@ -211,7 +210,7 @@ export function useBackup(): BackupState & BackupActions {
         if (result.refusal === 'auth') await refreshAccount();
         return refused;
       }
-      await saveLastBackup(result.last);
+      await saveLastBackup(ownerId, result.last);
       setSettings((current) => ({ ...current, last: result.last }));
       const done: BackupOutcome = { kind: 'ok', records: result.last.records };
       setOutcome(done);
@@ -221,47 +220,56 @@ export function useBackup(): BackupState & BackupActions {
     }
   }, [ownerId, records, settings.network, refreshAccount]);
 
-  const setFrequencyAction = useCallback(async (frequency: BackupFrequency): Promise<void> => {
-    setSettings((current) => ({ ...current, frequency }));
-    await saveFrequency(frequency);
-  }, []);
+  const setFrequencyAction = useCallback(
+    async (frequency: BackupFrequency): Promise<void> => {
+      setSettings((current) => ({ ...current, frequency }));
+      await saveFrequency(ownerId, frequency);
+    },
+    [ownerId],
+  );
 
-  const setNetworkAction = useCallback(async (network: SyncNetworkPreference): Promise<void> => {
-    setSettings((current) => ({ ...current, network }));
-    await saveNetwork(network);
-  }, []);
+  const setNetworkAction = useCallback(
+    async (network: SyncNetworkPreference): Promise<void> => {
+      setSettings((current) => ({ ...current, network }));
+      await saveNetwork(ownerId, network);
+    },
+    [ownerId],
+  );
 
   const createKey = useCallback(async (): Promise<string> => {
     const key = mintRecoveryKey();
-    await saveRecoveryKey(key);
+    await saveRecoveryKey(ownerId, key);
     setHasKey(true);
     return bytesToHex(key);
-  }, []);
+  }, [ownerId]);
 
   const revealKey = useCallback(async (): Promise<string | null> => {
-    const key = await loadRecoveryKey();
+    const key = ownerId ? await loadRecoveryKey(ownerId) : null;
     return key ? bytesToHex(key) : null;
-  }, []);
+  }, [ownerId]);
 
-  const acceptKey = useCallback(async (input: string): Promise<boolean> => {
-    const key = parseRecoveryKey(input);
-    if (!key) return false;
-    await saveRecoveryKey(key);
-    setHasKey(true);
-    // A key typed in from elsewhere has self-evidently been kept somewhere, so
-    // there is nothing left to warn this person about.
-    await markKeySeen();
-    setSettings((current) => ({ ...current, keySeen: true }));
-    return true;
-  }, []);
+  const acceptKey = useCallback(
+    async (input: string): Promise<boolean> => {
+      const key = parseRecoveryKey(input);
+      if (!key) return false;
+      await saveRecoveryKey(ownerId, key);
+      setHasKey(true);
+      // A key typed in from elsewhere has self-evidently been kept somewhere,
+      // so there is nothing left to warn this person about.
+      await markKeySeen(ownerId);
+      setSettings((current) => ({ ...current, keySeen: true }));
+      return true;
+    },
+    [ownerId],
+  );
 
   const confirmKeySeen = useCallback(async (): Promise<void> => {
     setSettings((current) => ({ ...current, keySeen: true }));
-    await markKeySeen();
-  }, []);
+    await markKeySeen(ownerId);
+  }, [ownerId]);
 
   const scan = useCallback(async (): Promise<RestoreScan> => {
-    const key = await loadRecoveryKey();
+    const key = ownerId ? await loadRecoveryKey(ownerId) : null;
     if (!key) return { ok: false, refusal: 'no-key' };
     return scanBackup({ ownerId, key, localIds });
   }, [ownerId, localIds]);

--- a/apps/mobile/src/lib/bytes.ts
+++ b/apps/mobile/src/lib/bytes.ts
@@ -1,0 +1,16 @@
+/**
+ * A size a person reads, localised.
+ *
+ * Two screens now say how big something is — the storage meter and the backup's
+ * "last backup" line — and a number formatted two ways in one app is the kind of
+ * inconsistency nobody reports and everybody notices. Binary units (a KB is
+ * 1024 bytes) because that is what both the storage cap and the file sizes are
+ * counted in.
+ */
+export function formatBytes(bytes: number, locale: string): string {
+  const number = (value: number, fractionDigits: number): string =>
+    new Intl.NumberFormat(locale, { maximumFractionDigits: fractionDigits }).format(value);
+  if (bytes > 0 && bytes < 1024 * 1024) return `${number(bytes / 1024, 0)} KB`;
+  const mb = bytes / (1024 * 1024);
+  return `${number(mb, mb < 10 ? 1 : 0)} MB`;
+}

--- a/apps/mobile/src/lib/cloud/config.ts
+++ b/apps/mobile/src/lib/cloud/config.ts
@@ -1,0 +1,49 @@
+/**
+ * Which OAuth client this build presents, and whether it has one at all.
+ *
+ * Drive needs its own client ids — the app's *login* goes through Supabase's
+ * hosted Google flow and never holds a Google client id of its own, so nothing
+ * here is shared with sign-in. Google binds a native OAuth client to a platform
+ * identity: Android to the package name plus the signing SHA-1, iOS to the
+ * bundle id. One id therefore cannot serve both, and the release and debug
+ * Android builds need separate ones because they are signed with different
+ * keys.
+ *
+ * The ids are not secret — a native OAuth client has no secret, which is why
+ * this app uses PKCE — but they name a Google Cloud project that belongs to
+ * whoever is building, so they are read from the environment rather than
+ * committed. `EXPO_PUBLIC_*` is inlined by Metro at build time, which is why
+ * each one is spelled out statically below: a computed `process.env[key]` is
+ * not substituted and would read as undefined in a release bundle.
+ *
+ * With none set the app builds and runs; the backup screen says the destination
+ * is unavailable in this build instead of opening a consent page that would be
+ * rejected. See README, "Backing the personal ledger up to Drive".
+ */
+
+import { Platform } from 'react-native';
+
+import type { CloudProviderId } from './types';
+
+/** The Drive OAuth client for the platform this build is running on. */
+function googleDriveClientId(): string | undefined {
+  const id = Platform.select({
+    android: process.env.EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_ANDROID,
+    ios: process.env.EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_IOS,
+    default: process.env.EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_WEB,
+  });
+  return id && id.length > 0 ? id : undefined;
+}
+
+export function clientId(provider: CloudProviderId): string {
+  const id = provider === 'gdrive' ? googleDriveClientId() : undefined;
+  // Callers gate on `isConfigured` first; reaching here without an id is a
+  // programming error, not a user-facing state, so it throws rather than
+  // sending an empty `client_id` to a consent page.
+  if (!id) throw new Error(`no OAuth client id configured for ${provider}`);
+  return id;
+}
+
+export function isConfigured(provider: CloudProviderId): boolean {
+  return provider === 'gdrive' && googleDriveClientId() !== undefined;
+}

--- a/apps/mobile/src/lib/cloud/googleDrive.ts
+++ b/apps/mobile/src/lib/cloud/googleDrive.ts
@@ -1,0 +1,184 @@
+/**
+ * Google Drive, as a place to keep one encrypted backup file.
+ *
+ * The scope is `drive.appdata` and nothing else. That is the narrowest thing
+ * Google offers: it grants access to a hidden per-application folder — the
+ * *appDataFolder* — and to nothing whatsoever in the user's visible Drive. The
+ * app cannot list their documents, cannot read a photo, cannot be tricked into
+ * it, because the token was never issued for it. The wider `drive.file` scope
+ * the deleted receipt-backup version used would have put the backup in the
+ * user's own file list, which reads as tidier and is strictly more access than
+ * this needs; `drive` (full) is never requested and never should be.
+ *
+ * What the user sees in exchange for the narrow scope: the file does not show
+ * up in their Drive. It is still theirs — Drive's storage settings list the app
+ * and offer "Delete hidden app data", and the quota it uses is their quota —
+ * but they cannot open it, and it would be meaningless if they did, because it
+ * is sealed with a key Google does not have (see `backup/recoveryKey.ts`).
+ *
+ * There is exactly one file, overwritten in place, so the appDataFolder never
+ * accumulates and a restore never has to choose between candidates.
+ */
+
+import { authorize, isExpired, refresh, type OAuthConfig } from './oauth';
+import { requestJson, requestRaw, requestText } from './http';
+import { clientId, isConfigured as clientConfigured } from './config';
+import type { CloudFile, CloudProvider, CloudTokens } from './types';
+
+const DISCOVERY = {
+  authorizationEndpoint: 'https://accounts.google.com/o/oauth2/v2/auth',
+  tokenEndpoint: 'https://oauth2.googleapis.com/token',
+  revocationEndpoint: 'https://oauth2.googleapis.com/revoke',
+};
+
+/** The hidden per-app folder. Not an id we look up — Drive accepts the alias. */
+const APP_DATA = 'appDataFolder';
+/** The fields worth asking for; Drive returns only what it is asked for. */
+const FILE_FIELDS = 'id,name,size,modifiedTime';
+
+function config(): OAuthConfig {
+  return {
+    clientId: clientId('gdrive'),
+    scopes: ['https://www.googleapis.com/auth/drive.appdata'],
+    discovery: DISCOVERY,
+    // `offline` plus a forced consent is what makes Google hand back a refresh
+    // token; without it an automatic backup would stop working an hour after
+    // the person connected, and they would find out weeks later.
+    extraParams: { access_type: 'offline', prompt: 'consent' },
+  };
+}
+
+function authHeader(tokens: CloudTokens): Record<string, string> {
+  return { Authorization: `Bearer ${tokens.accessToken}` };
+}
+
+/** Drive reports `size` as a string of bytes, and omits it for some kinds. */
+function toFile(raw: Record<string, unknown>): CloudFile {
+  const modified = typeof raw.modifiedTime === 'string' ? Date.parse(raw.modifiedTime) : NaN;
+  const size = Number(raw.size);
+  return {
+    remoteId: String(raw.id ?? ''),
+    name: typeof raw.name === 'string' ? raw.name : '',
+    size: Number.isFinite(size) && size > 0 ? size : 0,
+    modifiedAt: Number.isFinite(modified) ? modified : null,
+  };
+}
+
+export const googleDrive: CloudProvider = {
+  id: 'gdrive',
+  label: 'Google Drive',
+  isConfigured: () => clientConfigured('gdrive'),
+  connect: () => authorize(config()),
+  ensureValid: (tokens) =>
+    isExpired(tokens) ? refresh(config(), tokens) : Promise.resolve(tokens),
+
+  /**
+   * The signed-in Google account's address, for the screen's "Google account"
+   * row. `drive.about.get` is reachable under `drive.appdata`, but the exact
+   * set of scopes Google accepts here has changed before, so a refusal is
+   * swallowed: not knowing the address is a cosmetic loss, and widening the
+   * scope to `userinfo.email` just to print a string would not be worth it.
+   */
+  async account(tokens: CloudTokens): Promise<string | null> {
+    try {
+      const about = await requestJson(
+        'https://www.googleapis.com/drive/v3/about?fields=user(emailAddress,displayName)',
+        { headers: authHeader(tokens) },
+      );
+      const user = about.user as { emailAddress?: string; displayName?: string } | undefined;
+      return user?.emailAddress ?? user?.displayName ?? null;
+    } catch {
+      return null;
+    }
+  },
+
+  async find(tokens: CloudTokens, name: string): Promise<CloudFile | null> {
+    // The name is ours, not the user's, so there is nothing to escape — but the
+    // query is a string Drive parses, so quote-strip anyway rather than trust
+    // that it stays that way.
+    const safe = name.replace(/'/g, '');
+    const q = encodeURIComponent(`name='${safe}' and trashed=false`);
+    const found = await requestJson(
+      `https://www.googleapis.com/drive/v3/files?spaces=${APP_DATA}&q=${q}` +
+        `&fields=files(${FILE_FIELDS})&pageSize=10`,
+      { headers: authHeader(tokens) },
+    );
+    const files = (found.files as Record<string, unknown>[] | undefined) ?? [];
+    // Newest wins if a past failure ever left two behind, so a restore reads
+    // the most recent backup rather than whichever Drive listed first.
+    const best = files
+      .map(toFile)
+      .filter((file) => file.remoteId.length > 0)
+      .sort((a, b) => (b.modifiedAt ?? 0) - (a.modifiedAt ?? 0))[0];
+    return best ?? null;
+  },
+
+  async put(
+    tokens: CloudTokens,
+    name: string,
+    content: string,
+    existingId: string | null,
+  ): Promise<CloudFile> {
+    // An overwrite is a plain media PATCH: the name and the parent are already
+    // right, and re-sending `parents` on an update is an error in Drive v3.
+    if (existingId) {
+      const updated = await requestRaw(
+        `https://www.googleapis.com/upload/drive/v3/files/${existingId}` +
+          `?uploadType=media&fields=${FILE_FIELDS}`,
+        {
+          method: 'PATCH',
+          headers: { ...authHeader(tokens), 'Content-Type': 'application/json' },
+          body: content,
+        },
+      );
+      return toFile(updated);
+    }
+
+    // A create has to carry the metadata (the name, and the appDataFolder
+    // parent) alongside the bytes, which in Drive v3 means one multipart/related
+    // body with the JSON metadata as the first part and the content as the
+    // second. Built by hand: the payload is a string we already hold, and
+    // FormData would give us multipart/form-data, which Drive does not accept.
+    const boundary = `waves-${Math.random().toString(36).slice(2)}-${Date.now()}`;
+    const metadata = JSON.stringify({ name, parents: [APP_DATA] });
+    const body =
+      `--${boundary}\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n${metadata}\r\n` +
+      `--${boundary}\r\nContent-Type: application/json\r\n\r\n${content}\r\n` +
+      `--${boundary}--`;
+
+    const created = await requestRaw(
+      `https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&fields=${FILE_FIELDS}`,
+      {
+        method: 'POST',
+        headers: {
+          ...authHeader(tokens),
+          'Content-Type': `multipart/related; boundary=${boundary}`,
+        },
+        body,
+      },
+    );
+    return toFile(created);
+  },
+
+  read(tokens: CloudTokens, remoteId: string): Promise<string> {
+    return requestText(`https://www.googleapis.com/drive/v3/files/${remoteId}?alt=media`, {
+      headers: authHeader(tokens),
+    });
+  },
+
+  /**
+   * Hand the grant back when somebody unlinks, so "disconnect" means it in
+   * Google's account settings too and not only in this app's keystore. The
+   * refresh token is the one worth revoking — revoking it kills the access
+   * token with it.
+   */
+  async revoke(tokens: CloudTokens): Promise<void> {
+    const token = tokens.refreshToken ?? tokens.accessToken;
+    if (!token) return;
+    await fetch(DISCOVERY.revocationEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: `token=${encodeURIComponent(token)}`,
+    });
+  },
+};

--- a/apps/mobile/src/lib/cloud/googleDrive.ts
+++ b/apps/mobile/src/lib/cloud/googleDrive.ts
@@ -20,7 +20,7 @@
  * accumulates and a restore never has to choose between candidates.
  */
 
-import { authorize, isExpired, refresh, type OAuthConfig } from './oauth';
+import { asAuthFailure, authorize, isExpired, refresh, type OAuthConfig } from './oauth';
 import { requestJson, requestRaw, requestText } from './http';
 import { clientId, isConfigured as clientConfigured } from './config';
 import type { CloudFile, CloudProvider, CloudTokens } from './types';
@@ -69,8 +69,26 @@ export const googleDrive: CloudProvider = {
   label: 'Google Drive',
   isConfigured: () => clientConfigured('gdrive'),
   connect: () => authorize(config()),
-  ensureValid: (tokens) =>
-    isExpired(tokens) ? refresh(config(), tokens) : Promise.resolve(tokens),
+
+  /**
+   * Fresh tokens, refreshing first when the access token is stale.
+   *
+   * A refresh Google rejects because the grant is gone — revoked in the user's
+   * account settings, consent withdrawn, the app removed — is turned into the
+   * same 401 a Drive API call would produce, so the one caller-side predicate
+   * (`isAuthFailure`) recognises it. Everything else is left as it is: a token
+   * endpoint that timed out is a transport failure, and treating it as a dead
+   * link would sign the person out of their own backup over a bad minute of
+   * signal.
+   */
+  async ensureValid(tokens: CloudTokens): Promise<CloudTokens> {
+    if (!isExpired(tokens)) return tokens;
+    try {
+      return await refresh(config(), tokens);
+    } catch (error) {
+      throw asAuthFailure(error) ?? error;
+    }
+  },
 
   /**
    * The signed-in Google account's address, for the screen's "Google account"

--- a/apps/mobile/src/lib/cloud/http.ts
+++ b/apps/mobile/src/lib/cloud/http.ts
@@ -1,0 +1,79 @@
+/**
+ * The HTTP shapes the providers need, in one place.
+ *
+ * A ledger backup is a string the app already holds in memory, not a file on
+ * disk, so there is nothing to stream: plain `fetch` covers every call. (The
+ * deleted image-backup version of this module used expo-file-system's native
+ * uploader to avoid base64-ing megabytes of JPEG through the bridge; a few
+ * hundred kilobytes of JSON does not earn that.)
+ *
+ * Everything non-2xx throws a `CloudHttpError` carrying the status and body,
+ * so the backup engine can tell a retryable network blip from a dead token —
+ * and so the raw body never has to be shown to anybody: it goes to the crash
+ * reporter through `friendlyError`, and the screen gets a sentence.
+ */
+
+export class CloudHttpError extends Error {
+  constructor(
+    readonly status: number,
+    readonly body: string,
+  ) {
+    super(`cloud request failed (${status}): ${body.slice(0, 300)}`);
+    this.name = 'CloudHttpError';
+  }
+}
+
+/** True for the statuses that mean "these tokens are no longer any good". */
+export function isAuthFailure(error: unknown): boolean {
+  return error instanceof CloudHttpError && (error.status === 401 || error.status === 403);
+}
+
+/** A JSON request; returns the parsed body. */
+export async function requestJson(
+  url: string,
+  options: { method?: string; headers?: Record<string, string>; body?: unknown } = {},
+): Promise<Record<string, unknown>> {
+  const response = await fetch(url, {
+    method: options.method ?? 'GET',
+    headers: { 'Content-Type': 'application/json', ...options.headers },
+    body: options.body === undefined ? undefined : JSON.stringify(options.body),
+  });
+  const text = await response.text();
+  if (!response.ok) throw new CloudHttpError(response.status, text);
+  return parse(text);
+}
+
+/** A request whose body is raw text (an upload); returns the parsed response. */
+export async function requestRaw(
+  url: string,
+  options: { method: string; headers: Record<string, string>; body: string },
+): Promise<Record<string, unknown>> {
+  const response = await fetch(url, {
+    method: options.method,
+    headers: options.headers,
+    body: options.body,
+  });
+  const text = await response.text();
+  if (!response.ok) throw new CloudHttpError(response.status, text);
+  return parse(text);
+}
+
+/** A request whose *response* is the payload — the download side. */
+export async function requestText(
+  url: string,
+  options: { headers: Record<string, string> },
+): Promise<string> {
+  const response = await fetch(url, { headers: options.headers });
+  const text = await response.text();
+  if (!response.ok) throw new CloudHttpError(response.status, text);
+  return text;
+}
+
+function parse(text: string): Record<string, unknown> {
+  if (!text) return {};
+  try {
+    return JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    return { raw: text };
+  }
+}

--- a/apps/mobile/src/lib/cloud/oauth.ts
+++ b/apps/mobile/src/lib/cloud/oauth.ts
@@ -23,6 +23,7 @@ import {
 } from 'expo-auth-session';
 import * as WebBrowser from 'expo-web-browser';
 
+import { CloudHttpError } from './http';
 import type { CloudTokens } from './types';
 
 // Lets the auth popup hand its result back and close itself when the app is
@@ -106,6 +107,44 @@ export async function refresh(config: OAuthConfig, tokens: CloudTokens): Promise
     config.discovery,
   );
   return toTokens(token, tokens.refreshToken);
+}
+
+/**
+ * The OAuth error codes that mean the grant is gone and only a new consent will
+ * bring it back — a revoked refresh token, a withdrawn consent, a client that
+ * is no longer allowed. Anything else (a dead network, a 500 at the token
+ * endpoint) is a transport failure that a retry might fix, and must not be
+ * mistaken for one.
+ */
+const DEAD_GRANT_CODES = new Set([
+  'invalid_grant',
+  'invalid_client',
+  'unauthorized_client',
+  'invalid_scope',
+  'access_denied',
+]);
+
+/**
+ * Normalise a failed token exchange into the same 401 the resource API
+ * produces, or null when the failure was not about the grant.
+ *
+ * The point is that one predicate — `isAuthFailure` — covers both halves of the
+ * provider. Without this, a refresh rejected because the user revoked access in
+ * their Google account settings throws a `TokenError` that nothing recognises,
+ * and the caller ends up reporting "nothing is linked" while the dead tokens sit
+ * on disk. The screen then offers the wrong remedy for the rest of time.
+ */
+export function asAuthFailure(error: unknown): CloudHttpError | null {
+  // A rejection is not guaranteed to be an object at all, and a thrown
+  // TypeError here would replace the failure being classified with a worse one.
+  if (typeof error !== 'object' || error === null) return null;
+  const code = (error as { code?: unknown }).code;
+  if (typeof code !== 'string' || !DEAD_GRANT_CODES.has(code)) return null;
+  const description = (error as { description?: unknown }).description;
+  return new CloudHttpError(
+    401,
+    typeof description === 'string' ? `${code}: ${description}` : code,
+  );
 }
 
 /** A minute's grace, so a token that expires mid-upload is refreshed first. */

--- a/apps/mobile/src/lib/cloud/oauth.ts
+++ b/apps/mobile/src/lib/cloud/oauth.ts
@@ -1,0 +1,121 @@
+/**
+ * The OAuth dance every personal-cloud provider shares.
+ *
+ * Authorization code + PKCE, the only flow that is honest on a phone: there is
+ * nowhere safe to keep a client secret in a binary somebody can unzip, so the
+ * proof is a verifier the app generates per attempt and never sends until the
+ * code comes back. Each provider supplies its endpoints, its scopes and the
+ * couple of extra query params it wants; the flow itself lives here once.
+ *
+ * The redirect comes back to the app's own `waves://` scheme — the same
+ * mechanism the Supabase sign-in already uses, on its own `oauthredirect` path
+ * so the two are never confused. `+native-intent.ts` explains what happens to
+ * the copy of that link the OS *also* delivers as an app intent.
+ */
+
+import {
+  AuthRequest,
+  exchangeCodeAsync,
+  makeRedirectUri,
+  refreshAsync,
+  type AuthDiscoveryDocument,
+  type TokenResponse,
+} from 'expo-auth-session';
+import * as WebBrowser from 'expo-web-browser';
+
+import type { CloudTokens } from './types';
+
+// Lets the auth popup hand its result back and close itself when the app is
+// re-focused after the redirect. A no-op on native, required on web.
+WebBrowser.maybeCompleteAuthSession();
+
+/** The endpoints for one provider. `revocationEndpoint` is optional. */
+export interface OAuthEndpoints extends AuthDiscoveryDocument {
+  readonly authorizationEndpoint: string;
+  readonly tokenEndpoint: string;
+}
+
+export interface OAuthConfig {
+  readonly clientId: string;
+  readonly scopes: readonly string[];
+  readonly discovery: OAuthEndpoints;
+  /** Provider-specific query params, e.g. Google's `access_type=offline`. */
+  readonly extraParams?: Record<string, string>;
+}
+
+/** The one path every provider redirects to — distinct from `auth` sign-in. */
+export function redirectUri(): string {
+  return makeRedirectUri({ scheme: 'waves', path: 'oauthredirect' });
+}
+
+function toTokens(response: TokenResponse, previousRefresh?: string | null): CloudTokens {
+  return {
+    accessToken: response.accessToken,
+    // A refresh returns a new refresh token only sometimes; keep the old one
+    // when it doesn't, or the next refresh has nothing to present.
+    refreshToken: response.refreshToken ?? previousRefresh ?? null,
+    expiresAt: response.expiresIn ? Date.now() + response.expiresIn * 1000 : null,
+  };
+}
+
+/**
+ * Run the interactive flow. Resolves to tokens, or null if the person closed
+ * the browser without granting — a cancel, not an error, and the caller must
+ * treat it as one rather than showing a failure they caused on purpose.
+ */
+export async function authorize(config: OAuthConfig): Promise<CloudTokens | null> {
+  const request = new AuthRequest({
+    clientId: config.clientId,
+    scopes: [...config.scopes],
+    redirectUri: redirectUri(),
+    usePKCE: true,
+    extraParams: config.extraParams,
+  });
+
+  const result = await request.promptAsync(config.discovery);
+  if (result.type !== 'success' || !result.params.code) return null;
+
+  const token = await exchangeCodeAsync(
+    {
+      clientId: config.clientId,
+      code: result.params.code,
+      redirectUri: redirectUri(),
+      // PKCE proof: the verifier behind the challenge sent in the auth request.
+      extraParams: { code_verifier: request.codeVerifier ?? '' },
+    },
+    config.discovery,
+  );
+
+  return toTokens(token);
+}
+
+/**
+ * Trade a refresh token for a fresh access token. Returns the input unchanged
+ * when there is no refresh token to use — the caller then re-authorises.
+ */
+export async function refresh(config: OAuthConfig, tokens: CloudTokens): Promise<CloudTokens> {
+  if (!tokens.refreshToken) return tokens;
+  const token = await refreshAsync(
+    {
+      clientId: config.clientId,
+      refreshToken: tokens.refreshToken,
+      // `prompt=consent` belongs to the interactive leg only; sending it on a
+      // refresh is meaningless at best and rejected at worst.
+      extraParams: undefined,
+    },
+    config.discovery,
+  );
+  return toTokens(token, tokens.refreshToken);
+}
+
+/** A minute's grace, so a token that expires mid-upload is refreshed first. */
+const EXPIRY_SKEW_MS = 60_000;
+
+/** True when the access token is missing or about to expire. */
+export function isExpired(tokens: CloudTokens): boolean {
+  if (!tokens.accessToken) return true;
+  // An unknown expiry is treated as expired so a refreshable token is renewed
+  // rather than used until the server rejects it.
+  if (tokens.expiresAt === null) return tokens.refreshToken !== null;
+  return tokens.expiresAt - EXPIRY_SKEW_MS <= Date.now();
+}

--- a/apps/mobile/src/lib/cloud/providers.ts
+++ b/apps/mobile/src/lib/cloud/providers.ts
@@ -1,0 +1,16 @@
+/** The provider registry — the one place that knows the implementations. */
+
+import { googleDrive } from './googleDrive';
+import { CLOUD_PROVIDER_IDS, type CloudProvider, type CloudProviderId } from './types';
+
+const REGISTRY: Record<CloudProviderId, CloudProvider> = {
+  gdrive: googleDrive,
+};
+
+export function providerFor(id: CloudProviderId): CloudProvider {
+  return REGISTRY[id];
+}
+
+export function allProviders(): readonly CloudProvider[] {
+  return CLOUD_PROVIDER_IDS.map((id) => REGISTRY[id]);
+}

--- a/apps/mobile/src/lib/cloud/tokens.ts
+++ b/apps/mobile/src/lib/cloud/tokens.ts
@@ -1,0 +1,41 @@
+/**
+ * Where a provider's OAuth tokens live: the OS keystore, not AsyncStorage.
+ *
+ * A refresh token for someone's Google Drive is exactly the kind of long-lived
+ * credential the app's own session hardening moved out of plaintext, so it
+ * rides the same chunked SecureStore adapter (`secureAuthStorage`) that the
+ * Supabase session uses — Keychain on iOS, Keystore on Android, AsyncStorage
+ * only on web where there is no keystore.
+ */
+
+import { secureAuthStorage } from '../secureStorage';
+import type { CloudProviderId, CloudTokens } from './types';
+
+const key = (id: CloudProviderId): string => `waves.cloud.tokens.${id}`;
+
+export async function loadTokens(id: CloudProviderId): Promise<CloudTokens | null> {
+  const raw = await secureAuthStorage.getItem(key(id)).catch(() => null);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<CloudTokens>;
+    // A stored blob with no access token is not usable and not worth keeping
+    // as "connected" — treat it as absent so the screen offers Connect.
+    return typeof parsed.accessToken === 'string' && parsed.accessToken.length > 0
+      ? {
+          accessToken: parsed.accessToken,
+          refreshToken: typeof parsed.refreshToken === 'string' ? parsed.refreshToken : null,
+          expiresAt: typeof parsed.expiresAt === 'number' ? parsed.expiresAt : null,
+        }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveTokens(id: CloudProviderId, tokens: CloudTokens): Promise<void> {
+  await secureAuthStorage.setItem(key(id), JSON.stringify(tokens)).catch(() => undefined);
+}
+
+export async function clearTokens(id: CloudProviderId): Promise<void> {
+  await secureAuthStorage.removeItem(key(id)).catch(() => undefined);
+}

--- a/apps/mobile/src/lib/cloud/tokens.ts
+++ b/apps/mobile/src/lib/cloud/tokens.ts
@@ -1,20 +1,31 @@
 /**
- * Where a provider's OAuth tokens live: the OS keystore, not AsyncStorage.
+ * Where a provider's OAuth tokens live: the OS keystore, not AsyncStorage, and
+ * under the account that granted them.
  *
  * A refresh token for someone's Google Drive is exactly the kind of long-lived
  * credential the app's own session hardening moved out of plaintext, so it
  * rides the same chunked SecureStore adapter (`secureAuthStorage`) that the
  * Supabase session uses — Keychain on iOS, Keystore on Android, AsyncStorage
  * only on web where there is no keystore.
+ *
+ * The owner id in the key is not decoration. These are device-wide stores on a
+ * device that is not always one person's: without it, B signing in after A
+ * inherits a live, write-capable token into A's Drive. Scoping is the first of
+ * three guards (the other two are the sign-out wipe in `backup/engine.ts` and
+ * the owner in the remote filename); each covers a case the others do not.
  */
 
 import { secureAuthStorage } from '../secureStorage';
 import type { CloudProviderId, CloudTokens } from './types';
 
-const key = (id: CloudProviderId): string => `waves.cloud.tokens.${id}`;
+const key = (id: CloudProviderId, ownerId: string): string => `waves.cloud.tokens.${id}.${ownerId}`;
 
-export async function loadTokens(id: CloudProviderId): Promise<CloudTokens | null> {
-  const raw = await secureAuthStorage.getItem(key(id)).catch(() => null);
+export async function loadTokens(
+  id: CloudProviderId,
+  ownerId: string,
+): Promise<CloudTokens | null> {
+  if (!ownerId) return null;
+  const raw = await secureAuthStorage.getItem(key(id, ownerId)).catch(() => null);
   if (!raw) return null;
   try {
     const parsed = JSON.parse(raw) as Partial<CloudTokens>;
@@ -32,10 +43,23 @@ export async function loadTokens(id: CloudProviderId): Promise<CloudTokens | nul
   }
 }
 
-export async function saveTokens(id: CloudProviderId, tokens: CloudTokens): Promise<void> {
-  await secureAuthStorage.setItem(key(id), JSON.stringify(tokens)).catch(() => undefined);
+export async function saveTokens(
+  id: CloudProviderId,
+  ownerId: string,
+  tokens: CloudTokens,
+): Promise<void> {
+  if (!ownerId) return;
+  await secureAuthStorage.setItem(key(id, ownerId), JSON.stringify(tokens)).catch(() => undefined);
 }
 
-export async function clearTokens(id: CloudProviderId): Promise<void> {
-  await secureAuthStorage.removeItem(key(id)).catch(() => undefined);
+/**
+ * Forget a provider's tokens for one account.
+ *
+ * Unlike the reads and writes above this does **not** swallow: its callers are
+ * an unlink, which should say so when it fails, and the sign-out wipe, where a
+ * credential left behind is a privacy problem rather than a cosmetic one.
+ */
+export async function clearTokens(id: CloudProviderId, ownerId: string): Promise<void> {
+  if (!ownerId) return;
+  await secureAuthStorage.removeItem(key(id, ownerId));
 }

--- a/apps/mobile/src/lib/cloud/types.ts
+++ b/apps/mobile/src/lib/cloud/types.ts
@@ -1,0 +1,74 @@
+/**
+ * The shape a personal-cloud backend is reduced to.
+ *
+ * Only Google Drive implements this today, and that is deliberate — but the
+ * seam stays because the interesting part of "back up somewhere that is yours"
+ * is the *somewhere*, and Dropbox, OneDrive and Box are the same three calls
+ * with different endpoints. An earlier version of this file carried all four
+ * (PR #164, deleted by #393 when receipt images moved to R2); this one is the
+ * ledger-backup half of that, narrowed to one provider so there is exactly one
+ * OAuth console dependency to set up rather than four.
+ *
+ * The interface is deliberately not about images. A personal backup is one
+ * small named blob of text that gets read back whole, so the provider only has
+ * to find it, write it, and hand it back — no folder trees, no thumbnails, no
+ * partial reads.
+ */
+
+/** Every backend this build knows how to talk to. One, for now. */
+export type CloudProviderId = 'gdrive';
+
+export const CLOUD_PROVIDER_IDS: readonly CloudProviderId[] = ['gdrive'];
+
+/** OAuth tokens for one provider, as stored in the keystore. */
+export interface CloudTokens {
+  readonly accessToken: string;
+  /** Null when the provider issued no refresh token (re-auth needed on expiry). */
+  readonly refreshToken: string | null;
+  /** Epoch ms the access token expires, or null when the provider didn't say. */
+  readonly expiresAt: number | null;
+}
+
+/** One file in the provider's app storage, as the backup engine sees it. */
+export interface CloudFile {
+  /** The provider's own id — the handle for a later read or overwrite. */
+  readonly remoteId: string;
+  readonly name: string;
+  /** Bytes, or 0 when the provider did not report a size. */
+  readonly size: number;
+  /** Epoch ms of the last write, or null when the provider did not say. */
+  readonly modifiedAt: number | null;
+}
+
+export interface CloudProvider {
+  readonly id: CloudProviderId;
+  readonly label: string;
+  /** False when this build has no client id — "Connect" is inert, not broken. */
+  isConfigured(): boolean;
+  /** Interactive OAuth. Resolves to tokens, or null if the user cancelled. */
+  connect(): Promise<CloudTokens | null>;
+  /** Tokens good to use now, refreshed first if they are near expiry. */
+  ensureValid(tokens: CloudTokens): Promise<CloudTokens>;
+  /**
+   * Which account these tokens belong to, for the "Google account" row.
+   * Null when the provider will not say under the scopes we hold — the screen
+   * then names the provider without naming the person, rather than guessing.
+   */
+  account(tokens: CloudTokens): Promise<string | null>;
+  /** The named file in the app's private storage, or null when absent. */
+  find(tokens: CloudTokens, name: string): Promise<CloudFile | null>;
+  /**
+   * Write `content` as `name`. `existingId` overwrites that file in place;
+   * null creates a new one. Resolves with the stored file.
+   */
+  put(
+    tokens: CloudTokens,
+    name: string,
+    content: string,
+    existingId: string | null,
+  ): Promise<CloudFile>;
+  /** Read a file's whole text back. */
+  read(tokens: CloudTokens, remoteId: string): Promise<string>;
+  /** Best-effort token revocation on unlink. Optional; failure is not fatal. */
+  revoke?(tokens: CloudTokens): Promise<void>;
+}

--- a/apps/mobile/src/lib/syncNetwork.tsx
+++ b/apps/mobile/src/lib/syncNetwork.tsx
@@ -24,6 +24,7 @@ import {
   type ReactNode,
 } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { NetworkStateType } from 'expo-network';
 
 import { legacyKeysMigrated } from './legacyKeys';
 
@@ -61,6 +62,28 @@ export async function loadSyncNetworkPreference(): Promise<SyncNetworkPreference
   await legacyKeysMigrated;
   const raw = await AsyncStorage.getItem(KEY).catch(() => null);
   return parse(raw);
+}
+
+/**
+ * Whether a connection of type `type` is one `preference` allows. Pure, so the
+ * two callers that gate on it — the sync engine's flush and the personal-ledger
+ * backup, which keeps its own choice but not its own *idea* of what the choices
+ * mean — agree by construction rather than by both being written carefully.
+ *
+ * `null`/`undefined` is an unknown interface type, which only happens off real
+ * phones (web, desktop) where "Wi‑Fi only" is not a meaningful gate. It fails
+ * open: better a request that should have waited than a queue silently stalled
+ * forever on a platform that cannot answer the question.
+ */
+export function networkAllows(
+  preference: SyncNetworkPreference,
+  type: NetworkStateType | null | undefined,
+): boolean {
+  if (preference === SyncNetworkPreference.Both) return true;
+  if (type == null) return true;
+  return preference === SyncNetworkPreference.Wifi
+    ? type === NetworkStateType.WIFI
+    : type === NetworkStateType.CELLULAR;
 }
 
 interface SyncNetworkValue {

--- a/apps/mobile/src/sync/engine.ts
+++ b/apps/mobile/src/sync/engine.ts
@@ -34,7 +34,7 @@ import {
 
 import { reportHandled } from '@/lib/observability';
 import { backend } from '@/lib/backend';
-import { loadSyncNetworkPreference, SyncNetworkPreference } from '@/lib/syncNetwork';
+import { loadSyncNetworkPreference, networkAllows, SyncNetworkPreference } from '@/lib/syncNetwork';
 
 import { createLocalStore, type LocalStore, type StoredRow } from './store';
 
@@ -653,10 +653,7 @@ async function networkAllowed(): Promise<boolean> {
   if (preference === SyncNetworkPreference.Both) return true;
   try {
     const { type } = await Network.getNetworkStateAsync();
-    if (type == null) return true;
-    return preference === SyncNetworkPreference.Wifi
-      ? type === Network.NetworkStateType.WIFI
-      : type === Network.NetworkStateType.CELLULAR;
+    return networkAllows(preference, type);
   } catch {
     return true;
   }

--- a/apps/mobile/src/sync/provider.tsx
+++ b/apps/mobile/src/sync/provider.tsx
@@ -24,6 +24,7 @@ import type { MutationEnvelope, MutationKind } from '@waves/core';
 
 import { useAuth } from '@/lib/auth';
 import { reportHandled } from '@/lib/observability';
+import { clearBackupState } from '@/lib/backup/engine';
 import { clearReceiptQueue, flushReceiptQueue } from '@/lib/receiptQueue';
 import { clearImageCache } from '@/lib/storage/imageCache';
 
@@ -48,10 +49,26 @@ interface SyncContextValue extends SyncState {
 
 const SyncContext = createContext<SyncContextValue | null>(null);
 
-async function clearLocalPrivateData(): Promise<void> {
+/**
+ * Everything of the departing account's that lives on this device.
+ *
+ * `ownerId` is who is leaving, captured before the session went null — the
+ * backup state is keyed by account (its tokens are a live, write-capable grant
+ * into that person's Google Drive, and its recovery key opens their backup), so
+ * the wipe has to be told whose. The keystore cannot be enumerated, which is
+ * why this is targeted rather than a prefix sweep, and a prefix sweep would be
+ * wrong anyway: a third account's settings on a shared phone are not this
+ * sign-out's to delete.
+ *
+ * Every step is attempted even after one fails, and the first failure is
+ * rethrown. A wipe that stopped halfway is a privacy problem, not a cosmetic
+ * one.
+ */
+async function clearLocalPrivateData(ownerId: string): Promise<void> {
   const failures: unknown[] = [];
   await syncEngine.clear().catch((error: unknown) => failures.push(error));
   await clearReceiptQueue().catch((error: unknown) => failures.push(error));
+  await clearBackupState(ownerId).catch((error: unknown) => failures.push(error));
   try {
     clearImageCache();
   } catch (error) {
@@ -92,7 +109,12 @@ export function SyncProvider({ children }: { children: ReactNode }) {
   const { session } = useAuth();
   const [state, setState] = useState<SyncState>(() => syncEngine.getState());
   const signedIn = Boolean(session);
-  const wasSignedIn = useRef(signedIn);
+  const ownerId = session?.user?.id ?? null;
+  // Who is signed in, held across the render in which they stop being — the
+  // sign-out wipe needs the id, and by the time it runs the session is gone.
+  // Null when signed out, which is also the "was anybody here?" test the old
+  // boolean served.
+  const lastOwnerId = useRef<string | null>(ownerId);
   // The in-flight sign-out cleanup, if any. Sign-out does not block on it, but
   // the next sign-in must: the receipt queue and image cache are device-global,
   // so a cleanup still deleting when a new account signs in would wipe the new
@@ -109,17 +131,18 @@ export function SyncProvider({ children }: { children: ReactNode }) {
       // cosmetic one — but not worth throwing at a screen mid-sign-out. The
       // promise is kept (never rejects — the catch resolves it) so the next
       // sign-in can await its completion before hydrating.
-      if (wasSignedIn.current) {
-        pendingCleanup.current = clearLocalPrivateData().catch((error: unknown) =>
+      const departing = lastOwnerId.current;
+      if (departing !== null) {
+        pendingCleanup.current = clearLocalPrivateData(departing).catch((error: unknown) =>
           reportHandled(error, 'sync.clearPrivateData'),
         );
       }
-      wasSignedIn.current = false;
+      lastOwnerId.current = null;
       syncEngine.stop();
       return;
     }
 
-    wasSignedIn.current = true;
+    lastOwnerId.current = ownerId;
     let cancelled = false;
     void (async () => {
       // A prior sign-out's cleanup may still be deleting the device-global
@@ -151,7 +174,11 @@ export function SyncProvider({ children }: { children: ReactNode }) {
       cancelled = true;
       syncEngine.stop();
     };
-  }, [signedIn]);
+    // `ownerId` is only recorded for the wipe, but it is a render value read in
+    // here, so it belongs in the list. It changes exactly when `signedIn` does
+    // — or when one account is swapped for another without a signed-out frame
+    // between, which is the case the ref exists to survive.
+  }, [signedIn, ownerId]);
 
   // Coming back to the app is the most likely moment for the world to have
   // moved on without us.

--- a/apps/mobile/test/backupAccountScope.test.ts
+++ b/apps/mobile/test/backupAccountScope.test.ts
@@ -1,0 +1,199 @@
+/**
+ * A shared phone: A signs out, B signs in.
+ *
+ * Every store the backup subsystem uses is device-wide — the keystore for the
+ * OAuth tokens and the recovery key, AsyncStorage for the schedule — and none
+ * of them knows about accounts unless it is told. Unscoped, B's Backup screen
+ * showed A's Google account linked, held A's recovery key, and inherited A's
+ * schedule; worse, B's first backup would have found A's file under a fixed
+ * filename and overwritten it with a ledger sealed to a different owner, which
+ * A could then never open.
+ *
+ * Three guards, and this covers all three, because any one alone leaves a hole:
+ * the keys carry the owner, sign-out wipes the departing account, and the
+ * remote filename carries the owner too (for two Waves accounts sharing one
+ * Google account, where scoped local keys do nothing).
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Hoisted so the stand-ins are in place before the modules load their natives.
+const hoisted = vi.hoisted(() => ({ keystore: new Map<string, string>() }));
+
+vi.mock('expo-secure-store', () => ({
+  AFTER_FIRST_UNLOCK: 'after-first-unlock',
+  AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: 'after-first-unlock-this-device-only',
+  getItemAsync: async (key: string) => hoisted.keystore.get(key) ?? null,
+  setItemAsync: async (key: string, value: string) => {
+    hoisted.keystore.set(key, value);
+  },
+  deleteItemAsync: async (key: string) => {
+    hoisted.keystore.delete(key);
+  },
+}));
+
+vi.mock('expo-crypto', () => ({
+  getRandomBytes: (length: number) => {
+    const bytes = new Uint8Array(length);
+    globalThis.crypto.getRandomValues(bytes);
+    return bytes;
+  },
+}));
+
+// The engine pulls the whole provider seam in at import time. Nothing in this
+// file runs a backup or opens a browser, so these only have to load: the real
+// react-native entry point is Flow-typed and unparseable outside Metro, and the
+// auth-session modules reach for native views on import.
+vi.mock('expo-network', () => ({
+  getNetworkStateAsync: async () => ({ isInternetReachable: true, type: 'wifi' }),
+  NetworkStateType: { WIFI: 'wifi', CELLULAR: 'cellular' },
+}));
+
+vi.mock('react-native', () => ({
+  Platform: {
+    OS: 'android',
+    select: (options: Record<string, unknown>) => options.android ?? options.default,
+  },
+}));
+
+vi.mock('expo-web-browser', () => ({ maybeCompleteAuthSession: () => undefined }));
+
+vi.mock('expo-auth-session', () => ({
+  AuthRequest: class {},
+  exchangeCodeAsync: async () => ({}),
+  makeRedirectUri: () => 'waves://oauthredirect',
+  refreshAsync: async () => ({}),
+}));
+
+const AsyncStorage = (await import('@react-native-async-storage/async-storage')).default;
+const { clearTokens, loadTokens, saveTokens } = await import('../src/lib/cloud/tokens');
+const { bytesToHex, loadRecoveryKey, parseRecoveryKey, saveRecoveryKey } =
+  await import('../src/lib/backup/recoveryKey');
+const { loadBackupSettings, markKeySeen, saveFrequency, saveLastBackup, saveNetwork } =
+  await import('../src/lib/backup/settings');
+const { BackupFrequency } = await import('../src/lib/backup/schedule');
+const { SyncNetworkPreference } = await import('../src/lib/syncNetwork');
+const { backupFileName, clearBackupState } = await import('../src/lib/backup/engine');
+
+const A = 'aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa';
+const B = 'bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb';
+
+const TOKENS = { accessToken: 'at-a', refreshToken: 'rt-a', expiresAt: null };
+const KEY_A = parseRecoveryKey('11'.repeat(32))!;
+
+/** Everything a linked, scheduled, backed-up account leaves on the device. */
+async function signInAndSetUp(ownerId: string): Promise<void> {
+  await saveTokens('gdrive', ownerId, TOKENS);
+  await saveRecoveryKey(ownerId, KEY_A);
+  await markKeySeen(ownerId);
+  await saveFrequency(ownerId, BackupFrequency.Daily);
+  await saveNetwork(ownerId, SyncNetworkPreference.Both);
+  await saveLastBackup(ownerId, { at: 1_757_000_000_000, size: 4096, records: 12 });
+}
+
+beforeEach(async () => {
+  hoisted.keystore.clear();
+  await AsyncStorage.clear();
+});
+
+describe('A signs out, B signs in', () => {
+  it('leaves B with no Drive link, no key, and the plain defaults', async () => {
+    await signInAndSetUp(A);
+    await clearBackupState(A);
+
+    expect(await loadTokens('gdrive', B)).toBeNull();
+    expect(await loadRecoveryKey(B)).toBeNull();
+    const settings = await loadBackupSettings(B);
+    expect(settings.frequency).toBe(BackupFrequency.Off);
+    expect(settings.network).toBe(SyncNetworkPreference.Wifi);
+    expect(settings.last).toBeNull();
+    expect(settings.keySeen).toBe(false);
+  });
+
+  it('really removes A’s credentials, not just hides them behind a key name', async () => {
+    await signInAndSetUp(A);
+    await clearBackupState(A);
+
+    expect(await loadTokens('gdrive', A)).toBeNull();
+    expect(await loadRecoveryKey(A)).toBeNull();
+    expect(await loadBackupSettings(A)).toEqual({
+      frequency: BackupFrequency.Off,
+      network: SyncNetworkPreference.Wifi,
+      last: null,
+      keySeen: false,
+    });
+    // Nothing of A's is left anywhere in the keystore under any name.
+    expect([...hoisted.keystore.keys()].filter((key) => key.includes('waves.'))).toEqual([]);
+  });
+
+  it('does not touch a third account signed in on the same phone', async () => {
+    await signInAndSetUp(A);
+    await signInAndSetUp(B);
+    await clearBackupState(A);
+
+    expect(await loadTokens('gdrive', B)).toEqual(TOKENS);
+    expect((await loadBackupSettings(B)).frequency).toBe(BackupFrequency.Daily);
+  });
+
+  it('is a no-op with no owner, rather than wiping something arbitrary', async () => {
+    await signInAndSetUp(A);
+    await clearBackupState('');
+    expect(await loadTokens('gdrive', A)).toEqual(TOKENS);
+  });
+});
+
+describe('the stores are keyed by account even before any wipe', () => {
+  it('does not hand B the tokens A granted', async () => {
+    await saveTokens('gdrive', A, TOKENS);
+    expect(await loadTokens('gdrive', A)).toEqual(TOKENS);
+    expect(await loadTokens('gdrive', B)).toBeNull();
+  });
+
+  it('does not hand B the key that opens A’s backup', async () => {
+    await saveRecoveryKey(A, KEY_A);
+    expect(bytesToHex((await loadRecoveryKey(A))!)).toBe(bytesToHex(KEY_A));
+    expect(await loadRecoveryKey(B)).toBeNull();
+  });
+
+  it('does not show B the schedule and last-backup time A set', async () => {
+    await signInAndSetUp(A);
+    const mine = await loadBackupSettings(B);
+    expect(mine.frequency).toBe(BackupFrequency.Off);
+    expect(mine.last).toBeNull();
+  });
+
+  it('unlinking one account leaves the other linked', async () => {
+    await saveTokens('gdrive', A, TOKENS);
+    await saveTokens('gdrive', B, TOKENS);
+    await clearTokens('gdrive', A);
+    expect(await loadTokens('gdrive', A)).toBeNull();
+    expect(await loadTokens('gdrive', B)).toEqual(TOKENS);
+  });
+
+  it('reads and writes nothing at all for a signed-out caller', async () => {
+    await saveTokens('gdrive', '', TOKENS);
+    await saveRecoveryKey('', KEY_A);
+    await saveFrequency('', BackupFrequency.Daily);
+    expect(hoisted.keystore.size).toBe(0);
+    expect(await AsyncStorage.getAllKeys()).toEqual([]);
+    expect(await loadTokens('gdrive', '')).toBeNull();
+    expect(await loadRecoveryKey('')).toBeNull();
+  });
+});
+
+describe('the remote filename', () => {
+  it('carries the owner, so two Waves accounts on one Google account do not collide', () => {
+    // This is the case scoped local keys cannot reach: both accounts hold their
+    // own valid tokens into the *same* appDataFolder.
+    expect(backupFileName(A)).not.toBe(backupFileName(B));
+    expect(backupFileName(A)).toContain(A);
+  });
+
+  it('is stable for one owner, so a backup overwrites rather than accumulates', () => {
+    expect(backupFileName(A)).toBe(backupFileName(A));
+  });
+
+  it('narrows the id rather than trusting it into a Drive query', () => {
+    expect(backupFileName("x' or name!='")).toBe('waves-personal-backup-xorname.json');
+  });
+});

--- a/apps/mobile/test/backupAuthRefusal.test.ts
+++ b/apps/mobile/test/backupAuthRefusal.test.ts
@@ -1,0 +1,217 @@
+/**
+ * A revoked Drive grant must read as "re-authorise", not "nothing is linked".
+ *
+ * The two states look identical from the outside — no usable tokens either way
+ * — and the engine used to flatten them into one with a `.catch(() => null)`
+ * around the refresh. The screen then offered connect-from-scratch as the
+ * remedy for a link that already existed, while the dead tokens sat on disk
+ * being retried forever.
+ *
+ * The provider seam is what tells them apart: `ensureValid` normalises an OAuth
+ * error that means the grant is gone into the same 401 a Drive API call
+ * produces, so one predicate covers both halves. A refresh that failed because
+ * the network dropped is deliberately *not* that, and must not sign anybody out
+ * of their own backup over a bad minute of signal.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  keystore: new Map<string, string>(),
+  /** What `ensureValid` should do on the next call. */
+  refresh: 'ok' as 'ok' | 'revoked' | 'network',
+  find: vi.fn(),
+  put: vi.fn(),
+  read: vi.fn(),
+}));
+
+vi.mock('expo-secure-store', () => ({
+  AFTER_FIRST_UNLOCK: 'after-first-unlock',
+  AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: 'after-first-unlock-this-device-only',
+  getItemAsync: async (key: string) => hoisted.keystore.get(key) ?? null,
+  setItemAsync: async (key: string, value: string) => {
+    hoisted.keystore.set(key, value);
+  },
+  deleteItemAsync: async (key: string) => {
+    hoisted.keystore.delete(key);
+  },
+}));
+
+vi.mock('expo-crypto', () => ({
+  getRandomBytes: (length: number) => {
+    const bytes = new Uint8Array(length);
+    globalThis.crypto.getRandomValues(bytes);
+    return bytes;
+  },
+}));
+
+vi.mock('expo-network', () => ({
+  getNetworkStateAsync: async () => ({ isInternetReachable: true, type: 'wifi' }),
+  NetworkStateType: { WIFI: 'wifi', CELLULAR: 'cellular' },
+}));
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'android', select: (o: Record<string, unknown>) => o.android ?? o.default },
+}));
+
+vi.mock('expo-web-browser', () => ({ maybeCompleteAuthSession: () => undefined }));
+
+vi.mock('expo-auth-session', () => ({
+  AuthRequest: class {},
+  exchangeCodeAsync: async () => ({}),
+  makeRedirectUri: () => 'waves://oauthredirect',
+  refreshAsync: async () => ({}),
+}));
+
+// A stand-in for Google Drive. `isConfigured` is true so the engine gets past
+// the client-id gate without this build needing OAuth ids.
+vi.mock('@/lib/cloud/providers', async () => {
+  const { CloudHttpError } = await import('../src/lib/cloud/http');
+  const provider = {
+    id: 'gdrive' as const,
+    label: 'Google Drive',
+    isConfigured: () => true,
+    connect: async () => null,
+    async ensureValid(tokens: unknown) {
+      if (hoisted.refresh === 'revoked') {
+        // What googleDrive.ensureValid produces for `invalid_grant`.
+        throw new CloudHttpError(401, 'invalid_grant: Token has been expired or revoked.');
+      }
+      if (hoisted.refresh === 'network') throw new TypeError('Network request failed');
+      return tokens;
+    },
+    account: async () => 'someone@example.com',
+    find: hoisted.find,
+    put: hoisted.put,
+    read: hoisted.read,
+  };
+  return { providerFor: () => provider, allProviders: () => [provider] };
+});
+
+const { loadTokens, saveTokens } = await import('../src/lib/cloud/tokens');
+const { runBackup, scanBackup } = await import('../src/lib/backup/engine');
+const { parseRecoveryKey } = await import('../src/lib/backup/recoveryKey');
+const { SyncNetworkPreference } = await import('../src/lib/syncNetwork');
+const { asAuthFailure } = await import('../src/lib/cloud/oauth');
+const { isAuthFailure } = await import('../src/lib/cloud/http');
+
+const OWNER = 'aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa';
+const KEY = parseRecoveryKey('11'.repeat(32))!;
+const TOKENS = { accessToken: 'stale', refreshToken: 'revoked-by-the-user', expiresAt: 1 };
+
+const backupInput = {
+  ownerId: OWNER,
+  records: [],
+  key: KEY,
+  network: SyncNetworkPreference.Both,
+  manual: true,
+};
+
+beforeEach(() => {
+  hoisted.keystore.clear();
+  hoisted.refresh = 'ok';
+  hoisted.find.mockReset().mockResolvedValue(null);
+  hoisted.put.mockReset().mockResolvedValue({
+    remoteId: 'file-1',
+    name: 'x.json',
+    size: 100,
+    modifiedAt: null,
+  });
+  hoisted.read.mockReset();
+});
+
+describe('a refresh token the user has revoked', () => {
+  it('makes a backup say "auth", not "not connected"', async () => {
+    await saveTokens('gdrive', OWNER, TOKENS);
+    hoisted.refresh = 'revoked';
+
+    const result = await runBackup(backupInput);
+    expect(result).toEqual({ ok: false, refusal: 'auth' });
+  });
+
+  it('drops the dead tokens, so the screen stops offering a retry that cannot work', async () => {
+    await saveTokens('gdrive', OWNER, TOKENS);
+    hoisted.refresh = 'revoked';
+
+    await runBackup(backupInput);
+    expect(await loadTokens('gdrive', OWNER)).toBeNull();
+  });
+
+  it('never reaches Drive with tokens it already knows are dead', async () => {
+    await saveTokens('gdrive', OWNER, TOKENS);
+    hoisted.refresh = 'revoked';
+
+    await runBackup(backupInput);
+    expect(hoisted.find).not.toHaveBeenCalled();
+    expect(hoisted.put).not.toHaveBeenCalled();
+  });
+
+  it('makes a restore say "auth" too', async () => {
+    await saveTokens('gdrive', OWNER, TOKENS);
+    hoisted.refresh = 'revoked';
+
+    const result = await scanBackup({ ownerId: OWNER, key: KEY, localIds: new Set() });
+    expect(result).toEqual({ ok: false, refusal: 'auth' });
+    expect(hoisted.read).not.toHaveBeenCalled();
+  });
+});
+
+describe('no tokens at all', () => {
+  it('is still "not connected", which is a different problem with a different fix', async () => {
+    expect(await runBackup(backupInput)).toEqual({ ok: false, refusal: 'not-connected' });
+    expect(await scanBackup({ ownerId: OWNER, key: KEY, localIds: new Set() })).toEqual({
+      ok: false,
+      refusal: 'not-connected',
+    });
+  });
+});
+
+describe('a refresh that failed for any other reason', () => {
+  it('throws, so the caller launders it — a dropped connection is not a dead link', async () => {
+    await saveTokens('gdrive', OWNER, TOKENS);
+    hoisted.refresh = 'network';
+
+    await expect(runBackup(backupInput)).rejects.toThrow(/network request failed/i);
+  });
+
+  it('leaves the tokens alone, so the next attempt on a good connection works', async () => {
+    await saveTokens('gdrive', OWNER, TOKENS);
+    hoisted.refresh = 'network';
+
+    await runBackup(backupInput).catch(() => undefined);
+    expect(await loadTokens('gdrive', OWNER)).toEqual(TOKENS);
+
+    hoisted.refresh = 'ok';
+    expect((await runBackup(backupInput)).ok).toBe(true);
+  });
+});
+
+describe('a Drive call that 401s after a good refresh', () => {
+  it('is the same "auth" refusal, and clears the tokens the same way', async () => {
+    const { CloudHttpError } = await import('../src/lib/cloud/http');
+    await saveTokens('gdrive', OWNER, TOKENS);
+    hoisted.find.mockRejectedValue(new CloudHttpError(401, 'insufficient permissions'));
+
+    expect(await runBackup(backupInput)).toEqual({ ok: false, refusal: 'auth' });
+    expect(await loadTokens('gdrive', OWNER)).toBeNull();
+  });
+});
+
+describe('what the provider seam recognises as a dead grant', () => {
+  // The engine's half is mocked above; this is the real mapping the Drive
+  // provider applies, so the two halves are known to meet.
+  it.each(['invalid_grant', 'invalid_client', 'unauthorized_client', 'access_denied'])(
+    'turns %s into the 401 the rest of the code already understands',
+    (code) => {
+      const mapped = asAuthFailure({ code, description: 'Token has been revoked.' });
+      expect(mapped?.status).toBe(401);
+      expect(isAuthFailure(mapped)).toBe(true);
+    },
+  );
+
+  it('leaves a transport failure alone — it is not about the grant', () => {
+    expect(asAuthFailure(new TypeError('Network request failed'))).toBeNull();
+    expect(asAuthFailure({ code: 'server_error' })).toBeNull();
+    expect(asAuthFailure(undefined)).toBeNull();
+  });
+});

--- a/apps/mobile/test/backupPayload.test.ts
+++ b/apps/mobile/test/backupPayload.test.ts
@@ -1,0 +1,181 @@
+/**
+ * The pure half of the personal-ledger backup: what goes in the envelope, what
+ * comes back out of it, and what a restore would actually write.
+ *
+ * The interesting cases are all about *not* losing something — a field this
+ * build does not understand, a record the person deleted on purpose, a file
+ * written by a newer app.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  BACKUP_FORMAT,
+  BACKUP_VERSION,
+  backupAad,
+  buildBody,
+  buildFile,
+  parseBody,
+  parseFile,
+  planRestore,
+  BackupFormatError,
+  BackupOpenError,
+  type SourceRecord,
+} from '../src/lib/backup/payload';
+
+const OWNER = '11111111-1111-4111-8111-111111111111';
+const NOW = new Date('2026-09-05T10:00:00.000Z');
+
+function row(id: string, over: Partial<SourceRecord> = {}): SourceRecord {
+  return {
+    id,
+    record_kind: 'txn',
+    data: { amount: '1200', currency: 'INR', date: '2026-09-01' },
+    created_at: '2026-09-01T00:00:00.000Z',
+    deleted_at: null,
+    ...over,
+  };
+}
+
+describe('building a backup body', () => {
+  it('keeps every record, in a stable order whatever the mirror gives', () => {
+    const a = buildBody(OWNER, [row('c'), row('a'), row('b')], NOW);
+    const b = buildBody(OWNER, [row('b'), row('c'), row('a')], NOW);
+    expect(a.records.map((record) => record.id)).toEqual(['a', 'b', 'c']);
+    expect(JSON.stringify(a)).toEqual(JSON.stringify(b));
+  });
+
+  it('carries the data blob through untouched, fields we do not know included', () => {
+    const data = { amount: '900', currency: 'INR', somethingFuture: { nested: true } };
+    const body = buildBody(OWNER, [row('a', { data })], NOW);
+    expect(body.records[0]?.data).toEqual(data);
+  });
+
+  it('stamps the owner and the moment', () => {
+    const body = buildBody(OWNER, [], NOW);
+    expect(body.ownerId).toBe(OWNER);
+    expect(body.createdAt).toBe(NOW.toISOString());
+  });
+});
+
+describe('the envelope', () => {
+  it('says almost nothing in the clear — no counts, no dates of spending', () => {
+    const body = buildBody(OWNER, [row('a'), row('b')], NOW);
+    const file = buildFile('v1:sealed', body.createdAt);
+    const text = JSON.stringify(file);
+    expect(text).not.toContain(OWNER);
+    expect(text).not.toContain('1200');
+    expect(text).not.toContain('2026-09-01');
+  });
+
+  it('round-trips through parseFile', () => {
+    const file = buildFile('v1:sealed', NOW.toISOString());
+    expect(parseFile(JSON.stringify(file))).toEqual(file);
+  });
+
+  it('rejects a file that is not ours', () => {
+    expect(() => parseFile(JSON.stringify({ format: 'something.else', version: 1 }))).toThrow(
+      BackupFormatError,
+    );
+    expect(() => parseFile('not json at all')).toThrow(BackupFormatError);
+  });
+
+  it('refuses a version newer than this build rather than guessing at it', () => {
+    const future = JSON.stringify({
+      format: BACKUP_FORMAT,
+      version: BACKUP_VERSION + 1,
+      alg: 'xchacha20poly1305',
+      createdAt: NOW.toISOString(),
+      sealed: 'v1:whatever',
+    });
+    expect(() => parseFile(future)).toThrow(BackupFormatError);
+  });
+
+  it('refuses an algorithm it does not implement', () => {
+    const wrong = JSON.stringify({
+      format: BACKUP_FORMAT,
+      version: BACKUP_VERSION,
+      alg: 'rot13',
+      createdAt: NOW.toISOString(),
+      sealed: 'v1:whatever',
+    });
+    expect(() => parseFile(wrong)).toThrow(BackupFormatError);
+  });
+});
+
+describe('the associated data', () => {
+  it('names the format, the version and the owner, so a file cannot be swapped', () => {
+    expect(backupAad(OWNER)).toBe(`${BACKUP_FORMAT}:v${BACKUP_VERSION}:${OWNER}`);
+    expect(backupAad('other')).not.toBe(backupAad(OWNER));
+  });
+});
+
+describe('reading a body back', () => {
+  it('round-trips', () => {
+    const body = buildBody(OWNER, [row('a'), row('b')], NOW);
+    expect(parseBody(JSON.stringify(body), OWNER)).toEqual(body);
+  });
+
+  it('refuses a body belonging to another account', () => {
+    const body = buildBody(OWNER, [row('a')], NOW);
+    expect(() => parseBody(JSON.stringify(body), 'somebody-else')).toThrow(BackupOpenError);
+  });
+
+  it('drops a malformed record rather than restoring one with no id', () => {
+    const body = {
+      ownerId: OWNER,
+      createdAt: NOW.toISOString(),
+      records: [
+        { id: '', kind: 'txn', data: {}, createdAt: '', deletedAt: null },
+        { id: 'a', kind: '', data: {}, createdAt: '', deletedAt: null },
+        { id: 'b', kind: 'txn', data: null, createdAt: '', deletedAt: null },
+        { id: 'c', kind: 'txn', data: {}, createdAt: '', deletedAt: null },
+      ],
+    };
+    expect(parseBody(JSON.stringify(body), OWNER).records.map((r) => r.id)).toEqual(['c']);
+  });
+
+  it('throws on a body that is not JSON at all', () => {
+    expect(() => parseBody('{{', OWNER)).toThrow(BackupOpenError);
+  });
+});
+
+describe('planning a restore', () => {
+  const body = {
+    records: [
+      { id: 'a', kind: 'txn', data: {}, createdAt: '', deletedAt: null },
+      { id: 'b', kind: 'loan', data: {}, createdAt: '', deletedAt: null },
+      { id: 'c', kind: 'txn', data: {}, createdAt: '', deletedAt: '2026-09-02T00:00:00.000Z' },
+    ],
+  };
+
+  it('brings back only what this device is missing', () => {
+    const plan = planRestore(new Set(['a']), body);
+    expect(plan.restore.map((r) => r.id)).toEqual(['b']);
+    expect(plan.alreadyHere).toBe(1);
+  });
+
+  it('never resurrects a record deleted on this device', () => {
+    // 'b' was deleted here; its id is in localIds even though it is not live.
+    const plan = planRestore(new Set(['a', 'b']), body);
+    expect(plan.restore).toHaveLength(0);
+  });
+
+  it('never re-applies a tombstone from the backup', () => {
+    const plan = planRestore(new Set(), body);
+    expect(plan.restore.map((r) => r.id)).toEqual(['a', 'b']);
+    expect(plan.deleted).toBe(1);
+  });
+
+  it('is idempotent: running it against its own result writes nothing more', () => {
+    const first = planRestore(new Set(), body);
+    const after = new Set(first.restore.map((record) => record.id));
+    expect(planRestore(after, body).restore).toHaveLength(0);
+  });
+
+  it('restores everything onto a fresh install', () => {
+    const plan = planRestore(new Set(), { records: [body.records[0]!, body.records[1]!] });
+    expect(plan.restore).toHaveLength(2);
+    expect(plan.alreadyHere).toBe(0);
+  });
+});

--- a/apps/mobile/test/backupRecoveryKey.test.ts
+++ b/apps/mobile/test/backupRecoveryKey.test.ts
@@ -1,0 +1,120 @@
+/**
+ * The user-held backup key: how it is written down, how it is read back, and
+ * what happens when the wrong one is presented to a sealed backup.
+ *
+ * The last of those is the one that matters. The whole key model rests on a
+ * backup being *unopenable* without the key, and on a file from one account
+ * being unopenable under another's associated data — so both are asserted here
+ * against the real cipher rather than taken on trust.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+// Hoisted above the imports so the stand-ins are in place before recoveryKey.ts
+// loads expo-secure-store / expo-crypto.
+const hoisted = vi.hoisted(() => ({ keystore: new Map<string, string>() }));
+
+vi.mock('expo-secure-store', () => ({
+  AFTER_FIRST_UNLOCK: 'after-first-unlock',
+  AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: 'after-first-unlock-this-device-only',
+  getItemAsync: async (key: string) => hoisted.keystore.get(key) ?? null,
+  setItemAsync: async (key: string, value: string) => {
+    hoisted.keystore.set(key, value);
+  },
+  deleteItemAsync: async (key: string) => {
+    hoisted.keystore.delete(key);
+  },
+}));
+
+vi.mock('expo-crypto', () => ({
+  getRandomBytes: (length: number) => {
+    const bytes = new Uint8Array(length);
+    globalThis.crypto.getRandomValues(bytes);
+    return bytes;
+  },
+}));
+
+const {
+  RECOVERY_KEY_LENGTH,
+  bytesToHex,
+  formatRecoveryKey,
+  mintRecoveryKey,
+  openBackup,
+  parseRecoveryKey,
+  sealBackup,
+} = await import('../src/lib/backup/recoveryKey');
+const { backupAad } = await import('../src/lib/backup/payload');
+
+const NONCE = new Uint8Array(24).fill(9);
+const OWNER = 'owner-1';
+
+describe('minting a key', () => {
+  it('is 32 bytes — 64 hexadecimal characters when written down', () => {
+    const key = mintRecoveryKey();
+    expect(key).toHaveLength(32);
+    expect(bytesToHex(key)).toHaveLength(RECOVERY_KEY_LENGTH);
+  });
+
+  it('is different every time', () => {
+    expect(bytesToHex(mintRecoveryKey())).not.toBe(bytesToHex(mintRecoveryKey()));
+  });
+});
+
+describe('reading a key off a screen and typing it back', () => {
+  const hex = 'a'.repeat(8) + 'b'.repeat(8) + '0123456789abcdef'.repeat(3);
+
+  it('shows 16 groups of 4, upper case', () => {
+    const shown = formatRecoveryKey(hex);
+    expect(shown.split(' ')).toHaveLength(16);
+    expect(shown).toBe(shown.toUpperCase());
+  });
+
+  it('reads back exactly what was shown', () => {
+    expect(bytesToHex(parseRecoveryKey(formatRecoveryKey(hex))!)).toBe(hex);
+  });
+
+  it('forgives spaces, dashes and case, because people paste from anywhere', () => {
+    const messy = `  ${hex.slice(0, 32).toUpperCase()} - ${hex.slice(32)}\n`;
+    expect(bytesToHex(parseRecoveryKey(messy)!)).toBe(hex);
+  });
+
+  it('refuses anything that is not exactly 64 hex characters', () => {
+    expect(parseRecoveryKey('')).toBeNull();
+    expect(parseRecoveryKey(hex.slice(0, 63))).toBeNull();
+    expect(parseRecoveryKey(hex + '0')).toBeNull();
+    expect(parseRecoveryKey('z'.repeat(64))).toBeNull();
+  });
+});
+
+describe('sealing a backup', () => {
+  const key = parseRecoveryKey('11'.repeat(32))!;
+  const other = parseRecoveryKey('22'.repeat(32))!;
+  const plain = JSON.stringify({ ownerId: OWNER, records: [{ id: 'a' }] });
+
+  it('round-trips under the right key and the right owner', () => {
+    const sealed = sealBackup(key, NONCE, plain, backupAad(OWNER));
+    expect(openBackup(key, sealed, backupAad(OWNER))).toBe(plain);
+  });
+
+  it('leaves nothing of the ledger legible in the sealed form', () => {
+    const sealed = sealBackup(key, NONCE, plain, backupAad(OWNER));
+    expect(sealed).not.toContain(OWNER);
+    expect(sealed).not.toContain('records');
+  });
+
+  it('will not open under the wrong key — the whole premise of the model', () => {
+    const sealed = sealBackup(key, NONCE, plain, backupAad(OWNER));
+    expect(() => openBackup(other, sealed, backupAad(OWNER))).toThrow();
+  });
+
+  it('will not open under another account, even with the right key', () => {
+    const sealed = sealBackup(key, NONCE, plain, backupAad(OWNER));
+    expect(() => openBackup(key, sealed, backupAad('somebody-else'))).toThrow();
+  });
+
+  it('will not open once a byte has been changed', () => {
+    const sealed = sealBackup(key, NONCE, plain, backupAad(OWNER));
+    const tampered = `${sealed.slice(0, -4)}${sealed.slice(-4) === 'AAAA' ? 'BBBB' : 'AAAA'}`;
+    expect(() => openBackup(key, tampered, backupAad(OWNER))).toThrow();
+  });
+});

--- a/apps/mobile/test/backupSchedule.test.ts
+++ b/apps/mobile/test/backupSchedule.test.ts
@@ -1,0 +1,102 @@
+/**
+ * When the next automatic backup is owed. The month boundaries are the only
+ * part of this that has ever been wrong anywhere, so that is where the tests
+ * are: 31 January plus a month must not be 3 March.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  BackupFrequency,
+  DEFAULT_FREQUENCY,
+  isDue,
+  nextDueAt,
+  parseFrequency,
+} from '../src/lib/backup/schedule';
+
+const DAY = 24 * 60 * 60 * 1000;
+const at = (iso: string): number => new Date(iso).getTime();
+
+describe('parsing a stored frequency', () => {
+  it('takes the four it knows', () => {
+    expect(parseFrequency('daily')).toBe(BackupFrequency.Daily);
+    expect(parseFrequency('weekly')).toBe(BackupFrequency.Weekly);
+    expect(parseFrequency('monthly')).toBe(BackupFrequency.Monthly);
+    expect(parseFrequency('off')).toBe(BackupFrequency.Off);
+  });
+
+  it('falls back to off for anything else, including nothing stored', () => {
+    expect(parseFrequency(null)).toBe(DEFAULT_FREQUENCY);
+    expect(parseFrequency('hourly')).toBe(DEFAULT_FREQUENCY);
+    expect(DEFAULT_FREQUENCY).toBe(BackupFrequency.Off);
+  });
+});
+
+describe('when the next one is due', () => {
+  it('is never, when the schedule is off', () => {
+    expect(nextDueAt(at('2026-09-05T10:00:00Z'), BackupFrequency.Off)).toBeNull();
+    expect(nextDueAt(null, BackupFrequency.Off)).toBeNull();
+  });
+
+  it('is now, when nothing has ever been backed up', () => {
+    // Turning the schedule on should produce a backup, not a day of waiting.
+    expect(isDue(null, BackupFrequency.Daily, at('2026-09-05T10:00:00Z'))).toBe(true);
+    expect(isDue(null, BackupFrequency.Monthly, at('2026-09-05T10:00:00Z'))).toBe(true);
+  });
+
+  it('counts a day and a week from the last backup', () => {
+    const last = at('2026-09-05T10:00:00Z');
+    expect(nextDueAt(last, BackupFrequency.Daily)).toBe(last + DAY);
+    expect(nextDueAt(last, BackupFrequency.Weekly)).toBe(last + 7 * DAY);
+  });
+
+  it('measures from the last run, not a fixed clock — a late run does not stack', () => {
+    const late = at('2026-09-05T23:00:00Z');
+    expect(isDue(late, BackupFrequency.Daily, at('2026-09-06T09:00:00Z'))).toBe(false);
+    expect(isDue(late, BackupFrequency.Daily, at('2026-09-07T00:00:00Z'))).toBe(true);
+  });
+
+  it('is not due one second early, and is due exactly on time', () => {
+    const last = at('2026-09-05T10:00:00Z');
+    expect(isDue(last, BackupFrequency.Daily, last + DAY - 1)).toBe(false);
+    expect(isDue(last, BackupFrequency.Daily, last + DAY)).toBe(true);
+  });
+});
+
+describe('monthly, which is calendar months and not thirty days', () => {
+  // Built from local-time parts: the arithmetic is local, so the assertions
+  // must be too, or this passes in UTC and fails in Chennai.
+  const local = (y: number, m: number, d: number): number =>
+    new Date(y, m - 1, d, 9, 0, 0).getTime();
+  const monthAndDay = (ms: number): [number, number] => {
+    const date = new Date(ms);
+    return [date.getMonth() + 1, date.getDate()];
+  };
+
+  it('lands on the same day of the next month', () => {
+    expect(monthAndDay(nextDueAt(local(2026, 9, 5), BackupFrequency.Monthly)!)).toEqual([10, 5]);
+  });
+
+  it('clamps 31 January to the end of February rather than spilling into March', () => {
+    expect(monthAndDay(nextDueAt(local(2026, 1, 31), BackupFrequency.Monthly)!)).toEqual([2, 28]);
+  });
+
+  it('clamps to 29 February in a leap year', () => {
+    expect(monthAndDay(nextDueAt(local(2028, 1, 31), BackupFrequency.Monthly)!)).toEqual([2, 29]);
+  });
+
+  it('clamps 31 March to 30 April', () => {
+    expect(monthAndDay(nextDueAt(local(2026, 3, 31), BackupFrequency.Monthly)!)).toEqual([4, 30]);
+  });
+
+  it('rolls the year over in December', () => {
+    const due = new Date(nextDueAt(local(2026, 12, 15), BackupFrequency.Monthly)!);
+    expect([due.getFullYear(), due.getMonth() + 1, due.getDate()]).toEqual([2027, 1, 15]);
+  });
+
+  it('keeps the time of day, so a backup does not creep across the clock', () => {
+    const last = local(2026, 9, 5);
+    const due = new Date(nextDueAt(last, BackupFrequency.Monthly)!);
+    expect([due.getHours(), due.getMinutes()]).toEqual([9, 0]);
+  });
+});

--- a/apps/mobile/test/syncEngine.test.ts
+++ b/apps/mobile/test/syncEngine.test.ts
@@ -52,6 +52,11 @@ vi.mock('@/lib/backend', () => ({
 vi.mock('@/lib/syncNetwork', () => ({
   SyncNetworkPreference: { Wifi: 'wifi', Cellular: 'cellular', Both: 'both' },
   loadSyncNetworkPreference: h.syncPreference,
+  // The real predicate's semantics, restated against the stub enum above — the
+  // engine only asks the question, and the question is answered the same way
+  // for the cloud backup (see lib/syncNetwork.tsx).
+  networkAllows: (preference: string, type: string | null | undefined) =>
+    preference === 'both' || type == null || preference === type,
 }));
 
 // Keep Sentry out of a unit test; the engine only ever calls `reportHandled`.

--- a/packages/core/src/sync/mirror.ts
+++ b/packages/core/src/sync/mirror.ts
@@ -943,11 +943,15 @@ export interface MirrorPersonalRecord extends MirrorRow {
  * the queue replayed on top. `ownerId` is the personal scope; every queued
  * personal mutation carries `personalScope(ownerId)` in the envelope's group
  * slot. Deleted rows are dropped — the caller sees only live records.
+ *
+ * `includeDeleted` keeps the tombstones. One caller wants them: a restore from
+ * a cloud backup, which has to know that a record it is about to bring back was
+ * deleted here on purpose. Everything that renders a list wants the default.
  */
 export function materialisePersonalRecords(
   state: MirrorState,
   queue: readonly QueuedMutation[],
-  options: { readonly ownerId: string },
+  options: { readonly ownerId: string; readonly includeDeleted?: boolean },
 ): MirrorPersonalRecord[] {
   const scope = personalScope(options.ownerId);
   const byId = new Map<string, MirrorPersonalRecord>();
@@ -987,7 +991,8 @@ export function materialisePersonalRecords(
     }
   }
 
-  return [...byId.values()].filter((record) => record.deleted_at === null);
+  const all = [...byId.values()];
+  return options.includeDeleted ? all : all.filter((record) => record.deleted_at === null);
 }
 
 /**


### PR DESCRIPTION
The **Me** tab is the one part of Waves that lives nowhere else. Solo expenses, income, recurring rules, loans and budgets ride a personal sync scope where the server is a pure relay — it stores an opaque blob and reads nothing. Lose the phone with an undrained queue and the ledger is gone. This gives it WhatsApp's Chat backup screen.

## What it does

`Settings → Data & privacy → Backup` (`apps/mobile/src/app/settings/backup.tsx`):

- **Back up now**, with a live line — gathering / locking / uploading — and a result line under the button that made it.
- **Automatic backup**: Off / Daily / Weekly / Monthly, persisted on the device.
- **Google account**: which one is linked, with unlink (which also revokes the grant with Google, not just locally).
- **Last backup**: timestamp and payload size, both in the user's locale.
- **Back up over**: Wi‑Fi only, or Wi‑Fi and mobile data.
- **Restore**: reads the Drive file, tells you how many records it would bring back and from when, *then* asks.

## Storage: the narrowest scope Google offers

Drive's hidden per-application folder, under `https://www.googleapis.com/auth/drive.appdata`. Not `drive.file` (which the deleted receipt-backup version used and which would put the file in the user's own file list), and never full `drive`. The app cannot see, list or read anything else in the user's Drive because the token was never issued for it. One file, `waves-personal-backup.json`, overwritten in place, so the folder never accumulates and a restore never has to choose between candidates.

## The key model, and the tradeoff

This is the decision worth arguing about, and the reasoning is written into the header of `apps/mobile/src/lib/backup/recoveryKey.ts`.

The mirror is already encrypted at rest with a 256-bit key kept under `AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY` — deliberately non-portable, so a restored SQLite file is unreadable on a new phone. That is right for a cache and useless for a backup: a Drive file sealed with it could never be opened on the phone the backup exists for.

Three options, and the one taken:

1. **Plaintext.** Then the whole private ledger is readable by anyone who reaches the Google account, and by Google. The premise of the Me tab is that it is private. Rejected.
2. **A user-chosen password.** Nicest to use — and only safe behind Argon2id/scrypt, which is a new crypto dependency plus a tuning decision that is slow on a laptop and slower on a five-year-old Android. Half-doing it produces something that *looks* encrypted. Deliberately not done.
3. **A generated key.** ✅ 32 random bytes, shown once as 64 hex characters in 16 groups, used directly as the XChaCha20-Poly1305 key through the same `seal`/`open` the mirror uses. Full 256-bit entropy, so there is nothing to grind offline and no KDF to get wrong. Kept in this device's keystore for convenience; typed in on any new device. This is WhatsApp's "64-digit encryption key" option, without the password beside it.

**The tradeoff, said plainly: lose the key and the backup is unrecoverable.** Not by Waves, which never sees it, and not by Google, which holds only ciphertext. The screen says so before it makes one, and refuses to back anything up until the person has been shown the key and confirmed they kept it. A password option can be added later without a format change — the envelope already names its algorithm, and a password variant would add a `kdf` block rather than replace anything.

The envelope's plaintext header is deliberately almost empty: format, version, algorithm, timestamp. No record count, no owner id, no dates of spending. The AEAD's associated data binds the body to `format:version:ownerId`, so a sealed body lifted into another account's file fails to open rather than silently restoring one person's ledger into someone else's.

## Restore only ever adds

Records carry client-chosen ids that are *already* the idempotency key for `personal.upsert`. So a restore re-queues what this device is missing, skips what it already has, and — the case worth being careful about — skips what it has **deleted on purpose**. That needed a new `includeDeleted` option on `materialisePersonalRecords`, since the live rows alone cannot tell "deleted here" from "never seen". Tombstones in the backup are never re-applied: a backup that can delete is a backup that can lose data. Running a restore twice does nothing the second time.

It writes through the ordinary offline queue rather than around it, so it works with **no connection at all** — the rows land locally and leave when the queue next drains. Which is the ADR-005 promise applied to the moment people are least likely to have signal: setting up a new phone.

## The provider seam, recovered

`apps/mobile/src/lib/cloud/` is the subsystem deleted by `e96038e` (PR #393, images → R2), brought back and narrowed to a ledger backup: PKCE OAuth, keystore-backed tokens, the provider interface. Only Google Drive is implemented — Dropbox/OneDrive/Box files are deliberately *not* resurrected — but the seam stays so they could return without a rewrite. The interface is now about one small named blob rather than images and sidecars.

## Also in here

- **`networkAllows`** extracted from the sync engine into `lib/syncNetwork.tsx`, so "Back up over" reuses the existing network-scope vocabulary and predicate instead of inventing a second one. Backup keeps its own stored value (it defaults to Wi‑Fi where sync defaults to any connection) but not its own idea of what the words mean.
- **`formatBytes`** lifted out of `settings/storage.tsx` into `lib/bytes.ts`, now shared.
- **`waves://oauthredirect`** handled in `+native-intent.ts`. Without it, linking Drive lands on "Unmatched Route" — the same trap Google sign-in hit. Unlike sign-in it routes back to `/settings/backup` rather than the root, because the person is standing on that screen and expects to still be there.
- **The dead `backup` string block** left over from the deleted receipt-backup feature is replaced rather than left to rot. All new copy is in en/ta/hi/ar with full Arabic plural forms; the key input forces LTR so a hex key stays readable and typeable in an RTL layout.

## Deliberately left out

- **No OS background task.** The automatic check runs on mount and on foreground, throttled. iOS background refresh is discretionary and Android's Doze defers alarms; an app that says "daily" and means it needs a native worker and a battery conversation. The screen says when the last backup was rather than implying a schedule the OS never promised to keep, and `frequencyNote` says it in words.
- **Shared groups are not backed up.** They already live on the server and are already exportable (ADR-012). This is for the half that does not.
- **No password option** (see above).
- **Dropbox / OneDrive / Box.**

## Console setup required before this can run live

Drive needs **its own OAuth clients**. The app's login goes through Supabase's hosted Google flow and holds no Google client id of its own, so this is a new console dependency, not an existing one. In a Google Cloud project with the Drive API enabled:

1. Create an OAuth client **per platform**: Android bound to `app.waves.mobile` + the signing SHA-1 (one for the debug key, one for release), iOS bound to the bundle id.
2. Add `.../auth/drive.appdata` to the consent screen.
3. Set `EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_ANDROID` / `_IOS` / `_WEB` in `apps/mobile/.env`.

They are not secrets (a native OAuth client has none — hence PKCE) but they name a project, so they are read from the environment rather than committed. With none set the app builds and runs; the screen says the destination is unavailable in this build rather than opening a consent page Google would reject. A `drive.appdata` app also stays in testing until the consent screen is verified — until then only listed test users can link.

## Gates

`pnpm run lint` clean (3 pre-existing warnings in `phone.tsx`), `tsc --noEmit` clean for mobile, core, ui, admin, web, api-client, website. 797 mobile tests and 842 core tests pass, including **42 new** ones:

- `test/backupPayload.test.ts` — envelope round-trip, the header leaking nothing, version/algorithm refusals, malformed-record dropping, and the restore plan (fresh install, partial loss, a locally-deleted record staying deleted, idempotency).
- `test/backupSchedule.test.ts` — the month boundaries, which is the only part of this that is ever wrong anywhere: 31 Jan → 28 Feb, leap year → 29 Feb, 31 Mar → 30 Apr, December → January, and "measured from the last run, not a fixed clock".
- `test/backupRecoveryKey.test.ts` — key formatting and forgiving parse, and the premise itself asserted against the real cipher: will not open under the wrong key, will not open under another account, will not open after a byte changes.

`syncEngine.test.ts`'s `@/lib/syncNetwork` mock gained `networkAllows` to match the moved boundary.

## Not verified, needs a device

Everything that touches Google. No OAuth client ids exist yet, so the consent flow, the token refresh, the `appDataFolder` create/overwrite/read, the `about.get` account-address lookup (coded defensively — a refusal shows the destination name instead of widening the scope to `userinfo.email`), the `waves://oauthredirect` double-delivery, and the end-to-end back-up-then-restore-on-a-second-phone have all been written but never run against Google. The pure halves — payload, schedule, key, cipher — are covered by tests; the network halves are not, and cannot be from here.
