### PR TITLE
fix(feedback): make "sent" the whole screen, not a notice above an empty one

### DIFF
--- a/apps/mobile/src/app/settings/feedback.tsx
+++ b/apps/mobile/src/app/settings/feedback.tsx
@@ -1,8 +1,16 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import Constants from 'expo-constants';
 import { router } from 'expo-router';
-import { ActivityIndicator, Platform, Pressable, ScrollView, TextInput, View } from 'react-native';
+import {
+  ActivityIndicator,
+  Animated,
+  Platform,
+  Pressable,
+  ScrollView,
+  TextInput,
+  View,
+} from 'react-native';
 
 import {
   Button,
@@ -22,6 +30,7 @@ import {
 import { submitFeedback, type FeedbackRating } from '@/data/api';
 import { plural, useStrings } from '@/i18n';
 import { friendlyError } from '@/lib/errors';
+import { useReducedMotion } from '@/lib/reducedMotion';
 
 enum Kind {
   General = 'general',
@@ -86,26 +95,32 @@ export default function FeedbackScreen() {
         <View style={{ width: 44 }} />
       </Row>
 
-      <ScrollView
-        style={{ flex: 1 }}
-        contentContainerStyle={{
-          paddingHorizontal: theme.spacing.xl,
-          paddingBottom: clearance,
-          paddingTop: theme.spacing.lg,
-          gap: theme.spacing.xl,
-        }}
-        keyboardShouldPersistTaps="handled"
-        showsVerticalScrollIndicator={false}
-      >
-        {sent ? (
-          <Card style={{ gap: theme.spacing.md, alignItems: 'center' }}>
-            <Ionicons name="checkmark-circle" size={iconSize.hero} color={theme.color.positive} />
-            <Text variant="subheading" align="center">
-              {t.privacy.feedbackThanks}
-            </Text>
-            <Button label={t.common.close} variant="secondary" onPress={() => router.back()} />
-          </Card>
-        ) : (
+      {sent ? (
+        <Sent
+          onDone={() => router.back()}
+          onAnother={() => {
+            // Back to an empty form, not the one they just sent: a second
+            // thought is a new message, and the kind it belongs to is theirs to
+            // choose again. The rating is the one thing that would be a lie
+            // twice over, so it goes too.
+            setSent(false);
+            setMessage('');
+            setRating(null);
+            setKind(Kind.General);
+          }}
+        />
+      ) : (
+        <ScrollView
+          style={{ flex: 1 }}
+          contentContainerStyle={{
+            paddingHorizontal: theme.spacing.xl,
+            paddingBottom: clearance,
+            paddingTop: theme.spacing.lg,
+            gap: theme.spacing.xl,
+          }}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
           <>
             <Text variant="body" tone="muted">
               {t.privacy.feedbackHint}
@@ -211,8 +226,93 @@ export default function FeedbackScreen() {
               onPress={() => void send()}
             />
           </>
-        )}
-      </ScrollView>
+        </ScrollView>
+      )}
     </Screen>
+  );
+}
+
+/**
+ * What "sent" looks like.
+ *
+ * It used to be a small card at the top of an otherwise empty screen — the form
+ * vanished and left a notice stranded above a whole page of nothing, which
+ * reads less like an acknowledgement than like the screen half-loaded. A
+ * confirmation is the only thing on the screen at that moment, so it should
+ * occupy it: centred, one clear mark, and the two things a person might want
+ * next.
+ *
+ * The mark is `brand`, not `positive`. `positive` is the money colour — in dark
+ * mode it is the blue that means "you are owed" — and a tick borrowing it on a
+ * screen with no money in it says something it does not mean.
+ */
+function Sent({ onDone, onAnother }: { onDone: () => void; onAnother: () => void }) {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const reduceMotion = useReducedMotion();
+
+  // A single entrance, and only a small one: the tick settles in rather than
+  // simply appearing, which is what makes it read as a reply to the tap. Under
+  // reduced motion it is already in place on the first frame.
+  const [enter] = useState(() => new Animated.Value(reduceMotion ? 1 : 0));
+  useEffect(() => {
+    if (reduceMotion) return;
+    Animated.spring(enter, {
+      toValue: 1,
+      damping: 14,
+      stiffness: 170,
+      mass: 0.7,
+      useNativeDriver: true,
+    }).start();
+  }, [enter, reduceMotion]);
+
+  return (
+    <View
+      style={{
+        flex: 1,
+        alignItems: 'center',
+        justifyContent: 'center',
+        paddingHorizontal: theme.spacing.xl,
+        gap: theme.spacing.xl,
+      }}
+    >
+      <Animated.View
+        style={{
+          width: 96,
+          height: 96,
+          borderRadius: 48,
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: theme.color.brandSoft,
+          opacity: enter,
+          transform: [{ scale: enter.interpolate({ inputRange: [0, 1], outputRange: [0.7, 1] }) }],
+        }}
+      >
+        <Ionicons name="checkmark" size={iconSize.hero} color={theme.color.brand} />
+      </Animated.View>
+
+      <View style={{ gap: theme.spacing.sm }}>
+        <Text variant="title" align="center">
+          {t.privacy.feedbackThanks}
+        </Text>
+        <Text variant="body" tone="muted" align="center">
+          {t.privacy.feedbackThanksBody}
+        </Text>
+      </View>
+
+      {/* Done first: most people are finished. "Send another" is there because
+          the thought that arrives right after sending used to cost a trip back
+          out through settings. */}
+      <View style={{ alignSelf: 'stretch', gap: theme.spacing.sm }}>
+        <Button label={t.common.done} size="lg" fullWidth onPress={onDone} />
+        <Button
+          label={t.privacy.feedbackAnother}
+          variant="ghost"
+          size="lg"
+          fullWidth
+          onPress={onAnother}
+        />
+      </View>
+    </View>
   );
 }

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -2402,6 +2402,10 @@ export interface UiStrings {
     feedbackPlaceholder: string;
     feedbackSend: string;
     feedbackThanks: string;
+    /** Under the thanks: what actually happens to what they just wrote. */
+    feedbackThanksBody: string;
+    /** Back to an empty form, for the thought that arrives straight after. */
+    feedbackAnother: string;
     feedbackRating: string;
     feedbackRatingHint: string;
     /** A star's accessibility label, e.g. "3 stars". `{n}` is the star. */
@@ -4581,6 +4585,9 @@ const en: UiStrings = {
     feedbackPlaceholder: 'What happened, or what you wish it did',
     feedbackSend: 'Send',
     feedbackThanks: 'Thank you — that has been received.',
+    feedbackThanksBody:
+      'A person reads every one of these. We cannot always reply, but nothing is lost.',
+    feedbackAnother: 'Send another',
     feedbackRating: 'How is Waves so far?',
     feedbackRatingHint: 'Optional',
     feedbackStarLabel: { one: '{n} star', other: '{n} stars' },
@@ -6871,6 +6878,9 @@ const ta: UiStrings = {
     feedbackPlaceholder: 'என்ன நடந்தது, அல்லது என்ன இருக்க வேண்டும் என நினைக்கிறீர்கள்',
     feedbackSend: 'அனுப்பு',
     feedbackThanks: 'நன்றி — கிடைத்துவிட்டது.',
+    feedbackThanksBody:
+      'ஒவ்வொன்றையும் ஒரு நபர் படிக்கிறார். எப்போதும் பதில் தர முடியாது, ஆனால் எதுவும் தொலைந்து போகாது.',
+    feedbackAnother: 'இன்னொன்று அனுப்பு',
     feedbackRating: 'Waves இதுவரை எப்படி இருக்கிறது?',
     feedbackRatingHint: 'விருப்பம்',
     feedbackStarLabel: { one: '{n} நட்சத்திரம்', other: '{n} நட்சத்திரங்கள்' },
@@ -9077,6 +9087,8 @@ const hi: UiStrings = {
     feedbackPlaceholder: 'क्या हुआ, या आप क्या चाहते थे कि यह करे',
     feedbackSend: 'भेजें',
     feedbackThanks: 'धन्यवाद — मिल गया।',
+    feedbackThanksBody: 'हर संदेश एक इंसान पढ़ता है। जवाब हमेशा नहीं दे पाते, पर कुछ भी खोता नहीं।',
+    feedbackAnother: 'एक और भेजें',
     feedbackRating: 'Waves अब तक कैसा लगा?',
     feedbackRatingHint: 'वैकल्पिक',
     feedbackStarLabel: { one: '{n} तारा', other: '{n} तारे' },
@@ -11528,6 +11540,8 @@ const ar: UiStrings = {
     feedbackPlaceholder: 'ماذا حدث، أو ما الذي كنت تتمناه',
     feedbackSend: 'إرسال',
     feedbackThanks: 'شكرًا — وصلتنا.',
+    feedbackThanksBody: 'يقرأ كل رسالة شخص حقيقي. لا نستطيع الرد دائمًا، لكن لا شيء يضيع.',
+    feedbackAnother: 'إرسال رسالة أخرى',
     feedbackRating: 'كيف تجد بـاقي حتى الآن؟',
     feedbackRatingHint: 'اختياري',
     feedbackStarLabel: { one: '{n} نجمة', other: '{n} نجوم' },


### PR DESCRIPTION
## Before

The form vanishes on send and leaves a small card at the top of the page it just vacated — a tick and a Close button stranded above a whole screen of nothing. It reads less like an acknowledgement than like a screen that half-loaded.

The tick was also `theme.color.positive`, which in dark mode is `#60A5FA` — the *money* blue that means "you are owed". A success mark borrowing the balance colour on a screen with no money in it says something it does not mean.

## After

The confirmation is the only thing on screen at that moment, so it occupies it: centred, one mark in a `brandSoft` disc, the thanks, and a line saying what actually happens to what they wrote.

- **`brand`, not `positive`** — see above.
- **Two actions, not one.** Done, and *Send another*, which returns an empty form (message, rating and kind all cleared — a second thought is a new message). The thought that arrives right after sending used to cost a trip back out through settings and in again.
- **A small spring entrance on the tick**, so it reads as a reply to the tap rather than something that was always there. Skipped entirely under `useReducedMotion`.
- Two new strings, `feedbackThanksBody` and `feedbackAnother`, in **en / ta / hi / ar**.

The compose form itself is untouched.

`pnpm typecheck` and `pnpm lint` clean in `apps/mobile` (3 pre-existing `phone.tsx` warnings); prettier clean. Not device-tested. Branched off `main`, independent of #667/#668/#669.
