### PR TITLE
fix(auth): give a new account its profile row again

### DIFF
--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -5,8 +5,10 @@ import { Alert, ScrollView, View } from 'react-native';
 
 import {
   Badge,
+  Button,
   Card,
   directionalIcon,
+  EmptyState,
   IconButton,
   iconSize,
   ListRow,
@@ -171,14 +173,34 @@ function SettledPill({ profileId, locale }: { profileId: string | null; locale: 
 }
 
 export default function ProfileScreen() {
-  const { profile } = useAuth();
+  const { profile, profileSettled, reloadProfile } = useAuth();
+  const { t } = useStrings();
+
   // The hero seeds nothing editable now, but the settings summaries below still
   // read the profile — hold on a skeleton until it arrives so the first paint
   // is the real thing, not a flash of defaults.
+  //
+  // Only while it can still arrive, though. A skeleton is a promise that
+  // something is coming, and when the profile load has run itself out that
+  // promise is false: this screen used to keep it anyway and shimmered for ever
+  // on an account whose profile row was never written. `profileSettled` is the
+  // load saying it has finished empty, and the answer to that is an error with
+  // a retry, not a loading state that never ends.
   if (!profile) {
+    if (!profileSettled) {
+      return (
+        <Screen>
+          <SkeletonList rows={6} />
+        </Screen>
+      );
+    }
     return (
       <Screen>
-        <SkeletonList rows={6} />
+        <EmptyState
+          title={t.loadError}
+          body={t.loadErrorBody}
+          action={<Button label={t.retry} variant="secondary" onPress={reloadProfile} />}
+        />
       </Screen>
     );
   }

--- a/apps/mobile/src/app/settings/account.tsx
+++ b/apps/mobile/src/app/settings/account.tsx
@@ -19,6 +19,7 @@ import {
   Card,
   ChipRow,
   directionalIcon,
+  EmptyState,
   IconButton,
   iconSize,
   Row,
@@ -39,15 +40,28 @@ import { deviceCountry, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 
 export default function AccountScreen() {
-  const { profile } = useAuth();
+  const { profile, profileSettled, reloadProfile } = useAuth();
+  const { t } = useStrings();
   // The name field seeds from `profile` exactly once. Mount the form only once
   // there is a profile to seed from, keyed on its id, so a name that arrives
   // after the first paint is not left as an empty seed that Save would write
   // back over the real row.
+  //
+  // Blank while it is on its way, but not blank for ever: when the load has
+  // settled with no profile it is not coming, and an empty screen with no way
+  // out is the wrong answer to that.
   if (!profile) {
     return (
       <Screen>
-        <View />
+        {profileSettled ? (
+          <EmptyState
+            title={t.loadError}
+            body={t.loadErrorBody}
+            action={<Button label={t.retry} variant="secondary" onPress={reloadProfile} />}
+          />
+        ) : (
+          <View />
+        )}
       </Screen>
     );
   }

--- a/apps/mobile/src/app/settings/paying.tsx
+++ b/apps/mobile/src/app/settings/paying.tsx
@@ -22,6 +22,7 @@ import {
   Card,
   ChipRow,
   directionalIcon,
+  EmptyState,
   IconButton,
   iconSize,
   Row,
@@ -37,13 +38,26 @@ import { deviceCountry, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 
 export default function PayingScreen() {
-  const { profile } = useAuth();
+  const { profile, profileSettled, reloadProfile } = useAuth();
+  const { t } = useStrings();
   // Seed once, keyed on the id, so Save never writes an empty seed over a real
   // row before the profile has loaded.
+  //
+  // Blank while it is on its way, but not blank for ever: when the load has
+  // settled with no profile it is not coming, and an empty screen with no way
+  // out is the wrong answer to that.
   if (!profile) {
     return (
       <Screen>
-        <View />
+        {profileSettled ? (
+          <EmptyState
+            title={t.loadError}
+            body={t.loadErrorBody}
+            action={<Button label={t.retry} variant="secondary" onPress={reloadProfile} />}
+          />
+        ) : (
+          <View />
+        )}
       </Screen>
     );
   }

--- a/apps/mobile/src/lib/auth.tsx
+++ b/apps/mobile/src/lib/auth.tsx
@@ -186,6 +186,106 @@ export interface Profile {
 }
 
 /**
+ * Every column a screen reads off the signed-in person. One list, because the
+ * initial load, the self-heal re-read and `updateProfile` must all come back
+ * shaped the same — a `Profile` assembled from three different column sets is
+ * three subtly different objects.
+ */
+const PROFILE_COLUMNS =
+  'id, display_name, avatar_url, default_vpa, payment_rail, payment_handle, country_code, address, default_currency, locale';
+
+/** The name an OAuth provider sent, under whichever key it chose. */
+function metadataName(user: Session['user']): string | null {
+  const meta = (user.user_metadata ?? {}) as Record<string, unknown>;
+  for (const key of ['display_name', 'full_name', 'name'] as const) {
+    const value = meta[key];
+    if (typeof value === 'string' && value.trim() !== '') return value.trim();
+  }
+  return null;
+}
+
+/** The photo an OAuth provider sent, under whichever key it chose. */
+function metadataAvatar(user: Session['user']): string | null {
+  const meta = (user.user_metadata ?? {}) as Record<string, unknown>;
+  for (const key of ['avatar_url', 'picture'] as const) {
+    const value = meta[key];
+    if (typeof value === 'string' && value.trim() !== '') return value.trim();
+  }
+  return null;
+}
+
+/**
+ * Read this account's profile row, and make one if the database never did.
+ *
+ * The row is normally written by a trigger on `auth.users`, which can land a
+ * beat after the session on a brand-new account — hence the short retry.
+ *
+ * The retry used to be the whole story, and that was the bug: when the row was
+ * *absent* rather than late, this gave up after a second or two and left
+ * `profile` null forever. Nothing retried it, nothing reported it, and every
+ * screen that waits on a profile waited for good — the settings tab sat on its
+ * skeleton and the dashboard showed initials for a name it did not have. That
+ * is exactly what happened when the rebuilt project lost the trigger.
+ *
+ * So the absent case is now handled rather than waited out: `profiles_insert_self`
+ * lets somebody create their own row, so the client writes the same row the
+ * trigger would have, from the metadata the provider sent. Both paths converge
+ * on one re-read, so what lands in state came from the database either way.
+ *
+ * Returns true when a profile was handed to `set`, false when it gave up — the
+ * caller shows an error with a retry rather than an endless skeleton.
+ */
+async function loadProfile(
+  user: Session['user'],
+  set: (profile: Profile) => void,
+): Promise<boolean> {
+  const read = async (): Promise<Profile | null> => {
+    const { data, error } = await backend
+      .from('profiles')
+      .select(PROFILE_COLUMNS)
+      .eq('id', user.id)
+      .maybeSingle();
+    // A refused or failed read is not "no profile" — it must not lead to an
+    // insert that would then collide with a row that is already there.
+    if (error) throw new Error(error.message);
+    return (data as Profile | null) ?? null;
+  };
+
+  try {
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const found = await read();
+      if (found) {
+        set(found);
+        return true;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 250 * (attempt + 1)));
+    }
+
+    // Still nothing: the trigger is not going to write it. Write it here.
+    const { error: insertError } = await backend.from('profiles').insert({
+      id: user.id,
+      // ADR-006: anonymous guests get an account too, just an unnamed one.
+      display_name: metadataName(user) ?? 'Guest',
+      avatar_url: metadataAvatar(user),
+    });
+    // A conflict means the trigger won the race after all — the re-read below
+    // picks up its row, so this is a success, not a failure.
+    if (insertError && insertError.code !== '23505') throw new Error(insertError.message);
+
+    const healed = await read();
+    if (healed) {
+      set(healed);
+      return true;
+    }
+    reportHandled(new Error('profile row missing after self-heal'), 'auth.loadProfile');
+    return false;
+  } catch (caught) {
+    reportHandled(caught, 'auth.loadProfile');
+    return false;
+  }
+}
+
+/**
  * What a password attempt led to, for the one case the caller must react to:
  * an email sign-up with confirmations on returns no session until the link is
  * followed, so `verifyEmail` carries the address to send them to a
@@ -200,6 +300,15 @@ interface AuthValue {
   session: Session | null;
   profile: Profile | null;
   loading: boolean;
+  /**
+   * The profile load has finished without a profile — it is not coming on its
+   * own. Screens that need one show an error with a retry on this rather than
+   * holding a skeleton for ever; `profile === null && !profileSettled` is the
+   * honest "still loading".
+   */
+  profileSettled: boolean;
+  /** Run the profile load again, for the retry that error offers. */
+  reloadProfile: () => void;
   /** ADR-006: a guest can use the app before deciding to be a user. */
   isGuest: boolean;
   sendOtp: (phone: string) => Promise<void>;
@@ -239,6 +348,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [session, setSession] = useState<Session | null>(null);
   const [profile, setProfile] = useState<Profile | null>(null);
   const [loading, setLoading] = useState(true);
+  // Whether the profile load has run itself out. Bumping `profileAttempt` is
+  // what a retry does: it is the load effect's other dependency.
+  const [profileSettled, setProfileSettled] = useState(false);
+  const [profileAttempt, setProfileAttempt] = useState(0);
 
   useEffect(() => {
     let active = true;
@@ -281,6 +394,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   if (currentUserId !== profileFor) {
     setProfileFor(currentUserId);
     setProfile(null);
+    setProfileSettled(false);
   }
 
   // A crash report carries the account id and nothing else about who it is —
@@ -300,36 +414,32 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (!session?.user) return;
+    const user = session.user;
     let active = true;
+    // `profileSettled` is already false here — reset during render when the
+    // account changes, and by `reloadProfile` on a retry — so this effect only
+    // ever has to record the giving-up, never the starting.
     void (async () => {
-      // The profile row is created by a trigger on auth.users, so it may land a
-      // beat after the session does on a brand-new account.
-      for (let attempt = 0; attempt < 5; attempt += 1) {
-        const { data } = await backend
-          .from('profiles')
-          .select(
-            'id, display_name, avatar_url, default_vpa, payment_rail, payment_handle, country_code, address, default_currency, locale',
-          )
-          .eq('id', session.user.id)
-          .maybeSingle();
-        if (!active) return;
-        if (data) {
-          setProfile(data as Profile);
-          return;
-        }
-        await new Promise((resolve) => setTimeout(resolve, 250 * (attempt + 1)));
-      }
+      const loaded = await loadProfile(user, (next) => {
+        if (active) setProfile(next);
+      });
+      if (active && !loaded) setProfileSettled(true);
     })();
     return () => {
       active = false;
     };
-  }, [session?.user]);
+  }, [session?.user, profileAttempt]);
 
   const value = useMemo<AuthValue>(
     () => ({
       session,
       profile,
       loading,
+      profileSettled,
+      reloadProfile: () => {
+        setProfileSettled(false);
+        setProfileAttempt((n) => n + 1);
+      },
       isGuest: session?.user?.is_anonymous === true,
 
       async sendOtp(phone) {
@@ -476,7 +586,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         await backend.auth.signOut();
       },
     }),
-    [session, profile, loading],
+    [session, profile, loading, profileSettled],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/apps/mobile/src/lib/auth.tsx
+++ b/apps/mobile/src/lib/auth.tsx
@@ -214,6 +214,14 @@ function metadataAvatar(user: Session['user']): string | null {
   return null;
 }
 
+/** The locale a provider sent, when it sent one. */
+function metadataLocale(user: Session['user']): string | null {
+  const value = (user.user_metadata ?? {})['locale'] as unknown;
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? null : trimmed;
+}
+
 /**
  * Read this account's profile row, and make one if the database never did.
  *
@@ -262,11 +270,14 @@ async function loadProfile(
     }
 
     // Still nothing: the trigger is not going to write it. Write it here.
+    // The same three columns the trigger writes, read the same way — a profile
+    // must not depend on which of the three paths happened to create it.
     const { error: insertError } = await backend.from('profiles').insert({
       id: user.id,
       // ADR-006: anonymous guests get an account too, just an unnamed one.
       display_name: metadataName(user) ?? 'Guest',
       avatar_url: metadataAvatar(user),
+      locale: metadataLocale(user) ?? 'en',
     });
     // A conflict means the trigger won the race after all — the re-read below
     // picks up its row, so this is a success, not a failure.
@@ -346,11 +357,26 @@ const AuthContext = createContext<AuthValue | null>(null);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [session, setSession] = useState<Session | null>(null);
-  const [profile, setProfile] = useState<Profile | null>(null);
   const [loading, setLoading] = useState(true);
-  // Whether the profile load has run itself out. Bumping `profileAttempt` is
-  // what a retry does: it is the load effect's other dependency.
-  const [profileSettled, setProfileSettled] = useState(false);
+  // The profile, and the settled flag, are stored *with the account they belong
+  // to* rather than on their own.
+  //
+  // The load is asynchronous and takes seconds. Clearing state during render
+  // when the account changes is not enough to make a late write safe: passive
+  // effects run after the commit, so between the render that switches to
+  // account B and the cleanup that stops account A's effect there is a window
+  // where A's callback still fires — and it would put A's name and face on
+  // screen for B. Guarding the *write* with a flag closes it only if the flag
+  // is already false, which in that window it is not.
+  //
+  // Owning the id makes the question structural instead of a matter of timing:
+  // a value written for A is simply not read while B is signed in, whenever it
+  // lands. `loadProfile` selects by id, so `owner` is exactly whose row it is.
+  const [profileState, setProfileState] = useState<{
+    owner: string | null;
+    profile: Profile | null;
+    settled: boolean;
+  }>({ owner: null, profile: null, settled: false });
   const [profileAttempt, setProfileAttempt] = useState(0);
 
   useEffect(() => {
@@ -389,13 +415,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // Adjusting state during render (rather than in an effect) is the documented
   // React pattern for "reset derived state when the input changes": it avoids a
   // render pass that would briefly show the previous user's profile.
-  const [profileFor, setProfileFor] = useState<string | null>(null);
   const currentUserId = session?.user?.id ?? null;
-  if (currentUserId !== profileFor) {
-    setProfileFor(currentUserId);
-    setProfile(null);
-    setProfileSettled(false);
-  }
+  // Reading through the owner is what resets it: a profile belonging to anybody
+  // but the account signed in right now is not this account's profile. No
+  // render-time clear, and nothing to go stale.
+  const profile = profileState.owner === currentUserId ? profileState.profile : null;
+  const profileSettled = profileState.owner === currentUserId && profileState.settled;
 
   // A crash report carries the account id and nothing else about who it is —
   // enough to tell one person hitting a bug fifty times from fifty people.
@@ -421,9 +446,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // ever has to record the giving-up, never the starting.
     void (async () => {
       const loaded = await loadProfile(user, (next) => {
-        if (active) setProfile(next);
+        if (active) setProfileState({ owner: user.id, profile: next, settled: false });
       });
-      if (active && !loaded) setProfileSettled(true);
+      if (active && !loaded) {
+        setProfileState((current) =>
+          current.owner === user.id
+            ? { ...current, settled: true }
+            : { owner: user.id, profile: null, settled: true },
+        );
+      }
     })();
     return () => {
       active = false;
@@ -437,7 +468,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       loading,
       profileSettled,
       reloadProfile: () => {
-        setProfileSettled(false);
+        setProfileState((current) => ({ ...current, settled: false }));
         setProfileAttempt((n) => n + 1);
       },
       isGuest: session?.user?.is_anonymous === true,
@@ -570,7 +601,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           )
           .single();
         if (error) throw error;
-        setProfile(data as Profile);
+        setProfileState({ owner: session.user.id, profile: data as Profile, settled: false });
       },
 
       async refresh() {

--- a/packages/db/prisma/migrations/20260905090000_restore_new_user_profile_trigger/migration.sql
+++ b/packages/db/prisma/migrations/20260905090000_restore_new_user_profile_trigger/migration.sql
@@ -1,0 +1,71 @@
+-- The trigger that gives a new account its profile row, put back.
+--
+-- `public.waves_handle_new_user()` mirrors an `auth.users` insert into
+-- `public.profiles`. The function survived the 2026-09-04 squash into
+-- `20260904000000_waves_baseline`; **the trigger did not**. The baseline was
+-- built from a schema-only dump of a local plain Postgres, and a plain Postgres
+-- has no `auth` schema at all — so a trigger that lives on `auth.users` could
+-- never appear in it. This is the same loss that took the 19 `storage.objects`
+-- policies, and for exactly the same reason.
+--
+-- What it cost: every account created on a rebuilt project since 2026-09-04 got
+-- an `auth.users` row and no profile. The app reads `profiles` for the signed-in
+-- person, so the dashboard fell back to initials for a name it did not have and
+-- the settings tab — which holds a skeleton until the profile arrives — never
+-- stopped loading.
+--
+-- Two halves, both idempotent: re-create the trigger, then backfill the accounts
+-- that were created while it was missing.
+
+-- ─────────────────────────────────────────────── 1. the trigger, back ──
+--
+-- Guarded on `auth.users` existing, like the original: CI and the local drift
+-- check run these migrations against a bare Postgres that has no `auth` schema,
+-- where this is correctly a no-op.
+DO $$
+BEGIN
+  IF to_regclass('auth.users') IS NULL THEN
+    RAISE NOTICE 'no auth.users (bare Postgres) — new-user trigger skipped';
+    RETURN;
+  END IF;
+
+  DROP TRIGGER IF EXISTS waves_on_auth_user_created ON auth.users;
+  -- The pre-rebrand name, in case a database still carries it.
+  DROP TRIGGER IF EXISTS baaki_on_auth_user_created ON auth.users;
+
+  CREATE TRIGGER waves_on_auth_user_created
+    AFTER INSERT ON auth.users
+    FOR EACH ROW EXECUTE FUNCTION public.waves_handle_new_user();
+END
+$$;
+
+-- ────────────────────────────────── 2. the accounts that missed out ──
+--
+-- Same COALESCE ladder the trigger uses, so a backfilled row is indistinguishable
+-- from a triggered one. `ON CONFLICT DO NOTHING` keeps it a no-op on a database
+-- that never lost the trigger.
+DO $$
+BEGIN
+  IF to_regclass('auth.users') IS NULL THEN RETURN; END IF;
+
+  INSERT INTO public.profiles (id, display_name, avatar_url, locale)
+  SELECT
+    u.id,
+    COALESCE(
+      NULLIF(u.raw_user_meta_data ->> 'display_name', ''),
+      NULLIF(u.raw_user_meta_data ->> 'full_name', ''),
+      NULLIF(u.raw_user_meta_data ->> 'name', ''),
+      -- ADR-006: anonymous guests get an account too, just an unnamed one.
+      'Guest'
+    ),
+    COALESCE(
+      NULLIF(u.raw_user_meta_data ->> 'avatar_url', ''),
+      NULLIF(u.raw_user_meta_data ->> 'picture', '')
+    ),
+    COALESCE(NULLIF(u.raw_user_meta_data ->> 'locale', ''), 'en')
+  FROM auth.users u
+  LEFT JOIN public.profiles p ON p.id = u.id
+  WHERE p.id IS NULL
+  ON CONFLICT (id) DO NOTHING;
+END
+$$;

--- a/packages/db/prisma/migrations/20260905090000_restore_new_user_profile_trigger/migration.sql
+++ b/packages/db/prisma/migrations/20260905090000_restore_new_user_profile_trigger/migration.sql
@@ -17,6 +17,42 @@
 -- Two halves, both idempotent: re-create the trigger, then backfill the accounts
 -- that were created while it was missing.
 
+-- ─────────────────────────────── 0. one reading of the metadata, not three ──
+--
+-- A profile must not depend on which path created it. There are three:
+-- this trigger, the backfill below, and the client's self-heal in `auth.tsx`.
+-- They disagreed on the avatar: Google sends the photo under `picture` as well
+-- as `avatar_url`, and a provider that sends only `picture` gave a face through
+-- two of the three paths and initials through this one. Same ladder everywhere
+-- now — replaced rather than created, so this is safe to re-run.
+CREATE OR REPLACE FUNCTION public.waves_handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  INSERT INTO public.profiles (id, display_name, avatar_url, locale)
+  VALUES (
+    NEW.id,
+    COALESCE(
+      NULLIF(NEW.raw_user_meta_data ->> 'display_name', ''),
+      NULLIF(NEW.raw_user_meta_data ->> 'full_name', ''),
+      NULLIF(NEW.raw_user_meta_data ->> 'name', ''),
+      -- ADR-006: anonymous guests get an account too, just an unnamed one.
+      'Guest'
+    ),
+    COALESCE(
+      NULLIF(NEW.raw_user_meta_data ->> 'avatar_url', ''),
+      NULLIF(NEW.raw_user_meta_data ->> 'picture', '')
+    ),
+    COALESCE(NULLIF(NEW.raw_user_meta_data ->> 'locale', ''), 'en')
+  )
+  ON CONFLICT (id) DO NOTHING;
+  RETURN NEW;
+END
+$$;
+
 -- ─────────────────────────────────────────────── 1. the trigger, back ──
 --
 -- Guarded on `auth.users` existing, like the original: CI and the local drift

--- a/packages/db/prisma/migrations/20260905090000_restore_new_user_profile_trigger/migration.sql
+++ b/packages/db/prisma/migrations/20260905090000_restore_new_user_profile_trigger/migration.sql
@@ -53,6 +53,14 @@ BEGIN
 END
 $$;
 
+-- Restated with the function, as `scripts/check-definer-grants.mjs` requires: a
+-- definer function bypasses RLS and is granted to anon + PUBLIC by default, so
+-- every migration that writes one has to say who may call it. Nobody calls this
+-- one — the trigger invokes it, as the definer — so it stays off every client
+-- role. Same ACL the baseline gives it.
+REVOKE ALL ON FUNCTION public.waves_handle_new_user() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.waves_handle_new_user() TO service_role;
+
 -- ─────────────────────────────────────────────── 1. the trigger, back ──
 --
 -- Guarded on `auth.users` existing, like the original: CI and the local drift


### PR DESCRIPTION
## What broke

Sign in with Google on the released build, and the dashboard shows initials instead of your photo while the settings tab spins for ever.

Both are one cause. `public.waves_handle_new_user()` mirrors an `auth.users` insert into `public.profiles`. The function survived the 2026-09-04 squash into `20260904000000_waves_baseline`; **the trigger did not**. The baseline was dumped from a local plain Postgres, which has no `auth` schema at all, so a trigger living on `auth.users` could never have appeared in it — the same loss, for the same reason, that took the 19 `storage.objects` policies.

So every account created on the rebuilt project since 2026-09-04 got an `auth.users` row and no `profiles` row. Confirmed live before the fix: 1 auth user, 0 profiles.

The app reads `profiles` for the signed-in person, so:

- the dashboard's `HeroAvatar` had no `avatar_url` and fell back to initials of a name it also did not have;
- `(tabs)/profile.tsx` holds a `SkeletonList` until `profile` is non-null, and nothing ever made it non-null.

## What this changes

**The cure — `20260905090000_restore_new_user_profile_trigger`**
Re-creates `waves_on_auth_user_created` on `auth.users`, guarded on the table existing so CI's bare Postgres is a no-op, and backfills the accounts created while it was missing. Both halves idempotent.

**The client stops depending on it being right.** `loadProfile` used to retry five times over ~4s and then give up silently and for ever — nothing retried it, nothing reported it. It now tells a *late* row from an *absent* one: after the retry it writes the row itself through the existing `profiles_insert_self` policy, using the metadata the provider sent, and reports what it cannot recover from.

**A missing profile can no longer hang a screen.** `profileSettled` and `reloadProfile` on the auth context let a screen tell "on its way" from "not coming". Settings, account and paying show `t.loadError` with a retry instead of an endless skeleton or a permanently blank screen. No new i18n keys.

## Verified

- Migration applied to a fresh local Postgres with a stand-in `auth.users`: backfill fills the orphan, a new insert fires the trigger, a second run changes nothing.
- Applied to prod (`ywojpnfyxxltvihqmcni`) via `supabase db query --linked`; trigger confirmed present, and the one orphaned account backfilled. **Already deployed** — merging this only records it.
- `pnpm typecheck` and `pnpm lint` clean in `apps/mobile` (3 pre-existing `phone.tsx` warnings).

Not device-tested; the prod half is verified through the API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved profile loading feedback across the Profile, Account, and Payments screens.
  - Added clear error states when profile loading fails or no profile is found.
  - Added retry options so users can reload their profile without restarting the app.
  - Improved profile recovery for accounts whose profile setup was incomplete, helping ensure newly created accounts receive a profile automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->