### PR TITLE
fix(sync): validate budget payload clears

### DIFF
--- a/supabase/functions/sync/budgetPayload.test.ts
+++ b/supabase/functions/sync/budgetPayload.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Budget and trip-rate sync payloads are a boundary, not a typed function call.
+ *
+ * The app sends these from four different shapes of use: a user/rider setting
+ * their own trip ceiling, a traveller/admin setting the whole trip and category
+ * caps, and a financer/admin pinning an FX rate. The intended clear operation is
+ * explicit `null`; a missing or non-text amount/rate is a malformed payload and
+ * must be refused before it reaches the RPC. Otherwise an older or buggy client
+ * can accidentally clear a budget/rate by omitting a field.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { SyncSession } from './index.ts';
+
+const OWNER = 'owner-profile-id';
+const GROUP_ID = '99999999-8888-7777-6666-555555555555';
+const MEMBER_ID = '11111111-2222-3333-4444-555555555555';
+
+function caller() {
+  const rpc = vi.fn((name: string) =>
+    Promise.resolve({ data: name === 'waves_my_member_id' ? MEMBER_ID : {}, error: null }),
+  );
+  const from = vi.fn(() => {
+    const builder: Record<string, unknown> = {};
+    builder.select = () => builder;
+    builder.eq = () => builder;
+    builder.maybeSingle = () => Promise.resolve({ data: null, error: null });
+    return builder;
+  });
+  return { client: { rpc, from } as never, rpc };
+}
+
+function service() {
+  const insert = vi.fn(() => Promise.resolve({ error: null }));
+  const from = vi.fn(() => {
+    const builder: Record<string, unknown> = { insert };
+    builder.select = () => builder;
+    builder.eq = () => builder;
+    builder.maybeSingle = () => Promise.resolve({ data: null, error: null });
+    return builder;
+  });
+  return { client: { from } as never };
+}
+
+function mutation(kind: string, payload: Record<string, unknown>, clientMutationId = kind) {
+  return {
+    clientMutationId,
+    kind,
+    groupId: GROUP_ID,
+    seq: 1,
+    clientCreatedAt: '2026-09-06T04:00:00.000Z',
+    payload,
+  } as never;
+}
+
+describe('trip budget and rate sync payloads', () => {
+  it('lets a rider set their own trip budget with a string amount', async () => {
+    const scoped = caller();
+    const session = new SyncSession(scoped.client, service().client, OWNER);
+
+    const outcome = await session.apply(
+      mutation('member_budget.set', {
+        amountMinor: '120000',
+        currency: 'INR',
+        visibility: 'group',
+      }),
+    );
+
+    expect(outcome).toMatchObject({ status: 'applied' });
+    expect(scoped.rpc).toHaveBeenCalledWith('waves_set_my_trip_budget', {
+      p_group_id: GROUP_ID,
+      p_amount_minor: '120000',
+      p_currency: 'INR',
+      p_visibility: 'group',
+    });
+  });
+
+  it.each([
+    ['missing amount', {}],
+    ['numeric amount', { amountMinor: 120000 }],
+    ['null amount', { amountMinor: null }],
+  ])('refuses a rider member-budget set with %s', async (_label, payload) => {
+    const scoped = caller();
+    const session = new SyncSession(scoped.client, service().client, OWNER);
+
+    const outcome = await session.apply(mutation('member_budget.set', payload));
+
+    expect(outcome).toMatchObject({ status: 'rejected', code: 'VALIDATION_FAILED' });
+    expect(scoped.rpc).not.toHaveBeenCalled();
+  });
+
+  it('lets a traveller clear the overall trip budget with explicit null', async () => {
+    const scoped = caller();
+    const session = new SyncSession(scoped.client, service().client, OWNER);
+
+    const outcome = await session.apply(
+      mutation('group_budget.set', { amountMinor: null, currency: null }),
+    );
+
+    expect(outcome).toMatchObject({ status: 'applied' });
+    expect(scoped.rpc).toHaveBeenCalledWith('waves_set_group_budget', {
+      p_group_id: GROUP_ID,
+      p_amount_minor: null,
+      p_currency: null,
+    });
+  });
+
+  it.each([
+    ['missing amount', {}],
+    ['numeric amount', { amountMinor: 120000 }],
+  ])(
+    'refuses a traveller group-budget set with %s instead of clearing it',
+    async (_label, payload) => {
+      const scoped = caller();
+      const session = new SyncSession(scoped.client, service().client, OWNER);
+
+      const outcome = await session.apply(mutation('group_budget.set', payload));
+
+      expect(outcome).toMatchObject({ status: 'rejected', code: 'VALIDATION_FAILED' });
+      expect(scoped.rpc).not.toHaveBeenCalled();
+    },
+  );
+
+  it('lets a traveller clear one category budget with explicit null', async () => {
+    const scoped = caller();
+    const session = new SyncSession(scoped.client, service().client, OWNER);
+
+    const outcome = await session.apply(
+      mutation('category_budget.set', { category: 'food', amountMinor: null, currency: null }),
+    );
+
+    expect(outcome).toMatchObject({ status: 'applied' });
+    expect(scoped.rpc).toHaveBeenCalledWith('waves_set_category_budget', {
+      p_group_id: GROUP_ID,
+      p_category: 'food',
+      p_amount_minor: null,
+      p_currency: null,
+    });
+  });
+
+  it.each([
+    ['missing category', { amountMinor: '25000' }],
+    ['numeric category', { category: 12, amountMinor: '25000' }],
+    ['missing amount', { category: 'food' }],
+    ['numeric amount', { category: 'food', amountMinor: 25000 }],
+  ])('refuses a traveller category-budget set with %s', async (_label, payload) => {
+    const scoped = caller();
+    const session = new SyncSession(scoped.client, service().client, OWNER);
+
+    const outcome = await session.apply(mutation('category_budget.set', payload));
+
+    expect(outcome).toMatchObject({ status: 'rejected', code: 'VALIDATION_FAILED' });
+    expect(scoped.rpc).not.toHaveBeenCalled();
+  });
+
+  it('lets a financer clear a pinned FX rate with explicit nulls', async () => {
+    const scoped = caller();
+    const session = new SyncSession(scoped.client, service().client, OWNER);
+
+    const outcome = await session.apply(
+      mutation('group_fx_rate.set', { from: 'USD', num: null, den: null, source: 'manual' }),
+    );
+
+    expect(outcome).toMatchObject({ status: 'applied' });
+    expect(scoped.rpc).toHaveBeenCalledWith('waves_set_group_fx_rate', {
+      p_group_id: GROUP_ID,
+      p_from: 'USD',
+      p_num: null,
+      p_den: null,
+      p_source: 'manual',
+    });
+  });
+
+  it.each([
+    ['missing currency', { num: '83', den: '1' }],
+    ['numeric currency', { from: 840, num: '83', den: '1' }],
+    ['missing numerator', { from: 'USD', den: '1' }],
+    ['numeric numerator', { from: 'USD', num: 83, den: '1' }],
+    ['missing denominator', { from: 'USD', num: '83' }],
+    ['numeric denominator', { from: 'USD', num: '83', den: 1 }],
+  ])('refuses a financer FX-rate set with %s', async (_label, payload) => {
+    const scoped = caller();
+    const session = new SyncSession(scoped.client, service().client, OWNER);
+
+    const outcome = await session.apply(mutation('group_fx_rate.set', payload));
+
+    expect(outcome).toMatchObject({ status: 'rejected', code: 'VALIDATION_FAILED' });
+    expect(scoped.rpc).not.toHaveBeenCalled();
+  });
+});

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -571,20 +571,22 @@ export class SyncSession {
         });
       case 'group_budget.set':
         // Admin-gated inside the RPC — kept a distinct kind rather than widening
-        // group.update, so any member cannot move the overall ceiling.
+        // group.update, so any member cannot move the overall ceiling. `null` is
+        // the clear operation; absent or malformed is a rejected payload, not an
+        // accidental clear.
         return await this.rpcAsCaller('waves_set_group_budget', {
           p_group_id: mutation.groupId,
-          p_amount_minor: (mutation.payload.amountMinor as string | null) ?? null,
-          p_currency: (mutation.payload.currency as string | undefined) ?? null,
+          p_amount_minor: nullableString(mutation.payload.amountMinor, 'amountMinor'),
+          p_currency: optionalText(mutation.payload.currency, 'currency'),
         });
       case 'category_budget.set':
         // Admin-gated inside the RPC, same as the overall budget; a null amount
         // clears that category's cap.
         return await this.rpcAsCaller('waves_set_category_budget', {
           p_group_id: mutation.groupId,
-          p_category: mutation.payload.category as string,
-          p_amount_minor: (mutation.payload.amountMinor as string | null) ?? null,
-          p_currency: (mutation.payload.currency as string | undefined) ?? null,
+          p_category: requireString(mutation.payload.category, 'category'),
+          p_amount_minor: nullableString(mutation.payload.amountMinor, 'amountMinor'),
+          p_currency: optionalText(mutation.payload.currency, 'currency'),
         });
       case 'group_fx_rate.set':
         // Admin-gated inside the RPC, like the budgets; a null ratio clears that
@@ -592,10 +594,10 @@ export class SyncSession {
         // computed — never a decimal (ADR-003).
         return await this.rpcAsCaller('waves_set_group_fx_rate', {
           p_group_id: mutation.groupId,
-          p_from: mutation.payload.from as string,
-          p_num: (mutation.payload.num as string | null) ?? null,
-          p_den: (mutation.payload.den as string | null) ?? null,
-          p_source: (mutation.payload.source as string | undefined) ?? 'manual',
+          p_from: requireString(mutation.payload.from, 'from'),
+          p_num: nullableString(mutation.payload.num, 'num'),
+          p_den: nullableString(mutation.payload.den, 'den'),
+          p_source: optionalText(mutation.payload.source, 'source') ?? 'manual',
         });
       default:
         throw new HttpError(
@@ -1285,6 +1287,24 @@ async function pull(
 function requireString(value: unknown, field: string): string {
   if (typeof value !== 'string' || value.length === 0) {
     throw new HttpError(400, 'VALIDATION_FAILED', `${field} is required`);
+  }
+  return value;
+}
+
+/**
+ * A required field whose explicit `null` means "clear it". Missing is not the
+ * same thing as clearing, and a non-text value is a malformed sync payload.
+ */
+function nullableString(value: unknown, field: string): string | null {
+  if (value === null) return null;
+  return requireString(value, field);
+}
+
+/** Optional text that may be absent/null, but may not be some other shape. */
+function optionalText(value: unknown, field: string): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== 'string') {
+    throw new HttpError(400, 'VALIDATION_FAILED', `${field} must be text`);
   }
   return value;
 }


### PR DESCRIPTION
## Summary
- validate nullable budget/rate payload fields at the sync edge before dispatching RPCs
- keep explicit null as the clear operation while rejecting missing or non-text values
- add user/rider/traveller/financer-style coverage for trip budget and FX-rate payloads

## Tests
- pnpm test:edge