### PR TITLE
fix(settings): one sign out, in one place

### DIFF
--- a/apps/mobile/src/app/settings/lock.tsx
+++ b/apps/mobile/src/app/settings/lock.tsx
@@ -1,19 +1,21 @@
 /**
  * Security.
  *
- * Two settings and a way out. The lock guards the screen when the phone is
- * handed over; the delay decides how often that guard gets in the way of the
- * person who owns it. Both matter, because a lock that asks too often is a lock
- * somebody turns off, and a lock nobody turns on protects nothing.
+ * Two settings. The lock guards the screen when the phone is handed over; the
+ * delay decides how often that guard gets in the way of the person who owns it.
+ * Both matter, because a lock that asks too often is a lock somebody turns off,
+ * and a lock nobody turns on protects nothing.
+ *
+ * Signing out used to sit here too, and was the same button the settings list
+ * already carries. One way out, in one place: settings owns it.
  */
 
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
-import { Alert, ScrollView, View } from 'react-native';
+import { ScrollView, View } from 'react-native';
 
 import {
   Badge,
-  Button,
   Card,
   Chip,
   directionalIcon,
@@ -28,7 +30,6 @@ import {
 } from '@waves/ui';
 
 import { useStrings } from '@/i18n';
-import { useAuth } from '@/lib/auth';
 import { describeGrace, GRACE_CHOICES, useLock } from '@/lib/lock';
 
 export default function LockSettingsScreen() {
@@ -36,23 +37,6 @@ export default function LockSettingsScreen() {
   const clearance = useTabBarClearance();
   const { t, locale } = useStrings();
   const { enabled, supported, graceSeconds, setEnabled, setGraceSeconds } = useLock();
-  const { isGuest, signOut } = useAuth();
-
-  const confirmSignOut = (): void => {
-    Alert.alert(
-      t.lock.signOutQuestion,
-      isGuest
-        ? // The one case where signing out is not reversible: a guest session
-          // lives on this device and nowhere else, so there is no credential to
-          // come back with.
-          t.lock.signOutGuestWarning
-        : t.lock.signOutReassure,
-      [
-        { text: t.lock.staySignedIn, style: 'cancel' },
-        { text: t.lock.signOut, style: 'destructive', onPress: () => void signOut() },
-      ],
-    );
-  };
 
   return (
     <Screen>
@@ -119,14 +103,6 @@ export default function LockSettingsScreen() {
             </Text>
           </Card>
         ) : null}
-
-        <Card style={{ gap: theme.spacing.md }}>
-          <Text variant="subheading">{t.lock.signOut}</Text>
-          <Text variant="caption" tone="muted">
-            {isGuest ? t.lock.signOutGuest : t.lock.signOutMember}
-          </Text>
-          <Button label={t.lock.signOut} variant="secondary" fullWidth onPress={confirmSignOut} />
-        </Card>
 
         <Text variant="micro" tone="muted" align="center">
           {t.lock.footnote}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -756,8 +756,6 @@ export interface UiStrings {
     graceMinutes: PluralForms;
     reopenAlwaysAsks: string;
     signOut: string;
-    signOutGuest: string;
-    signOutMember: string;
     signOutQuestion: string;
     signOutGuestWarning: string;
     signOutReassure: string;
@@ -3059,8 +3057,6 @@ const en: UiStrings = {
     graceMinutes: { one: 'After a minute', other: 'After {n} minutes' },
     reopenAlwaysAsks: 'Reopening Waves after it has been closed always asks, whatever this says.',
     signOut: 'Sign out',
-    signOutGuest: 'This account lives on this device only. Signing out ends it.',
-    signOutMember: 'Your groups and history stay exactly where they are.',
     signOutQuestion: 'Sign out?',
     signOutGuestWarning:
       'This is a guest account, so signing out leaves no way back into it. Add an email or phone number first if you want to keep it.',
@@ -5263,9 +5259,6 @@ const ta: UiStrings = {
     graceMinutes: { one: 'ஒரு நிமிடம் கழித்து', other: '{n} நிமிடங்கள் கழித்து' },
     reopenAlwaysAsks: 'Waves-ஐ மூடிவிட்டுத் திறந்தால் இது என்னவாக இருந்தாலும் எப்போதும் கேட்கும்.',
     signOut: 'வெளியேறு',
-    signOutGuest:
-      'இந்தக் கணக்கு இந்தச் சாதனத்தில் மட்டுமே உள்ளது. வெளியேறினால் அது முடிந்துவிடும்.',
-    signOutMember: 'உங்கள் குழுக்களும் வரலாறும் அப்படியே இருக்கும்.',
     signOutQuestion: 'வெளியேறவா?',
     signOutGuestWarning:
       'இது விருந்தினர் கணக்கு, வெளியேறினால் திரும்ப வர வழி இல்லை. வைத்திருக்க விரும்பினால் முதலில் மின்னஞ்சல் அல்லது தொலைபேசி எண்ணைச் சேர்க்கவும்.',
@@ -7541,8 +7534,6 @@ const hi: UiStrings = {
     graceMinutes: { one: 'एक मिनट बाद', other: '{n} मिनट बाद' },
     reopenAlwaysAsks: 'Waves को बंद करके दोबारा खोलने पर हमेशा पूछा जाएगा, यहाँ कुछ भी लिखा हो।',
     signOut: 'साइन आउट',
-    signOutGuest: 'यह खाता सिर्फ़ इसी डिवाइस पर है। साइन आउट करने से यह खत्म हो जाएगा।',
-    signOutMember: 'आपके समूह और इतिहास जहाँ हैं वहीं रहेंगे।',
     signOutQuestion: 'साइन आउट करें?',
     signOutGuestWarning:
       'यह मेहमान खाता है, साइन आउट करने पर वापस आने का कोई रास्ता नहीं बचेगा। इसे रखना है तो पहले ईमेल या फ़ोन नंबर जोड़ें।',
@@ -9777,8 +9768,6 @@ const ar: UiStrings = {
     },
     reopenAlwaysAsks: 'إعادة فتح Waves بعد إغلاقه تطلب التحقق دائمًا، مهما كان هذا الإعداد.',
     signOut: 'تسجيل الخروج',
-    signOutGuest: 'هذا الحساب موجود على هذا الجهاز فقط. تسجيل الخروج ينهيه.',
-    signOutMember: 'مجموعاتك وسجلك يبقيان كما هما تمامًا.',
     signOutQuestion: 'تسجيل الخروج؟',
     signOutGuestWarning:
       'هذا حساب ضيف، وتسجيل الخروج لا يترك طريقًا للعودة إليه. أضف بريدًا إلكترونيًا أو رقم هاتف أولًا إن أردت الاحتفاظ به.',


### PR DESCRIPTION
Security (`settings/lock.tsx`) carried a sign-out card, and the settings list it is reached from carries the same row — the same action, twice, two taps apart. A way out of the account is not a security setting; it sits with the account.

- Removes the card and `confirmSignOut`, which nothing else called.
- Removes `lock.signOutGuest` and `lock.signOutMember` — the card's two body lines, read from nowhere else — from the interface and all four locales. Every other `lock.signOut*` string stays: `(tabs)/profile.tsx` still uses them.
- Prunes the imports that fell out (`Alert`, `Button`, `useAuth`).

The settings row keeps its own confirmation, which already says the same things, guest warning included — the one case where signing out is not reversible.

`pnpm typecheck` and `pnpm lint` clean in `apps/mobile` (3 pre-existing `phone.tsx` warnings); prettier clean. Branched off `main`, independent of #667.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Changes**
  * Removed the sign-out action from the lock settings screen.
  * Sign-out is now accessed from the main settings list.
* **Localization**
  * Removed lock-screen sign-out messages that distinguished between guest and member accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->