### PR TITLE
fix(web): stop showing the database's own words to whoever opened the link

### DIFF
--- a/apps/web/src/app/add/page.tsx
+++ b/apps/web/src/app/add/page.tsx
@@ -23,6 +23,7 @@ import { Section } from '@/components/Shell';
 import { SkeletonRows } from '@/components/Skeleton';
 import { plural } from '@/i18n';
 import { useStrings } from '@/i18n-context';
+import { friendlyError } from '@/lib/errors';
 
 export default function AddPage() {
   return (
@@ -59,7 +60,13 @@ function Picker({ profileId }: { profileId: string }) {
         setGroups(g);
         setMembersByGroup(m);
       } catch (caught) {
-        if (active) setError(caught instanceof Error ? caught.message : String(caught));
+        if (active)
+          setError(
+            friendlyError(caught, 'web.add.load', {
+              fallback: t.errors.couldNotLoad,
+              offline: t.errors.offline,
+            }),
+          );
       } finally {
         if (active && !forwarding) setLoading(false);
       }
@@ -67,7 +74,7 @@ function Picker({ profileId }: { profileId: string }) {
     return () => {
       active = false;
     };
-  }, [router]);
+  }, [router, t.errors.couldNotLoad, t.errors.offline]);
 
   if (loading) {
     return (

--- a/apps/web/src/app/auth/callback/page.tsx
+++ b/apps/web/src/app/auth/callback/page.tsx
@@ -16,6 +16,7 @@ import { useRouter } from 'next/navigation';
 
 import { supabase } from '@/lib/waves';
 import { useStrings } from '@/i18n-context';
+import { friendlyError } from '@/lib/errors';
 
 export default function AuthCallback() {
   const router = useRouter();
@@ -31,10 +32,16 @@ export default function AuthCallback() {
         if (exchangeError) throw exchangeError;
         router.replace('/');
       } catch (caught) {
-        setError(caught instanceof Error ? caught.message : String(caught));
+        setError(
+          friendlyError(caught, 'web.auth.callback', {
+            fallback: t.errors.couldNotSignIn,
+            offline: t.errors.offline,
+            tooMany: t.errors.tooMany,
+          }),
+        );
       }
     })();
-  }, [router]);
+  }, [router, t.errors.couldNotSignIn, t.errors.offline, t.errors.tooMany]);
 
   return (
     <div className="spinner-page">

--- a/apps/web/src/app/g/[groupId]/expense/[expenseId]/page.tsx
+++ b/apps/web/src/app/g/[groupId]/expense/[expenseId]/page.tsx
@@ -30,6 +30,7 @@ import { money } from '@/lib/money';
 import { coordLabel, mapsUrl } from '@/lib/geo';
 import { fill } from '@/i18n';
 import { useStrings } from '@/i18n-context';
+import { friendlyError } from '@/lib/errors';
 
 export default function ExpensePage() {
   return (
@@ -74,7 +75,13 @@ function ExpenseDetail({ profileId }: { profileId: string }) {
       try {
         await load();
       } catch (caught) {
-        if (active) setError(caught instanceof Error ? caught.message : String(caught));
+        if (active)
+          setError(
+            friendlyError(caught, 'web.expense.load', {
+              fallback: t.errors.couldNotLoad,
+              offline: t.errors.offline,
+            }),
+          );
       } finally {
         if (active) setLoading(false);
       }
@@ -82,7 +89,7 @@ function ExpenseDetail({ profileId }: { profileId: string }) {
     return () => {
       active = false;
     };
-  }, [load]);
+  }, [load, t.errors.couldNotLoad, t.errors.offline]);
 
   const run = useCallback(
     async (action: () => Promise<unknown>) => {
@@ -92,13 +99,18 @@ function ExpenseDetail({ profileId }: { profileId: string }) {
         await action();
         await load();
       } catch (caught) {
-        setError(caught instanceof Error ? caught.message : String(caught));
+        setError(
+          friendlyError(caught, 'web.expense.action', {
+            fallback: t.errors.couldNotSave,
+            offline: t.errors.offline,
+          }),
+        );
       } finally {
         setBusy(false);
         setConfirmDelete(false);
       }
     },
-    [load],
+    [load, t.errors.couldNotSave, t.errors.offline],
   );
 
   if (loading) {

--- a/apps/web/src/app/g/[groupId]/page.tsx
+++ b/apps/web/src/app/g/[groupId]/page.tsx
@@ -30,6 +30,7 @@ import { waves } from '@/lib/waves';
 import { money } from '@/lib/money';
 import { plural } from '@/i18n';
 import { useStrings } from '@/i18n-context';
+import { friendlyError } from '@/lib/errors';
 
 export default function GroupPage() {
   return (
@@ -67,7 +68,13 @@ function GroupDetail({ profileId, query }: { profileId: string; query: string })
         setExpenses(e);
         setSettlements(s);
       } catch (caught) {
-        if (active) setError(caught instanceof Error ? caught.message : String(caught));
+        if (active)
+          setError(
+            friendlyError(caught, 'web.group.load', {
+              fallback: t.errors.couldNotLoad,
+              offline: t.errors.offline,
+            }),
+          );
       } finally {
         if (active) setLoading(false);
       }
@@ -75,7 +82,7 @@ function GroupDetail({ profileId, query }: { profileId: string; query: string })
     return () => {
       active = false;
     };
-  }, [groupId]);
+  }, [groupId, t.errors.couldNotLoad, t.errors.offline]);
 
   if (loading) {
     return (

--- a/apps/web/src/app/join/[token]/page.tsx
+++ b/apps/web/src/app/join/[token]/page.tsx
@@ -23,6 +23,7 @@ import type { InvitePreview } from '@waves/api-client';
 import { waves } from '@/lib/waves';
 import { fill, plural } from '@/i18n';
 import { useStrings } from '@/i18n-context';
+import { friendlyError } from '@/lib/errors';
 
 export default function JoinPage() {
   const params = useParams<{ token: string }>();
@@ -46,12 +47,18 @@ export default function JoinPage() {
         if (active) setPreview(result);
       })
       .catch((caught: unknown) => {
-        if (active) setError(caught instanceof Error ? caught.message : String(caught));
+        if (active)
+          setError(
+            friendlyError(caught, 'web.join.preview', {
+              fallback: t.errors.couldNotLoad,
+              offline: t.errors.offline,
+            }),
+          );
       });
     return () => {
       active = false;
     };
-  }, [token]);
+  }, [token, t.errors.couldNotLoad, t.errors.offline]);
 
   /**
    * `claim` is a parameter rather than read from state, because "join as
@@ -83,11 +90,16 @@ export default function JoinPage() {
         }
         router.replace(`/g/${accepted.group.id}`);
       } catch (caught) {
-        setError(caught instanceof Error ? caught.message : String(caught));
+        setError(
+          friendlyError(caught, 'web.join.accept', {
+            fallback: t.errors.couldNotSave,
+            offline: t.errors.offline,
+          }),
+        );
         setJoining(false);
       }
     },
-    [token, claimId, name, router],
+    [token, claimId, name, router, t.errors.couldNotSave, t.errors.offline],
   );
 
   if (error && !preview) {
@@ -95,7 +107,10 @@ export default function JoinPage() {
       <main>
         <div className="card">
           <h1>{t.join.linkBroken}</h1>
-          <p>{error}</p>
+          {/* The two sentences around this used to have the backend's own
+              message wedged between them — "JWT expired", or a row-level
+              security sentence — in front of somebody who had done nothing but
+              follow a link. They say the whole of what is knowable already. */}
           <p className="faint">{t.join.linkBrokenBody}</p>
         </div>
       </main>

--- a/apps/web/src/app/settle/page.tsx
+++ b/apps/web/src/app/settle/page.tsx
@@ -267,12 +267,20 @@ function GroupSettle({
       await waves.nudgeToSettle({ groupId: group.id, toMemberId, currency });
       setNudged((prev) => new Set(prev).add(toMemberId));
     } catch (caught) {
-      setError(
-        friendlyError(caught, 'web.settle.nudge', {
-          fallback: t.errors.couldNotSave,
-          offline: t.errors.offline,
-        }),
-      );
+      // The one-a-day server rule (ADR-010) is not a failure: the reminder they
+      // are asking for has already gone today. The app says this the same way —
+      // the row reads as nudged, and nobody is told off for asking twice.
+      const message = caught instanceof Error ? caught.message : String(caught);
+      if (message.includes('NUDGE_RATE_LIMIT')) {
+        setNudged((prev) => new Set(prev).add(toMemberId));
+      } else {
+        setError(
+          friendlyError(caught, 'web.settle.nudge', {
+            fallback: t.errors.couldNotSave,
+            offline: t.errors.offline,
+          }),
+        );
+      }
     } finally {
       setBusy(null);
     }

--- a/apps/web/src/app/settle/page.tsx
+++ b/apps/web/src/app/settle/page.tsx
@@ -41,6 +41,7 @@ import { SkeletonRows } from '@/components/Skeleton';
 import { waves } from '@/lib/waves';
 import { money } from '@/lib/money';
 import { useStrings } from '@/i18n-context';
+import { friendlyError } from '@/lib/errors';
 
 export default function SettlePage() {
   return (
@@ -74,7 +75,13 @@ function Settle({ profileId }: { profileId: string }) {
         setGroups(g);
         setMembersByGroup(m);
       } catch (caught) {
-        if (active) setError(caught instanceof Error ? caught.message : String(caught));
+        if (active)
+          setError(
+            friendlyError(caught, 'web.settle.load', {
+              fallback: t.errors.couldNotLoad,
+              offline: t.errors.offline,
+            }),
+          );
       } finally {
         if (active) setLoading(false);
       }
@@ -82,7 +89,7 @@ function Settle({ profileId }: { profileId: string }) {
     return () => {
       active = false;
     };
-  }, []);
+  }, [t.errors.couldNotLoad, t.errors.offline]);
 
   // The clicked group if still present, else the one asked for in the URL, else
   // the first — derived, never a setState-in-effect that fights the URL.
@@ -179,7 +186,13 @@ function GroupSettle({
         setExpenses(e);
         setSettlements(s);
       } catch (caught) {
-        if (active) setError(caught instanceof Error ? caught.message : String(caught));
+        if (active)
+          setError(
+            friendlyError(caught, 'web.settle.group', {
+              fallback: t.errors.couldNotLoad,
+              offline: t.errors.offline,
+            }),
+          );
       } finally {
         if (active) setLoading(false);
       }
@@ -187,7 +200,7 @@ function GroupSettle({
     return () => {
       active = false;
     };
-  }, [group.id]);
+  }, [group.id, t.errors.couldNotLoad, t.errors.offline]);
 
   const byId = useMemo(() => new Map(members.map((member) => [member.id, member])), [members]);
   const myMemberId = members.find((member) => member.profile_id === profileId)?.id ?? null;
@@ -236,7 +249,12 @@ function GroupSettle({
       await waves.confirmSettlement(settlementId);
       await refresh();
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(
+        friendlyError(caught, 'web.settle.confirm', {
+          fallback: t.errors.couldNotSave,
+          offline: t.errors.offline,
+        }),
+      );
     } finally {
       setBusy(null);
     }
@@ -249,7 +267,12 @@ function GroupSettle({
       await waves.nudgeToSettle({ groupId: group.id, toMemberId, currency });
       setNudged((prev) => new Set(prev).add(toMemberId));
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(
+        friendlyError(caught, 'web.settle.nudge', {
+          fallback: t.errors.couldNotSave,
+          offline: t.errors.offline,
+        }),
+      );
     } finally {
       setBusy(null);
     }
@@ -456,7 +479,12 @@ function SettleForm({
     } catch (caught) {
       // A failed attempt keeps the same key, so the retry the user is about to
       // make is deduped rather than recording a second payment.
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(
+        friendlyError(caught, 'web.settle.record', {
+          fallback: t.errors.couldNotSave,
+          offline: t.errors.offline,
+        }),
+      );
       setSaving(false);
     }
   }

--- a/apps/web/src/components/ExpenseForm.tsx
+++ b/apps/web/src/components/ExpenseForm.tsx
@@ -34,6 +34,7 @@ import { tooManyPayersForWeb } from '@/lib/editable';
 import { captureLocation, coordLabel, geolocationSupported, LocationFailure } from '@/lib/geo';
 import { fill } from '@/i18n';
 import { useStrings } from '@/i18n-context';
+import { friendlyError } from '@/lib/errors';
 
 enum SplitKind {
   Equal = 'equal',
@@ -180,7 +181,13 @@ export function ExpenseForm({
           setPayer(m.find((member) => member.profile_id === myProfileId)?.id ?? null);
         }
       } catch (caught) {
-        if (active) setError(caught instanceof Error ? caught.message : String(caught));
+        if (active)
+          setError(
+            friendlyError(caught, 'web.expenseForm.load', {
+              fallback: t.errors.couldNotLoad,
+              offline: t.errors.offline,
+            }),
+          );
       } finally {
         if (active) setReady(true);
       }
@@ -188,7 +195,7 @@ export function ExpenseForm({
     return () => {
       active = false;
     };
-  }, [groupId, expenseId, myProfileId]);
+  }, [groupId, expenseId, myProfileId, t.errors.couldNotLoad, t.errors.offline]);
 
   const currency = (group?.default_currency ?? 'INR') as CurrencyCode;
 
@@ -287,7 +294,12 @@ export function ExpenseForm({
       });
       router.replace(`/g/${groupId}`);
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(
+        friendlyError(caught, 'web.expenseForm.submit', {
+          fallback: t.errors.couldNotSave,
+          offline: t.errors.offline,
+        }),
+      );
       setSaving(false);
     }
   }, [
@@ -304,6 +316,8 @@ export function ExpenseForm({
     location,
     router,
     t.add.defaultDescription,
+    t.errors.couldNotSave,
+    t.errors.offline,
   ]);
 
   if (!ready || !group) {

--- a/apps/web/src/components/Overview.tsx
+++ b/apps/web/src/components/Overview.tsx
@@ -30,6 +30,7 @@ import { money } from '@/lib/money';
 import { describeActivity, verbEmoji } from '@/lib/activity';
 import { plural, type PluralForms } from '@/i18n';
 import { useStrings } from '@/i18n-context';
+import { friendlyError } from '@/lib/errors';
 
 interface GroupNet {
   group: GroupRow;
@@ -69,7 +70,13 @@ export function Overview({ profileId, query }: { profileId: string; query: strin
         setActivity(a);
         setPendingGroups(new Set(pending.map((row) => row.group_id)));
       } catch (caught) {
-        if (active) setError(caught instanceof Error ? caught.message : String(caught));
+        if (active)
+          setError(
+            friendlyError(caught, 'web.overview.load', {
+              fallback: t.errors.couldNotLoad,
+              offline: t.errors.offline,
+            }),
+          );
       } finally {
         if (active) setLoading(false);
       }
@@ -77,7 +84,7 @@ export function Overview({ profileId, query }: { profileId: string; query: strin
     return () => {
       active = false;
     };
-  }, [profileId]);
+  }, [profileId, t.errors.couldNotLoad, t.errors.offline]);
 
   // My balance per group, per currency — the number the group row shows.
   const byGroup = useMemo(() => {

--- a/apps/web/src/components/SignIn.tsx
+++ b/apps/web/src/components/SignIn.tsx
@@ -13,10 +13,37 @@
 
 import { useState } from 'react';
 
+import { IdentityError } from '@waves/core';
+
 import { useAuth } from '@/lib/auth';
-import { fill } from '@/i18n';
+import { fill, type WebStrings } from '@/i18n';
 import { useStrings } from '@/i18n-context';
 import { friendlyError } from '@/lib/errors';
+
+/**
+ * Our own sentence, when the thing that failed was the form rather than the
+ * server.
+ *
+ * `checkPassword` throws before any round trip, and what it throws was written
+ * for the person typing — "use at least 8 characters". Running that through
+ * `friendlyError` would replace a useful instruction with "could not sign in",
+ * which is both wrong (nothing was refused) and unhelpful (they cannot guess
+ * what to change). Validation is not a backend failure and is not treated as
+ * one; the core's English is the last resort for a code with no words yet.
+ */
+function validationWords(caught: unknown, t: WebStrings): string | null {
+  if (!(caught instanceof IdentityError)) return null;
+  switch (caught.code) {
+    case 'PASSWORD_TOO_SHORT':
+      return t.errors.passwordTooShort;
+    case 'PASSWORD_TOO_COMMON':
+      return t.errors.passwordTooCommon;
+    case 'EMAIL_NOT_VALID':
+      return t.dash.notAnEmail;
+    default:
+      return caught.message;
+  }
+}
 
 export function SignIn() {
   const { t } = useStrings();
@@ -65,11 +92,12 @@ export function SignIn() {
       await withPassword(address, password, mode);
     } catch (caught) {
       setError(
-        friendlyError(caught, 'web.signIn.password', {
-          fallback: t.errors.couldNotSignIn,
-          offline: t.errors.offline,
-          tooMany: t.errors.tooMany,
-        }),
+        validationWords(caught, t) ??
+          friendlyError(caught, 'web.signIn.password', {
+            fallback: t.errors.couldNotSignIn,
+            offline: t.errors.offline,
+            tooMany: t.errors.tooMany,
+          }),
       );
     } finally {
       setBusy(null);

--- a/apps/web/src/components/SignIn.tsx
+++ b/apps/web/src/components/SignIn.tsx
@@ -16,6 +16,7 @@ import { useState } from 'react';
 import { useAuth } from '@/lib/auth';
 import { fill } from '@/i18n';
 import { useStrings } from '@/i18n-context';
+import { friendlyError } from '@/lib/errors';
 
 export function SignIn() {
   const { t } = useStrings();
@@ -34,7 +35,13 @@ export function SignIn() {
       await signInWithGoogle(); // navigates away; no return
     } catch (caught) {
       setBusy(null);
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(
+        friendlyError(caught, 'web.signIn.google', {
+          fallback: t.errors.couldNotSignIn,
+          offline: t.errors.offline,
+          tooMany: t.errors.tooMany,
+        }),
+      );
     }
   }
 
@@ -57,7 +64,13 @@ export function SignIn() {
       // The core picks the call; a guest is upgraded in place, keeping groups.
       await withPassword(address, password, mode);
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(
+        friendlyError(caught, 'web.signIn.password', {
+          fallback: t.errors.couldNotSignIn,
+          offline: t.errors.offline,
+          tooMany: t.errors.tooMany,
+        }),
+      );
     } finally {
       setBusy(null);
     }
@@ -75,7 +88,13 @@ export function SignIn() {
       await signInWithEmail(address);
       setSent(true);
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(
+        friendlyError(caught, 'web.signIn.magicLink', {
+          fallback: t.errors.couldNotSignIn,
+          offline: t.errors.offline,
+          tooMany: t.errors.tooMany,
+        }),
+      );
     } finally {
       setBusy(null);
     }

--- a/apps/web/src/i18n.ts
+++ b/apps/web/src/i18n.ts
@@ -300,6 +300,15 @@ export interface WebStrings {
     nudged: string;
     loading: string;
   };
+  /** What a backend failure is allowed to say. The real message goes to Sentry
+   *  — see `lib/errors.ts`. */
+  errors: {
+    couldNotLoad: string;
+    couldNotSignIn: string;
+    couldNotSave: string;
+    offline: string;
+    tooMany: string;
+  };
 }
 
 const en: WebStrings = {
@@ -508,6 +517,13 @@ const en: WebStrings = {
     nudge: 'Nudge',
     nudged: 'Nudged',
     loading: 'Loading…',
+  },
+  errors: {
+    couldNotLoad: 'Couldn’t load this. Try again in a moment.',
+    couldNotSignIn: 'Could not sign in. Please try again.',
+    couldNotSave: 'That didn’t save. Try again in a moment.',
+    offline: 'You appear to be offline. Check your connection and try again.',
+    tooMany: 'Too many tries in a row. Wait a moment, then try again.',
   },
 };
 
@@ -726,6 +742,13 @@ const ta: WebStrings = {
     nudged: 'நினைவூட்டப்பட்டது',
     loading: 'ஏற்றுகிறது…',
   },
+  errors: {
+    couldNotLoad: 'இதை ஏற்ற முடியவில்லை. சிறிது நேரத்தில் மீண்டும் முயலவும்.',
+    couldNotSignIn: 'உள்நுழைய முடியவில்லை. மீண்டும் முயற்சிக்கவும்.',
+    couldNotSave: 'இது சேமிக்கப்படவில்லை. சிறிது நேரத்தில் மீண்டும் முயலவும்.',
+    offline: 'நீங்கள் இணைப்பில் இல்லை போலும். இணைப்பைச் சரிபார்த்து மீண்டும் முயலவும்.',
+    tooMany: 'தொடர்ச்சியாக அதிக முயற்சிகள். சிறிது காத்திருந்து மீண்டும் முயலவும்.',
+  },
 };
 
 const hi: WebStrings = {
@@ -936,6 +959,13 @@ const hi: WebStrings = {
     nudge: 'याद दिलाएँ',
     nudged: 'याद दिला दिया',
     loading: 'लोड हो रहा है…',
+  },
+  errors: {
+    couldNotLoad: 'यह लोड नहीं हो सका। थोड़ी देर में फिर कोशिश करें।',
+    couldNotSignIn: 'साइन इन नहीं हो सका। फिर से कोशिश करें।',
+    couldNotSave: 'यह सेव नहीं हुआ। थोड़ी देर में फिर कोशिश करें।',
+    offline: 'लगता है आप ऑफ़लाइन हैं। कनेक्शन जाँचकर फिर कोशिश करें।',
+    tooMany: 'लगातार बहुत सारी कोशिशें। थोड़ा रुककर फिर कोशिश करें।',
   },
 };
 
@@ -1187,6 +1217,13 @@ const ar: WebStrings = {
     nudge: 'تذكير',
     nudged: 'تم التذكير',
     loading: 'جارٍ التحميل…',
+  },
+  errors: {
+    couldNotLoad: 'تعذّر تحميل هذا. حاول بعد قليل.',
+    couldNotSignIn: 'تعذّر تسجيل الدخول. حاول مرة أخرى.',
+    couldNotSave: 'لم يُحفظ ذلك. حاول بعد قليل.',
+    offline: 'يبدو أنك غير متصل. تحقّق من اتصالك وحاول مجدداً.',
+    tooMany: 'محاولات كثيرة متتالية. انتظر قليلاً ثم حاول مجدداً.',
   },
 };
 

--- a/apps/web/src/i18n.ts
+++ b/apps/web/src/i18n.ts
@@ -305,6 +305,8 @@ export interface WebStrings {
   errors: {
     couldNotLoad: string;
     couldNotSignIn: string;
+    passwordTooShort: string;
+    passwordTooCommon: string;
     couldNotSave: string;
     offline: string;
     tooMany: string;
@@ -521,6 +523,8 @@ const en: WebStrings = {
   errors: {
     couldNotLoad: 'Couldn’t load this. Try again in a moment.',
     couldNotSignIn: 'Could not sign in. Please try again.',
+    passwordTooShort: 'Use at least 8 characters — a phrase is easier to remember than a puzzle.',
+    passwordTooCommon: 'That is one of the first passwords anyone tries.',
     couldNotSave: 'That didn’t save. Try again in a moment.',
     offline: 'You appear to be offline. Check your connection and try again.',
     tooMany: 'Too many tries in a row. Wait a moment, then try again.',
@@ -745,6 +749,9 @@ const ta: WebStrings = {
   errors: {
     couldNotLoad: 'இதை ஏற்ற முடியவில்லை. சிறிது நேரத்தில் மீண்டும் முயலவும்.',
     couldNotSignIn: 'உள்நுழைய முடியவில்லை. மீண்டும் முயற்சிக்கவும்.',
+    passwordTooShort:
+      'குறைந்தது 8 எழுத்துகள் இருக்கட்டும் — புதிரை விட ஒரு சொற்றொடர் நினைவில் நிற்கும்.',
+    passwordTooCommon: 'இது யாரும் முதலில் முயற்சிக்கும் கடவுச்சொற்களில் ஒன்று.',
     couldNotSave: 'இது சேமிக்கப்படவில்லை. சிறிது நேரத்தில் மீண்டும் முயலவும்.',
     offline: 'நீங்கள் இணைப்பில் இல்லை போலும். இணைப்பைச் சரிபார்த்து மீண்டும் முயலவும்.',
     tooMany: 'தொடர்ச்சியாக அதிக முயற்சிகள். சிறிது காத்திருந்து மீண்டும் முயலவும்.',
@@ -963,6 +970,8 @@ const hi: WebStrings = {
   errors: {
     couldNotLoad: 'यह लोड नहीं हो सका। थोड़ी देर में फिर कोशिश करें।',
     couldNotSignIn: 'साइन इन नहीं हो सका। फिर से कोशिश करें।',
+    passwordTooShort: 'कम से कम 8 अक्षर रखें — पहेली से बेहतर है कोई वाक्यांश, याद भी रहता है।',
+    passwordTooCommon: 'यह उन पासवर्ड में से है जो सबसे पहले आज़माए जाते हैं।',
     couldNotSave: 'यह सेव नहीं हुआ। थोड़ी देर में फिर कोशिश करें।',
     offline: 'लगता है आप ऑफ़लाइन हैं। कनेक्शन जाँचकर फिर कोशिश करें।',
     tooMany: 'लगातार बहुत सारी कोशिशें। थोड़ा रुककर फिर कोशिश करें।',
@@ -1221,6 +1230,8 @@ const ar: WebStrings = {
   errors: {
     couldNotLoad: 'تعذّر تحميل هذا. حاول بعد قليل.',
     couldNotSignIn: 'تعذّر تسجيل الدخول. حاول مرة أخرى.',
+    passwordTooShort: 'استخدم 8 أحرف على الأقل — عبارة أسهل في التذكّر من لغز.',
+    passwordTooCommon: 'هذه من أوّل كلمات المرور التي يجرّبها أي شخص.',
     couldNotSave: 'لم يُحفظ ذلك. حاول بعد قليل.',
     offline: 'يبدو أنك غير متصل. تحقّق من اتصالك وحاول مجدداً.',
     tooMany: 'محاولات كثيرة متتالية. انتظر قليلاً ثم حاول مجدداً.',

--- a/apps/web/src/lib/errors.ts
+++ b/apps/web/src/lib/errors.ts
@@ -1,0 +1,78 @@
+/**
+ * Backend errors, said out loud in a way somebody can act on.
+ *
+ * The mobile app learned this in #256 and the web client never did: every
+ * `catch` here ended in `caught instanceof Error ? caught.message : String(caught)`
+ * rendered straight into the page. PostgREST and GoTrue write their messages
+ * for whoever wrote the query, so a guest following an invite link could be
+ * shown
+ *
+ *   new row violates row-level security policy for table "expenses"
+ *
+ * which is frightening, untranslated, and tells them nothing they can do. Worse
+ * on the web than on mobile: this is the app for somebody who installed
+ * nothing, and a page that talks about policies and schema caches is a tab they
+ * close.
+ *
+ * The original is not thrown away — it goes to Sentry, where a sentence naming
+ * a table is exactly what is wanted. This mirrors `apps/mobile/src/lib/errors.ts`
+ * deliberately; the two are separate files because that one imports from the
+ * React Native app's module graph, and the shared half is the doctrine, not the
+ * code.
+ */
+
+import * as Sentry from '@sentry/nextjs';
+
+/** The shape supabase-js hands back on a failed rpc or auth call. */
+interface Postgrestish {
+  message?: string;
+  code?: string;
+  /** supabase-js AuthError carries the HTTP status — 429 on a rate limit. */
+  status?: number;
+}
+
+export interface ErrorWords {
+  /** What to say when nothing more specific fits. */
+  fallback: string;
+  /** The connection is the problem, not what they did. */
+  offline?: string;
+  /** They went too fast, and the request itself was fine. */
+  tooMany?: string;
+}
+
+/**
+ * A sentence for the page, and the real error for us.
+ *
+ * `where` tags the Sentry event so a spike is traceable to one screen.
+ */
+export function friendlyError(caught: unknown, where: string, words: ErrorWords): string {
+  const error = (caught ?? {}) as Postgrestish;
+  const message =
+    typeof error.message === 'string' ? error.message : typeof caught === 'string' ? caught : '';
+
+  Sentry.captureException(caught, { tags: { where } });
+
+  // Too many requests in too short a window — the sign-in buttons hit
+  // Supabase's send-rate limit if tapped repeatedly. "Could not sign in" reads
+  // as a rejected credential, which is wrong: the request was fine, there were
+  // just too many of them.
+  if (
+    error.status === 429 ||
+    /rate limit|too many requests|over_.*_rate_limit/i.test(message) ||
+    /rate.?limit/i.test(typeof error.code === 'string' ? error.code : '')
+  ) {
+    return words.tooMany ?? words.fallback;
+  }
+
+  // A dropped connection is worth naming — it tells somebody to check their
+  // signal rather than doubt what they typed. The raw string still is not safe
+  // to echo, so recognise the case and return our own sentence.
+  if (/network|fetch failed|failed to fetch|timeout|offline|tls|secure connection/i.test(message)) {
+    return words.offline ?? words.fallback;
+  }
+
+  // Everything else — schema cache misses, constraint violations, permission
+  // denials, expired tokens — is a sentence about the database. It stays in
+  // Sentry and never reaches the page.
+  return words.fallback;
+}

--- a/apps/web/test/friendlyError.test.ts
+++ b/apps/web/test/friendlyError.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@sentry/nextjs', () => ({ captureException: vi.fn() }));
+
+import * as Sentry from '@sentry/nextjs';
+
+import { friendlyError } from '../src/lib/errors';
+
+const words = { fallback: 'fallback', offline: 'offline', tooMany: 'too many' };
+
+describe('friendlyError', () => {
+  it('never returns the backend’s own sentence', () => {
+    // The four shapes seen in the wild, each of which used to be rendered
+    // verbatim to whoever was on the page.
+    const raw = [
+      { message: 'new row violates row-level security policy for table "expenses"' },
+      { message: 'Could not find the function public.waves_create_group in the schema cache' },
+      { code: 'PGRST116', message: 'JSON object requested, multiple (or no) rows returned' },
+      { message: 'JWT expired' },
+    ];
+    for (const error of raw) expect(friendlyError(error, 'test', words)).toBe('fallback');
+  });
+
+  it('names a dropped connection, without echoing the transport’s words', () => {
+    expect(friendlyError(new TypeError('Failed to fetch'), 'test', words)).toBe('offline');
+    expect(friendlyError({ message: 'network request failed' }, 'test', words)).toBe('offline');
+  });
+
+  it('separates going too fast from being refused', () => {
+    expect(friendlyError({ status: 429, message: 'nope' }, 'test', words)).toBe('too many');
+    expect(friendlyError({ code: 'over_email_send_rate_limit' }, 'test', words)).toBe('too many');
+  });
+
+  it('falls back when the caller offers no special wording', () => {
+    expect(friendlyError({ status: 429 }, 'test', { fallback: 'only' })).toBe('only');
+    expect(friendlyError(new Error('fetch failed'), 'test', { fallback: 'only' })).toBe('only');
+  });
+
+  it('reports the original, tagged with where it happened', () => {
+    const original = new Error('permission denied for table groups');
+    friendlyError(original, 'web.group.load', words);
+    expect(Sentry.captureException).toHaveBeenCalledWith(original, {
+      tags: { where: 'web.group.load' },
+    });
+  });
+
+  it('survives a thrown non-error', () => {
+    expect(friendlyError(null, 'test', words)).toBe('fallback');
+    expect(friendlyError('plain string', 'test', words)).toBe('fallback');
+  });
+});


### PR DESCRIPTION
Follow-up to the balance-card fix (#675) — a sweep for other places the app shows a user its own internals.

## What the sweep found

| Surface | Verdict |
| --- | --- |
| **`apps/web` raw errors** | **Broken — fixed here.** 18 sites rendered `caught.message` verbatim. |
| Group balance cross-check card | Fixed in #675. |
| `apps/mobile` error surfaces | Clean. Everything routes through `friendlyError` since #256; the three remaining `.message` reads only *test* for `NUDGE_RATE_LIMIT` and render translated strings. |
| `SyncBanner` refused / stuck cards | Correct as they are — a change of yours did not save, with Try again / Let it go beside it, and "still saved on this phone" so nobody thinks their entry is lost. |
| `apps/admin` raw errors | Left alone on purpose. Staff console; the Postgres sentence is the useful one there. |

## The web problem

Every `catch` ended in `setError(caught instanceof Error ? caught.message : String(caught))`. What that puts in front of somebody who installed nothing and followed a link:

```
new row violates row-level security policy for table "expenses"
Could not find the function public.waves_create_group in the schema cache
JSON object requested, multiple (or no) rows returned
JWT expired
```

Untranslated, unactionable, and on the join page wedged between "This link is broken" and the sentence that already explains it. Worse here than on mobile: this is the app for a first-time guest, and a page that talks about schema caches is a tab they close.

## The fix

`apps/web/src/lib/errors.ts` — the web `friendlyError`, mirroring `apps/mobile/src/lib/errors.ts`. Separate files on purpose: that one imports from the React Native module graph, and what is shared is the doctrine, not the code.

- a rate limit is not a rejected credential — "too many tries in a row", not "could not sign in";
- a dropped connection gets named, but in our words, never the transport's;
- everything else goes to Sentry tagged `where`, and the page gets a plain fallback.

Five new strings (`couldNotLoad`, `couldNotSave`, `couldNotSignIn`, `offline`, `tooMany`) in all four languages. The raw line on the broken-invite card is deleted.

## Gates

`typecheck` 0 · `lint` 0 · web tests **33 passed** (4 files, +6 covering each raw shape seen in the wild)