### PR TITLE
fix(sync): a refusal is not a deletion — a rejected mutation keeps its row

### DIFF
--- a/apps/mobile/src/components/SyncBanner.tsx
+++ b/apps/mobile/src/components/SyncBanner.tsx
@@ -11,7 +11,7 @@ import { useEffect, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Animated, Easing, Pressable, View } from 'react-native';
 
-import { deadLettered } from '@waves/core';
+import { deadLettered, pendingMutations } from '@waves/core';
 import { Card, iconSize, Row, Text, useTheme } from '@waves/ui';
 
 import { plural, useStrings } from '@/i18n';
@@ -47,7 +47,11 @@ export function SyncStatusIcon({
   // keeps the whole-account view. Connection status (offline/syncing) stays
   // global, since the network is not per-group.
   const refused = groupId ? rejected.filter((item) => item.groupId === groupId) : rejected;
-  const pending = groupId ? queue.filter((item) => item.groupId === groupId) : queue;
+  // Refusals stay in the queue now (they are what keeps their row on screen),
+  // so "pending" has to mean the ones still on their way — otherwise a refused
+  // change would be counted twice: once as red, once as "sending…".
+  const unsent = pendingMutations(queue);
+  const pending = groupId ? unsent.filter((item) => item.groupId === groupId) : unsent;
   // A mutation that has exhausted its retries is not "syncing" — it has stopped,
   // and it blocks everything queued behind it in its group. Under the old
   // glyph it still counted as pending, so the header said "sending 1 change…"
@@ -146,7 +150,11 @@ export function SyncBanner({ groupId }: { groupId?: string }) {
   const { status, queue, rejected, retry, discard } = useSync();
   const { preference: syncNetwork } = useSyncNetwork();
 
-  const pending = groupId ? queue.filter((item) => item.groupId === groupId) : queue;
+  // Refusals stay in the queue now (they are what keeps their row on screen),
+  // so "pending" has to mean the ones still on their way — otherwise a refused
+  // change would be counted twice: once as red, once as "sending…".
+  const unsent = pendingMutations(queue);
+  const pending = groupId ? unsent.filter((item) => item.groupId === groupId) : unsent;
   const refused = groupId ? rejected.filter((item) => item.groupId === groupId) : rejected;
   const stuck = deadLettered(pending);
 

--- a/apps/mobile/src/components/SyncBanner.tsx
+++ b/apps/mobile/src/components/SyncBanner.tsx
@@ -12,7 +12,7 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { Animated, Easing, Pressable, View } from 'react-native';
 
 import { deadLettered, pendingMutations } from '@waves/core';
-import { Card, iconSize, Row, Text, useTheme } from '@waves/ui';
+import { Card, iconSize, Row, Sheet, Text, useTheme } from '@waves/ui';
 
 import { plural, useStrings } from '@/i18n';
 
@@ -60,6 +60,7 @@ export function SyncStatusIcon({
   const stuck = deadLettered(pending);
   const stopped = refused.length + stuck.length;
 
+  const [detailOpen, setDetailOpen] = useState(false);
   const spin = useState(() => new Animated.Value(0))[0];
   const spinning = status === SyncStatus.Syncing && !reduceMotion;
   useEffect(() => {
@@ -120,27 +121,59 @@ export function SyncStatusIcon({
   if (!state) return null;
 
   const glyph = <Ionicons name={state.icon} size={iconSize.xl} color={state.color} />;
+  const body = spinning ? (
+    <Animated.View
+      style={{
+        transform: [
+          { rotate: spin.interpolate({ inputRange: [0, 1], outputRange: ['0deg', '360deg'] }) },
+        ],
+      }}
+    >
+      {glyph}
+    </Animated.View>
+  ) : (
+    glyph
+  );
+
+  // Offline, queued, in flight: nothing to decide, so the glyph stays a plain
+  // mark. Red is different — it means a change needs a person, and the red mark
+  // used to be the whole of what they got. The inline banner that carries retry
+  // and discard renders on one screen, `group/[id]`, scoped to that group; a
+  // capture or a personal record has no such screen (both ride a scope keyed on
+  // the owner's user id), so a refusal there blocked its scope with no way
+  // anywhere to clear it. Opening the account-wide banner from the mark itself
+  // makes the thing that reports the problem the thing that fixes it, for every
+  // scope at once.
+  if (stopped === 0) {
+    return (
+      <View
+        accessibilityRole="image"
+        accessibilityLabel={state.label}
+        style={{ padding: theme.spacing.xs }}
+      >
+        {body}
+      </View>
+    );
+  }
 
   return (
-    <View
-      accessibilityRole="image"
-      accessibilityLabel={state.label}
-      style={{ padding: theme.spacing.xs }}
-    >
-      {spinning ? (
-        <Animated.View
-          style={{
-            transform: [
-              { rotate: spin.interpolate({ inputRange: [0, 1], outputRange: ['0deg', '360deg'] }) },
-            ],
-          }}
-        >
-          {glyph}
-        </Animated.View>
-      ) : (
-        glyph
-      )}
-    </View>
+    <>
+      <Pressable
+        onPress={() => setDetailOpen(true)}
+        accessibilityRole="button"
+        accessibilityLabel={state.label}
+        accessibilityHint={t.sync.openDetail}
+        hitSlop={8}
+        style={({ pressed }) => ({ padding: theme.spacing.xs, opacity: pressed ? 0.6 : 1 })}
+      >
+        {body}
+      </Pressable>
+      <Sheet visible={detailOpen} onClose={() => setDetailOpen(false)} closeLabel={t.common.close}>
+        {/* Account-wide on purpose, even on a group screen: what is blocking
+            you may be a capture, which belongs to no group. */}
+        <SyncBanner />
+      </Sheet>
+    </>
   );
 }
 

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -741,6 +741,9 @@ export interface UiStrings {
     stuckCount: PluralForms;
     /** The line under that heading: still saved, just not sent. */
     stuckExplain: string;
+    /** Screen-reader hint on the header's red sync mark, which opens the
+     *  account-wide banner carrying retry and discard. */
+    openDetail: string;
   };
   /** The app lock, the delay before it asks again, and the way out. */
   lock: {
@@ -3043,6 +3046,7 @@ const en: UiStrings = {
     },
     stuckExplain:
       'Still saved on this phone — it just keeps failing to send. Try again, or let it go.',
+    openDetail: 'Opens what needs your decision',
   },
   lock: {
     title: 'Security',
@@ -5247,6 +5251,7 @@ const ta: UiStrings = {
     },
     stuckExplain:
       'இந்த ஃபோனில் இன்னும் சேமிக்கப்பட்டுள்ளது — அனுப்ப முடியவில்லை. மீண்டும் முயற்சிக்கவும், அல்லது நீக்கிவிடவும்.',
+    openDetail: 'உங்கள் முடிவு தேவைப்படுவதைத் திறக்கும்',
   },
   lock: {
     title: 'பாதுகாப்பு',
@@ -7526,6 +7531,7 @@ const hi: UiStrings = {
     },
     stuckExplain:
       'इस फ़ोन पर अब भी सहेजा है — बस भेजा नहीं जा पा रहा। दोबारा कोशिश करें, या हटा दें।',
+    openDetail: 'आपके निर्णय की ज़रूरत वाली चीज़ खोलता है',
   },
   lock: {
     title: 'सुरक्षा',
@@ -9748,6 +9754,7 @@ const ar: UiStrings = {
       other: '{n} تغيير عالق',
     },
     stuckExplain: 'ما زال محفوظًا على هذا الهاتف — لكنه لا يُرسَل. أعد المحاولة، أو تجاهله.',
+    openDetail: 'يفتح ما يحتاج إلى قرارك',
   },
   lock: {
     title: 'الأمان',

--- a/apps/mobile/src/sync/engine.ts
+++ b/apps/mobile/src/sync/engine.ts
@@ -312,6 +312,11 @@ export class SyncEngine {
       rejected: describeRejections(queue),
     });
     await this.store.writeQueue(queue);
+    // What was discarded was blocking its group — a refused or dead-lettered
+    // mutation holds back everything queued behind it, since those depend on
+    // it. Removing it makes them sendable, so send them, rather than leaving
+    // them to wait out the 30s poll for no reason. `retry` already does this.
+    void this.flush();
   }
 
   /** Push the queue and pull whatever changed. Safe to call at any time. */

--- a/apps/mobile/src/sync/engine.ts
+++ b/apps/mobile/src/sync/engine.ts
@@ -18,13 +18,13 @@ import {
   dialingCodeForCountry,
   emptyMirror,
   enqueue as enqueueMutation,
-  clearRejection,
   markFailed,
   MutationKind,
   nextBatch,
-  rejectedMutations,
   normalisePhoneInRegion,
   reconcile,
+  rejectedMutations,
+  retryNow,
   SyncTable,
   type MirrorRow,
   type MirrorState,
@@ -287,9 +287,10 @@ export class SyncEngine {
   }
 
   async retry(clientMutationId: string): Promise<void> {
-    // Clears the refusal as well as the backoff: a marked mutation is never
-    // picked up by `nextBatch`, so without this the retry would do nothing.
-    const queue = clearRejection(this.state.queue, clientMutationId);
+    // `retryNow` clears the refusal as well as the backoff — a marked mutation
+    // is never picked up by `nextBatch`, so resetting only the attempts would
+    // leave it exactly as stuck.
+    const queue = retryNow(this.state.queue, clientMutationId);
     this.set({
       queue,
       rejected: describeRejections(queue),

--- a/apps/mobile/src/sync/engine.ts
+++ b/apps/mobile/src/sync/engine.ts
@@ -18,9 +18,11 @@ import {
   dialingCodeForCountry,
   emptyMirror,
   enqueue as enqueueMutation,
+  clearRejection,
   markFailed,
   MutationKind,
   nextBatch,
+  rejectedMutations,
   normalisePhoneInRegion,
   reconcile,
   SyncTable,
@@ -130,14 +132,21 @@ function sameQueue(a: readonly QueuedMutation[], b: readonly QueuedMutation[]): 
   return true;
 }
 
-function appendRejected(
-  existing: readonly RejectedMutation[],
-  incoming: readonly RejectedMutation[],
-): RejectedMutation[] {
-  if (incoming.length === 0) return [...existing];
-  const byId = new Map(existing.map((item) => [item.clientMutationId, item]));
-  for (const item of incoming) byId.set(item.clientMutationId, item);
-  return [...byId.values()];
+/**
+ * The refusals the queue is holding, as the UI wants to read them.
+ *
+ * A projection, not a second store. The list used to be accumulated separately
+ * from the queue, which meant the two could disagree about what had been
+ * refused; now the queue is the single fact and this is a view of it.
+ */
+function describeRejections(queue: readonly QueuedMutation[]): RejectedMutation[] {
+  return rejectedMutations(queue).map((item) => ({
+    clientMutationId: item.clientMutationId,
+    kind: item.kind,
+    groupId: item.groupId,
+    code: item.rejection?.code ?? 'VALIDATION_FAILED',
+    message: item.rejection?.message ?? 'The server refused this change',
+  }));
 }
 
 export class SyncEngine {
@@ -190,7 +199,15 @@ export class SyncEngine {
       tables[row.table][row.id] = row.row;
     }
 
-    this.set({ hydrated: true, mirror: { cursors, tables }, queue });
+    // A refusal is part of the queue on disk now, so it survives a restart —
+    // and so must the list the UI reads from it, or the group would be back on
+    // screen with nothing explaining why it is not syncing.
+    this.set({
+      hydrated: true,
+      mirror: { cursors, tables },
+      queue,
+      rejected: describeRejections(queue),
+    });
   }
 
   start(): void {
@@ -270,24 +287,29 @@ export class SyncEngine {
   }
 
   async retry(clientMutationId: string): Promise<void> {
-    const queue = this.state.queue.map((item) =>
-      item.clientMutationId === clientMutationId
-        ? { ...item, attempts: 0, nextAttemptAt: 0, lastError: null }
-        : item,
-    );
+    // Clears the refusal as well as the backoff: a marked mutation is never
+    // picked up by `nextBatch`, so without this the retry would do nothing.
+    const queue = clearRejection(this.state.queue, clientMutationId);
     this.set({
       queue,
-      rejected: this.state.rejected.filter((item) => item.clientMutationId !== clientMutationId),
+      rejected: describeRejections(queue),
     });
     await this.store.writeQueue(queue);
     void this.flush();
   }
 
+  /**
+   * Give up on a refused change — and on whatever it made.
+   *
+   * This is the only path that removes it, and it is deliberately a person's
+   * decision: dropping a rejected `group.create` takes the group off the phone,
+   * because the queue overlay is the only place that group has ever existed.
+   */
   async discard(clientMutationId: string): Promise<void> {
     const queue = this.state.queue.filter((item) => item.clientMutationId !== clientMutationId);
     this.set({
       queue,
-      rejected: this.state.rejected.filter((item) => item.clientMutationId !== clientMutationId),
+      rejected: describeRejections(queue),
     });
     await this.store.writeQueue(queue);
   }
@@ -403,24 +425,17 @@ export class SyncEngine {
       // — no region, a genuinely invalid number, or a rejection for some other
       // reason — falls through to `rejected` and is shown as a friendly line.
       const requeue: MutationEnvelope[] = [];
-      const stillRejected: {
-        mutation: QueuedMutation;
-        code: SyncRejectionCode;
-        message: string;
-      }[] = [];
+      // A rejection now stays in the queue (queue.ts rule 3), so a healed one has
+      // to be taken out of it explicitly — otherwise the fixed copy would be
+      // queued *behind* the marked original, which blocks its own group forever.
+      const healedIds = new Set<string>();
       for (const entry of folded.rejected) {
         const healed = this.healRejectedGhostPhone(entry);
-        if (healed) requeue.push(healed);
-        else stillRejected.push(entry);
+        if (healed) {
+          requeue.push(healed);
+          healedIds.add(entry.mutation.clientMutationId);
+        }
       }
-
-      const rejected: RejectedMutation[] = stillRejected.map((entry) => ({
-        clientMutationId: entry.mutation.clientMutationId,
-        kind: entry.mutation.kind,
-        groupId: entry.mutation.groupId,
-        code: entry.code,
-        message: entry.message,
-      }));
 
       const changes = response.changes ?? [];
       const merged = reconcile(this.state.mirror, changes);
@@ -449,10 +464,14 @@ export class SyncEngine {
         !mirrorChanged && !cursorsChanged
           ? this.state.mirror
           : { cursors: nextCursors, tables: merged.state.tables };
-      const queue =
-        folded.rejected.length === 0 && sameQueue(this.state.queue, folded.queue)
-          ? this.state.queue
-          : folded.queue;
+      const foldedQueue =
+        healedIds.size === 0
+          ? folded.queue
+          : folded.queue.filter((item) => !healedIds.has(item.clientMutationId));
+      const queue = sameQueue(this.state.queue, foldedQueue) ? this.state.queue : foldedQueue;
+      // Derived from the queue rather than accumulated alongside it, so the list
+      // the UI shows and the mutations actually held can never drift apart.
+      const rejected = describeRejections(queue);
       const madeProgress = mirrorChanged || cursorsChanged;
 
       await this.persist(appliedChanges, mirror, queue);
@@ -461,7 +480,7 @@ export class SyncEngine {
         status: SyncStatus.Idle,
         mirror,
         queue,
-        rejected: appendRejected(this.state.rejected, rejected),
+        rejected,
         lastSyncedAt: response.serverTime ?? new Date().toISOString(),
         lastError: null,
       });

--- a/apps/mobile/src/sync/provider.tsx
+++ b/apps/mobile/src/sync/provider.tsx
@@ -20,6 +20,7 @@ import { AppState } from 'react-native';
 import * as Network from 'expo-network';
 import { randomUUID } from 'expo-crypto';
 
+import { pendingMutations } from '@waves/core';
 import type { MutationEnvelope, MutationKind } from '@waves/core';
 
 import { useAuth } from '@/lib/auth';
@@ -233,7 +234,10 @@ export function SyncProvider({ children }: { children: ReactNode }) {
       retry: (id: string) => syncEngine.retry(id),
       discard: (id: string) => syncEngine.discard(id),
       forgetGroup: (groupId: string) => syncEngine.forgetGroup(groupId),
-      pendingCount: state.queue.length,
+      // What is genuinely still on its way. A refused mutation stays in the
+      // queue so its row stays on screen, but it is not in flight — counting it
+      // as pending would show a "sending…" that never finishes.
+      pendingCount: pendingMutations(state.queue).length,
     }),
     [state, mutate],
   );

--- a/apps/mobile/test/syncEngine.test.ts
+++ b/apps/mobile/test/syncEngine.test.ts
@@ -643,6 +643,49 @@ describe('queue and draft controls', () => {
     expect(engine.getState().rejected).toEqual([]);
   });
 
+  it('sends what a discarded mutation was blocking, without waiting for the poll', async () => {
+    online();
+    h.invoke.mockResolvedValue({
+      data: {
+        outcomes: [
+          {
+            clientMutationId: 'blocker',
+            status: 'rejected',
+            code: 'VALIDATION_FAILED',
+            message: 'Nope',
+          },
+        ],
+        changes: [],
+        cursors: {},
+        serverTime: 'reject',
+      },
+      error: null,
+    });
+    const engine = new SyncEngine();
+    await engine.enqueue({
+      clientMutationId: 'blocker',
+      kind: 'group.create' as never,
+      groupId: 'g-new',
+      clientCreatedAt: '2026-09-06T00:00:00.000Z',
+      payload: { name: null, type: 'trip', currency: 'INR' },
+    });
+    await engine.enqueue({
+      clientMutationId: 'behind-it',
+      kind: 'expense.create' as never,
+      groupId: 'g-new',
+      clientCreatedAt: '2026-09-06T00:00:01.000Z',
+      payload: {},
+    });
+    await engine.flush();
+    const callsBefore = h.invoke.mock.calls.length;
+
+    // Discarding the blocker makes what was queued behind it sendable — so it
+    // has to be sent, not left to wait out the 30-second poll.
+    await engine.discard('blocker');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(h.invoke.mock.calls.length).toBeGreaterThan(callsBefore);
+  });
+
   it('discard removes a still-queued failed mutation from memory and disk', async () => {
     online();
     h.invoke.mockResolvedValue({ data: null, error: new Error('network down') });

--- a/apps/mobile/test/syncEngine.test.ts
+++ b/apps/mobile/test/syncEngine.test.ts
@@ -578,12 +578,69 @@ describe('queue and draft controls', () => {
       payload: { name: '' },
     });
     await engine.flush();
-    expect(engine.getState().queue).toEqual([]);
+    // The refusal stays in the queue — that is what keeps whatever it made on
+    // screen — and is reported through `rejected` rather than removed.
+    expect(engine.getState().queue.map((item) => item.clientMutationId)).toEqual(['bad-edit']);
+    expect(engine.getState().queue[0]?.rejection?.message).toBe('Nope');
     expect(engine.getState().rejected.map((item) => item.clientMutationId)).toEqual(['bad-edit']);
 
+    // The server takes it on the retry, so nothing is left refused.
+    h.invoke.mockResolvedValue({
+      data: {
+        outcomes: [{ clientMutationId: 'bad-edit', status: 'applied' }],
+        changes: [],
+        cursors: {},
+        serverTime: 'accepted',
+      },
+      error: null,
+    });
     await engine.retry('bad-edit');
     expect(engine.getState().rejected).toEqual([]);
+    await engine.flush();
+    expect(engine.getState().queue).toEqual([]);
     expect(h.disk.queue).toEqual([]);
+  });
+
+  it('keeps a refused group.create so the group does not vanish', async () => {
+    online();
+    h.invoke.mockResolvedValue({
+      data: {
+        outcomes: [
+          {
+            clientMutationId: 'made-a-group',
+            status: 'rejected',
+            code: 'VALIDATION_FAILED',
+            message: 'Nope',
+          },
+        ],
+        changes: [],
+        cursors: {},
+        serverTime: 'reject',
+      },
+      error: null,
+    });
+    const engine = new SyncEngine();
+    await engine.enqueue({
+      clientMutationId: 'made-a-group',
+      kind: 'group.create' as never,
+      groupId: 'g-new',
+      clientCreatedAt: '2026-09-06T00:00:00.000Z',
+      payload: { name: null, type: 'trip', currency: 'INR' },
+    });
+    await engine.flush();
+
+    // The whole point: the group is still on the phone. Every local read is the
+    // mirror with the queue over it, so dropping this envelope would delete the
+    // group somebody just made and leave "Group not found" behind it.
+    const held = engine.getState().queue;
+    expect(held.map((item) => item.groupId)).toEqual(['g-new']);
+    expect(held[0]?.rejection?.code).toBe('VALIDATION_FAILED');
+    expect(h.disk.queue).toHaveLength(1);
+
+    // It only leaves when a person says so.
+    await engine.discard('made-a-group');
+    expect(engine.getState().queue).toEqual([]);
+    expect(engine.getState().rejected).toEqual([]);
   });
 
   it('discard removes a still-queued failed mutation from memory and disk', async () => {

--- a/packages/core/src/sync/queue.ts
+++ b/packages/core/src/sync/queue.ts
@@ -56,6 +56,9 @@ export function enqueue(
   queue: readonly QueuedMutation[],
   envelope: MutationEnvelope,
 ): QueuedMutation[] {
+  const resolved = resolveRejectedMutation(queue, envelope);
+  if (resolved) return resolved;
+
   // Re-making a mutation that is already here replaces it, in its own place in
   // the order. This matters now that a refusal stays in the queue: appending
   // would leave two entries under one `clientMutationId` — two rows in the
@@ -79,6 +82,224 @@ export function enqueue(
     );
   }
   return coalesce([...queue, queued]);
+}
+
+/**
+ * A refused pending row is still the only copy the device has. If the person
+ * edits it, repair the queued mutation instead of putting an update behind a
+ * blocker. If they delete/clear it, remove the rejected pending row altogether:
+ * there is nothing on the server to delete, and keeping it would keep the UI
+ * stuck on something the person just removed.
+ */
+function resolveRejectedMutation(
+  queue: readonly QueuedMutation[],
+  envelope: MutationEnvelope,
+): QueuedMutation[] | null {
+  const incoming = targetOf(envelope);
+  if (!incoming) return null;
+
+  const index = queue.findIndex((item) => {
+    if (!item.rejection) return false;
+    const existing = targetOf(item);
+    return (
+      existing !== null &&
+      existing.primaryKind === item.kind &&
+      existing.groupId === incoming.groupId &&
+      existing.id === incoming.id &&
+      (existing.correctionKinds.includes(envelope.kind) ||
+        existing.removalKinds.includes(envelope.kind))
+    );
+  });
+  if (index < 0) return null;
+
+  const pending = queue[index]!;
+  const target = targetOf(pending)!;
+  if (target.removalKinds.includes(envelope.kind)) {
+    return queue.filter((_item, itemIndex) => itemIndex !== index);
+  }
+
+  const corrected: QueuedMutation = {
+    ...pending,
+    payload: target.mergeCorrection
+      ? mergePayload(pending.payload, envelope.payload)
+      : envelope.payload,
+    attempts: 0,
+    nextAttemptAt: 0,
+    lastError: null,
+    rejection: null,
+  };
+  return queue.map((item, itemIndex) => (itemIndex === index ? corrected : item));
+}
+
+interface MutationTarget {
+  readonly primaryKind: MutationKind;
+  readonly correctionKinds: readonly MutationKind[];
+  readonly removalKinds: readonly MutationKind[];
+  readonly groupId: string;
+  readonly id: string;
+  readonly mergeCorrection: boolean;
+}
+
+function targetOf(mutation: MutationEnvelope): MutationTarget | null {
+  if (mutation.kind === MutationKind.GroupCreate || mutation.kind === MutationKind.GroupUpdate) {
+    return {
+      primaryKind: MutationKind.GroupCreate,
+      correctionKinds: [MutationKind.GroupUpdate],
+      removalKinds: [],
+      groupId: mutation.groupId,
+      id: mutation.groupId,
+      mergeCorrection: true,
+    };
+  }
+
+  const expenseId = stringPayloadField(mutation.payload, 'expenseId');
+  if (
+    expenseId &&
+    (mutation.kind === MutationKind.ExpenseCreate ||
+      mutation.kind === MutationKind.ExpenseUpdate ||
+      mutation.kind === MutationKind.ExpenseDelete)
+  ) {
+    return {
+      primaryKind: MutationKind.ExpenseCreate,
+      correctionKinds: [MutationKind.ExpenseUpdate],
+      removalKinds: [MutationKind.ExpenseDelete],
+      groupId: mutation.groupId,
+      id: expenseId,
+      mergeCorrection: true,
+    };
+  }
+
+  const captureId = stringPayloadField(mutation.payload, 'captureId');
+  if (
+    captureId &&
+    (mutation.kind === MutationKind.CaptureCreate ||
+      mutation.kind === MutationKind.CaptureUpdate ||
+      mutation.kind === MutationKind.CaptureDelete)
+  ) {
+    return {
+      primaryKind: MutationKind.CaptureCreate,
+      correctionKinds: [MutationKind.CaptureUpdate],
+      removalKinds: [MutationKind.CaptureDelete],
+      groupId: mutation.groupId,
+      id: captureId,
+      mergeCorrection: true,
+    };
+  }
+
+  const tagId = stringPayloadField(mutation.payload, 'tagId');
+  if (
+    tagId &&
+    (mutation.kind === MutationKind.TagCreate ||
+      mutation.kind === MutationKind.TagUpdate ||
+      mutation.kind === MutationKind.TagDelete)
+  ) {
+    return {
+      primaryKind: MutationKind.TagCreate,
+      correctionKinds: [MutationKind.TagUpdate],
+      removalKinds: [MutationKind.TagDelete],
+      groupId: mutation.groupId,
+      id: tagId,
+      mergeCorrection: true,
+    };
+  }
+
+  const itemId = stringPayloadField(mutation.payload, 'itemId');
+  if (
+    itemId &&
+    (mutation.kind === MutationKind.PlanItemCreate ||
+      mutation.kind === MutationKind.PlanItemUpdate ||
+      mutation.kind === MutationKind.PlanItemDelete)
+  ) {
+    return {
+      primaryKind: MutationKind.PlanItemCreate,
+      correctionKinds: [MutationKind.PlanItemUpdate],
+      removalKinds: [MutationKind.PlanItemDelete],
+      groupId: mutation.groupId,
+      id: itemId,
+      mergeCorrection: true,
+    };
+  }
+
+  if (
+    mutation.kind === MutationKind.MemberBudgetSet ||
+    mutation.kind === MutationKind.MemberBudgetClear
+  ) {
+    return {
+      primaryKind: MutationKind.MemberBudgetSet,
+      correctionKinds: [MutationKind.MemberBudgetSet],
+      removalKinds: [MutationKind.MemberBudgetClear],
+      groupId: mutation.groupId,
+      id: mutation.groupId,
+      mergeCorrection: false,
+    };
+  }
+
+  if (mutation.kind === MutationKind.GroupBudgetSet) {
+    return {
+      primaryKind: MutationKind.GroupBudgetSet,
+      correctionKinds: [MutationKind.GroupBudgetSet],
+      removalKinds: [],
+      groupId: mutation.groupId,
+      id: mutation.groupId,
+      mergeCorrection: false,
+    };
+  }
+
+  const category = stringPayloadField(mutation.payload, 'category');
+  if (category && mutation.kind === MutationKind.CategoryBudgetSet) {
+    return {
+      primaryKind: MutationKind.CategoryBudgetSet,
+      correctionKinds: [MutationKind.CategoryBudgetSet],
+      removalKinds: [],
+      groupId: mutation.groupId,
+      id: category,
+      mergeCorrection: false,
+    };
+  }
+
+  const from = stringPayloadField(mutation.payload, 'from');
+  if (from && mutation.kind === MutationKind.GroupFxRateSet) {
+    return {
+      primaryKind: MutationKind.GroupFxRateSet,
+      correctionKinds: [MutationKind.GroupFxRateSet],
+      removalKinds: [],
+      groupId: mutation.groupId,
+      id: from,
+      mergeCorrection: false,
+    };
+  }
+
+  const recordId = stringPayloadField(mutation.payload, 'recordId');
+  if (
+    recordId &&
+    (mutation.kind === MutationKind.PersonalUpsert || mutation.kind === MutationKind.PersonalDelete)
+  ) {
+    return {
+      primaryKind: MutationKind.PersonalUpsert,
+      correctionKinds: [MutationKind.PersonalUpsert],
+      removalKinds: [MutationKind.PersonalDelete],
+      groupId: mutation.groupId,
+      id: recordId,
+      mergeCorrection: false,
+    };
+  }
+
+  return null;
+}
+
+function stringPayloadField(payload: unknown, field: string): string | null {
+  if (!payload || typeof payload !== 'object' || !(field in payload)) return null;
+  const value = payload[field as keyof typeof payload];
+  return typeof value === 'string' ? value : null;
+}
+
+function mergePayload(first: unknown, second: unknown): unknown {
+  if (!isRecord(first) || !isRecord(second)) return second;
+  return { ...first, ...second };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
 /**
@@ -119,8 +340,7 @@ function coalesce(queue: readonly QueuedMutation[]): QueuedMutation[] {
 }
 
 function expenseIdOf(mutation: MutationEnvelope): string | undefined {
-  const payload = mutation.payload as { expenseId?: unknown } | null;
-  return typeof payload?.expenseId === 'string' ? payload.expenseId : undefined;
+  return stringPayloadField(mutation.payload, 'expenseId') ?? undefined;
 }
 
 export interface BatchOptions {

--- a/packages/core/src/sync/queue.ts
+++ b/packages/core/src/sync/queue.ts
@@ -399,18 +399,6 @@ export function pendingMutations(queue: readonly QueuedMutation[]): QueuedMutati
   return queue.filter((item) => !item.rejection);
 }
 
-/** Clear a refusal so the mutation is sent again from a clean slate. */
-export function clearRejection(
-  queue: readonly QueuedMutation[],
-  clientMutationId: string,
-): QueuedMutation[] {
-  return queue.map((item) =>
-    item.clientMutationId === clientMutationId
-      ? { ...item, rejection: null, attempts: 0, nextAttemptAt: 0, lastError: null }
-      : item,
-  );
-}
-
 /** Mutations that have given up retrying and need the user to decide. */
 export function deadLettered(
   queue: readonly QueuedMutation[],
@@ -489,14 +477,20 @@ export function discard(
   return queue.filter((item) => item.clientMutationId !== clientMutationId);
 }
 
-/** Send it again now, ignoring the backoff — the user tapped "retry". */
+/**
+ * Send it again now — the user tapped "retry".
+ *
+ * Clears the refusal as well as the backoff. `nextBatch` skips a marked
+ * mutation outright, so resetting only `attempts` would leave the mutation
+ * exactly as stuck as it was: a retry that visibly does nothing.
+ */
 export function retryNow(
   queue: readonly QueuedMutation[],
   clientMutationId: string,
 ): QueuedMutation[] {
   return queue.map((item) =>
     item.clientMutationId === clientMutationId
-      ? { ...item, attempts: 0, nextAttemptAt: 0, lastError: null }
+      ? { ...item, attempts: 0, nextAttemptAt: 0, lastError: null, rejection: null }
       : item,
   );
 }

--- a/packages/core/src/sync/queue.ts
+++ b/packages/core/src/sync/queue.ts
@@ -118,18 +118,80 @@ function resolveRejectedMutation(
     return queue.filter((_item, itemIndex) => itemIndex !== index);
   }
 
+  // Translate the correction into the shape the blocked mutation speaks, and
+  // find out what will not fit. `leftover` is the part of the edit the create
+  // cannot carry — it is a real change somebody made, so it is queued behind
+  // the now-unblocked create rather than quietly dropped.
+  const { translated, leftover } = target.correctionKeyMap
+    ? splitCorrection(envelope.payload, target.correctionKeyMap)
+    : { translated: envelope.payload, leftover: null };
+
   const corrected: QueuedMutation = {
     ...pending,
-    payload: target.mergeCorrection
-      ? mergePayload(pending.payload, envelope.payload)
-      : envelope.payload,
+    payload: target.mergeCorrection ? mergePayload(pending.payload, translated) : translated,
     attempts: 0,
     nextAttemptAt: 0,
     lastError: null,
     rejection: null,
   };
-  return queue.map((item, itemIndex) => (itemIndex === index ? corrected : item));
+  const repaired = queue.map((item, itemIndex) => (itemIndex === index ? corrected : item));
+  if (leftover === null) return repaired;
+  return enqueue(repaired, { ...envelope, payload: leftover });
 }
+
+/**
+ * Split a correction into the keys the blocked mutation can carry, renamed to
+ * its shape, and the keys it cannot.
+ *
+ * `leftover` is null when everything fitted — the common case, and the one that
+ * queues nothing extra.
+ */
+function splitCorrection(
+  payload: unknown,
+  keyMap: Readonly<Record<string, string>>,
+): { translated: unknown; leftover: Record<string, unknown> | null } {
+  if (!isRecord(payload)) return { translated: payload, leftover: null };
+  const translated: Record<string, unknown> = {};
+  const leftover: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(payload)) {
+    const mapped = keyMap[key];
+    if (mapped === undefined) leftover[key] = value;
+    else translated[mapped] = value;
+  }
+  return {
+    translated,
+    leftover: Object.keys(leftover).length > 0 ? leftover : null,
+  };
+}
+
+/**
+ * A `group.update` speaks in column names; a queued `group.create` payload does
+ * not. Merging one into the other therefore lines up on `name` and `type` and
+ * on nothing else — so correcting a refused group's icon, currency, country or
+ * "simplify" wrote a key the create handler never reads, and the edit silently
+ * reverted. These are the pairs, and anything not here (trip dates,
+ * `archived_at`) has no create-side equivalent at all and has to stay behind as
+ * a follow-up rather than be swallowed.
+ */
+const GROUP_UPDATE_TO_CREATE: Readonly<Record<string, string>> = {
+  name: 'name',
+  type: 'type',
+  cover_emoji: 'emoji',
+  default_currency: 'currency',
+  simplify_debts: 'simplify',
+  country_code: 'country',
+  photo_path: 'photoPath',
+};
+
+/**
+ * The same for a plan item: a create carries the day and the title, an update
+ * carries `done`, and only the first two exist on the create.
+ */
+const PLAN_ITEM_UPDATE_TO_CREATE: Readonly<Record<string, string>> = {
+  itemId: 'itemId',
+  day: 'day',
+  title: 'title',
+};
 
 interface MutationTarget {
   readonly primaryKind: MutationKind;
@@ -138,6 +200,13 @@ interface MutationTarget {
   readonly groupId: string;
   readonly id: string;
   readonly mergeCorrection: boolean;
+  /**
+   * How a correction's keys are named in the create's payload, when the two
+   * disagree. Absent means they already speak the same shape and the whole
+   * payload merges. Present means a key missing from the map cannot be carried
+   * by the create and is queued behind it instead of being dropped.
+   */
+  readonly correctionKeyMap?: Readonly<Record<string, string>>;
 }
 
 function targetOf(mutation: MutationEnvelope): MutationTarget | null {
@@ -149,6 +218,7 @@ function targetOf(mutation: MutationEnvelope): MutationTarget | null {
       groupId: mutation.groupId,
       id: mutation.groupId,
       mergeCorrection: true,
+      correctionKeyMap: GROUP_UPDATE_TO_CREATE,
     };
   }
 
@@ -217,6 +287,7 @@ function targetOf(mutation: MutationEnvelope): MutationTarget | null {
       groupId: mutation.groupId,
       id: itemId,
       mergeCorrection: true,
+      correctionKeyMap: PLAN_ITEM_UPDATE_TO_CREATE,
     };
   }
 

--- a/packages/core/src/sync/queue.ts
+++ b/packages/core/src/sync/queue.ts
@@ -12,8 +12,17 @@
  *     never overtake it, so a stalled mutation blocks everything behind it in
  *     the same group — and nothing at all in any other group.
  *  2. **Nothing is ever silently dropped.** A mutation leaves the queue only
- *     when the server confirms it applied, confirms it is a duplicate, or
- *     rejects it with a reason the user can be shown.
+ *     when the server confirms it applied or confirms it is a duplicate.
+ *  3. **A refusal is not a deletion.** A rejected mutation *stays* in the
+ *     queue, marked with its reason, until a person retries or discards it.
+ *
+ * Rule 3 is not bookkeeping — it is what keeps the thing the mutation made on
+ * screen. Every local read is the mirror with the queue laid over it, so a
+ * group created offline is visible because its `group.create` is in the queue.
+ * Dropping a rejection therefore *deleted* the group: the phone showed "Group
+ * not found" for a group somebody had just made, and the only trace was a red
+ * glyph in a corner. What the person made is theirs; a server that will not
+ * take it does not get to take it away.
  */
 
 import { MutationKind } from './protocol';
@@ -26,6 +35,12 @@ export interface QueuedMutation extends MutationEnvelope {
   /** Unix ms before which this mutation must not be retried. */
   readonly nextAttemptAt: number;
   readonly lastError?: string | null;
+  /**
+   * Set when the server refused this mutation. It stays in the queue carrying
+   * this, rather than leaving — see rule 3 above. Never retried on its own; a
+   * person clears it by retrying or discarding.
+   */
+  readonly rejection?: { readonly code: SyncRejectionCode; readonly message: string } | null;
 }
 
 /** Mutations that failed this many times stop retrying and ask the user. */
@@ -41,14 +56,28 @@ export function enqueue(
   queue: readonly QueuedMutation[],
   envelope: MutationEnvelope,
 ): QueuedMutation[] {
-  const seq = queue.reduce((highest, item) => Math.max(highest, item.seq), 0) + 1;
+  // Re-making a mutation that is already here replaces it, in its own place in
+  // the order. This matters now that a refusal stays in the queue: appending
+  // would leave two entries under one `clientMutationId` — two rows in the
+  // overlay and two banners for one change — and the server, which dedupes on
+  // that id, would only ever hear about one of them.
+  const existing = queue.find((item) => item.clientMutationId === envelope.clientMutationId);
+  const seq = existing
+    ? existing.seq
+    : queue.reduce((highest, item) => Math.max(highest, item.seq), 0) + 1;
   const queued: QueuedMutation = {
     ...envelope,
     seq,
     attempts: 0,
     nextAttemptAt: 0,
     lastError: null,
+    rejection: null,
   };
+  if (existing) {
+    return queue.map((item) =>
+      item.clientMutationId === envelope.clientMutationId ? queued : item,
+    );
+  }
   return coalesce([...queue, queued]);
 }
 
@@ -67,6 +96,9 @@ function coalesce(queue: readonly QueuedMutation[]): QueuedMutation[] {
     const previous = result[result.length - 1];
     const collapsible =
       previous !== undefined &&
+      // A refused edit has been seen by the server and is waiting on a person;
+      // folding a newer edit into it would silently change what they decide about.
+      !previous.rejection &&
       previous.kind === MutationKind.ExpenseUpdate &&
       item.kind === MutationKind.ExpenseUpdate &&
       previous.attempts === 0 &&
@@ -115,6 +147,14 @@ export function nextBatch(
 
   for (const item of [...queue].sort((a, b) => a.seq - b.seq)) {
     if (blocked.has(item.groupId)) continue;
+    // A refusal is the server's settled answer, so this is not a backoff to
+    // wait out — resending would fail identically, forever. It blocks its group
+    // for the same reason a stalled mutation does: what is queued behind it
+    // depends on it.
+    if (item.rejection) {
+      blocked.add(item.groupId);
+      continue;
+    }
     if (item.attempts >= maxAttempts || item.nextAttemptAt > now) {
       blocked.add(item.groupId);
       continue;
@@ -123,6 +163,32 @@ export function nextBatch(
     if (batch.length >= limit) break;
   }
   return batch;
+}
+
+/** The refused mutations still sitting in the queue, oldest first. */
+export function rejectedMutations(queue: readonly QueuedMutation[]): QueuedMutation[] {
+  return queue.filter((item) => Boolean(item.rejection)).sort((a, b) => a.seq - b.seq);
+}
+
+/**
+ * What is genuinely still on its way — the queue minus what the server has
+ * already refused. This is the count a "sending 1 change…" line may use: a
+ * refusal is not in flight, and saying it is would be a lie that never resolves.
+ */
+export function pendingMutations(queue: readonly QueuedMutation[]): QueuedMutation[] {
+  return queue.filter((item) => !item.rejection);
+}
+
+/** Clear a refusal so the mutation is sent again from a clean slate. */
+export function clearRejection(
+  queue: readonly QueuedMutation[],
+  clientMutationId: string,
+): QueuedMutation[] {
+  return queue.map((item) =>
+    item.clientMutationId === clientMutationId
+      ? { ...item, rejection: null, attempts: 0, nextAttemptAt: 0, lastError: null }
+      : item,
+  );
 }
 
 /** Mutations that have given up retrying and need the user to decide. */
@@ -164,7 +230,14 @@ export function applyOutcomes(
       continue;
     }
     if (outcome.status === 'applied' || outcome.status === 'duplicate') continue;
-    rejected.push({ mutation: item, code: outcome.code, message: outcome.message });
+    // Kept, not dropped (rule 3): the queue overlay is what puts this mutation's
+    // row on screen, so removing it here would delete what the person made.
+    const marked: QueuedMutation = {
+      ...item,
+      rejection: { code: outcome.code, message: outcome.message },
+    };
+    remaining.push(marked);
+    rejected.push({ mutation: marked, code: outcome.code, message: outcome.message });
   }
 
   return { queue: remaining, rejected: [...rejected] };

--- a/packages/core/test/sync.property.test.ts
+++ b/packages/core/test/sync.property.test.ts
@@ -659,6 +659,90 @@ describe('the mutation queue', () => {
     ]);
   });
 
+  /**
+   * A `group.update` speaks in column names and a queued `group.create` payload
+   * does not, so a plain merge lined up on `name` and nothing else: correcting
+   * a refused group's icon wrote `cover_emoji` into a payload the create reads
+   * as `emoji`, and the edit silently reverted.
+   */
+  it('translates a group correction into the shape the blocked create speaks', () => {
+    let queue: QueuedMutation[] = [];
+    queue = enqueue(queue, {
+      clientMutationId: 'create-goa',
+      kind: MutationKind.GroupCreate,
+      groupId: GROUP,
+      clientCreatedAt: '2026-03-01T00:00:00Z',
+      payload: { name: null, type: 'trip', currency: 'INR', emoji: '🏖️', simplify: true },
+    });
+    queue = applyOutcomes(queue, [
+      {
+        clientMutationId: 'create-goa',
+        status: 'rejected',
+        code: SyncRejectionCode.ValidationFailed,
+        message: 'no',
+      },
+    ]).queue;
+
+    queue = enqueue(queue, {
+      clientMutationId: 'rename-goa',
+      kind: MutationKind.GroupUpdate,
+      groupId: GROUP,
+      clientCreatedAt: '2026-03-01T00:01:00Z',
+      payload: { name: 'Goa', cover_emoji: '⛱️', default_currency: 'USD' },
+    });
+
+    // One entry still — the create, repaired and sendable again.
+    expect(queue).toHaveLength(1);
+    expect(queue[0]?.rejection).toBeFalsy();
+    expect(queue[0]?.payload).toMatchObject({
+      name: 'Goa',
+      emoji: '⛱️',
+      currency: 'USD',
+      type: 'trip',
+    });
+    // And nothing left speaking the column names the create cannot read.
+    expect(queue[0]?.payload).not.toHaveProperty('cover_emoji');
+    expect(queue[0]?.payload).not.toHaveProperty('default_currency');
+  });
+
+  it('queues what a create cannot carry behind it rather than swallowing it', () => {
+    let queue: QueuedMutation[] = [];
+    queue = enqueue(queue, {
+      clientMutationId: 'create-goa',
+      kind: MutationKind.GroupCreate,
+      groupId: GROUP,
+      clientCreatedAt: '2026-03-01T00:00:00Z',
+      payload: { name: 'Goa', type: 'trip', currency: 'INR' },
+    });
+    queue = applyOutcomes(queue, [
+      {
+        clientMutationId: 'create-goa',
+        status: 'rejected',
+        code: SyncRejectionCode.ValidationFailed,
+        message: 'no',
+      },
+    ]).queue;
+
+    // Trip dates have no create-side equivalent — they are a real edit and must
+    // survive as a follow-up, not disappear into a payload that ignores them.
+    queue = enqueue(queue, {
+      clientMutationId: 'dates-goa',
+      kind: MutationKind.GroupUpdate,
+      groupId: GROUP,
+      clientCreatedAt: '2026-03-01T00:01:00Z',
+      payload: { name: 'Goa trip', start_date: '2026-04-01', end_date: '2026-04-07' },
+    });
+
+    expect(queue).toHaveLength(2);
+    expect(queue[0]?.payload).toMatchObject({ name: 'Goa trip' });
+    expect(queue[1]?.payload).toEqual({ start_date: '2026-04-01', end_date: '2026-04-07' });
+    // The create is unblocked, so both flow, in order.
+    expect(nextBatch(queue, { now: 10_000_000 }).map((item) => item.clientMutationId)).toEqual([
+      'create-goa',
+      'dates-goa',
+    ]);
+  });
+
   it('lets a user delete a rejected pending expense instead of keeping it as a blocker', () => {
     let queue: QueuedMutation[] = [];
     queue = enqueue(queue, {

--- a/packages/core/test/sync.property.test.ts
+++ b/packages/core/test/sync.property.test.ts
@@ -493,6 +493,346 @@ describe('the mutation queue', () => {
     ]);
   });
 
+  it('lets a user correct a rejected group create instead of blocking the edit behind it', () => {
+    let queue: QueuedMutation[] = [];
+    queue = enqueue(queue, {
+      clientMutationId: 'create-group',
+      kind: MutationKind.GroupCreate,
+      groupId: 'g-draft',
+      clientCreatedAt: '2026-03-01T00:00:00Z',
+      payload: { name: '', type: 'trip', currency: 'INR' },
+    });
+    queue = applyOutcomes(queue, [
+      {
+        clientMutationId: 'create-group',
+        status: 'rejected',
+        code: SyncRejectionCode.ValidationFailed,
+        message: 'Name required',
+      },
+    ]).queue;
+
+    queue = enqueue(queue, {
+      clientMutationId: 'rename-group',
+      kind: MutationKind.GroupUpdate,
+      groupId: 'g-draft',
+      clientCreatedAt: '2026-03-01T00:01:00Z',
+      payload: { name: 'Goa riders' },
+    });
+
+    expect(queue).toHaveLength(1);
+    expect(rejectedMutations(queue)).toEqual([]);
+    expect(queue[0]?.clientMutationId).toBe('create-group');
+    expect(queue[0]?.kind).toBe(MutationKind.GroupCreate);
+    expect(queue[0]?.payload).toMatchObject({ name: 'Goa riders', type: 'trip' });
+    expect(nextBatch(queue, { now: 10_000_000 }).map((item) => item.clientMutationId)).toEqual([
+      'create-group',
+    ]);
+  });
+
+  it('lets a rider fix a rejected expense create with a later edit of the same expense', () => {
+    const payload: ExpenseCreatePayload = {
+      expenseId: 'e-ride',
+      description: 'Cab',
+      expenseDate: '2026-03-01',
+      currency: INR,
+      amount: '1200',
+      splitParams: { kind: 'equal' },
+      participants: ['m1'],
+      payers: { m1: '1200' },
+    };
+    const first: MutationEnvelope = {
+      clientMutationId: 'create-ride',
+      kind: MutationKind.ExpenseCreate,
+      groupId: GROUP,
+      clientCreatedAt: '2026-03-01T00:00:00Z',
+      payload,
+    };
+    let queue = applyOutcomes(enqueue([], first), [
+      {
+        clientMutationId: 'create-ride',
+        status: 'rejected',
+        code: SyncRejectionCode.ShareMismatch,
+        message: 'Shares do not add up',
+      },
+    ]).queue;
+
+    queue = enqueue(queue, {
+      ...first,
+      clientMutationId: 'fix-ride',
+      kind: MutationKind.ExpenseUpdate,
+      payload: { ...payload, participants: members },
+    });
+
+    expect(queue).toHaveLength(1);
+    expect(queue[0]?.clientMutationId).toBe('create-ride');
+    expect(queue[0]?.kind).toBe(MutationKind.ExpenseCreate);
+    expect((queue[0]?.payload as { participants: readonly string[] }).participants).toEqual(
+      members,
+    );
+    expect(nextBatch(queue, { now: 10_000_000 }).map((item) => item.clientMutationId)).toEqual([
+      'create-ride',
+    ]);
+  });
+
+  it('lets a traveller fix a rejected plan item create with a later update', () => {
+    let queue: QueuedMutation[] = [];
+    queue = enqueue(queue, {
+      clientMutationId: 'create-stop',
+      kind: MutationKind.PlanItemCreate,
+      groupId: GROUP,
+      clientCreatedAt: '2026-03-01T00:00:00Z',
+      payload: { itemId: 'plan-1', title: '', position: 1 },
+    });
+    queue = applyOutcomes(queue, [
+      {
+        clientMutationId: 'create-stop',
+        status: 'rejected',
+        code: SyncRejectionCode.ValidationFailed,
+        message: 'Title required',
+      },
+    ]).queue;
+
+    queue = enqueue(queue, {
+      clientMutationId: 'fix-stop',
+      kind: MutationKind.PlanItemUpdate,
+      groupId: GROUP,
+      clientCreatedAt: '2026-03-01T00:01:00Z',
+      payload: { itemId: 'plan-1', title: 'Airport transfer' },
+    });
+
+    expect(queue).toHaveLength(1);
+    expect(queue[0]?.clientMutationId).toBe('create-stop');
+    expect(queue[0]?.kind).toBe(MutationKind.PlanItemCreate);
+    expect(queue[0]?.payload).toMatchObject({ itemId: 'plan-1', title: 'Airport transfer' });
+    expect(rejectedMutations(queue)).toEqual([]);
+  });
+
+  it('lets a financer correct a rejected personal-record upsert with a later upsert', () => {
+    let queue: QueuedMutation[] = [];
+    queue = enqueue(queue, {
+      clientMutationId: 'create-loan',
+      kind: MutationKind.PersonalUpsert,
+      groupId: 'p-me:personal',
+      clientCreatedAt: '2026-03-01T00:00:00Z',
+      payload: {
+        recordId: 'loan-1',
+        recordKind: 'loan',
+        data: { person: '', principalMinor: '5000' },
+      },
+    });
+    queue = applyOutcomes(queue, [
+      {
+        clientMutationId: 'create-loan',
+        status: 'rejected',
+        code: SyncRejectionCode.ValidationFailed,
+        message: 'Person required',
+      },
+    ]).queue;
+
+    queue = enqueue(queue, {
+      clientMutationId: 'fix-loan',
+      kind: MutationKind.PersonalUpsert,
+      groupId: 'p-me:personal',
+      clientCreatedAt: '2026-03-01T00:01:00Z',
+      payload: {
+        recordId: 'loan-1',
+        recordKind: 'loan',
+        data: { person: 'Asha', principalMinor: '5000' },
+      },
+    });
+
+    expect(queue).toHaveLength(1);
+    expect(queue[0]?.clientMutationId).toBe('create-loan');
+    expect(queue[0]?.kind).toBe(MutationKind.PersonalUpsert);
+    expect(queue[0]?.payload).toMatchObject({
+      recordId: 'loan-1',
+      data: { person: 'Asha', principalMinor: '5000' },
+    });
+    expect(nextBatch(queue, { now: 10_000_000 }).map((item) => item.clientMutationId)).toEqual([
+      'create-loan',
+    ]);
+  });
+
+  it('lets a user delete a rejected pending expense instead of keeping it as a blocker', () => {
+    let queue: QueuedMutation[] = [];
+    queue = enqueue(queue, {
+      clientMutationId: 'create-snack',
+      kind: MutationKind.ExpenseCreate,
+      groupId: GROUP,
+      clientCreatedAt: '2026-03-01T00:00:00Z',
+      payload: {
+        expenseId: 'e-snack',
+        description: 'Snack',
+        expenseDate: '2026-03-01',
+        currency: INR,
+        amount: '0',
+        splitParams: { kind: 'equal' },
+        participants: members,
+        payers: { m1: '0' },
+      },
+    });
+    queue = applyOutcomes(queue, [
+      {
+        clientMutationId: 'create-snack',
+        status: 'rejected',
+        code: SyncRejectionCode.ValidationFailed,
+        message: 'Amount required',
+      },
+    ]).queue;
+
+    queue = enqueue(queue, {
+      clientMutationId: 'delete-snack',
+      kind: MutationKind.ExpenseDelete,
+      groupId: GROUP,
+      clientCreatedAt: '2026-03-01T00:01:00Z',
+      payload: { expenseId: 'e-snack' },
+    });
+
+    expect(queue).toEqual([]);
+  });
+
+  it('lets a rider clear a rejected pending personal trip budget', () => {
+    let queue: QueuedMutation[] = [];
+    queue = enqueue(queue, {
+      clientMutationId: 'set-rider-budget',
+      kind: MutationKind.MemberBudgetSet,
+      groupId: GROUP,
+      clientCreatedAt: '2026-03-01T00:00:00Z',
+      payload: { amountMinor: '-1', currency: INR, visibility: 'private' },
+    });
+    queue = applyOutcomes(queue, [
+      {
+        clientMutationId: 'set-rider-budget',
+        status: 'rejected',
+        code: SyncRejectionCode.ValidationFailed,
+        message: 'Budget must be positive',
+      },
+    ]).queue;
+
+    queue = enqueue(queue, {
+      clientMutationId: 'clear-rider-budget',
+      kind: MutationKind.MemberBudgetClear,
+      groupId: GROUP,
+      clientCreatedAt: '2026-03-01T00:01:00Z',
+      payload: {},
+    });
+
+    expect(queue).toEqual([]);
+  });
+
+  it('lets a traveller correct rejected trip budget and rate settings', () => {
+    let queue: QueuedMutation[] = [];
+    queue = enqueue(queue, {
+      clientMutationId: 'set-trip-budget',
+      kind: MutationKind.GroupBudgetSet,
+      groupId: GROUP,
+      clientCreatedAt: '2026-03-01T00:00:00Z',
+      payload: { amountMinor: '-1', currency: INR },
+    });
+    queue = enqueue(queue, {
+      clientMutationId: 'set-food-budget',
+      kind: MutationKind.CategoryBudgetSet,
+      groupId: GROUP,
+      clientCreatedAt: '2026-03-01T00:00:01Z',
+      payload: { category: 'food', amountMinor: '-1', currency: INR },
+    });
+    queue = enqueue(queue, {
+      clientMutationId: 'set-usd-rate',
+      kind: MutationKind.GroupFxRateSet,
+      groupId: GROUP,
+      clientCreatedAt: '2026-03-01T00:00:02Z',
+      payload: { from: 'USD', num: '0', den: '0', source: 'manual' },
+    });
+    queue = applyOutcomes(queue, [
+      {
+        clientMutationId: 'set-trip-budget',
+        status: 'rejected',
+        code: SyncRejectionCode.ValidationFailed,
+        message: 'Budget must be positive',
+      },
+      {
+        clientMutationId: 'set-food-budget',
+        status: 'rejected',
+        code: SyncRejectionCode.ValidationFailed,
+        message: 'Budget must be positive',
+      },
+      {
+        clientMutationId: 'set-usd-rate',
+        status: 'rejected',
+        code: SyncRejectionCode.ValidationFailed,
+        message: 'Rate must be positive',
+      },
+    ]).queue;
+
+    queue = enqueue(queue, {
+      clientMutationId: 'fix-trip-budget',
+      kind: MutationKind.GroupBudgetSet,
+      groupId: GROUP,
+      clientCreatedAt: '2026-03-01T00:01:00Z',
+      payload: { amountMinor: '100000', currency: INR },
+    });
+    queue = enqueue(queue, {
+      clientMutationId: 'fix-food-budget',
+      kind: MutationKind.CategoryBudgetSet,
+      groupId: GROUP,
+      clientCreatedAt: '2026-03-01T00:01:01Z',
+      payload: { category: 'food', amountMinor: '25000', currency: INR },
+    });
+    queue = enqueue(queue, {
+      clientMutationId: 'fix-usd-rate',
+      kind: MutationKind.GroupFxRateSet,
+      groupId: GROUP,
+      clientCreatedAt: '2026-03-01T00:01:02Z',
+      payload: { from: 'USD', num: '83', den: '1', source: 'manual' },
+    });
+
+    expect(queue).toHaveLength(3);
+    expect(rejectedMutations(queue)).toEqual([]);
+    expect(queue.map((item) => item.clientMutationId)).toEqual([
+      'set-trip-budget',
+      'set-food-budget',
+      'set-usd-rate',
+    ]);
+    expect(queue.map((item) => item.payload)).toEqual([
+      { amountMinor: '100000', currency: INR },
+      { category: 'food', amountMinor: '25000', currency: INR },
+      { from: 'USD', num: '83', den: '1', source: 'manual' },
+    ]);
+  });
+
+  it('lets a financer delete a rejected pending personal record', () => {
+    let queue: QueuedMutation[] = [];
+    queue = enqueue(queue, {
+      clientMutationId: 'create-budget',
+      kind: MutationKind.PersonalUpsert,
+      groupId: 'p-me:personal',
+      clientCreatedAt: '2026-03-01T00:00:00Z',
+      payload: {
+        recordId: 'budget-1',
+        recordKind: 'budget',
+        data: { category: 'food', amountMinor: '-1' },
+      },
+    });
+    queue = applyOutcomes(queue, [
+      {
+        clientMutationId: 'create-budget',
+        status: 'rejected',
+        code: SyncRejectionCode.ValidationFailed,
+        message: 'Budget must be positive',
+      },
+    ]).queue;
+
+    queue = enqueue(queue, {
+      clientMutationId: 'delete-budget',
+      kind: MutationKind.PersonalDelete,
+      groupId: 'p-me:personal',
+      clientCreatedAt: '2026-03-01T00:01:00Z',
+      payload: { recordId: 'budget-1' },
+    });
+
+    expect(queue).toEqual([]);
+  });
+
   it('backs off exponentially and gives up rather than retrying forever', () => {
     expect(backoffMs(1)).toBe(2000);
     expect(backoffMs(2)).toBe(4000);

--- a/packages/core/test/sync.property.test.ts
+++ b/packages/core/test/sync.property.test.ts
@@ -19,7 +19,6 @@ import fc from 'fast-check';
 import {
   applyOutcomes,
   backoffMs,
-  clearRejection,
   discard,
   emptyMirror,
   enqueue,
@@ -485,7 +484,14 @@ describe('the mutation queue', () => {
     expect(nextBatch(queue, { now: 10_000_000 })).toEqual([]);
 
     // A person retrying clears the mark and the whole group flows again.
-    const retried = clearRejection(queue, 'a');
+    //
+    // `retryNow` has to clear the *rejection*, not just the backoff. Resetting
+    // `attempts` alone leaves the mutation exactly as stuck, because
+    // `nextBatch` skips a marked one outright — a retry button that visibly
+    // does nothing. There is deliberately only one retry function for this
+    // reason; a second would be the one that forgets.
+    const retried = retryNow(queue, 'a');
+    expect(retried.find((item) => item.clientMutationId === 'a')?.rejection).toBeFalsy();
     expect(rejectedMutations(retried)).toEqual([]);
     expect(nextBatch(retried, { now: 10_000_000 }).map((item) => item.clientMutationId)).toEqual([
       'a',

--- a/packages/core/test/sync.property.test.ts
+++ b/packages/core/test/sync.property.test.ts
@@ -19,6 +19,7 @@ import fc from 'fast-check';
 import {
   applyOutcomes,
   backoffMs,
+  clearRejection,
   discard,
   emptyMirror,
   enqueue,
@@ -28,6 +29,8 @@ import {
   MutationKind,
   nextBatch,
   overlayPending,
+  pendingMutations,
+  rejectedMutations,
   reconcile,
   retryNow,
   SyncRejectionCode,
@@ -450,9 +453,44 @@ describe('the mutation queue', () => {
       },
     ]);
 
-    expect(result.queue).toHaveLength(0);
+    // Applied and duplicate both leave. The refusal does not: it stays, marked,
+    // because the queue overlay is what keeps its row on screen (rule 3).
+    expect(result.queue.map((item) => item.clientMutationId)).toEqual(['c']);
+    expect(result.queue[0]?.rejection?.code).toBe('SHARE_MISMATCH');
     expect(result.rejected).toHaveLength(1);
     expect(result.rejected[0]?.code).toBe('SHARE_MISMATCH');
+  });
+
+  it('keeps a refused mutation but never sends it again on its own', () => {
+    let queue: QueuedMutation[] = [];
+    queue = enqueue(queue, envelope('a', GROUP, MutationKind.GroupCreate));
+    queue = enqueue(queue, envelope('b', GROUP, MutationKind.ExpenseCreate));
+
+    queue = applyOutcomes(queue, [
+      {
+        clientMutationId: 'a',
+        status: 'rejected',
+        code: SyncRejectionCode.ValidationFailed,
+        message: 'no',
+      },
+    ]).queue;
+
+    // Still there — this is the group the person made.
+    expect(queue).toHaveLength(2);
+    expect(rejectedMutations(queue).map((item) => item.clientMutationId)).toEqual(['a']);
+    // Not in flight, so nothing claims to be sending it.
+    expect(pendingMutations(queue).map((item) => item.clientMutationId)).toEqual(['b']);
+    // And not resent by itself — nor is what is queued behind it, which depends
+    // on the create having landed.
+    expect(nextBatch(queue, { now: 10_000_000 })).toEqual([]);
+
+    // A person retrying clears the mark and the whole group flows again.
+    const retried = clearRejection(queue, 'a');
+    expect(rejectedMutations(retried)).toEqual([]);
+    expect(nextBatch(retried, { now: 10_000_000 }).map((item) => item.clientMutationId)).toEqual([
+      'a',
+      'b',
+    ]);
   });
 
   it('backs off exponentially and gives up rather than retrying forever', () => {


### PR DESCRIPTION
## The rule this restores

**A group you make is yours. A server that will not take it does not get to take it away.**

## What was happening

Every local read is the mirror with the queue laid over it. That is how a group created offline is on the dashboard before any server has heard of it — its `group.create` sits in the queue and `buildGroups` overlays it with `pending: true`. Offline creation worked exactly as intended.

`applyOutcomes` then dropped a **rejected** mutation from that queue:

```ts
if (outcome.status === 'applied' || outcome.status === 'duplicate') continue;
rejected.push({ mutation: item, code: outcome.code, message: outcome.message });
// ...never pushed to `remaining`
```

So a refusal did not merely fail to sync — it **deleted what the person had made**. The overlay went with the queue entry, the group vanished from the dashboard, the screen already open on it said "Group not found", and the only trace was a red glyph in a corner with no reason attached.

That is the whole chain behind #669: the nameless `group.create` was refused, and the group went with it.

## What changes

The queue module's own rule 2 already said *nothing is ever silently dropped*. This adds rule 3 and makes it true for refusals:

- **`QueuedMutation.rejection`**, and `applyOutcomes` marks instead of removing. The overlay survives, so the group stays where it was.
- **`nextBatch` never picks up a marked mutation.** A refusal is the server's settled answer, not a backoff to wait out — resending would fail identically, forever. It blocks its group for the same reason a stalled mutation does: what is queued behind a create depends on it.
- **It leaves only when a person decides.** `retry` clears the mark and the backoff; `discard` removes it. `discard` is now the single path that can take a group off the phone, and it is deliberately a person's call.
- **`enqueue` replaces a same-id mutation in place** rather than appending. With refusals staying, appending would leave two entries under one `clientMutationId` — two rows in the overlay, two banners for one change, and a server that dedupes on that id hearing about only one.
- **The engine derives `rejected` from the queue** (`describeRejections`) instead of accumulating a parallel list that could disagree with it — including on `hydrate`, so a refusal survives a restart with its reason intact.
- **`pendingCount` and the sync banner count `pendingMutations`**, so a refusal is not also reported as "sending 1 change…" forever.

The group screen already renders the inline `SyncBanner` (with retry / discard) whenever a mutation for that group was refused — so the group now **opens on an explanation** instead of "Group not found".

## Verified

- `pnpm test:core` — 57 files, **843** tests green. The property test that asserted the old contract now asserts the new one, plus a new case: a refused mutation stays, is not in `pendingMutations`, is not picked by `nextBatch` (nor is what is queued behind it), and `clearRejection` releases the whole group.
- `pnpm test:app` — 63 files, **823** tests green, including a new `keeps a refused group.create so the group does not vanish`.
- `pnpm typecheck` and `pnpm lint` clean across the workspace (3 pre-existing `phone.tsx` warnings).

Not device-tested. Branched off `main`; complements #669, which removes the specific refusal that triggered this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Rejected offline changes now remain visible with their rejection details until retried or discarded.
  - Rejected changes are no longer counted as actively syncing or sent repeatedly.
  - Retrying a rejected change clears its previous rejection status and resumes synchronization.
  - Local group changes remain visible after a rejected creation until explicitly discarded.
  - Re-enqueued changes now replace existing queued entries correctly, while preserving the order and status of related changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->