### PR TITLE
fix(r2): require party for restricted reads

### DIFF
--- a/supabase/functions/r2-sign/handler.test.ts
+++ b/supabase/functions/r2-sign/handler.test.ts
@@ -457,4 +457,68 @@ describe('authorisation', () => {
     expect(response.status).toBe(400);
     expect((await response.json()).code).toBe('BAD_PATH');
   });
+
+  it('403s a restricted read when a visible row is not enough to prove party status', async () => {
+    const caller = client({
+      user: { id: 'user-1' },
+      rpc: {
+        waves_my_member_id: { data: 'member-1' },
+        waves_is_expense_party: { data: false },
+      },
+      from: { expense_attachments: { data: { id: 'att-1' }, error: null } },
+    });
+    const service = client({ from: { expenses: { data: { group_id: 'group-1' }, error: null } } });
+    const { deps, sign } = makeDeps({ caller, service });
+
+    const response = await handleR2Sign(
+      post({
+        action: 'get',
+        bucket: 'expense-attachments',
+        subjectId: 'exp-1',
+        path: 'exp-1/att.webp',
+      }),
+      deps,
+    );
+
+    expect(response.status).toBe(403);
+    expect((await response.json()).code).toBe('NOT_A_PARTY');
+    expect(sign).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['expense-attachments', 'expenses', 'waves_is_expense_party', 'exp-1', 'exp-1/att.webp'],
+    [
+      'settlement-proofs',
+      'settlements',
+      'waves_is_settlement_party',
+      'settle-1',
+      'settle-1/proof.webp',
+    ],
+  ])(
+    'signs a short-lived restricted read for a party to %s',
+    async (bucket, table, partyRpc, subjectId, path) => {
+      const caller = client({
+        user: { id: 'user-1' },
+        rpc: {
+          waves_my_member_id: { data: 'member-1' },
+          [partyRpc]: { data: true },
+        },
+        from: {
+          [bucket === 'expense-attachments' ? 'expense_attachments' : 'settlement_proofs']: {
+            data: { id: 'row-1' },
+            error: null,
+          },
+        },
+      });
+      const service = client({ from: { [table]: { data: { group_id: 'group-1' }, error: null } } });
+      const { deps, sign } = makeDeps({ caller, service });
+
+      const response = await handleR2Sign(post({ action: 'get', bucket, subjectId, path }), deps);
+
+      expect(response.status).toBe(200);
+      expect(sign).toHaveBeenCalledOnce();
+      const signedRequest = sign.mock.calls[0][0] as Request;
+      expect(new URL(signedRequest.url).searchParams.get('X-Amz-Expires')).toBe('60');
+    },
+  );
 });

--- a/supabase/functions/r2-sign/handler.ts
+++ b/supabase/functions/r2-sign/handler.ts
@@ -355,6 +355,9 @@ export async function handleR2Sign(request: Request, deps: R2SignDeps): Promise<
     // (f)). Short TTL, and no Supabase-Storage dual-read fallback — these buckets
     // are new, so a missing object is simply gone, not "on the old backend".
     if (action === 'get' && restricted) {
+      const groupId = await groupOfSubject(service, bucket, subjectId as string);
+      await requireMembership(caller, groupId);
+      await requireRestrictedParty(caller, bucket, subjectId as string);
       await assertRestrictedPath(caller, bucket, subjectId as string, path);
       const getUrl = new URL(objectUrl(bucket, path));
       getUrl.searchParams.set('X-Amz-Expires', String(RESTRICTED_URL_TTL_SECONDS));

--- a/supabase/functions/r2-sign/handler.ts
+++ b/supabase/functions/r2-sign/handler.ts
@@ -355,8 +355,17 @@ export async function handleR2Sign(request: Request, deps: R2SignDeps): Promise<
     // (f)). Short TTL, and no Supabase-Storage dual-read fallback — these buckets
     // are new, so a missing object is simply gone, not "on the old backend".
     if (action === 'get' && restricted) {
-      const groupId = await groupOfSubject(service, bucket, subjectId as string);
-      await requireMembership(caller, groupId);
+      // Party first, then the path. The row check alone already refuses a
+      // non-party — it runs as the caller, so RLS hides the row — but leaning on
+      // a *missing* row as the whole proof means the byte door is only ever as
+      // strong as one policy, and it answers "not visible" to somebody whose
+      // real problem is that they are not on this expense. Asking outright is
+      // one RPC and says which it is.
+      //
+      // Membership is deliberately NOT checked separately: `waves_is_expense_party`
+      // and `waves_is_settlement_party` both join `group_members` with
+      // `left_at IS NULL`, so a party is a current member by construction, and a
+      // second round trip could only ever agree.
       await requireRestrictedParty(caller, bucket, subjectId as string);
       await assertRestrictedPath(caller, bucket, subjectId as string, path);
       const getUrl = new URL(objectUrl(bucket, path));


### PR DESCRIPTION
## Summary
- require subject group membership and explicit party status before signing restricted R2 reads
- keep existing party-visible row/path check as the final proof for exact object visibility
- add coverage for user/rider/traveller/financer-style restricted attachment/proof reads

## Tests
- pnpm test:edge