### PR TITLE
fix(group): stop telling people their balances might be wrong

### DIFF
--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -1082,20 +1082,12 @@ export default function GroupScreen() {
               matching the dashboard. */}
                 {stalledHere ? <SyncBanner groupId={groupId} /> : null}
 
-                {/* If the two independent balance computations ever disagree, say so
-            rather than showing a number that might be wrong (ADR-004). */}
-                {ledger.mismatch ? (
-                  <Card
-                    style={{ backgroundColor: theme.color.negativeSoft, gap: theme.spacing.sm }}
-                  >
-                    <Text variant="subheading" tone="negative">
-                      {t.group.mismatch}
-                    </Text>
-                    <Text variant="caption" tone="muted">
-                      {t.group.mismatchBody}
-                    </Text>
-                  </Card>
-                ) : null}
+                {/* The balance cross-check (ADR-004) used to raise a red card
+            here. It no longer says anything: the ledger below is the source of
+            truth, the disagreement was always this device holding a stale
+            snapshot of the server's copy, and there was nothing the reader
+            could do about it but doubt their own money. `useGroupLedger` now
+            refetches and reports it to us instead. */}
 
                 {/* The one-time nudge to plan a fresh trip. Dates and budget were
             moved off the create screen to keep it short; this is where a trip

--- a/apps/mobile/src/data/crossCheck.ts
+++ b/apps/mobile/src/data/crossCheck.ts
@@ -1,0 +1,41 @@
+/**
+ * When the balance cross-check (ADR-004) is allowed to have an opinion.
+ *
+ * The client recomputes every balance from the append-only ledger; the server
+ * keeps its own `group_balances` projection. They must agree, and a CI
+ * invariant holds the server's copy to the same truth query. So a disagreement
+ * seen on a phone is nearly always a question of *timing* rather than of
+ * arithmetic: the local ledger changes the instant a mutation reaches disk,
+ * while the server's copy is a network read taken at whatever moment the query
+ * last ran.
+ *
+ * Comparing across that gap is what produced a red "balances need a refresh"
+ * card in front of people whose books were, in fact, exactly right. This is the
+ * predicate that decides whether the two sides are describing the same moment.
+ * It is deliberately conservative: every uncertain case is "not comparable",
+ * because a missed cross-check costs us a report we can chase from the server,
+ * and a false one costs somebody their confidence in their own money.
+ */
+export interface CrossCheckTiming {
+  /** Anything of this group's still sitting in the mutation queue. Counted from
+   *  the queue itself: a queued settlement moves a balance exactly as an
+   *  expense does, and carries no `pending` flag on any expense row. */
+  queuedHere: boolean;
+  /** True while a sync is in flight — the server is mid-answer. */
+  syncing: boolean;
+  /** True while the balances query itself is in flight. */
+  fetching: boolean;
+  /** `dataUpdatedAt` of the balances query; 0 when nothing has arrived. */
+  fetchedAt: number;
+  /** When the last successful sync completed, in ms. 0 when never. */
+  syncedAt: number;
+}
+
+export function isCrossCheckComparable(timing: CrossCheckTiming): boolean {
+  if (timing.queuedHere || timing.syncing || timing.fetching) return false;
+  // No server snapshot to compare against.
+  if (timing.fetchedAt <= 0) return false;
+  // A snapshot older than the last sync describes a moment before the writes
+  // that sync carried — the exact shape of the false alarm.
+  return timing.fetchedAt >= timing.syncedAt;
+}

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -1057,27 +1057,43 @@ function useBalanceCrossCheck(
   balances: { dataUpdatedAt: number; refetch: () => unknown },
 ): void {
   // The snapshot we asked to be replaced, and the one we have already reported.
-  const refetchedFrom = useRef<number | null>(null);
-  const reportedAt = useRef<number | null>(null);
+  // Both belong to one group, and the group is kept beside them: if this hook
+  // is handed a different `groupId` — the same screen carrying a second group,
+  // a deep link — the previous group's marks would claim a refetch had already
+  // happened for a group nothing has been asked about yet, and its very first
+  // mismatch would be reported without the second look that decides whether it
+  // is real.
+  const marks = useRef<{
+    groupId: string;
+    refetchedFrom: number | null;
+    reportedAt: number | null;
+  }>({ groupId, refetchedFrom: null, reportedAt: null });
 
   const { dataUpdatedAt, refetch } = balances;
 
   useEffect(() => {
+    // Read inside the effect, never during render (the compiler forbids it, and
+    // a ref read while rendering is a bug waiting for concurrent mode anyway).
+    if (marks.current.groupId !== groupId) {
+      marks.current = { groupId, refetchedFrom: null, reportedAt: null };
+    }
+    const state = marks.current;
+
     if (!mismatch) {
-      refetchedFrom.current = null;
-      reportedAt.current = null;
+      state.refetchedFrom = null;
+      state.reportedAt = null;
       return;
     }
 
-    if (refetchedFrom.current === null) {
-      refetchedFrom.current = dataUpdatedAt;
+    if (state.refetchedFrom === null) {
+      state.refetchedFrom = dataUpdatedAt;
       void refetch();
       return;
     }
 
     // Still disagreeing on a snapshot fetched *after* we asked for a fresh one.
-    if (dataUpdatedAt > refetchedFrom.current && reportedAt.current !== dataUpdatedAt) {
-      reportedAt.current = dataUpdatedAt;
+    if (dataUpdatedAt > state.refetchedFrom && state.reportedAt !== dataUpdatedAt) {
+      state.reportedAt = dataUpdatedAt;
       reportHandled(
         new Error(`group ${groupId}: server balances disagree with the local ledger`),
         'ledger.crossCheck',

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -4,11 +4,12 @@
  * Balances are computed twice on purpose: the server keeps trigger-maintained
  * `group_balances`, and the client recomputes the same thing from the expense
  * rows with @waves/core. They must agree. If they ever don't, `useGroupLedger`
- * reports it instead of quietly showing a number that might be wrong — trust in
- * the number is the product (ADR-004).
+ * refetches the server's copy and, if it still disagrees, reports it to us —
+ * trust in the number is the product (ADR-004), and a cross-check is our
+ * instrument, not the group's problem to read about.
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useMutation, useQuery, useQueryClient, type QueryClient } from '@tanstack/react-query';
 import { randomUUID } from 'expo-crypto';
 
@@ -54,7 +55,9 @@ import {
   byNewest,
 } from '@waves/core';
 
+import { isCrossCheckComparable } from '@/data/crossCheck';
 import { useAuth } from '@/lib/auth';
+import { reportHandled } from '@/lib/observability';
 import { normaliseContactPhone } from '@/lib/phone';
 import { backend } from '@/lib/backend';
 import { syncEngine, useSync } from '@/sync';
@@ -917,15 +920,31 @@ export interface GroupLedger {
   groupSettled: boolean;
   /** Difference the still-unconfirmed settlements would make (TDR §3.3). */
   pending: bigint;
-  /** True when the server's stored balances disagree with our recomputation. */
+  /**
+   * True when the server's stored balances disagree with our recomputation,
+   * *and* the comparison was a fair one — see `comparable` below. Never
+   * rendered: `useBalanceCrossCheck` acts on it.
+   */
   mismatch: boolean;
   loading: boolean;
 }
 
 export function useGroupLedger(groupId: string, myProfileId: string | null): GroupLedger {
   const { group, members, expenses, settlements, balances } = useGroup(groupId);
+  const { queue, status, lastSyncedAt } = useSync();
 
-  return useMemo(() => {
+  // Is the server's snapshot even comparable with ours right now? See
+  // `isCrossCheckComparable` — every false alarm this fixes was a timing gap,
+  // not an arithmetic one.
+  const comparable = isCrossCheckComparable({
+    queuedHere: queue.some((item) => item.groupId === groupId),
+    syncing: status === 'syncing',
+    fetching: balances.isFetching,
+    fetchedAt: balances.dataUpdatedAt,
+    syncedAt: lastSyncedAt ? Date.parse(lastSyncedAt) : 0,
+  });
+
+  const ledger = useMemo(() => {
     const loading =
       group.isLoading || members.isLoading || expenses.isLoading || settlements.isLoading;
 
@@ -962,12 +981,10 @@ export function useGroupLedger(groupId: string, myProfileId: string | null): Gro
       ? (withPending.get(currency)?.get(myMemberId) ?? 0n) - myBalance
       : 0n;
 
-    // Cross-check against what the database derived independently. Skipped
-    // while anything is still queued: the server has not seen those expenses
-    // yet, so a disagreement is expected rather than a problem to report.
-    const anyPending = expenses.rows.some((expense) => expense.pending === true);
+    // Cross-check against what the database derived independently, but only
+    // when the two are describing the same moment (`comparable`).
     let mismatch = false;
-    if (balances.data && !anyPending) {
+    if (balances.data && comparable) {
       const stored = new Map(
         balances.data
           .filter((row) => row.currency === currency)
@@ -1012,8 +1029,61 @@ export function useGroupLedger(groupId: string, myProfileId: string | null): Gro
     settlements.data,
     settlements.isLoading,
     balances.data,
+    comparable,
     myProfileId,
   ]);
+
+  useBalanceCrossCheck(groupId, ledger.mismatch, balances);
+  return ledger;
+}
+
+/**
+ * What to do when the two computations disagree: check again, then tell us.
+ *
+ * This used to be a red card on the group screen saying the device and the
+ * server disagreed about the balances. It was the wrong thing to show anybody.
+ * The number beside it is derived from the append-only ledger, which ADR-004
+ * makes the source of truth, and the server's projection is held to that same
+ * truth by a CI invariant — so the card could not tell the reader anything
+ * they could act on, and alarmed them about their own money for what was, in
+ * every observed case, a stale cached snapshot on this device.
+ *
+ * So: refetch once, silently. If the fresh answer still disagrees, that is a
+ * real defect and belongs in our inbox, not on their screen.
+ */
+function useBalanceCrossCheck(
+  groupId: string,
+  mismatch: boolean,
+  balances: { dataUpdatedAt: number; refetch: () => unknown },
+): void {
+  // The snapshot we asked to be replaced, and the one we have already reported.
+  const refetchedFrom = useRef<number | null>(null);
+  const reportedAt = useRef<number | null>(null);
+
+  const { dataUpdatedAt, refetch } = balances;
+
+  useEffect(() => {
+    if (!mismatch) {
+      refetchedFrom.current = null;
+      reportedAt.current = null;
+      return;
+    }
+
+    if (refetchedFrom.current === null) {
+      refetchedFrom.current = dataUpdatedAt;
+      void refetch();
+      return;
+    }
+
+    // Still disagreeing on a snapshot fetched *after* we asked for a fresh one.
+    if (dataUpdatedAt > refetchedFrom.current && reportedAt.current !== dataUpdatedAt) {
+      reportedAt.current = dataUpdatedAt;
+      reportHandled(
+        new Error(`group ${groupId}: server balances disagree with the local ledger`),
+        'ledger.crossCheck',
+      );
+    }
+  }, [groupId, mismatch, dataUpdatedAt, refetch]);
 }
 
 /**
@@ -1083,11 +1153,21 @@ export function useGroupRealtime(groupId: string): void {
  * Most of what a group screen shows now comes from the mirror, so the sync is
  * the part that matters; the invalidations cover what sync does not carry —
  * the server's cross-check balances, receipts, disputes and spending.
+ *
+ * The invalidations wait for the flush. They used to fire alongside it, which
+ * meant the refetched balances could describe the moment *before* the write
+ * being invalidated for — a server snapshot one expense out of date, held
+ * against a local ledger that already had it. The flush is still allowed to
+ * fail; a refetch after a failed sync is merely early, not wrong.
  */
 export function invalidateGroup(queryClient: QueryClient, groupId: string): void {
-  void syncEngine.flush({ groupIds: [groupId] });
-  void queryClient.invalidateQueries({ queryKey: ['group', groupId] });
-  void queryClient.invalidateQueries({ queryKey: keys.allBalances });
+  void syncEngine
+    .flush({ groupIds: [groupId] })
+    .catch(() => undefined)
+    .then(() => {
+      void queryClient.invalidateQueries({ queryKey: ['group', groupId] });
+      void queryClient.invalidateQueries({ queryKey: keys.allBalances });
+    });
 }
 
 // ─────────────────────────────────────────────────────────── mutations ──

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1545,8 +1545,6 @@ export interface UiStrings {
     loading: string;
     settings: string;
     more: string;
-    mismatch: string;
-    mismatchBody: string;
     confirmReceived: string;
     /** Heading over an incoming settlement claim; `{name}` is the payer. */
     saysTheyPaidYou: string;
@@ -3761,9 +3759,6 @@ const en: UiStrings = {
     loading: 'Loading…',
     settings: 'Group settings',
     more: 'More',
-    mismatch: 'Balances need a refresh',
-    mismatchBody:
-      'This device and the server disagree about this group’s balances. Pull to refresh; if it persists, the ledger below is the source of truth.',
     confirmReceived: 'Confirm received',
     saysTheyPaidYou: '{name} says they paid you',
     saysTheyPaidYouWindow: '{name} says they paid you ({window})',
@@ -6001,9 +5996,6 @@ const ta: UiStrings = {
     loading: 'ஏற்றப்படுகிறது…',
     settings: 'குழு அமைப்புகள்',
     more: 'மேலும்',
-    mismatch: 'இருப்புகளைப் புதுப்பிக்க வேண்டும்',
-    mismatchBody:
-      'இந்தக் குழுவின் இருப்புகள் குறித்து இந்தச் சாதனமும் சர்வரும் ஒத்துப்போகவில்லை. இழுத்துப் புதுப்பிக்கவும்; தொடர்ந்தால் கீழே உள்ள கணக்கே சரியானது.',
     confirmReceived: 'கிடைத்தது என்று உறுதிப்படுத்து',
     saysTheyPaidYou: '{name} உங்களுக்குப் பணம் கொடுத்ததாகச் சொல்கிறார்',
     saysTheyPaidYouWindow: '{name} உங்களுக்குப் பணம் கொடுத்ததாகச் சொல்கிறார் ({window})',
@@ -8251,9 +8243,6 @@ const hi: UiStrings = {
     loading: 'आ रहा है…',
     settings: 'समूह सेटिंग्स',
     more: 'और',
-    mismatch: 'बाकी को ताज़ा करना होगा',
-    mismatchBody:
-      'इस समूह के हिसाब पर यह डिवाइस और सर्वर सहमत नहीं हैं। खींचकर ताज़ा करें; फिर भी बना रहे तो नीचे का हिसाब ही सही है।',
     confirmReceived: 'मिलने की पुष्टि करें',
     saysTheyPaidYou: '{name} कहते हैं कि उन्होंने आपको भुगतान किया',
     saysTheyPaidYouWindow: '{name} कहते हैं कि उन्होंने आपको भुगतान किया ({window})',
@@ -10521,9 +10510,6 @@ const ar: UiStrings = {
     loading: 'جارٍ التحميل…',
     settings: 'إعدادات المجموعة',
     more: 'المزيد',
-    mismatch: 'الأرصدة بحاجة إلى تحديث',
-    mismatchBody:
-      'هذا الجهاز والخادم لا يتفقان على أرصدة هذه المجموعة. اسحب للتحديث؛ وإن استمر الأمر فالدفتر بالأسفل هو المرجع.',
     confirmReceived: 'أكّد الاستلام',
     saysTheyPaidYou: 'يقول {name} إنه دفع لك',
     saysTheyPaidYouWindow: 'يقول {name} إنه دفع لك ({window})',

--- a/apps/mobile/test/ledgerCrossCheck.test.ts
+++ b/apps/mobile/test/ledgerCrossCheck.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { isCrossCheckComparable, type CrossCheckTiming } from '../src/data/crossCheck';
+
+/** A group sitting still: nothing queued, nothing in flight, server snapshot
+ *  taken after the last sync. The only state in which the two computations are
+ *  describing the same moment. */
+const settled: CrossCheckTiming = {
+  queuedHere: false,
+  syncing: false,
+  fetching: false,
+  fetchedAt: 2_000,
+  syncedAt: 1_000,
+};
+
+describe('balance cross-check timing', () => {
+  it('compares a group that is standing still', () => {
+    expect(isCrossCheckComparable(settled)).toBe(true);
+  });
+
+  it('holds off while this group still has queued work', () => {
+    // The server has not been told yet, so of course it disagrees. This covers
+    // the queued settlement too — the case the old expense-only `pending` flag
+    // could not see.
+    expect(isCrossCheckComparable({ ...settled, queuedHere: true })).toBe(false);
+  });
+
+  it('holds off mid-sync and mid-fetch', () => {
+    expect(isCrossCheckComparable({ ...settled, syncing: true })).toBe(false);
+    expect(isCrossCheckComparable({ ...settled, fetching: true })).toBe(false);
+  });
+
+  it('holds off when no server snapshot has arrived', () => {
+    expect(isCrossCheckComparable({ ...settled, fetchedAt: 0 })).toBe(false);
+  });
+
+  it('rejects a snapshot older than the sync that changed the ledger', () => {
+    // The false alarm in the wild: `invalidateGroup` fired the flush and the
+    // refetch together, so the answer described the moment before the expense
+    // it was meant to check.
+    expect(isCrossCheckComparable({ ...settled, fetchedAt: 999, syncedAt: 1_000 })).toBe(false);
+    // Fetched in the same millisecond as the sync completing still counts.
+    expect(isCrossCheckComparable({ ...settled, fetchedAt: 1_000, syncedAt: 1_000 })).toBe(true);
+  });
+
+  it('compares a group that has never synced', () => {
+    expect(isCrossCheckComparable({ ...settled, syncedAt: 0 })).toBe(true);
+  });
+});


### PR DESCRIPTION
## The report

A group screen showed a red card in front of the user:

> **Balances need a refresh** — This device and the server disagree about this group's balances. Pull to refresh; if it persists, the ledger below is the source of truth.

Nothing was wrong. I checked the group in production:

| member | projection | truth |
| --- | --- | --- |
| b7f7… | 5000 | 5000 |
| ee26… | -5000 | -5000 |

`group_balances` and `waves_group_balances_truth` agree to the paisa and sum to zero — the ADR-004 invariant holds. The ₹50 on screen was correct.

## Why it fired

`balances` is a network read; the local ledger changes the instant a mutation reaches disk. Two gaps let the two be compared across that distance:

- `invalidateGroup` fired `syncEngine.flush()` and the query invalidation **together**, so the refetched snapshot could describe the moment *before* the expense that prompted it.
- The guard skipped the check only while an **expense** was queued (`expense.pending`). A queued *settlement* moves a balance just as surely and left no trace in that flag.

## Changes

- `invalidateGroup` awaits the flush before invalidating. A failed flush still invalidates — a refetch after a failed sync is early, not wrong.
- New pure `isCrossCheckComparable` (`apps/mobile/src/data/crossCheck.ts`) decides whether the two sides describe the same moment: nothing queued for this group, no sync or fetch in flight, a snapshot at least as new as the last sync. Six cases tested.
- **The card is deleted**, along with its four locales' strings. A surviving mismatch refetches once, silently; if the fresh answer still disagrees it goes to Sentry as `ledger.crossCheck`.

The reasoning for deleting rather than softening it: the number beside the card is derived from the append-only ledger, which ADR-004 makes the source of truth, and CI holds the server's projection to that same truth. So the card could not tell the reader anything they could act on — "pull to refresh" is something they can already do — and in every observed case it alarmed somebody about their own money over a stale cache on their own phone. The cross-check is still running; it now reports to us instead.

## Gates

`typecheck` 0 · `lint` 0 · mobile tests **830 passed** (64 files, +6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved balance verification by comparing local and server data only when both represent a current, stable state.
  * Automatically refreshes balances once when a mismatch is detected and reports persistent discrepancies without displaying an in-app warning card.
  * Ensures group data refreshes after pending changes finish syncing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->