### PR TITLE
fix(sync): a group does not need a name

### DIFF
--- a/supabase/functions/sync/groupCreate.test.ts
+++ b/supabase/functions/sync/groupCreate.test.ts
@@ -1,0 +1,112 @@
+/**
+ * A group does not need a name.
+ *
+ * `new-group.tsx` says so in as many words — "Blank is fine — the group gets
+ * labelled by who is in it instead" — and it sends `name: null` when nobody
+ * typed one. `waves_create_group` accepts that. This function did not: it ran
+ * the name through `requireString`, so a nameless group was rejected with
+ * `VALIDATION_FAILED: name is required` before it ever reached the database.
+ *
+ * The cost was worse than a failed save, because `group.create` has no
+ * optimistic mirror row — the group only exists on the phone once the server's
+ * change comes back. So the create was queued, refused, and never materialised:
+ * the phone opened "Group not found" for the group it had just made, the
+ * dashboard said "No groups yet", and the only clue was a red glyph in the
+ * header.
+ *
+ * The session is driven with a stubbed Supabase client: no Deno, no network, no
+ * database. What is asserted is the contract the client relies on — a name is
+ * optional, blank means null rather than an empty string, and a real name still
+ * arrives trimmed.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { SyncSession } from './index.ts';
+
+const OWNER = 'owner-profile-id';
+const GROUP_ID = '99999999-8888-7777-6666-555555555555';
+
+/** The caller-scoped client: `rpc` records the arguments and answers with an id. */
+function caller() {
+  const rpc = vi.fn(() => Promise.resolve({ data: GROUP_ID, error: null }));
+  const from = vi.fn(() => {
+    const builder: Record<string, unknown> = {};
+    builder.select = () => builder;
+    builder.eq = () => builder;
+    builder.maybeSingle = () => Promise.resolve({ data: null, error: null });
+    return builder;
+  });
+  return { client: { rpc, from } as never, rpc };
+}
+
+/** The service-role client: the replay guard's own table, and nothing else. */
+function service() {
+  const insert = vi.fn(() => Promise.resolve({ error: null }));
+  const from = vi.fn(() => {
+    const builder: Record<string, unknown> = { insert };
+    builder.select = () => builder;
+    builder.eq = () => builder;
+    builder.maybeSingle = () => Promise.resolve({ data: null, error: null });
+    return builder;
+  });
+  return { client: { from } as never, insert };
+}
+
+function createGroup(name: unknown, clientMutationId = 'mutation-1') {
+  return {
+    clientMutationId,
+    kind: 'group.create',
+    groupId: GROUP_ID,
+    seq: 1,
+    clientCreatedAt: '2026-09-06T01:57:00.000Z',
+    payload: {
+      name,
+      type: 'trip',
+      currency: 'INR',
+      simplify: true,
+      creatorMemberId: '11111111-2222-3333-4444-555555555555',
+    },
+  } as never;
+}
+
+describe('group.create without a name', () => {
+  it('applies a null name instead of refusing it', async () => {
+    const scoped = caller();
+    const session = new SyncSession(scoped.client, service().client, OWNER);
+
+    const outcome = await session.apply(createGroup(null));
+
+    expect(outcome).toMatchObject({ status: 'applied' });
+    expect(scoped.rpc).toHaveBeenCalledWith(
+      'waves_create_group',
+      expect.objectContaining({ p_name: null, p_group_id: GROUP_ID }),
+    );
+  });
+
+  it('treats a blank name as no name, not as an empty one', async () => {
+    // '' in `groups.name` is a name that renders as nothing everywhere, rather
+    // than falling back to the members — so it has to collapse to NULL.
+    const scoped = caller();
+    const session = new SyncSession(scoped.client, service().client, OWNER);
+
+    await session.apply(createGroup('   ', 'mutation-2'));
+
+    expect(scoped.rpc).toHaveBeenCalledWith(
+      'waves_create_group',
+      expect.objectContaining({ p_name: null }),
+    );
+  });
+
+  it('still passes a real name through, trimmed', async () => {
+    const scoped = caller();
+    const session = new SyncSession(scoped.client, service().client, OWNER);
+
+    await session.apply(createGroup('  Goa trip  ', 'mutation-3'));
+
+    expect(scoped.rpc).toHaveBeenCalledWith(
+      'waves_create_group',
+      expect.objectContaining({ p_name: 'Goa trip' }),
+    );
+  });
+});

--- a/supabase/functions/sync/groupCreate.test.ts
+++ b/supabase/functions/sync/groupCreate.test.ts
@@ -26,18 +26,28 @@ import { SyncSession } from './index.ts';
 
 const OWNER = 'owner-profile-id';
 const GROUP_ID = '99999999-8888-7777-6666-555555555555';
+const MEMBER_ID = '11111111-2222-3333-4444-555555555555';
 
-/** The caller-scoped client: `rpc` records the arguments and answers with an id. */
+/**
+ * The caller-scoped client: `rpc` records the arguments and answers with an id,
+ * `update` records the patch a `group.update` would write. `maybeSingle`
+ * answers the membership lookup `group.update` makes before it writes.
+ */
 function caller() {
   const rpc = vi.fn(() => Promise.resolve({ data: GROUP_ID, error: null }));
+  const update = vi.fn(() => Promise.resolve({ error: null }));
   const from = vi.fn(() => {
     const builder: Record<string, unknown> = {};
     builder.select = () => builder;
     builder.eq = () => builder;
-    builder.maybeSingle = () => Promise.resolve({ data: null, error: null });
+    builder.maybeSingle = () => Promise.resolve({ data: { id: MEMBER_ID }, error: null });
+    builder.update = (patch: Record<string, unknown>) => {
+      void update(patch);
+      return { eq: () => Promise.resolve({ error: null }) };
+    };
     return builder;
   });
-  return { client: { rpc, from } as never, rpc };
+  return { client: { rpc, from } as never, rpc, update };
 }
 
 /** The service-role client: the replay guard's own table, and nothing else. */
@@ -108,5 +118,76 @@ describe('group.create without a name', () => {
       'waves_create_group',
       expect.objectContaining({ p_name: 'Goa trip' }),
     );
+  });
+});
+
+function updateGroup(payload: Record<string, unknown>, clientMutationId = 'update-1') {
+  return {
+    clientMutationId,
+    kind: 'group.update',
+    groupId: GROUP_ID,
+    seq: 1,
+    clientCreatedAt: '2026-09-06T02:20:00.000Z',
+    payload,
+  } as never;
+}
+
+/**
+ * The same reading of a name on the way back out.
+ *
+ * Clearing a group's name is ordinary — it goes back to being labelled by who
+ * is in it — and it has to land as NULL. An empty string in `groups.name` is a
+ * name that renders as nothing everywhere instead of falling back to the
+ * members, which is exactly the state `group.create` refuses to create. The
+ * app's own rename screen trims before it queues, but `/sync` is a boundary: a
+ * column normalised on one path and trusted on the other is how the two ends
+ * drift apart.
+ */
+describe('group.update and the name column', () => {
+  it('clears the name to null when it is emptied', async () => {
+    const scoped = caller();
+    const session = new SyncSession(scoped.client, service().client, OWNER);
+
+    await session.apply(updateGroup({ name: '' }));
+
+    expect(scoped.update).toHaveBeenCalledWith({ name: null });
+  });
+
+  it('treats a whitespace-only name as cleared, not as a name of spaces', async () => {
+    const scoped = caller();
+    const session = new SyncSession(scoped.client, service().client, OWNER);
+
+    await session.apply(updateGroup({ name: '   ' }, 'update-2'));
+
+    expect(scoped.update).toHaveBeenCalledWith({ name: null });
+  });
+
+  it('passes an explicit null through unchanged', async () => {
+    const scoped = caller();
+    const session = new SyncSession(scoped.client, service().client, OWNER);
+
+    await session.apply(updateGroup({ name: null }, 'update-3'));
+
+    expect(scoped.update).toHaveBeenCalledWith({ name: null });
+  });
+
+  it('trims a real rename', async () => {
+    const scoped = caller();
+    const session = new SyncSession(scoped.client, service().client, OWNER);
+
+    await session.apply(updateGroup({ name: '  Goa trip  ' }, 'update-4'));
+
+    expect(scoped.update).toHaveBeenCalledWith({ name: 'Goa trip' });
+  });
+
+  it('leaves a patch that never mentioned the name alone', async () => {
+    const scoped = caller();
+    const session = new SyncSession(scoped.client, service().client, OWNER);
+
+    await session.apply(updateGroup({ cover_emoji: 'X' }, 'update-5'));
+
+    // No `name` key invented, so a rename is not written as a side effect of
+    // changing the icon.
+    expect(scoped.update).toHaveBeenCalledWith({ cover_emoji: 'X' });
   });
 });

--- a/supabase/functions/sync/groupCreate.test.ts
+++ b/supabase/functions/sync/groupCreate.test.ts
@@ -119,6 +119,29 @@ describe('group.create without a name', () => {
       expect.objectContaining({ p_name: 'Goa trip' }),
     );
   });
+
+  // The body is cast to `SyncRequest`, never parsed, so a payload can carry
+  // anything. Absent and wrong are not the same thing: folding a number into
+  // null would make a malformed create quietly produce an unnamed group.
+  it('refuses a name that is not text rather than treating it as absent', async () => {
+    const scoped = caller();
+    const session = new SyncSession(scoped.client, service().client, OWNER);
+
+    const outcome = await session.apply(createGroup(42, 'mutation-4'));
+
+    expect(outcome).toMatchObject({ status: 'rejected', code: 'VALIDATION_FAILED' });
+    expect(scoped.rpc).not.toHaveBeenCalled();
+  });
+
+  it('refuses an object name too', async () => {
+    const scoped = caller();
+    const session = new SyncSession(scoped.client, service().client, OWNER);
+
+    const outcome = await session.apply(createGroup({ evil: true }, 'mutation-5'));
+
+    expect(outcome).toMatchObject({ status: 'rejected', code: 'VALIDATION_FAILED' });
+    expect(scoped.rpc).not.toHaveBeenCalled();
+  });
 });
 
 function updateGroup(payload: Record<string, unknown>, clientMutationId = 'update-1') {
@@ -178,6 +201,18 @@ describe('group.update and the name column', () => {
     await session.apply(updateGroup({ name: '  Goa trip  ' }, 'update-4'));
 
     expect(scoped.update).toHaveBeenCalledWith({ name: 'Goa trip' });
+  });
+
+  // The destructive half of the same hole: a malformed rename must not clear a
+  // name somebody chose.
+  it('refuses a rename that is not text instead of clearing the name', async () => {
+    const scoped = caller();
+    const session = new SyncSession(scoped.client, service().client, OWNER);
+
+    const outcome = await session.apply(updateGroup({ name: 42 }, 'update-6'));
+
+    expect(outcome).toMatchObject({ status: 'rejected', code: 'VALIDATION_FAILED' });
+    expect(scoped.update).not.toHaveBeenCalled();
   });
 
   it('leaves a patch that never mentioned the name alone', async () => {

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -497,6 +497,15 @@ export class SyncSession {
         if (Object.keys(patch).length === 0) {
           throw new HttpError(400, 'VALIDATION_FAILED', 'No updatable fields in payload');
         }
+        // The same reading of a name that `group.create` uses. Clearing one is
+        // an ordinary thing to do — the group goes back to being labelled by
+        // who is in it — and it has to reach the column as NULL, because ''
+        // renders as nothing everywhere instead of falling back to the members.
+        // The app's own rename screen already trims, but `/sync` is a boundary:
+        // one column normalised on the way in and trusted on the way past is
+        // how the two ends drift apart. Only when the key is actually there, so
+        // a patch that never mentioned the name is untouched.
+        if ('name' in patch) patch.name = optionalString(patch.name);
         const { error } = await this.caller.from('groups').update(patch).eq('id', mutation.groupId);
         if (error) throw new HttpError(400, 'VALIDATION_FAILED', error.message);
         return { groupId: mutation.groupId };

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -469,7 +469,7 @@ export class SyncSession {
           // came back through the mirror either, and the phone showed "Group
           // not found" for the group it had just made, with a red refusal in
           // the header and no way to tell why.
-          p_name: optionalString(mutation.payload.name),
+          p_name: optionalString(mutation.payload.name, 'name'),
           p_type: (mutation.payload.type as string | undefined) ?? 'other',
           p_currency: (mutation.payload.currency as string | undefined) ?? 'INR',
           p_emoji: (mutation.payload.emoji as string | undefined) ?? null,
@@ -505,7 +505,7 @@ export class SyncSession {
         // one column normalised on the way in and trusted on the way past is
         // how the two ends drift apart. Only when the key is actually there, so
         // a patch that never mentioned the name is untouched.
-        if ('name' in patch) patch.name = optionalString(patch.name);
+        if ('name' in patch) patch.name = optionalString(patch.name, 'name');
         const { error } = await this.caller.from('groups').update(patch).eq('id', mutation.groupId);
         if (error) throw new HttpError(400, 'VALIDATION_FAILED', error.message);
         return { groupId: mutation.groupId };
@@ -1295,9 +1295,19 @@ function requireString(value: unknown, field: string): string {
  * Blank and whitespace-only collapse to null rather than travelling on as '':
  * the database's "no name" is NULL, and an empty string stored there is a name
  * that renders as nothing everywhere instead of falling back to the members.
+ *
+ * Absent and *wrong* are not the same thing, though, and this is a boundary:
+ * the request body is cast to `SyncRequest`, never parsed, so a payload can
+ * carry anything. Folding a number or an object into null would make a
+ * malformed `group.update` silently **clear** a name somebody chose — a
+ * destructive answer to a client bug. Only null and undefined mean "not given";
+ * anything else is refused and says so.
  */
-function optionalString(value: unknown): string | null {
-  if (typeof value !== 'string') return null;
+function optionalString(value: unknown, field: string): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== 'string') {
+    throw new HttpError(400, 'VALIDATION_FAILED', `${field} must be text`);
+  }
   const trimmed = value.trim();
   return trimmed.length === 0 ? null : trimmed;
 }

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -462,7 +462,14 @@ export class SyncSession {
         });
       case 'group.create':
         return await this.rpcAsCaller('waves_create_group', {
-          p_name: requireString(mutation.payload.name, 'name'),
+          // A group does not need a name — one with none is labelled by who is
+          // in it, which is what `new-group.tsx` sends ("Blank is fine") and
+          // what `waves_create_group` accepts. Requiring it here refused that
+          // create for good: the group never reached the server, so it never
+          // came back through the mirror either, and the phone showed "Group
+          // not found" for the group it had just made, with a red refusal in
+          // the header and no way to tell why.
+          p_name: optionalString(mutation.payload.name),
           p_type: (mutation.payload.type as string | undefined) ?? 'other',
           p_currency: (mutation.payload.currency as string | undefined) ?? 'INR',
           p_emoji: (mutation.payload.emoji as string | undefined) ?? null,
@@ -1271,6 +1278,19 @@ function requireString(value: unknown, field: string): string {
     throw new HttpError(400, 'VALIDATION_FAILED', `${field} is required`);
   }
   return value;
+}
+
+/**
+ * A string the client may legitimately leave out.
+ *
+ * Blank and whitespace-only collapse to null rather than travelling on as '':
+ * the database's "no name" is NULL, and an empty string stored there is a name
+ * that renders as nothing everywhere instead of falling back to the members.
+ */
+function optionalString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? null : trimmed;
 }
 
 /**


### PR DESCRIPTION
## What broke

Create a group without typing a name and it never arrives. The phone opens **"Group not found"** for the group it has just made, the dashboard goes back to **"No groups yet"**, and the only clue is a red alert glyph in the header. Reproduced from a released build; confirmed against prod, where the account had 0 groups after a create.

`new-group.tsx` treats a name as optional and says so in as many words:

```ts
// Blank is fine — the group gets labelled by who is in it instead.
name: name.trim() || null,
```

`waves_create_group` accepts a null name too. The `sync` function did not:

```ts
p_name: requireString(mutation.payload.name, 'name'),   // → VALIDATION_FAILED
```

So the mutation was refused before it reached the database.

The failure is loud because `group.create` has **no optimistic mirror row** — the group exists on the phone only once the server's change comes back. Queued, refused, never materialised. Nothing on the screen names the cause.

## What this changes

`p_name` goes through a new `optionalString`, which also collapses a blank or whitespace-only name to `null` rather than passing `''` on: an empty string in `groups.name` is a name that renders as nothing everywhere, instead of falling back to the members.

Every other `requireString` in the file was checked — they guard ids, a day, a title, an amount, and a ghost member's name, all genuinely required. Only this one was wrong.

## Verified

`supabase/functions/sync/groupCreate.test.ts` drives `SyncSession` with a stubbed client: `null` and `'   '` both reach the RPC as `p_name: null`, and `'  Goa trip  '` still arrives trimmed. `pnpm test:edge` — 7 files, 112 tests, green.

Branched off `main`, independent of #667 and #668.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Group creation now allows names to be omitted.
  - Blank or whitespace-only group names are stored as empty values.
  - Group names are automatically trimmed when creating or updating groups.

- **Bug Fixes**
  - Updating a group with a blank name now correctly clears the existing name.
  - Unrelated group update fields remain unchanged when the name is modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->