### PR TITLE
chore(ios): declare the Apple team, which the extension targets need to build

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -18,6 +18,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "app.wavs.mobile",
+      "appleTeamId": "JBAY4E524Q",
       "usesAppleSignIn": true
     },
     "android": {


### PR DESCRIPTION
One line. `expo prebuild` has been warning on every run:

```
[bacons/apple-targets] Expo config is missing required ios.appleTeamId property.
Find this in Xcode and add to the Expo Config to correct.
iOS builds may fail until this is corrected.
```

## Why it matters now

The widget extension and the watch app are **separate targets**. A target needs a team to resolve its own bundle id and provisioning profile. The main app inherits one from whatever signing identity EAS picks; the extensions do not.

So the first `eas build --platform ios` would fail — after the upload, after the queue, after the dependency install. This is the cheapest possible moment to fix it.

Team ID `JBAY4E524Q`, from the App ID registered today.

## Why app.json and not the environment

`app.config.ts` reads `googleServicesFile` and the Maps key from the environment, and its header explains why: they name an account belonging to whoever is building, and a committed placeholder would break `expo prebuild` for anyone who cloned this without one.

A Team ID is a different kind of thing. It is not a secret and not a file — it is an identifier, visible in the provisioning profile of any shipped binary, and it pairs with `bundleIdentifier`, which already sits in `app.json` two lines above. Splitting the pair across two files to no benefit would be the worse choice.

## Checked

`app.json` parses, prettier clean, and the diff is one line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added the Apple Developer Team ID to the iOS app configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->