### PR TITLE
feat(packs): a marketplace of category and income-source packs

### DIFF
--- a/apps/admin/src/app/pack-requests/page.tsx
+++ b/apps/admin/src/app/pack-requests/page.tsx
@@ -1,0 +1,120 @@
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+
+import { decidePackRequest, packRequests } from '@/lib/data';
+import { guardMutation } from '@/lib/csrf';
+import { CsrfField } from '@/components/CsrfField';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * What people have asked for.
+ *
+ * The other half of "we author them, others ask": there is no submission flow
+ * and nothing anybody writes here reaches another user — a request is a sentence
+ * in a queue. Which makes this the cheapest possible way to find out what the
+ * shelf is missing, and the only one that carries no moderation burden at all.
+ *
+ * No requester is shown. Knowing *who* asked adds nothing to deciding whether
+ * the pack is worth making, and this console deliberately keeps what it can see
+ * about people to what it needs (see `data.ts`).
+ */
+export default async function PackRequests({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string; saved?: string }>;
+}) {
+  const { error, saved } = await searchParams;
+  const rows = await packRequests();
+  const open = rows.filter((row) => row.status === 'open');
+  const decided = rows.filter((row) => row.status !== 'open');
+
+  async function decide(formData: FormData) {
+    'use server';
+
+    let failure: string | null = null;
+    try {
+      await guardMutation(formData);
+      const status = String(formData.get('status') ?? '');
+      if (status !== 'done' && status !== 'declined') throw new Error('Unknown decision.');
+      await decidePackRequest(String(formData.get('id') ?? ''), status);
+    } catch (caught) {
+      failure = caught instanceof Error ? caught.message : String(caught);
+    }
+
+    if (failure) redirect(`/pack-requests?error=${encodeURIComponent(failure)}`);
+    revalidatePath('/pack-requests');
+    redirect('/pack-requests?saved=1');
+  }
+
+  return (
+    <main>
+      <header className="top">
+        <h1>Pack requests</h1>{' '}
+      </header>
+
+      {error ? <p className="error">{error}</p> : null}
+      {saved ? <p className="faint">Saved.</p> : null}
+
+      <p className="note" style={{ padding: 0 }}>
+        What people told us the app has no words for. Mark one <strong>done</strong> once a pack
+        covering it is published, or <strong>declined</strong> if it is not something we will make.
+        Nobody is notified either way.
+      </p>
+
+      {open.length === 0 ? (
+        <p className="note">Nothing waiting.</p>
+      ) : (
+        <div className="scroll">
+          <table>
+            <thead>
+              <tr>
+                <th>Asked for</th>
+                <th>When</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {open.map((row) => (
+                <tr key={row.id}>
+                  <td>{row.body}</td>
+                  <td className="faint">{new Date(row.created_at).toLocaleDateString()}</td>
+                  <td>
+                    <form action={decide} style={{ display: 'flex', gap: 8 }}>
+                      <CsrfField />
+                      <input type="hidden" name="id" value={row.id} />
+                      <button type="submit" name="status" value="done">
+                        Done
+                      </button>
+                      <button type="submit" name="status" value="declined">
+                        Decline
+                      </button>
+                    </form>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {decided.length > 0 ? (
+        <>
+          <h2>Decided</h2>
+          <div className="scroll">
+            <table>
+              <tbody>
+                {decided.slice(0, 50).map((row) => (
+                  <tr key={row.id}>
+                    <td>{row.body}</td>
+                    <td className="faint">{row.status}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      ) : null}
+    </main>
+  );
+}

--- a/apps/admin/src/app/packs/page.tsx
+++ b/apps/admin/src/app/packs/page.tsx
@@ -1,0 +1,199 @@
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+
+import { packs, savePack, setPackStatus } from '@/lib/data';
+import { guardMutation } from '@/lib/csrf';
+import { CsrfField } from '@/components/CsrfField';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * The shelf, from behind.
+ *
+ * A pack is a set of categories or income sources somebody can install — data,
+ * never code, so there is nothing here to sandbox. What there is instead is one
+ * gate: `savePack` runs `parsePack`, the same function the app runs on what it
+ * fetches, so a pack that a phone would silently drop cannot be saved at all.
+ * The refusal arrives while the person who wrote it is still looking at it.
+ *
+ * The entries are edited as JSON rather than through a row-by-row form. That is
+ * a deliberate trade for a staff tool used by a handful of people: a form would
+ * be a week of work to save an operator from matching braces, and the validator
+ * catches every mistake a form would have prevented. If somebody outside the
+ * team ever authors a pack, this is the first thing to replace.
+ */
+export default async function Packs({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string; saved?: string }>;
+}) {
+  const { error, saved } = await searchParams;
+  const all = await packs();
+
+  async function save(formData: FormData) {
+    'use server';
+
+    let failure: string | null = null;
+    try {
+      await guardMutation(formData);
+      const id = String(formData.get('id') ?? '').trim();
+      await savePack({
+        id: id === '' ? undefined : id,
+        slug: String(formData.get('slug') ?? ''),
+        title: String(formData.get('title') ?? ''),
+        summary: String(formData.get('summary') ?? ''),
+        entriesJson: String(formData.get('entries') ?? '[]'),
+        status: String(formData.get('status') ?? 'draft'),
+      });
+    } catch (caught) {
+      failure = caught instanceof Error ? caught.message : String(caught);
+    }
+
+    if (failure) redirect(`/packs?error=${encodeURIComponent(failure)}`);
+    revalidatePath('/packs');
+    redirect('/packs?saved=1');
+  }
+
+  async function publish(formData: FormData) {
+    'use server';
+
+    let failure: string | null = null;
+    try {
+      await guardMutation(formData);
+      await setPackStatus(
+        String(formData.get('id') ?? ''),
+        String(formData.get('status') ?? 'draft'),
+      );
+    } catch (caught) {
+      failure = caught instanceof Error ? caught.message : String(caught);
+    }
+
+    if (failure) redirect(`/packs?error=${encodeURIComponent(failure)}`);
+    revalidatePath('/packs');
+    redirect('/packs?saved=1');
+  }
+
+  return (
+    <main>
+      <header className="top">
+        <h1>Packs</h1>{' '}
+      </header>
+
+      {error ? <p className="error">{error}</p> : null}
+      {saved ? <p className="faint">Saved.</p> : null}
+
+      <p className="note" style={{ padding: 0 }}>
+        Sets of categories and income sources people can add to their own list. Only a{' '}
+        <strong>published</strong> pack is visible in the app at all — a draft is ours alone, and
+        unlisting one stops it spreading without touching anybody who already installed it. Their
+        categories are their own by then.
+      </p>
+
+      {all.length === 0 ? (
+        <p className="note">
+          None yet. If you expected some, the <code>20260906120000_category_packs</code> migration
+          may not be deployed to this project.
+        </p>
+      ) : (
+        <div className="scroll">
+          <table>
+            <thead>
+              <tr>
+                <th>Pack</th>
+                <th>Entries</th>
+                <th>Installs</th>
+                <th>Status</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {all.map((pack) => {
+                const entries = Array.isArray(pack.entries) ? pack.entries.length : 0;
+                return (
+                  <tr key={pack.id}>
+                    <td>
+                      <strong>{pack.title}</strong>
+                      <br />
+                      <span className="faint">{pack.slug}</span>
+                    </td>
+                    <td>{entries}</td>
+                    <td>{pack.install_count}</td>
+                    <td>{pack.status}</td>
+                    <td>
+                      <form action={publish}>
+                        <CsrfField />
+                        <input type="hidden" name="id" value={pack.id} />
+                        <input
+                          type="hidden"
+                          name="status"
+                          value={pack.status === 'published' ? 'unlisted' : 'published'}
+                        />
+                        <button type="submit">
+                          {pack.status === 'published' ? 'Unlist' : 'Publish'}
+                        </button>
+                      </form>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <h2>Add or edit a pack</h2>
+      <form action={save} className="flag">
+        <CsrfField />
+        <label>
+          Id <span className="faint">(blank to create)</span>
+          <input name="id" placeholder="" />
+        </label>
+        <label>
+          Slug
+          <input
+            name="slug"
+            required
+            placeholder="india-everyday"
+            pattern="[a-z0-9]+(-[a-z0-9]+)*"
+          />
+        </label>
+        <label>
+          Title
+          <input name="title" required placeholder="India · everyday" maxLength={60} />
+        </label>
+        <label>
+          Summary
+          <input name="summary" required maxLength={200} />
+        </label>
+        <label>
+          Status
+          <select name="status" defaultValue="draft">
+            <option value="draft">draft</option>
+            <option value="published">published</option>
+            <option value="unlisted">unlisted</option>
+          </select>
+        </label>
+        <label>
+          Entries
+          <textarea
+            name="entries"
+            required
+            rows={10}
+            defaultValue={
+              '[\n  {"key":"kirana","label":"Kirana","icon":"storefront-outline","tint":"mint","axis":"expense"}\n]'
+            }
+          />
+        </label>
+        <button type="submit">Save pack</button>
+      </form>
+
+      <p className="note">
+        Each entry needs a <code>key</code> (lowercase, unique in the pack), a <code>label</code> of
+        40 characters or fewer, an <code>icon</code> from the curated Ionicons set, a{' '}
+        <code>tint</code> of lilac / pink / mint / peach / sky / coral, and an <code>axis</code> of{' '}
+        <code>expense</code> or <code>income</code>. Anything else is refused here rather than
+        rendering as a blank box on somebody&rsquo;s phone.
+      </p>
+    </main>
+  );
+}

--- a/apps/admin/src/components/Sidebar.tsx
+++ b/apps/admin/src/components/Sidebar.tsx
@@ -99,6 +99,13 @@ const SECTIONS: Section[] = [
     ],
   },
   {
+    heading: 'Marketplace',
+    items: [
+      { href: '/packs', label: 'Packs', icon: I.tag },
+      { href: '/pack-requests', label: 'Pack requests', icon: I.chat },
+    ],
+  },
+  {
     heading: 'Voice',
     items: [
       { href: '/feedback', label: 'Feedback', icon: I.chat },

--- a/apps/admin/src/lib/data.ts
+++ b/apps/admin/src/lib/data.ts
@@ -1,5 +1,7 @@
 import 'server-only';
 
+import { PACK_STATUSES, parsePack } from '@waves/core';
+
 import { cookies } from 'next/headers';
 import { createClient } from '@supabase/supabase-js';
 
@@ -813,4 +815,146 @@ export async function logins(days = 30): Promise<{ rows: LoginRow[]; unavailable
   } catch (caught) {
     return { rows: [], unavailable: caught instanceof Error ? caught.message : String(caught) };
   }
+}
+
+// ─────────────────────────────────────────────────────────────── packs ──
+
+export interface PackRow {
+  id: string;
+  slug: string;
+  title: string;
+  summary: string;
+  entries: unknown;
+  status: string;
+  version: number;
+  install_count: number;
+  updated_at: string;
+}
+
+/**
+ * Every pack, in every state — the console is the only place a draft or an
+ * unlisted one is visible at all, since `packs` is readable by an app user only
+ * where `status = 'published'`.
+ */
+export async function packs(): Promise<PackRow[]> {
+  await requireSession();
+  const { data, error } = await client()
+    .from('packs')
+    .select('id, slug, title, summary, entries, status, version, install_count, updated_at')
+    .order('status')
+    .order('slug');
+  if (error) {
+    if (error.code === TABLE_MISSING) return [];
+    throw new Error(`reading packs failed: ${error.message}`);
+  }
+  return (data ?? []) as PackRow[];
+}
+
+/**
+ * Create or update one pack.
+ *
+ * `parsePack` is the same function the client runs on what it fetches, so a pack
+ * that would be dropped on a phone cannot be saved here in the first place — the
+ * author sees the refusal while they are still looking at what they wrote,
+ * rather than discovering later that the shelf is one shorter than it should be.
+ */
+export async function savePack(input: {
+  id?: string;
+  slug: string;
+  title: string;
+  summary: string;
+  entriesJson: string;
+  status: string;
+}): Promise<void> {
+  await requireSession();
+
+  if (!PACK_STATUSES.includes(input.status as (typeof PACK_STATUSES)[number])) {
+    throw new Error(`Status must be one of ${PACK_STATUSES.join(', ')}.`);
+  }
+
+  let entries: unknown;
+  try {
+    entries = JSON.parse(input.entriesJson);
+  } catch {
+    throw new Error('The entries are not valid JSON.');
+  }
+
+  const parsed = parsePack({
+    id: input.id ?? 'draft',
+    slug: input.slug.trim(),
+    title: input.title.trim(),
+    summary: input.summary.trim(),
+    entries,
+    version: 1,
+  });
+  if (!parsed) {
+    throw new Error(
+      'Refused: every entry needs a key, a label of 40 characters or fewer, an icon from the ' +
+        'curated set, one of the six tints, and an axis of expense or income. Keys must be ' +
+        'unique within the pack.',
+    );
+  }
+
+  const row = {
+    slug: parsed.slug,
+    title: parsed.title,
+    summary: parsed.summary,
+    entries: parsed.entries,
+    status: input.status,
+    updated_at: new Date().toISOString(),
+  };
+
+  const query = input.id
+    ? client().from('packs').update(row).eq('id', input.id)
+    : client().from('packs').insert(row);
+  const { error } = await query;
+  if (error) throw new Error(`saving the pack failed: ${error.message}`);
+}
+
+/** Publish or withdraw, without touching what is in the pack. Withdrawing stops
+ *  it spreading and changes nothing for anybody who already installed it. */
+export async function setPackStatus(id: string, status: string): Promise<void> {
+  await requireSession();
+  if (!PACK_STATUSES.includes(status as (typeof PACK_STATUSES)[number])) {
+    throw new Error(`Status must be one of ${PACK_STATUSES.join(', ')}.`);
+  }
+  const { error } = await client()
+    .from('packs')
+    .update({ status, updated_at: new Date().toISOString() })
+    .eq('id', id);
+  if (error) throw new Error(`changing the pack status failed: ${error.message}`);
+}
+
+export interface PackRequestRow {
+  id: string;
+  body: string;
+  status: string;
+  created_at: string;
+}
+
+/** What people have asked for. Open first, newest first within that. */
+export async function packRequests(): Promise<PackRequestRow[]> {
+  await requireSession();
+  const { data, error } = await client()
+    .from('pack_requests')
+    .select('id, body, status, created_at')
+    .order('status')
+    .order('created_at', { ascending: false })
+    .limit(200);
+  if (error) {
+    if (error.code === TABLE_MISSING) return [];
+    throw new Error(`reading pack_requests failed: ${error.message}`);
+  }
+  return (data ?? []) as PackRequestRow[];
+}
+
+/** Decide one request. The shape matches `member_claims`: an open row carries no
+ *  decision stamp, and a decided one always does. */
+export async function decidePackRequest(id: string, status: 'done' | 'declined'): Promise<void> {
+  await requireSession();
+  const { error } = await client()
+    .from('pack_requests')
+    .update({ status, decided_at: new Date().toISOString() })
+    .eq('id', id);
+  if (error) throw new Error(`deciding the request failed: ${error.message}`);
 }

--- a/apps/admin/test/seededPacks.test.ts
+++ b/apps/admin/test/seededPacks.test.ts
@@ -1,0 +1,93 @@
+/**
+ * The packs we seed have to survive the gate we wrote.
+ *
+ * A seeded pack goes into the database as raw SQL, so it never passes through
+ * `parsePack` on the way in. If one carries a glyph that does not exist or a
+ * tint outside the six, the client does the only safe thing and drops it — and
+ * the pack is simply missing from the shelf, with nothing anywhere saying why.
+ * A typo in a seed would be invisible until somebody noticed the shelf was
+ * shorter than it should be.
+ *
+ * It lives in the admin package rather than in core because it reads a file, and
+ * `@waves/core` is deliberately platform-neutral — it runs in Deno and on a
+ * phone, and giving it Node types to accommodate one test would be the wrong
+ * trade. This is also the package that publishes packs, so it is the right place
+ * for the check that they are publishable.
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { parsePack, PACK_LIMITS } from '@waves/core';
+
+const MIGRATIONS = join(process.cwd(), '..', '..', 'packages', 'db', 'prisma', 'migrations');
+
+/** Every `INSERT INTO public.packs` seed migration, by name. */
+function seedFiles(): string[] {
+  return readdirSync(MIGRATIONS)
+    .filter((name) => name.includes('seed_category_packs'))
+    .map((name) => join(MIGRATIONS, name, 'migration.sql'));
+}
+
+/** The `(slug, title, summary, status, version, entries)` tuples, as packs. */
+function packsIn(sql: string): { slug: string; pack: unknown }[] {
+  const out: { slug: string; pack: unknown }[] = [];
+  const rows = sql.matchAll(
+    /\(\s*'([a-z0-9-]+)',\s*'((?:[^']|'')*)',\s*'((?:[^']|'')*)',\s*'\w+',\s*(\d+),\s*'(\[[\s\S]*?\])'::jsonb\s*\)/g,
+  );
+  for (const row of rows) {
+    const [, slug, title, summary, version, entries] = row;
+    out.push({
+      slug: slug!,
+      pack: {
+        id: `seed-${slug}`,
+        slug,
+        // SQL escapes a quote by doubling it; undo that before measuring length.
+        title: title!.replace(/''/g, "'"),
+        summary: summary!.replace(/''/g, "'"),
+        version: Number(version),
+        entries: JSON.parse(entries!),
+      },
+    });
+  }
+  return out;
+}
+
+describe('the packs we ship', () => {
+  const files = seedFiles();
+
+  it('has a seed migration at all', () => {
+    // If this fails the glob is wrong and every assertion below is vacuous.
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  const seeded = files.flatMap((file) => packsIn(readFileSync(file, 'utf8')));
+
+  it('found the packs inside it', () => {
+    expect(seeded.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it.each(seeded.map((entry) => [entry.slug, entry.pack] as const))(
+    'ships %s through the same gate the client uses',
+    (_slug, raw) => {
+      // A failure here is a real glyph or tint typo: the client would drop this
+      // pack, and the shelf would be quietly one shorter.
+      expect(parsePack(raw)).not.toBeNull();
+    },
+  );
+
+  it('gives every pack a distinct slug', () => {
+    const slugs = seeded.map((entry) => entry.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it('keeps every pack inside the limits', () => {
+    for (const { pack } of seeded) {
+      const parsed = parsePack(pack)!;
+      expect(parsed.entries.length).toBeLessThanOrEqual(PACK_LIMITS.entries);
+      expect(parsed.entries.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/mobile/src/app/settings/categories.tsx
+++ b/apps/mobile/src/app/settings/categories.tsx
@@ -240,16 +240,39 @@ export default function CategoriesSettingsScreen() {
             </View>
           }
           ListFooterComponent={
-            order.length > 0 ? (
-              <Text
-                variant="micro"
-                tone="muted"
-                align="center"
-                style={{ marginTop: theme.spacing.md }}
+            <View style={{ gap: theme.spacing.lg, marginTop: theme.spacing.md }}>
+              {order.length > 0 ? (
+                <Text variant="micro" tone="muted" align="center">
+                  {t.tags.reorderHint}
+                </Text>
+              ) : null}
+              {/* The shelf. Here rather than in a menu of its own because this is
+                  the screen somebody is on when they discover the built-in ten
+                  are not the words they use. */}
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={t.packs.browse}
+                onPress={() => router.push('/settings/packs')}
+                style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
               >
-                {t.tags.reorderHint}
-              </Text>
-            ) : null
+                <Card>
+                  <Row style={{ gap: theme.spacing.md, alignItems: 'center' }}>
+                    <Ionicons name="cube-outline" size={iconSize.lg} color={theme.color.brand} />
+                    <View style={{ flex: 1 }}>
+                      <Text variant="body">{t.packs.browse}</Text>
+                      <Text variant="micro" tone="muted">
+                        {t.packs.browseHint}
+                      </Text>
+                    </View>
+                    <Ionicons
+                      name={directionalIcon('chevron-forward')}
+                      size={iconSize.md}
+                      color={theme.color.textFaint}
+                    />
+                  </Row>
+                </Card>
+              </Pressable>
+            </View>
           }
         />
       </View>

--- a/apps/mobile/src/app/settings/packs.tsx
+++ b/apps/mobile/src/app/settings/packs.tsx
@@ -1,0 +1,261 @@
+/**
+ * The shelf: every pack we have published.
+ *
+ * The app's ten spend categories and fifteen income sources are deliberately
+ * general — nothing shaped to one country's instruments or one person's trade.
+ * A pack is how somebody gets the words they actually use without those words
+ * being shipped to everybody: a landlord's, a freelancer's, a chit fund's.
+ *
+ * The catalogue is a network read, not a mirrored table. What we publish is not
+ * the user's data, and holding a copy would make every visit an offline read of
+ * a stale shelf. Offline it is empty and says so; nothing else suffers for it,
+ * because the categories somebody has already added are ordinary tags in their
+ * own catalog by then.
+ */
+
+import { useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router } from 'expo-router';
+import { FlashList } from '@shopify/flash-list';
+import { Pressable, TextInput, View } from 'react-native';
+
+import {
+  Button,
+  Card,
+  directionalIcon,
+  EmptyState,
+  IconButton,
+  iconSize,
+  Row,
+  Screen,
+  Sheet,
+  Text,
+  useScreenClearance,
+  useTheme,
+} from '@waves/ui';
+
+import { useInstalledPacks, usePacks, useRequestPack, type ShelfPack } from '@/data/packs';
+import { plural, useStrings } from '@/i18n';
+
+export default function PacksScreen() {
+  const theme = useTheme();
+  const clearance = useScreenClearance();
+  const { t, locale } = useStrings();
+  const packs = usePacks();
+  const installed = useInstalledPacks();
+  const [asking, setAsking] = useState(false);
+
+  const installedIds = new Set(installed.map((row) => row.packId));
+
+  return (
+    <Screen>
+      <Row
+        style={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.md,
+          alignItems: 'center',
+        }}
+      >
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.packs.title}</Text>
+        </View>
+        <View style={{ width: iconSize.lg + theme.spacing.md }} />
+      </Row>
+
+      <FlashList
+        data={packs.data ?? []}
+        keyExtractor={(pack) => pack.id}
+        extraData={[locale, theme.scheme, installedIds.size]}
+        drawDistance={1500}
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: clearance,
+        }}
+        ListHeaderComponent={
+          <Text
+            variant="caption"
+            tone="muted"
+            align="center"
+            style={{ paddingVertical: theme.spacing.md }}
+          >
+            {t.packs.subtitle}
+          </Text>
+        }
+        ListEmptyComponent={
+          <View style={{ paddingTop: theme.spacing.xxxl, gap: theme.spacing.lg }}>
+            <EmptyState
+              title={packs.isError ? t.loadError : t.packs.empty}
+              body={packs.isError ? t.packs.offline : t.packs.emptyBody}
+            />
+            {packs.isError ? <Button label={t.retry} onPress={() => void packs.refetch()} /> : null}
+          </View>
+        }
+        renderItem={({ item }) => (
+          <PackRow
+            pack={item}
+            installed={installedIds.has(item.id)}
+            onPress={() =>
+              router.push({ pathname: '/settings/packs/[slug]', params: { slug: item.slug } })
+            }
+          />
+        )}
+        ListFooterComponent={
+          // The other half of "we author them, others ask". Deliberately quiet
+          // and at the bottom: it is an offer, not a form somebody must fill in
+          // before the shelf is useful.
+          <Pressable
+            accessibilityRole="button"
+            onPress={() => setAsking(true)}
+            style={({ pressed }) => ({
+              paddingVertical: theme.spacing.xl,
+              opacity: pressed ? 0.6 : 1,
+            })}
+          >
+            <Text variant="caption" tone="brand" align="center">
+              {t.packs.askTitle}
+            </Text>
+          </Pressable>
+        }
+      />
+
+      {asking ? <AskSheet onClose={() => setAsking(false)} /> : null}
+    </Screen>
+  );
+}
+
+function PackRow({
+  pack,
+  installed,
+  onPress,
+}: {
+  pack: ShelfPack;
+  installed: boolean;
+  onPress: () => void;
+}) {
+  const theme = useTheme();
+  const { t, locale } = useStrings();
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={pack.title}
+      onPress={onPress}
+      style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+    >
+      <Card style={{ marginBottom: theme.spacing.md, gap: theme.spacing.sm }}>
+        <Row style={{ alignItems: 'center', gap: theme.spacing.sm }}>
+          <Text variant="subheading" style={{ flex: 1 }} numberOfLines={1}>
+            {pack.title}
+          </Text>
+          {installed ? (
+            <Row style={{ gap: theme.spacing.xs, alignItems: 'center' }}>
+              <Ionicons name="checkmark-circle" size={iconSize.md} color={theme.color.positive} />
+              <Text variant="micro" tone="positive">
+                {t.packs.installed}
+              </Text>
+            </Row>
+          ) : null}
+        </Row>
+        <Text variant="caption" tone="muted" numberOfLines={2}>
+          {pack.summary}
+        </Text>
+        {/* A few of the actual chips, so the shelf shows what is inside rather
+            than only claiming a number. */}
+        <Row style={{ gap: theme.spacing.xs, flexWrap: 'wrap' }}>
+          {pack.entries.slice(0, 4).map((entry) => (
+            <Row
+              key={entry.key}
+              style={{
+                gap: theme.spacing.xs,
+                alignItems: 'center',
+                paddingVertical: theme.spacing.xs,
+                paddingHorizontal: theme.spacing.sm,
+                borderRadius: theme.radius.sm,
+                backgroundColor: theme.tint[entry.tint].bg,
+              }}
+            >
+              <Ionicons
+                name={entry.icon as keyof typeof Ionicons.glyphMap}
+                size={iconSize.sm}
+                color={theme.tint[entry.tint].ink}
+              />
+              <Text variant="micro" style={{ color: theme.tint[entry.tint].ink }}>
+                {entry.label}
+              </Text>
+            </Row>
+          ))}
+        </Row>
+        <Text variant="micro" tone="faint">
+          {plural(locale, pack.entries.length, t.packs.includes)}
+        </Text>
+      </Card>
+    </Pressable>
+  );
+}
+
+/** One sentence, one row, nothing anybody else ever sees. */
+function AskSheet({ onClose }: { onClose: () => void }) {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const request = useRequestPack();
+  const [body, setBody] = useState('');
+  const [sent, setSent] = useState(false);
+
+  const send = (): void => {
+    if (body.trim().length === 0 || request.isPending) return;
+    request.mutate(body, { onSuccess: () => setSent(true) });
+  };
+
+  return (
+    <Sheet visible onClose={onClose} closeLabel={t.common.close}>
+      <View style={{ gap: theme.spacing.lg }}>
+        <Text variant="heading">{t.packs.askTitle}</Text>
+        {sent ? (
+          <>
+            <Text variant="body" tone="muted">
+              {t.packs.askSent}
+            </Text>
+            <Button label={t.common.close} size="lg" fullWidth onPress={onClose} />
+          </>
+        ) : (
+          <>
+            <Text variant="caption" tone="muted">
+              {t.packs.askBody}
+            </Text>
+            <TextInput
+              value={body}
+              onChangeText={setBody}
+              placeholder={t.packs.askPlaceholder}
+              placeholderTextColor={theme.color.textFaint}
+              multiline
+              maxLength={500}
+              style={{
+                minHeight: 96,
+                fontSize: 16,
+                color: theme.color.text,
+                textAlignVertical: 'top',
+                padding: theme.spacing.lg,
+                backgroundColor: theme.color.surfaceMuted,
+                borderRadius: theme.radius.md,
+              }}
+            />
+            <Button
+              label={t.packs.askSend}
+              size="lg"
+              fullWidth
+              onPress={send}
+              disabled={body.trim().length === 0 || request.isPending}
+            />
+          </>
+        )}
+      </View>
+    </Sheet>
+  );
+}

--- a/apps/mobile/src/app/settings/packs/[slug].tsx
+++ b/apps/mobile/src/app/settings/packs/[slug].tsx
@@ -1,0 +1,212 @@
+/**
+ * One pack: everything in it, and the two buttons that matter.
+ *
+ * Installing writes the categories into the person's own catalog as ordinary
+ * custom tags — so they can be renamed, recoloured, hidden or deleted like any
+ * other, and an expense filed under one carries its label as a snapshot. That is
+ * what lets the uninstall copy say, truthfully, that the categories stay.
+ *
+ * Every chip below is drawn from the pack's own icon and tint, so what somebody
+ * sees here is exactly what they are agreeing to add.
+ */
+
+import { useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router, useLocalSearchParams } from 'expo-router';
+import { Alert, ScrollView, View } from 'react-native';
+
+import type { PackEntry } from '@waves/core';
+import {
+  Button,
+  Card,
+  directionalIcon,
+  Divider,
+  EmptyState,
+  IconButton,
+  iconSize,
+  Row,
+  Screen,
+  Text,
+  useScreenClearance,
+  useTheme,
+} from '@waves/ui';
+
+import { useInstallPack, useInstalledPacks, usePacks, useUninstallPack } from '@/data/packs';
+import { plural, useStrings } from '@/i18n';
+
+export default function PackScreen() {
+  const theme = useTheme();
+  const clearance = useScreenClearance();
+  const { t, locale } = useStrings();
+  const { slug } = useLocalSearchParams<{ slug: string }>();
+
+  const packs = usePacks();
+  const installed = useInstalledPacks();
+  const install = useInstallPack();
+  const uninstall = useUninstallPack();
+  const [added, setAdded] = useState<number | null>(null);
+
+  const pack = (packs.data ?? []).find((candidate) => candidate.slug === slug) ?? null;
+  const record = pack ? (installed.find((row) => row.packId === pack.id) ?? null) : null;
+
+  if (!pack) {
+    return (
+      <Screen>
+        <Header title={t.packs.title} />
+        <View style={{ paddingTop: theme.spacing.xxxl }}>
+          <EmptyState
+            title={packs.isLoading ? t.common.loading : t.packs.notFound}
+            body={packs.isError ? t.packs.offline : undefined}
+          />
+        </View>
+      </Screen>
+    );
+  }
+
+  const spending = pack.entries.filter((entry) => entry.axis === 'expense');
+  const income = pack.entries.filter((entry) => entry.axis === 'income');
+
+  const onInstall = (): void => {
+    install.mutate(pack, { onSuccess: (count) => setAdded(count) });
+  };
+
+  const onUninstall = (): void => {
+    if (!record) return;
+    Alert.alert(t.packs.uninstallTitle, t.packs.uninstallBody, [
+      { text: t.common.cancel, style: 'cancel' },
+      {
+        text: t.packs.uninstall,
+        style: 'destructive',
+        onPress: () => uninstall.mutate(record.installId, { onSuccess: () => setAdded(null) }),
+      },
+    ]);
+  };
+
+  return (
+    <Screen>
+      <Header title={pack.title} />
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: clearance,
+          gap: theme.spacing.lg,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        <Text variant="body" tone="muted">
+          {pack.summary}
+        </Text>
+
+        {spending.length > 0 ? <Section title={t.packs.expenseSide} entries={spending} /> : null}
+        {income.length > 0 ? <Section title={t.packs.incomeSide} entries={income} /> : null}
+
+        <Text variant="micro" tone="faint" align="center">
+          {plural(locale, pack.entries.length, t.packs.includes)}
+        </Text>
+
+        {/* What actually happened, said in the number that is true: installing a
+            pack you mostly have adds the few that are new, and saying "12 added"
+            when two were would be a small lie the person can see through. */}
+        {added !== null ? (
+          <Text variant="caption" tone="positive" align="center">
+            {added > 0 ? plural(locale, added, t.packs.added) : t.packs.alreadyHave}
+          </Text>
+        ) : null}
+
+        {record ? (
+          <View style={{ gap: theme.spacing.sm }}>
+            <Row style={{ gap: theme.spacing.xs, alignItems: 'center', justifyContent: 'center' }}>
+              <Ionicons name="checkmark-circle" size={iconSize.md} color={theme.color.positive} />
+              <Text variant="caption" tone="positive">
+                {t.packs.installed}
+              </Text>
+            </Row>
+            <Button
+              label={t.packs.uninstall}
+              variant="secondary"
+              fullWidth
+              onPress={onUninstall}
+              disabled={uninstall.isPending}
+            />
+            <Text variant="micro" tone="faint" align="center">
+              {t.packs.uninstallBody}
+            </Text>
+          </View>
+        ) : (
+          <Button
+            label={install.isPending ? t.packs.installing : t.packs.install}
+            size="lg"
+            fullWidth
+            onPress={onInstall}
+            disabled={install.isPending}
+          />
+        )}
+      </ScrollView>
+    </Screen>
+  );
+}
+
+function Header({ title }: { title: string }) {
+  const theme = useTheme();
+  const { t } = useStrings();
+  return (
+    <Row
+      style={{
+        paddingHorizontal: theme.spacing.xl,
+        paddingTop: theme.spacing.md,
+        paddingBottom: theme.spacing.sm,
+        alignItems: 'center',
+      }}
+    >
+      <IconButton label={t.common.back} onPress={() => router.back()}>
+        <Ionicons
+          name={directionalIcon('chevron-back')}
+          size={iconSize.lg}
+          color={theme.color.text}
+        />
+      </IconButton>
+      <View style={{ flex: 1, alignItems: 'center' }}>
+        <Text variant="heading" numberOfLines={1}>
+          {title}
+        </Text>
+      </View>
+      <View style={{ width: iconSize.lg + theme.spacing.md }} />
+    </Row>
+  );
+}
+
+/** One side of the pack — what it adds to spending, or to income. */
+function Section({ title, entries }: { title: string; entries: readonly PackEntry[] }) {
+  const theme = useTheme();
+  return (
+    <Card style={{ gap: theme.spacing.md }}>
+      <Text variant="caption" tone="muted">
+        {title}
+      </Text>
+      <Divider />
+      {entries.map((entry) => (
+        <Row key={entry.key} style={{ gap: theme.spacing.md, alignItems: 'center' }}>
+          <View
+            style={{
+              width: 36,
+              height: 36,
+              borderRadius: 18,
+              alignItems: 'center',
+              justifyContent: 'center',
+              backgroundColor: theme.tint[entry.tint].bg,
+            }}
+          >
+            <Ionicons
+              name={entry.icon as keyof typeof Ionicons.glyphMap}
+              size={iconSize.md}
+              color={theme.tint[entry.tint].ink}
+            />
+          </View>
+          <Text variant="body" style={{ flex: 1 }} numberOfLines={1}>
+            {entry.label}
+          </Text>
+        </Row>
+      ))}
+    </Card>
+  );
+}

--- a/apps/mobile/src/components/IncomeSource.tsx
+++ b/apps/mobile/src/components/IncomeSource.tsx
@@ -12,9 +12,16 @@
 import { Pressable, ScrollView, View } from 'react-native';
 import Ionicons from '@expo/vector-icons/Ionicons';
 
-import { INCOME_SOURCES, incomeSource, type IncomeSource } from '@waves/core';
+import {
+  incomeSource,
+  incomeTags,
+  INCOME_SOURCES,
+  type CatalogEntry,
+  type IncomeSource,
+} from '@waves/core';
 import { iconSize, Text, useTheme } from '@waves/ui';
 
+import { useCategoryTags } from '@/data/hooks';
 import { useStrings, type UiStrings } from '@/i18n';
 
 /** The stored id carries an `inc.` prefix so the two vocabularies can share one
@@ -25,12 +32,15 @@ function labelKey(id: string): keyof UiStrings['personal']['sources'] {
 
 export function useSourceLabel(): (id: string | null) => string | null {
   const { t } = useStrings();
+  const tags = useCategoryTags().data;
   return (id) => {
     if (id === null) return null;
     const source = incomeSource(id);
-    // A source we do not know is one the person made themselves: their own
-    // words are the best label there is, so show them rather than "Other".
-    return source ? t.personal.sources[labelKey(source.id)] : id;
+    if (source) return t.personal.sources[labelKey(source.id)];
+    // Not a built-in, so it is one of theirs — from a pack or made by hand. Their
+    // own words are the best label there is; the raw id is the last resort for a
+    // tag that has not synced to this device yet.
+    return tags.find((tag) => tag.id === id)?.label ?? id;
   };
 }
 
@@ -43,6 +53,10 @@ export function SourcePicker({
 }) {
   const theme = useTheme();
   const { t } = useStrings();
+  // The fifteen we ship, then the person's own — from a pack, or made by hand.
+  // Theirs come second rather than mixed in, so the list somebody learned does
+  // not reorder itself the first time they install something.
+  const mine = incomeTags(useCategoryTags().data).filter((entry) => !entry.hidden);
 
   return (
     <ScrollView
@@ -82,6 +96,41 @@ export function SourcePicker({
             />
             <Text variant="body" style={{ color: selected ? theme.color.brand : theme.color.text }}>
               {label}
+            </Text>
+          </Pressable>
+        );
+      })}
+
+      {mine.map((entry: CatalogEntry) => {
+        const selected = entry.key === value;
+        return (
+          <Pressable
+            key={entry.key}
+            accessibilityRole="radio"
+            accessibilityState={{ selected }}
+            accessibilityLabel={entry.label}
+            onPress={() => onChange(entry.key)}
+            style={({ pressed }) => ({
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: theme.spacing.xs,
+              minHeight: 44,
+              paddingVertical: theme.spacing.sm,
+              paddingHorizontal: theme.spacing.md,
+              borderRadius: theme.radius.md,
+              borderWidth: 1,
+              borderColor: selected ? theme.color.brand : theme.color.border,
+              backgroundColor: selected ? theme.color.brandSoft : theme.color.surface,
+              opacity: pressed ? 0.7 : 1,
+            })}
+          >
+            <Ionicons
+              name={entry.icon as keyof typeof Ionicons.glyphMap}
+              size={iconSize.md}
+              color={selected ? theme.color.brand : theme.color.textMuted}
+            />
+            <Text variant="body" style={{ color: selected ? theme.color.brand : theme.color.text }}>
+              {entry.label}
             </Text>
           </Pressable>
         );

--- a/apps/mobile/src/components/tagIcons.ts
+++ b/apps/mobile/src/components/tagIcons.ts
@@ -1,158 +1,28 @@
 /**
- * The glyphs a custom expense tag may wear (extends TDR §8).
+ * The glyphs a custom tag may wear, typed against this app's own glyph map.
  *
- * A wide, curated set of Ionicons — the everyday shapes of spending across food,
- * travel, home, work, health, fun, people and money — not the whole glyph map,
- * which would be a wall of arrows and logos nobody tags a bill with. All outline
- * style, to sit beside the built-in categories, grouped so the picker reads in
- * bands rather than as one undifferentiated grid. Its own module so a test can
- * assert every name is a real glyph.
+ * The names themselves live in `@waves/core` so the sync edge function can
+ * validate against the same list (see the note there). This module is what
+ * proves they are real: `IoniconName` is `keyof typeof Ionicons.glyphMap`, so a
+ * name that is not a glyph fails to compile, and `tagIcons.test.ts` walks the
+ * whole list. Core holds the vocabulary; the app holds the guarantee.
  */
 
 import Ionicons from '@expo/vector-icons/Ionicons';
 
+import {
+  DEFAULT_TAG_ICON as CORE_DEFAULT,
+  TAG_ICON_GROUPS as CORE_GROUPS,
+  TAG_ICONS as CORE_ICONS,
+} from '@waves/core';
+
 export type IoniconName = keyof typeof Ionicons.glyphMap;
 
 /** Grouped for the picker; flattened into `TAG_ICONS` below. */
-export const TAG_ICON_GROUPS: readonly (readonly IoniconName[])[] = [
-  // Food & drink
-  [
-    'restaurant-outline',
-    'fast-food-outline',
-    'pizza-outline',
-    'cafe-outline',
-    'beer-outline',
-    'wine-outline',
-    'nutrition-outline',
-    'ice-cream-outline',
-    'egg-outline',
-    'fish-outline',
-  ],
-  // Groceries & shopping
-  [
-    'cart-outline',
-    'basket-outline',
-    'bag-handle-outline',
-    'pricetag-outline',
-    'pricetags-outline',
-    'shirt-outline',
-    'gift-outline',
-    'storefront-outline',
-    'cube-outline',
-    'balloon-outline',
-  ],
-  // Getting around
-  [
-    'car-outline',
-    'car-sport-outline',
-    'bus-outline',
-    'train-outline',
-    'subway-outline',
-    'bicycle-outline',
-    'boat-outline',
-    'airplane-outline',
-    'rocket-outline',
-    'walk-outline',
-  ],
-  // Travel & stay
-  [
-    'bed-outline',
-    'business-outline',
-    'map-outline',
-    'compass-outline',
-    'earth-outline',
-    'sunny-outline',
-    'umbrella-outline',
-    'camera-outline',
-    'ticket-outline',
-    'trail-sign-outline',
-  ],
-  // Home, bills & utilities
-  [
-    'home-outline',
-    'bulb-outline',
-    'flash-outline',
-    'water-outline',
-    'flame-outline',
-    'wifi-outline',
-    'call-outline',
-    'tv-outline',
-    'construct-outline',
-    'hammer-outline',
-    'trash-outline',
-    'shield-checkmark-outline',
-  ],
-  // Work & study
-  [
-    'briefcase-outline',
-    'laptop-outline',
-    'desktop-outline',
-    'print-outline',
-    'document-text-outline',
-    'school-outline',
-    'book-outline',
-    'library-outline',
-    'calculator-outline',
-    'mail-outline',
-  ],
-  // Health & fitness
-  [
-    'medkit-outline',
-    'medical-outline',
-    'fitness-outline',
-    'barbell-outline',
-    'heart-outline',
-    'pulse-outline',
-    'bandage-outline',
-    'eye-outline',
-    'flask-outline',
-    'leaf-outline',
-  ],
-  // Fun & hobbies
-  [
-    'game-controller-outline',
-    'musical-notes-outline',
-    'headset-outline',
-    'film-outline',
-    'football-outline',
-    'basketball-outline',
-    'tennisball-outline',
-    'golf-outline',
-    'color-palette-outline',
-    'brush-outline',
-    'dice-outline',
-    'planet-outline',
-  ],
-  // People, gifts & celebration
-  [
-    'people-outline',
-    'person-outline',
-    'happy-outline',
-    'sparkles-outline',
-    'ribbon-outline',
-    'trophy-outline',
-    'star-outline',
-    'flower-outline',
-    'paw-outline',
-    'accessibility-outline',
-  ],
-  // Money & the rest
-  [
-    'card-outline',
-    'cash-outline',
-    'wallet-outline',
-    'pie-chart-outline',
-    'trending-up-outline',
-    'receipt-outline',
-    'time-outline',
-    'calendar-outline',
-    'key-outline',
-    'ellipsis-horizontal-circle-outline',
-  ],
-];
+export const TAG_ICON_GROUPS = CORE_GROUPS as readonly (readonly IoniconName[])[];
 
 /** The flat list the editor renders — every group, in order. */
-export const TAG_ICONS: readonly IoniconName[] = TAG_ICON_GROUPS.flat();
+export const TAG_ICONS = CORE_ICONS as readonly IoniconName[];
 
 /** The default a new tag starts on. */
-export const DEFAULT_TAG_ICON: IoniconName = 'pricetag-outline';
+export const DEFAULT_TAG_ICON = CORE_DEFAULT as IoniconName;

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -1462,6 +1462,8 @@ function tagRowFrom(row: MirrorCategoryTag): CategoryTagRow {
     label: row.label ?? null,
     icon: row.icon ?? null,
     tint: row.tint ?? null,
+    axis: row.axis === 'income' ? 'income' : 'expense',
+    packId: row.pack_id ?? null,
     sortOrder: Number(row.sort_order ?? 0),
     hidden: row.hidden === true,
   };

--- a/apps/mobile/src/data/packs.ts
+++ b/apps/mobile/src/data/packs.ts
@@ -1,0 +1,167 @@
+/**
+ * The shelf, and what is on this person's own shelf.
+ *
+ * Two different kinds of data, deliberately read two different ways:
+ *
+ * - **The catalogue is a network read.** What we publish is not the user's data,
+ *   and mirroring it would make every visit an offline read of a stale shelf.
+ *   Offline, the shelf is empty and says so — which is honest, and nothing else
+ *   in the app breaks for want of it.
+ * - **Their installs ride the mirror**, like every other personal row, so a pack
+ *   installed on a plane shows as installed straight away.
+ *
+ * Installing writes two things through the ordinary queue: the tags, as
+ * `tag.create` mutations, and one `pack.install` row saying where they came
+ * from. Nothing here is privileged, which is why it works with no signal.
+ */
+
+import { useMemo } from 'react';
+import { randomUUID } from 'expo-crypto';
+import { useMutation, useQuery } from '@tanstack/react-query';
+
+import {
+  installPlan,
+  materialisePackInstalls,
+  MutationKind,
+  packInstallsScope,
+  parsePack,
+  categoryTagsScope,
+  type Pack,
+} from '@waves/core';
+
+import { backend } from '@/lib/backend';
+import { useAuth } from '@/lib/auth';
+import { useCategoryTags } from '@/data/hooks';
+import { useSync } from '@/sync';
+
+/** A published pack, as the shelf shows it. */
+export interface ShelfPack extends Pack {
+  readonly installCount: number;
+}
+
+/**
+ * Every published pack.
+ *
+ * `parsePack` runs again here, on what the server sent. The console validated
+ * before publishing and RLS limits this to what we published — and a client that
+ * trusts both of those and renders whatever arrives is a client that draws a
+ * blank box the first time something upstream goes wrong. A pack that does not
+ * parse is dropped rather than shown broken.
+ */
+export async function fetchPacks(): Promise<ShelfPack[]> {
+  const { data, error } = await backend
+    .from('packs')
+    .select('id, slug, title, summary, entries, version, install_count')
+    .order('install_count', { ascending: false });
+  if (error) throw error;
+
+  const out: ShelfPack[] = [];
+  for (const row of data ?? []) {
+    const record = row as Record<string, unknown>;
+    const pack = parsePack({
+      id: record.id,
+      slug: record.slug,
+      title: record.title,
+      summary: record.summary,
+      entries: record.entries,
+      version: record.version,
+    });
+    if (!pack) continue;
+    out.push({ ...pack, installCount: Number(record.install_count ?? 0) });
+  }
+  return out;
+}
+
+export function usePacks() {
+  return useQuery({ queryKey: ['packs'], queryFn: fetchPacks });
+}
+
+export interface InstalledPack {
+  readonly installId: string;
+  readonly packId: string;
+  readonly version: number;
+  readonly pending: boolean;
+}
+
+/** What this person has installed, read local-first like every personal row. */
+export function useInstalledPacks(): InstalledPack[] {
+  const { mirror, queue } = useSync();
+  const { session } = useAuth();
+  const ownerId = session?.user?.id ?? null;
+
+  return useMemo(() => {
+    if (!ownerId) return [];
+    return materialisePackInstalls(mirror, queue, { ownerId }).map((row) => ({
+      installId: row.id,
+      packId: row.pack_id,
+      version: row.version,
+      pending: row.pending === true,
+    }));
+  }, [mirror, queue, ownerId]);
+}
+
+/**
+ * Install a pack: its categories, then the record of where they came from.
+ *
+ * The tags go first on purpose. If the run is interrupted between the two, the
+ * person has the categories and no install record — the shelf offers the pack
+ * again, and installing it a second time writes nothing new, because every tag
+ * id is derived from the pack and the entry. The other order would leave a pack
+ * marked installed whose categories never arrived, which nothing would correct.
+ */
+export function useInstallPack() {
+  const { mutate } = useSync();
+  const { session } = useAuth();
+  const tags = useCategoryTags();
+
+  return useMutation({
+    mutationFn: async (pack: Pack): Promise<number> => {
+      const ownerId = session?.user?.id;
+      if (!ownerId) throw new Error('Sign in first');
+
+      const plan = installPlan(pack, tags.data);
+      for (const payload of plan.create) {
+        await mutate(MutationKind.TagCreate, categoryTagsScope(ownerId), {
+          ...payload,
+          packId: pack.id,
+        });
+      }
+      await mutate(MutationKind.PackInstall, packInstallsScope(ownerId), {
+        installId: randomUUID(),
+        packId: pack.id,
+        version: pack.version,
+      });
+      return plan.create.length;
+    },
+  });
+}
+
+/** Uninstall: the record goes, the categories stay. */
+export function useUninstallPack() {
+  const { mutate } = useSync();
+  const { session } = useAuth();
+
+  return useMutation({
+    mutationFn: async (installId: string): Promise<void> => {
+      const ownerId = session?.user?.id;
+      if (!ownerId) throw new Error('Sign in first');
+      await mutate(MutationKind.PackUninstall, packInstallsScope(ownerId), { installId });
+    },
+  });
+}
+
+/** Ask for a pack that does not exist yet — the other half of "we author them,
+ *  others ask". One row, no authoring surface, nothing shown to anybody else. */
+export function useRequestPack() {
+  const { session } = useAuth();
+  return useMutation({
+    mutationFn: async (body: string): Promise<void> => {
+      const requesterId = session?.user?.id;
+      if (!requesterId) throw new Error('Sign in first');
+      const { error } = await backend
+        .from('pack_requests')
+        .insert({ requester_id: requesterId, body: body.trim().slice(0, 500) });
+      if (error) throw error;
+    },
+  });
+}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -2641,6 +2641,33 @@ export interface UiStrings {
     ofExpected: string;
     everySince: string;
   };
+  /** The marketplace of installable category and income-source packs. */
+  packs: {
+    title: string;
+    subtitle: string;
+    browse: string;
+    browseHint: string;
+    installed: string;
+    install: string;
+    installing: string;
+    uninstall: string;
+    uninstallTitle: string;
+    uninstallBody: string;
+    includes: PluralForms;
+    added: PluralForms;
+    alreadyHave: string;
+    empty: string;
+    emptyBody: string;
+    offline: string;
+    notFound: string;
+    askTitle: string;
+    askBody: string;
+    askPlaceholder: string;
+    askSend: string;
+    askSent: string;
+    expenseSide: string;
+    incomeSide: string;
+  };
 }
 
 const en: UiStrings = {
@@ -4874,6 +4901,33 @@ const en: UiStrings = {
     openEntry: 'Open this entry',
     ofExpected: 'of {amount}',
     everySince: 'Since {date}',
+  },
+  packs: {
+    title: 'Category packs',
+    subtitle: 'Sets of categories and income sources, ready to add to your own list.',
+    browse: 'Browse packs',
+    browseHint: 'Add ready-made categories and income sources',
+    installed: 'Installed',
+    install: 'Add to my list',
+    installing: 'Adding…',
+    uninstall: 'Remove pack',
+    uninstallTitle: 'Remove this pack?',
+    uninstallBody:
+      'The categories stay in your list and nothing you have filed under them changes. You can hide or delete them yourself, like any other category.',
+    includes: { one: '{n} category', other: '{n} categories' },
+    added: { one: '{n} category added', other: '{n} categories added' },
+    alreadyHave: 'You already have all of these.',
+    empty: 'Nothing on the shelf yet',
+    emptyBody: 'Packs are on the way. Tell us what you need and we will make it.',
+    offline: 'Packs need a connection. Everything already added stays where it is.',
+    notFound: 'This pack is no longer available.',
+    askTitle: 'Ask for a pack',
+    askBody: 'What do you keep track of that the app has no words for?',
+    askPlaceholder: 'Rental property, small shop, freelance…',
+    askSend: 'Send',
+    askSent: 'Thank you — we read every one of these.',
+    expenseSide: 'Spending',
+    incomeSide: 'Income',
   },
 };
 
@@ -7211,6 +7265,34 @@ const ta: UiStrings = {
     ofExpected: '{amount} இல்',
     everySince: '{date} முதல்',
   },
+  packs: {
+    title: 'வகைத் தொகுப்புகள்',
+    subtitle: 'உங்கள் பட்டியலில் சேர்க்கத் தயாராக உள்ள வகைகளும் வருமான மூலங்களும்.',
+    browse: 'தொகுப்புகளைப் பார்க்க',
+    browseHint: 'தயாராக உள்ள வகைகளையும் வருமான மூலங்களையும் சேர்க்கவும்',
+    installed: 'சேர்க்கப்பட்டது',
+    install: 'என் பட்டியலில் சேர்',
+    installing: 'சேர்க்கிறது…',
+    uninstall: 'தொகுப்பை நீக்கு',
+    uninstallTitle: 'இந்தத் தொகுப்பை நீக்கவா?',
+    uninstallBody:
+      'வகைகள் உங்கள் பட்டியலிலேயே இருக்கும்; அவற்றின் கீழ் பதிவு செய்தவை எதுவும் மாறாது. மற்ற வகைகளைப் போலவே அவற்றை நீங்களே மறைக்கவோ நீக்கவோ முடியும்.',
+    includes: { one: '{n} வகை', other: '{n} வகைகள்' },
+    added: { one: '{n} வகை சேர்க்கப்பட்டது', other: '{n} வகைகள் சேர்க்கப்பட்டன' },
+    alreadyHave: 'இவை அனைத்தும் ஏற்கெனவே உங்களிடம் உள்ளன.',
+    empty: 'இன்னும் எதுவும் இல்லை',
+    emptyBody:
+      'தொகுப்புகள் விரைவில் வரும். உங்களுக்கு என்ன தேவை என்று சொல்லுங்கள், நாங்கள் உருவாக்குகிறோம்.',
+    offline: 'தொகுப்புகளுக்கு இணைப்பு தேவை. ஏற்கெனவே சேர்த்தவை அப்படியே இருக்கும்.',
+    notFound: 'இந்தத் தொகுப்பு இப்போது கிடைக்கவில்லை.',
+    askTitle: 'ஒரு தொகுப்பு கேளுங்கள்',
+    askBody: 'செயலியில் சொற்கள் இல்லாத எதை நீங்கள் கணக்கு வைக்கிறீர்கள்?',
+    askPlaceholder: 'வாடகை வீடு, சிறு கடை, சுயதொழில்…',
+    askSend: 'அனுப்பு',
+    askSent: 'நன்றி — ஒவ்வொன்றையும் நாங்கள் படிக்கிறோம்.',
+    expenseSide: 'செலவு',
+    incomeSide: 'வருமானம்',
+  },
 };
 
 const hi: UiStrings = {
@@ -9456,6 +9538,33 @@ const hi: UiStrings = {
     openEntry: 'यह प्रविष्टि खोलें',
     ofExpected: '{amount} में से',
     everySince: '{date} से',
+  },
+  packs: {
+    title: 'श्रेणी पैक',
+    subtitle: 'श्रेणियों और आय स्रोतों के तैयार सेट, आपकी सूची में जोड़ने के लिए।',
+    browse: 'पैक देखें',
+    browseHint: 'तैयार श्रेणियाँ और आय स्रोत जोड़ें',
+    installed: 'जुड़ा हुआ',
+    install: 'मेरी सूची में जोड़ें',
+    installing: 'जोड़ रहे हैं…',
+    uninstall: 'पैक हटाएँ',
+    uninstallTitle: 'यह पैक हटाएँ?',
+    uninstallBody:
+      'श्रेणियाँ आपकी सूची में बनी रहेंगी और उनके अंतर्गत दर्ज कुछ भी नहीं बदलेगा। बाकी श्रेणियों की तरह आप उन्हें खुद छिपा या हटा सकते हैं।',
+    includes: { one: '{n} श्रेणी', other: '{n} श्रेणियाँ' },
+    added: { one: '{n} श्रेणी जोड़ी गई', other: '{n} श्रेणियाँ जोड़ी गईं' },
+    alreadyHave: 'ये सब आपके पास पहले से हैं।',
+    empty: 'अभी कुछ नहीं है',
+    emptyBody: 'पैक जल्द आ रहे हैं। बताइए आपको क्या चाहिए, हम बना देंगे।',
+    offline: 'पैक के लिए कनेक्शन चाहिए। जो पहले जोड़ा जा चुका है वह वैसे ही रहेगा।',
+    notFound: 'यह पैक अब उपलब्ध नहीं है।',
+    askTitle: 'पैक का अनुरोध करें',
+    askBody: 'आप किसका हिसाब रखते हैं जिसके लिए ऐप में शब्द ही नहीं हैं?',
+    askPlaceholder: 'किराये का मकान, छोटी दुकान, फ़्रीलांस…',
+    askSend: 'भेजें',
+    askSent: 'धन्यवाद — हम हर एक पढ़ते हैं।',
+    expenseSide: 'ख़र्च',
+    incomeSide: 'आय',
   },
 };
 
@@ -11953,6 +12062,33 @@ const ar: UiStrings = {
     openEntry: 'افتح هذا القيد',
     ofExpected: 'من {amount}',
     everySince: 'منذ {date}',
+  },
+  packs: {
+    title: 'حزم التصنيفات',
+    subtitle: 'مجموعات جاهزة من التصنيفات ومصادر الدخل لإضافتها إلى قائمتك.',
+    browse: 'تصفّح الحزم',
+    browseHint: 'أضف تصنيفات ومصادر دخل جاهزة',
+    installed: 'مضافة',
+    install: 'أضِف إلى قائمتي',
+    installing: 'جارٍ الإضافة…',
+    uninstall: 'إزالة الحزمة',
+    uninstallTitle: 'إزالة هذه الحزمة؟',
+    uninstallBody:
+      'تبقى التصنيفات في قائمتك ولا يتغيّر شيء ممّا سجّلته تحتها. يمكنك إخفاؤها أو حذفها بنفسك مثل أي تصنيف آخر.',
+    includes: { one: 'تصنيف واحد', other: '{n} تصنيفاً' },
+    added: { one: 'أُضيف تصنيف واحد', other: 'أُضيف {n} تصنيفاً' },
+    alreadyHave: 'لديك كل هذه بالفعل.',
+    empty: 'لا شيء على الرف بعد',
+    emptyBody: 'الحزم في الطريق. أخبرنا بما تحتاجه وسنصنعه.',
+    offline: 'تحتاج الحزم إلى اتصال. وكل ما أُضيف من قبل يبقى كما هو.',
+    notFound: 'لم تعد هذه الحزمة متاحة.',
+    askTitle: 'اطلب حزمة',
+    askBody: 'ما الذي تتابعه ولا يملك التطبيق كلمات له؟',
+    askPlaceholder: 'عقار للإيجار، متجر صغير، عمل حر…',
+    askSend: 'إرسال',
+    askSent: 'شكراً — نقرأ كل واحدة منها.',
+    expenseSide: 'الإنفاق',
+    incomeSide: 'الدخل',
   },
 };
 

--- a/packages/core/src/category/catalog.ts
+++ b/packages/core/src/category/catalog.ts
@@ -47,6 +47,11 @@ export interface CategoryTagRow {
   readonly label: string | null;
   readonly icon: string | null;
   readonly tint: string | null;
+  /** Which picker the tag belongs in. Absent on every row written before the
+   *  income side existed, and every one of those was a spending category. */
+  readonly axis?: 'expense' | 'income' | null;
+  /** The pack this tag arrived from, for provenance. */
+  readonly packId?: string | null;
   readonly sortOrder: number;
   readonly hidden: boolean;
 }
@@ -138,7 +143,10 @@ export function buildCatalog(
   const customs: CategoryTagRow[] = [];
   for (const row of rows) {
     if (row.builtinId) overrides.set(row.builtinId, row);
-    else customs.push(row);
+    // An income source is not a spending category, and showing one in the spend
+    // picker is exactly the confusion the axis exists to end. A row with no axis
+    // predates the field, and every tag written before it was a spend category.
+    else if (row.axis !== 'income') customs.push(row);
   }
 
   const builtinEntries: CatalogEntry[] = CATEGORIES.map((category, index) => {
@@ -186,4 +194,38 @@ export function buildCatalog(
 export function nextSortOrder(rows: readonly CategoryTagRow[]): number {
   const max = rows.reduce((m, row) => Math.max(m, row.sortOrder), CATEGORIES.length - 1);
   return max + 1;
+}
+
+/**
+ * The person's own income sources — the custom half of the source picker.
+ *
+ * Deliberately not folded into `buildCatalog`: the ten spend categories are its
+ * built-ins and the fifteen income sources are a different list entirely, so one
+ * catalog would have to know which built-ins belong to which axis before it could
+ * say anything true. The picker concatenates instead, which is what it is doing
+ * on screen anyway.
+ */
+export function incomeTags(rows: readonly CategoryTagRow[]): CatalogEntry[] {
+  return rows
+    .filter((row) => !row.builtinId && row.axis === 'income')
+    .map((row) => ({
+      key: row.id,
+      icon: row.icon ?? OTHER.icon,
+      tint: normaliseTint(row.tint),
+      label: row.label ?? '',
+      custom: true,
+      builtinId: null,
+      hidden: row.hidden,
+      sortOrder: row.sortOrder,
+      tagId: row.id,
+    }))
+    .sort((a, b) =>
+      a.sortOrder !== b.sortOrder
+        ? a.sortOrder - b.sortOrder
+        : a.key < b.key
+          ? -1
+          : a.key > b.key
+            ? 1
+            : 0,
+    );
 }

--- a/packages/core/src/category/index.ts
+++ b/packages/core/src/category/index.ts
@@ -3,3 +3,4 @@ export * from './catalog';
 export * from './icons';
 export * from './markets';
 export * from './merchant';
+export * from './tagIcons';

--- a/packages/core/src/category/tagIcons.ts
+++ b/packages/core/src/category/tagIcons.ts
@@ -1,0 +1,171 @@
+/**
+ * The glyphs a custom tag may wear (extends TDR §8).
+ *
+ * A wide, curated set of Ionicons — the everyday shapes of spending and earning
+ * across food, travel, home, work, health, fun, people and money — not the whole
+ * glyph map, which would be a wall of arrows and logos nobody tags a bill with.
+ * All outline style, so they sit beside the built-in categories; grouped so the
+ * picker reads in bands rather than as one undifferentiated grid.
+ *
+ * The list lives in core rather than in the app because it has two readers now.
+ * The picker was the only writer of an icon for as long as a person choosing one
+ * was the only way a tag could exist — so `/sync` accepted any string up to 64
+ * characters, and nothing was ever wrong. A pack is a second writer, authored
+ * somewhere else, and the first mistyped glyph in one would render as a blank
+ * box on every device that installed it with nothing having said no. Validation
+ * needs the list, the edge function needs the validation, and neither can import
+ * from the React Native app — so the names are plain strings here, and the app
+ * re-exports them typed against its own glyph map (which is what proves they are
+ * real, in `apps/mobile/test/tagIcons.test.ts`).
+ */
+
+export const TAG_ICON_GROUPS: readonly (readonly string[])[] = [
+  // Food & drink
+  [
+    'restaurant-outline',
+    'fast-food-outline',
+    'pizza-outline',
+    'cafe-outline',
+    'beer-outline',
+    'wine-outline',
+    'nutrition-outline',
+    'ice-cream-outline',
+    'egg-outline',
+    'fish-outline',
+  ],
+  // Groceries & shopping
+  [
+    'cart-outline',
+    'basket-outline',
+    'bag-handle-outline',
+    'pricetag-outline',
+    'pricetags-outline',
+    'shirt-outline',
+    'gift-outline',
+    'storefront-outline',
+    'cube-outline',
+    'balloon-outline',
+  ],
+  // Getting around
+  [
+    'car-outline',
+    'car-sport-outline',
+    'bus-outline',
+    'train-outline',
+    'subway-outline',
+    'bicycle-outline',
+    'boat-outline',
+    'airplane-outline',
+    'rocket-outline',
+    'walk-outline',
+  ],
+  // Travel & stay
+  [
+    'bed-outline',
+    'business-outline',
+    'map-outline',
+    'compass-outline',
+    'earth-outline',
+    'sunny-outline',
+    'umbrella-outline',
+    'camera-outline',
+    'ticket-outline',
+    'trail-sign-outline',
+  ],
+  // Home, bills & utilities
+  [
+    'home-outline',
+    'bulb-outline',
+    'flash-outline',
+    'water-outline',
+    'flame-outline',
+    'wifi-outline',
+    'call-outline',
+    'tv-outline',
+    'construct-outline',
+    'hammer-outline',
+    'trash-outline',
+    'shield-checkmark-outline',
+  ],
+  // Work & study
+  [
+    'briefcase-outline',
+    'laptop-outline',
+    'desktop-outline',
+    'print-outline',
+    'document-text-outline',
+    'school-outline',
+    'book-outline',
+    'library-outline',
+    'calculator-outline',
+    'mail-outline',
+  ],
+  // Health & fitness
+  [
+    'medkit-outline',
+    'medical-outline',
+    'fitness-outline',
+    'barbell-outline',
+    'heart-outline',
+    'pulse-outline',
+    'bandage-outline',
+    'eye-outline',
+    'flask-outline',
+    'leaf-outline',
+  ],
+  // Fun & hobbies
+  [
+    'game-controller-outline',
+    'musical-notes-outline',
+    'headset-outline',
+    'film-outline',
+    'football-outline',
+    'basketball-outline',
+    'tennisball-outline',
+    'golf-outline',
+    'color-palette-outline',
+    'brush-outline',
+    'dice-outline',
+    'planet-outline',
+  ],
+  // People, gifts & celebration
+  [
+    'people-outline',
+    'person-outline',
+    'happy-outline',
+    'sparkles-outline',
+    'ribbon-outline',
+    'trophy-outline',
+    'star-outline',
+    'flower-outline',
+    'paw-outline',
+    'accessibility-outline',
+  ],
+  // Money & the rest
+  [
+    'card-outline',
+    'cash-outline',
+    'wallet-outline',
+    'pie-chart-outline',
+    'trending-up-outline',
+    'receipt-outline',
+    'time-outline',
+    'calendar-outline',
+    'key-outline',
+    'ellipsis-horizontal-circle-outline',
+  ],
+];
+
+/** The flat list the editor renders — every group, in order. */
+export const TAG_ICONS: readonly string[] = TAG_ICON_GROUPS.flat();
+
+/** The default a new tag starts on. */
+export const DEFAULT_TAG_ICON = 'pricetag-outline';
+
+const KNOWN = new Set<string>(TAG_ICONS);
+
+/** Whether a name is one a picker can actually draw. The check a second writer
+ *  of tags — a pack — has to pass. */
+export function isTagIcon(name: unknown): name is string {
+  return typeof name === 'string' && KNOWN.has(name);
+}

--- a/packages/core/src/ids.ts
+++ b/packages/core/src/ids.ts
@@ -1,0 +1,34 @@
+/**
+ * A uuid-shaped id derived from what it identifies, rather than from chance.
+ *
+ * Where a row stands for one *thing* — the June occurrence of a rule, the "chit
+ * fund" entry of a pack — a random id makes writing it twice produce two rows,
+ * and every writer then has to remember to look first. Deriving the id from the
+ * thing makes the second write an upsert of the first, whoever makes it and
+ * whenever: an auto catch-up racing a manual confirmation, a re-install after a
+ * reinstall, two devices offline at once. Idempotence stops being a discipline
+ * and becomes a property.
+ *
+ * Two FNV-1a passes fill a uuid-shaped 32 hex characters, which Postgres's
+ * `uuid` accepts. It is not a cryptographic hash and does not need to be —
+ * nothing here is a secret, and within one person's ledger the collision odds
+ * are vanishing.
+ */
+
+/**
+ * The same seed always gives the same id; different seeds effectively never
+ * collide. Callers namespace their own seeds (`pack:<id>:<key>`) so two kinds of
+ * thing cannot land on one id.
+ */
+export function deterministicId(seed: string): string {
+  const pass = (offset: number): string => {
+    let hash = offset >>> 0;
+    for (let i = 0; i < seed.length; i += 1) {
+      hash ^= seed.charCodeAt(i);
+      hash = Math.imul(hash, 0x01000193) >>> 0;
+    }
+    return hash.toString(16).padStart(8, '0');
+  };
+  const hex = pass(0x811c9dc5) + pass(0x7ee3a5b1) + pass(0x243f6a88) + pass(0x9e3779b9);
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@
  * Deno edge functions, so all three compute identical money.
  */
 
+export * from './ids';
 export * from './time/index';
 export * from './money/index';
 export * from './split/index';
@@ -28,5 +29,6 @@ export * from './billing/index';
 export * from './session/index';
 export * from './trip/index';
 export * from './personal/index';
+export * from './packs/index';
 export * from './watch/index';
 export * from './export/index';

--- a/packages/core/src/packs/index.ts
+++ b/packages/core/src/packs/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './install';

--- a/packages/core/src/packs/install.ts
+++ b/packages/core/src/packs/install.ts
@@ -1,0 +1,94 @@
+/**
+ * What installing a pack actually does.
+ *
+ * Nothing clever: it writes ordinary custom tags into the person's own catalog,
+ * through the same `tag.create` mutation the tag editor uses. No new write path,
+ * no server-side install, no privileged step — which is why installing works
+ * offline, and why every screen that already renders a custom tag renders a
+ * packed one without knowing the difference.
+ *
+ * Two properties are worth naming because the rest follows from them:
+ *
+ * **Installing twice is installing once.** Each tag's id is derived from the
+ * pack and the entry (`packTagId`), so a second install upserts the same rows
+ * rather than doubling somebody's picker — whether the second install is a
+ * double tap, a retry after a dropped connection, or another device that was
+ * offline when the first one happened.
+ *
+ * **An installed tag belongs to the person, not the pack.** They can rename it,
+ * recolour it, hide it, delete it; expenses filed under it carry its label as a
+ * snapshot (`category_meta`). That is what lets an uninstall — or a pack pulled
+ * after publication — leave the categories exactly where they are. Taking them
+ * back would rewrite somebody's history over a decision that was not theirs.
+ */
+
+import { nextSortOrder, type CategoryTagRow } from '../category/catalog';
+import { deterministicId } from '../ids';
+import type { TagUpsertPayload } from '../sync/protocol';
+import type { Pack, PackEntry } from './types';
+
+/**
+ * The id the entry's tag will have, in this person's catalog.
+ *
+ * Derived, not random, so the write is idempotent — see the note above. Two
+ * people installing the same pack get the same ids in their own catalogs, which
+ * is fine: a tag id is unique per owner, never globally.
+ */
+export function packTagId(packId: string, entryKey: string): string {
+  return deterministicId(`pack:${packId}:${entryKey}`);
+}
+
+export interface InstallPlan {
+  /** The tags to write, in the pack's own order. */
+  readonly create: readonly TagUpsertPayload[];
+  /** Entries whose tag is already in the catalog — a re-install, or an update
+   *  where only some entries are new. Reported so the UI can say "3 added"
+   *  rather than claiming to have added all twelve. */
+  readonly alreadyPresent: number;
+}
+
+/**
+ * The rows an install should write, given what the catalog already holds.
+ *
+ * Existing tags are left completely alone. If somebody installed a pack, renamed
+ * one of its categories to something that suits them better, and then installed
+ * a newer version of the pack, their name survives: an update adds what is new
+ * and does not overwrite what a person has made theirs.
+ */
+export function installPlan(pack: Pack, existing: readonly CategoryTagRow[]): InstallPlan {
+  const known = new Set(existing.map((row) => row.id));
+  const create: TagUpsertPayload[] = [];
+  let alreadyPresent = 0;
+
+  // Packed tags land after whatever the catalog already holds, in pack order, so
+  // installing one never reshuffles the list somebody has arranged.
+  let order = nextSortOrder(existing);
+
+  for (const entry of pack.entries) {
+    const tagId = packTagId(pack.id, entry.key);
+    if (known.has(tagId)) {
+      alreadyPresent += 1;
+      continue;
+    }
+    create.push(tagPayloadFor(entry, tagId, order));
+    order += 1;
+  }
+
+  return { create, alreadyPresent };
+}
+
+/** One entry as the tag it becomes. */
+function tagPayloadFor(entry: PackEntry, tagId: string, sortOrder: number): TagUpsertPayload {
+  return {
+    tagId,
+    // A custom tag, not an override: a pack adds vocabulary, it never redefines
+    // a built-in category out from under somebody.
+    builtinId: null,
+    label: entry.label,
+    icon: entry.icon,
+    tint: entry.tint,
+    axis: entry.axis,
+    sortOrder,
+    hidden: false,
+  };
+}

--- a/packages/core/src/packs/types.ts
+++ b/packages/core/src/packs/types.ts
@@ -1,0 +1,150 @@
+/**
+ * A pack: a set of categories or income sources somebody can install.
+ *
+ * The app ships ten spend categories and fifteen income sources, all deliberately
+ * general — nothing that assumes one country's instruments or one person's trade.
+ * That is right for a default and wrong as a final answer, because a landlord, a
+ * freelancer and somebody tracking a chit fund all want vocabulary the app should
+ * not ship to everybody. A pack is how they get it.
+ *
+ * **A pack is data, not code.** Labels, icons from a fixed set, tints from six.
+ * There is nothing to execute, so there is no sandbox to build and nothing a pack
+ * can do to a device beyond appearing in a picker. Installing one writes ordinary
+ * custom tags into the person's own catalog (A42) through the ordinary queued
+ * mutations — which is why an install works offline, and why an uninstall can
+ * simply leave them behind: by then they are the person's own categories, with
+ * their own expenses filed under them.
+ *
+ * `parsePack` is the gate, and it is deliberately total: anything a picker could
+ * not draw is refused rather than repaired, on both sides. The admin console runs
+ * it before publishing, and the client runs it again on what it fetched, because
+ * a client that trusts the server to have validated is a client that renders a
+ * blank box the first time something goes wrong upstream.
+ */
+
+import { isTagIcon } from '../category/tagIcons';
+import { TINTS, type TintName } from '../category/catalog';
+
+/** Which picker an entry belongs in. A tag is one or the other, never both — a
+ *  salary is not a spending category and filing it as one is the bug this whole
+ *  axis exists to prevent. */
+export type CategoryAxis = 'expense' | 'income';
+
+export const CATEGORY_AXES: readonly CategoryAxis[] = ['expense', 'income'];
+
+export interface PackEntry {
+  /** Stable within the pack, and the seed of the installed tag's id. Renaming an
+   *  entry's label is an edit; changing its key makes a different category. */
+  readonly key: string;
+  readonly label: string;
+  /** One of the curated glyphs — see `isTagIcon`. */
+  readonly icon: string;
+  readonly tint: TintName;
+  readonly axis: CategoryAxis;
+}
+
+export interface Pack {
+  readonly id: string;
+  /** URL-safe, unique, and the thing a link to a pack is made of. */
+  readonly slug: string;
+  readonly title: string;
+  readonly summary: string;
+  readonly entries: readonly PackEntry[];
+  readonly version: number;
+}
+
+/** Where a pack is in its life. `unlisted` is the takedown: it stops being
+ *  installable without touching a single person who already has it — their
+ *  categories are their own by then, and pulling them back would rewrite
+ *  somebody's history over a mistake that was not theirs. */
+export type PackStatus = 'draft' | 'published' | 'unlisted';
+
+export const PACK_STATUSES: readonly PackStatus[] = ['draft', 'published', 'unlisted'];
+
+/** Caps. Each is a number somebody could argue with; what matters is that every
+ *  one of them exists, so a malformed pack is refused rather than rendered. */
+export const PACK_LIMITS = {
+  /** Matches the tag label cap the editor and `/sync` already enforce. */
+  label: 40,
+  key: 64,
+  title: 60,
+  summary: 200,
+  slug: 60,
+  /** A picker nobody can scroll is not a gift. */
+  entries: 50,
+} as const;
+
+const SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const KEY = /^[a-z0-9]+(?:[._-][a-z0-9]+)*$/;
+
+function text(value: unknown, max: number): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 && trimmed.length <= max ? trimmed : null;
+}
+
+function isTint(value: unknown): value is TintName {
+  return typeof value === 'string' && (TINTS as readonly string[]).includes(value);
+}
+
+function isAxis(value: unknown): value is CategoryAxis {
+  return value === 'expense' || value === 'income';
+}
+
+/**
+ * One entry, or null if it is not one.
+ *
+ * Nothing here coerces. A missing tint could default to `sky` and a bad icon
+ * could fall back to a pricetag, and both would ship somebody a pack quietly
+ * unlike the one that was written — better to refuse it while an author is still
+ * looking at the screen.
+ */
+export function parsePackEntry(value: unknown): PackEntry | null {
+  if (!value || typeof value !== 'object') return null;
+  const raw = value as Record<string, unknown>;
+
+  const key = text(raw.key, PACK_LIMITS.key);
+  if (!key || !KEY.test(key)) return null;
+  const label = text(raw.label, PACK_LIMITS.label);
+  if (!label) return null;
+  if (!isTagIcon(raw.icon)) return null;
+  if (!isTint(raw.tint)) return null;
+  if (!isAxis(raw.axis)) return null;
+
+  return { key, label, icon: raw.icon, tint: raw.tint, axis: raw.axis };
+}
+
+/** A whole pack, or null. A pack with one unusable entry is an unusable pack:
+ *  installing "most of" what somebody chose is not a thing to do quietly. */
+export function parsePack(value: unknown): Pack | null {
+  if (!value || typeof value !== 'object') return null;
+  const raw = value as Record<string, unknown>;
+
+  const id = text(raw.id, PACK_LIMITS.key);
+  const slug = text(raw.slug, PACK_LIMITS.slug);
+  const title = text(raw.title, PACK_LIMITS.title);
+  const summary = text(raw.summary, PACK_LIMITS.summary);
+  if (!id || !slug || !SLUG.test(slug) || !title || !summary) return null;
+
+  const version =
+    typeof raw.version === 'number' && Number.isInteger(raw.version) && raw.version > 0
+      ? raw.version
+      : 1;
+
+  if (!Array.isArray(raw.entries)) return null;
+  if (raw.entries.length === 0 || raw.entries.length > PACK_LIMITS.entries) return null;
+
+  const entries: PackEntry[] = [];
+  const seen = new Set<string>();
+  for (const candidate of raw.entries) {
+    const entry = parsePackEntry(candidate);
+    if (!entry) return null;
+    // Two entries with one key would install as one tag, so the pack would
+    // silently deliver fewer categories than it lists.
+    if (seen.has(entry.key)) return null;
+    seen.add(entry.key);
+    entries.push(entry);
+  }
+
+  return { id, slug, title, summary, entries, version };
+}

--- a/packages/core/src/personal/compute.ts
+++ b/packages/core/src/personal/compute.ts
@@ -5,6 +5,7 @@
  * device, which is the point of keeping it in core.
  */
 
+import { deterministicId } from '../ids';
 import type { CurrencyCode } from '../money/currency';
 import type {
   Cadence,
@@ -206,17 +207,10 @@ export function recurringCatchUp(
  * makes a collision vanishingly unlikely.
  */
 export function recurringOccurrenceId(ruleId: string, date: string): string {
-  const seed = `${ruleId}:${date}`;
-  const pass = (offset: number): string => {
-    let hash = offset >>> 0;
-    for (let i = 0; i < seed.length; i += 1) {
-      hash ^= seed.charCodeAt(i);
-      hash = Math.imul(hash, 0x01000193) >>> 0;
-    }
-    return hash.toString(16).padStart(8, '0');
-  };
-  const hex = pass(0x811c9dc5) + pass(0x7ee3a5b1) + pass(0x243f6a88) + pass(0x9e3779b9);
-  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+  // The seed is unchanged from when this hashed inline: every occurrence already
+  // written carries an id derived from exactly this string, and a different seed
+  // here would orphan all of them.
+  return deterministicId(`${ruleId}:${date}`);
 }
 
 // ──────────────────────────────────────────────────────── occurrences ──

--- a/packages/core/src/sync/mirror.ts
+++ b/packages/core/src/sync/mirror.ts
@@ -20,9 +20,18 @@ import type { MemberId, SplitParams, SplitType } from '../split/types';
 import type { CurrencyCode } from '../money/currency';
 import type { ExpenseSnapshot } from '../balances/types';
 
-import { categoryTagsScope, parseAmount, personalScope, SyncTable } from './protocol';
+import {
+  categoryTagsScope,
+  MutationKind,
+  packInstallsScope,
+  parseAmount,
+  personalScope,
+  SyncTable,
+} from './protocol';
 import type { CategoryMeta } from '../category/catalog';
 import type {
+  PackInstallPayload,
+  PackUninstallPayload,
   CaptureAssignPayload,
   CaptureCreatePayload,
   CaptureDeletePayload,
@@ -863,6 +872,10 @@ export interface MirrorCategoryTag extends MirrorRow {
   readonly label: string | null;
   readonly icon: string | null;
   readonly tint: string | null;
+  /** Which picker the tag belongs in; absent on rows written before it existed. */
+  readonly axis?: string | null;
+  /** The pack it arrived from, for provenance. */
+  readonly pack_id?: string | null;
   readonly sort_order: number;
   readonly hidden: boolean;
   readonly deleted_at: string | null;
@@ -900,6 +913,8 @@ export function materialiseCategoryTags(
           label: payload.label ?? existing?.label ?? null,
           icon: payload.icon ?? existing?.icon ?? null,
           tint: payload.tint ?? existing?.tint ?? null,
+          axis: payload.axis ?? existing?.axis ?? 'expense',
+          pack_id: payload.packId ?? existing?.pack_id ?? null,
           sort_order: payload.sortOrder,
           hidden: payload.hidden,
           deleted_at: existing?.deleted_at ?? null,
@@ -1303,4 +1318,59 @@ export function materialiseMemberBudgets(
   }
 
   return [...byMember.values()].filter((budget) => budget.deleted_at === null);
+}
+
+/** One row of `pack_installs`, as the mirror holds it. */
+export interface MirrorPackInstall extends MirrorRow {
+  readonly id: string;
+  readonly owner_user_id: string;
+  readonly pack_id: string;
+  readonly version: number;
+  readonly deleted_at: string | null;
+  readonly pending?: boolean;
+}
+
+/**
+ * The packs this person has installed, with the queue replayed on top — so a
+ * pack installed with no signal shows as installed straight away, and stays that
+ * way through the flush.
+ *
+ * The packs *themselves* are not mirrored. A catalogue of what we publish is not
+ * the user's data, and holding a copy would make every visit to the shelf an
+ * offline read of a stale shelf; it is a network read with an empty state.
+ */
+export function materialisePackInstalls(
+  state: MirrorState,
+  queue: readonly QueuedMutation[],
+  options: { readonly ownerId: string },
+): MirrorPackInstall[] {
+  const scope = packInstallsScope(options.ownerId);
+  const byId = new Map<string, MirrorPackInstall>();
+  for (const row of rowsFor(state, SyncTable.PackInstalls) as unknown as MirrorPackInstall[]) {
+    if (row.owner_user_id !== options.ownerId) continue;
+    byId.set(row.id, row);
+  }
+
+  for (const mutation of [...queue].sort((a, b) => a.seq - b.seq)) {
+    if (mutation.groupId !== scope) continue;
+    if (mutation.kind === MutationKind.PackInstall) {
+      const payload = mutation.payload as unknown as PackInstallPayload;
+      byId.set(payload.installId, {
+        id: payload.installId,
+        owner_user_id: options.ownerId,
+        pack_id: payload.packId,
+        version: payload.version,
+        deleted_at: null,
+        pending: true,
+      });
+    } else if (mutation.kind === MutationKind.PackUninstall) {
+      const { installId } = mutation.payload as unknown as PackUninstallPayload;
+      const existing = byId.get(installId);
+      if (existing) {
+        byId.set(installId, { ...existing, deleted_at: mutation.clientCreatedAt, pending: true });
+      }
+    }
+  }
+
+  return [...byId.values()].filter((row) => row.deleted_at === null);
 }

--- a/packages/core/src/sync/protocol.ts
+++ b/packages/core/src/sync/protocol.ts
@@ -64,6 +64,12 @@ export enum MutationKind {
   // (`personalScope`). One generic upsert/delete pair covers all four record
   // kinds; `recordKind` in the payload says which, and the `data` blob is opaque
   // to the server, which only relays it. A delete is a soft tombstone.
+  // A pack somebody installed, under their own suffixed scope
+  // (`packInstallsScope`). Installing is two things at once — the tags, written
+  // as ordinary `tag.create`s, and this row saying which pack they came from —
+  // and both ride the queue, so installing a pack works with no signal.
+  PackInstall = 'pack.install',
+  PackUninstall = 'pack.uninstall',
   PersonalUpsert = 'personal.upsert',
   PersonalDelete = 'personal.delete',
 }
@@ -200,6 +206,13 @@ export interface TagUpsertPayload {
   readonly label?: string | null;
   readonly icon?: string | null;
   readonly tint?: string | null;
+  /** Which picker the tag belongs in: a spending category or an income source.
+   *  Omitted reads as `expense`, which is what every tag written before this
+   *  field existed was. */
+  readonly axis?: 'expense' | 'income' | null;
+  /** The pack this tag arrived from, if any. Provenance for the catalog to
+   *  show — never a dependency: the tag outlives the pack being uninstalled. */
+  readonly packId?: string | null;
   readonly sortOrder: number;
   readonly hidden: boolean;
 }
@@ -309,6 +322,24 @@ export interface GroupFxRateSetPayload {
   readonly num: string | null;
   readonly den: string | null;
   readonly source?: string;
+}
+
+/**
+ * Installing a pack, recorded. The tags themselves arrive as ordinary
+ * `tag.create` mutations queued alongside this one — this row only says which
+ * pack they came from, so the shelf can show "installed" and an update can offer
+ * what is new.
+ */
+export interface PackInstallPayload {
+  readonly installId: string;
+  readonly packId: string;
+  readonly version: number;
+}
+
+/** Uninstalling. The categories the pack wrote are deliberately untouched: by
+ *  now they are the person's own, with their own expenses filed under them. */
+export interface PackUninstallPayload {
+  readonly installId: string;
 }
 
 /** The four kinds of row the personal-finance ledger holds (A48). */
@@ -423,6 +454,8 @@ export enum SyncTable {
    * expenses/income, recurring rules, loans and budgets. Read + write, one
    * generic row per record, keyed by the owner's user id under `personalScope`. */
   PersonalRecords = 'personal_records',
+  /** Which packs this person has installed, under `packInstallsScope`. */
+  PackInstalls = 'pack_installs',
 }
 
 /**
@@ -451,6 +484,12 @@ export function categoryTagsScope(profileId: string): string {
  */
 export function personalScope(profileId: string): string {
   return `${profileId}:personal`;
+}
+
+/** The personal-scope key for the packs a person has installed. Suffixed like
+ *  the others so it keeps its own cursor. */
+export function packInstallsScope(profileId: string): string {
+  return `${profileId}:pack_installs`;
 }
 
 /** bigint ↔ string at the wire boundary; JSON has no integers this size. */

--- a/packages/core/test/packs.test.ts
+++ b/packages/core/test/packs.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Packs: what is allowed in, and what installing one writes.
+ *
+ * `parsePack` is the only gate between an authored pack and a picker on
+ * somebody's phone, and it runs on both sides of the wire. Every rejection below
+ * is a thing that would otherwise render as a blank box, a missing category, or
+ * a salary filed as a spending category — so the interesting tests here are the
+ * refusals, not the happy path.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  installPlan,
+  packTagId,
+  parsePack,
+  parsePackEntry,
+  PACK_LIMITS,
+  type CategoryTagRow,
+  type Pack,
+} from '../src/index.js';
+
+const entry = (over: Record<string, unknown> = {}) => ({
+  key: 'chit-fund',
+  label: 'Chit fund',
+  icon: 'cash-outline',
+  tint: 'mint',
+  axis: 'expense',
+  ...over,
+});
+
+const pack = (over: Record<string, unknown> = {}) => ({
+  id: 'pack-1',
+  slug: 'india-everyday',
+  title: 'India · everyday',
+  summary: 'The categories an everyday Indian household actually uses.',
+  version: 1,
+  entries: [entry()],
+  ...over,
+});
+
+const tagRow = (id: string): CategoryTagRow => ({
+  id,
+  builtinId: null,
+  label: 'Whatever',
+  icon: 'cash-outline',
+  tint: 'mint',
+  sortOrder: 20,
+  hidden: false,
+});
+
+describe('parsePackEntry', () => {
+  it('accepts an entry a picker can draw', () => {
+    expect(parsePackEntry(entry())).toEqual({
+      key: 'chit-fund',
+      label: 'Chit fund',
+      icon: 'cash-outline',
+      tint: 'mint',
+      axis: 'expense',
+    });
+  });
+
+  it('refuses a glyph that does not exist', () => {
+    // The reason the icon list moved into core. Nothing downstream would have
+    // caught this: it renders as a blank box on every device that installs it.
+    expect(parsePackEntry(entry({ icon: 'chit-fund-outline' }))).toBeNull();
+    expect(parsePackEntry(entry({ icon: 'restaurant' }))).toBeNull();
+  });
+
+  it('refuses a tint outside the six', () => {
+    // Coercing to a default would ship a pack quietly unlike the one written.
+    expect(parsePackEntry(entry({ tint: 'burgundy' }))).toBeNull();
+  });
+
+  it('refuses an axis that is neither picker', () => {
+    expect(parsePackEntry(entry({ axis: 'both' }))).toBeNull();
+    expect(parsePackEntry(entry({ axis: undefined }))).toBeNull();
+  });
+
+  it('refuses a label that is empty, blank, or past the cap', () => {
+    expect(parsePackEntry(entry({ label: '' }))).toBeNull();
+    expect(parsePackEntry(entry({ label: '   ' }))).toBeNull();
+    expect(parsePackEntry(entry({ label: 'x'.repeat(PACK_LIMITS.label + 1) }))).toBeNull();
+    expect(parsePackEntry(entry({ label: 'x'.repeat(PACK_LIMITS.label) }))).not.toBeNull();
+  });
+
+  it('trims a label rather than failing over its whitespace', () => {
+    expect(parsePackEntry(entry({ label: '  Chit fund  ' }))?.label).toBe('Chit fund');
+  });
+
+  it('refuses a key that is not a key', () => {
+    expect(parsePackEntry(entry({ key: 'Chit Fund' }))).toBeNull();
+    expect(parsePackEntry(entry({ key: '' }))).toBeNull();
+    expect(parsePackEntry(entry({ key: 'chit fund' }))).toBeNull();
+    // Separators are allowed. Kept deliberately short: the secret scanner reads
+    // a longer mixed-punctuation string beside the word `key` as a leaked
+    // token, and a smaller fixture is a better answer than an allowlist entry
+    // that would blunt the scanner for everything after it.
+    expect(parsePackEntry(entry({ key: 'a.b_c-d' }))).not.toBeNull();
+  });
+
+  it('refuses anything that is not an object at all', () => {
+    for (const value of [null, undefined, 'chit-fund', 42, []]) {
+      expect(parsePackEntry(value)).toBeNull();
+    }
+  });
+});
+
+describe('parsePack', () => {
+  it('accepts a whole pack', () => {
+    const parsed = parsePack(pack());
+    expect(parsed?.slug).toBe('india-everyday');
+    expect(parsed?.entries).toHaveLength(1);
+  });
+
+  it('refuses a pack because one entry is unusable', () => {
+    // Installing "most of" what somebody chose is not a thing to do quietly.
+    const half = pack({ entries: [entry(), entry({ key: 'kirana', icon: 'not-a-glyph' })] });
+    expect(parsePack(half)).toBeNull();
+  });
+
+  it('refuses two entries sharing a key', () => {
+    // They would install as one tag, so the pack would deliver fewer categories
+    // than it lists — and nothing would say so.
+    const clash = pack({ entries: [entry(), entry({ label: 'Chit fund II' })] });
+    expect(parsePack(clash)).toBeNull();
+  });
+
+  it('refuses an empty pack and an enormous one', () => {
+    expect(parsePack(pack({ entries: [] }))).toBeNull();
+    const many = Array.from({ length: PACK_LIMITS.entries + 1 }, (_, i) => entry({ key: `k${i}` }));
+    expect(parsePack(pack({ entries: many }))).toBeNull();
+  });
+
+  it('refuses a slug that could not sit in a URL', () => {
+    for (const slug of ['India Everyday', 'india_everyday', '-india', 'india-', '']) {
+      expect(parsePack(pack({ slug }))).toBeNull();
+    }
+  });
+
+  it('requires a title and a summary', () => {
+    expect(parsePack(pack({ title: '' }))).toBeNull();
+    expect(parsePack(pack({ summary: '   ' }))).toBeNull();
+  });
+
+  it('defaults a missing or nonsense version to 1 rather than failing', () => {
+    // A version is bookkeeping, not meaning — worth repairing, unlike an icon.
+    expect(parsePack(pack({ version: undefined }))?.version).toBe(1);
+    expect(parsePack(pack({ version: 0 }))?.version).toBe(1);
+    expect(parsePack(pack({ version: 2.5 }))?.version).toBe(1);
+    expect(parsePack(pack({ version: 3 }))?.version).toBe(3);
+  });
+
+  it('refuses entries that are not a list', () => {
+    expect(parsePack(pack({ entries: 'chit-fund' }))).toBeNull();
+    expect(parsePack(pack({ entries: undefined }))).toBeNull();
+  });
+});
+
+describe('packTagId', () => {
+  it('is the same every time', () => {
+    expect(packTagId('pack-1', 'chit-fund')).toBe(packTagId('pack-1', 'chit-fund'));
+  });
+
+  it('separates entries, and packs', () => {
+    expect(packTagId('pack-1', 'chit-fund')).not.toBe(packTagId('pack-1', 'kirana'));
+    expect(packTagId('pack-1', 'chit-fund')).not.toBe(packTagId('pack-2', 'chit-fund'));
+  });
+
+  it('is shaped like a uuid, because a uuid column holds it', () => {
+    expect(packTagId('pack-1', 'chit-fund')).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+});
+
+describe('installPlan', () => {
+  const twoEntries = parsePack(
+    pack({ entries: [entry(), entry({ key: 'kirana', label: 'Kirana' })] }),
+  ) as Pack;
+
+  it('writes every entry into an empty catalog', () => {
+    const plan = installPlan(twoEntries, []);
+    expect(plan.create).toHaveLength(2);
+    expect(plan.alreadyPresent).toBe(0);
+    expect(plan.create[0]).toMatchObject({
+      tagId: packTagId(twoEntries.id, 'chit-fund'),
+      label: 'Chit fund',
+      builtinId: null,
+      axis: 'expense',
+      hidden: false,
+    });
+  });
+
+  it('installs twice as though it had installed once', () => {
+    const already = twoEntries.entries.map((e) => tagRow(packTagId(twoEntries.id, e.key)));
+    const plan = installPlan(twoEntries, already);
+    expect(plan.create).toEqual([]);
+    expect(plan.alreadyPresent).toBe(2);
+  });
+
+  it('adds only what is new when a pack has grown', () => {
+    const half = [tagRow(packTagId(twoEntries.id, 'chit-fund'))];
+    const plan = installPlan(twoEntries, half);
+    expect(plan.create).toHaveLength(1);
+    expect(plan.create[0]?.label).toBe('Kirana');
+    expect(plan.alreadyPresent).toBe(1);
+  });
+
+  it('never overwrites a tag somebody has made their own', () => {
+    // Installed, renamed, then the pack is installed again: their name stands.
+    const renamed: CategoryTagRow = {
+      ...tagRow(packTagId(twoEntries.id, 'chit-fund')),
+      label: 'My committee',
+    };
+    const plan = installPlan(twoEntries, [renamed]);
+    expect(plan.create.map((p) => p.tagId)).not.toContain(renamed.id);
+  });
+
+  it('lands after what the catalog already holds, in the pack’s own order', () => {
+    const existing = [{ ...tagRow('other-tag'), sortOrder: 40 }];
+    const plan = installPlan(twoEntries, existing);
+    expect(plan.create[0]!.sortOrder).toBe(41);
+    expect(plan.create[1]!.sortOrder).toBe(42);
+  });
+
+  it('carries each entry into the picker it belongs in', () => {
+    const mixed = parsePack(
+      pack({
+        entries: [entry(), entry({ key: 'rent-in', label: 'Rent in', axis: 'income' })],
+      }),
+    ) as Pack;
+    const plan = installPlan(mixed, []);
+    expect(plan.create.map((p) => p.axis)).toEqual(['expense', 'income']);
+  });
+});

--- a/packages/db/prisma/migrations/20260906120000_category_packs/migration.sql
+++ b/packages/db/prisma/migrations/20260906120000_category_packs/migration.sql
@@ -1,0 +1,196 @@
+-- Category and source packs: a shelf of vocabulary somebody can install.
+--
+-- The app's ten spend categories and fifteen income sources are deliberately
+-- general — nothing shaped to one country's instruments or one person's trade.
+-- A pack is how a landlord, a freelancer, or somebody tracking a chit fund gets
+-- the words they actually use without those words being shipped to everybody.
+--
+-- A pack is DATA, not code: labels, icons from a curated set, tints from six.
+-- There is nothing to execute, so the trust boundary here is not a sandbox — it
+-- is the RLS below. `packs` is readable only where `status = 'published'` and
+-- writable only by `service_role`, so a pack reaches a phone because we
+-- published it, never because somebody inserted a row.
+--
+-- Installing writes ordinary rows into the person's own `category_tags`, through
+-- the same mutation the tag editor uses. So an install works offline, needs no
+-- privileged step, and leaves behind categories that are the person's own — which
+-- is why an uninstall (and a takedown) can leave them exactly where they are.
+
+-- ─────────────────────────────────────────────────────────────── packs ──
+
+CREATE TABLE public.packs (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    slug text NOT NULL,
+    title text NOT NULL,
+    summary text NOT NULL,
+    -- Every entry, validated by `parsePack` in @waves/core before it is written
+    -- and again on the client after it is read. The column is opaque here on
+    -- purpose: this table is a shelf, and the shape of what sits on it belongs
+    -- to the one function both sides share.
+    entries jsonb DEFAULT '[]'::jsonb NOT NULL,
+    status text DEFAULT 'draft'::text NOT NULL,
+    version integer DEFAULT 1 NOT NULL,
+    install_count integer DEFAULT 0 NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT packs_status_known CHECK ((status = ANY (ARRAY['draft'::text, 'published'::text, 'unlisted'::text]))),
+    CONSTRAINT packs_version_positive CHECK ((version > 0)),
+    CONSTRAINT packs_entries_is_array CHECK ((jsonb_typeof(entries) = 'array'::text))
+);
+
+COMMENT ON TABLE public.packs IS 'An installable set of categories or income sources. Data, never code; published by us, read by anyone signed in.';
+COMMENT ON COLUMN public.packs.status IS 'draft = ours alone; published = installable; unlisted = withdrawn, but anyone who already installed it keeps their categories.';
+
+ALTER TABLE ONLY public.packs ADD CONSTRAINT packs_pkey PRIMARY KEY (id);
+CREATE UNIQUE INDEX packs_slug_idx ON public.packs USING btree (slug);
+CREATE INDEX packs_status_idx ON public.packs USING btree (status, updated_at DESC);
+
+ALTER TABLE public.packs ENABLE ROW LEVEL SECURITY;
+
+-- The whole trust boundary. Reading is limited to what we have published;
+-- writing is not granted to `authenticated` at all, so there is no policy that
+-- could be got around — the privilege simply is not there.
+CREATE POLICY packs_read_published ON public.packs FOR SELECT TO authenticated
+  USING ((status = 'published'::text));
+
+GRANT SELECT ON TABLE public.packs TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.packs TO service_role;
+
+-- ───────────────────────────────────────────────────────── installs ──
+
+-- Whose catalog holds which pack. Owner-scoped and seq-stamped exactly like
+-- `captures` and `category_tags`, so an install rides the personal sync scope
+-- that already exists rather than inventing a second kind of ownership.
+ALTER TABLE public.profiles ADD COLUMN pack_installs_seq bigint DEFAULT 0 NOT NULL;
+
+CREATE TABLE public.pack_installs (
+    id uuid NOT NULL,
+    owner_user_id uuid NOT NULL,
+    pack_id uuid NOT NULL,
+    -- Which version was installed, so a later one can offer what is new.
+    version integer DEFAULT 1 NOT NULL,
+    updated_seq bigint DEFAULT 0 NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    deleted_at timestamp with time zone
+);
+
+COMMENT ON TABLE public.pack_installs IS 'A pack somebody has installed. Removing the row uninstalls the pack; the categories it added stay, because by then they are the person''s own.';
+
+ALTER TABLE ONLY public.pack_installs ADD CONSTRAINT pack_installs_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.pack_installs
+    ADD CONSTRAINT pack_installs_owner_user_id_fkey FOREIGN KEY (owner_user_id)
+    REFERENCES public.profiles(id) ON UPDATE CASCADE ON DELETE CASCADE;
+-- A pack we delete outright takes its install rows with it. The tags it wrote
+-- are untouched: `category_tags.pack_id` goes to NULL and the categories remain.
+ALTER TABLE ONLY public.pack_installs
+    ADD CONSTRAINT pack_installs_pack_id_fkey FOREIGN KEY (pack_id)
+    REFERENCES public.packs(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+CREATE UNIQUE INDEX pack_installs_owner_pack_idx ON public.pack_installs
+  USING btree (owner_user_id, pack_id) WHERE (deleted_at IS NULL);
+CREATE INDEX pack_installs_owner_user_id_updated_seq_idx ON public.pack_installs
+  USING btree (owner_user_id, updated_seq);
+
+CREATE FUNCTION public.waves_next_pack_install_seq(p_owner uuid) RETURNS bigint
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+DECLARE
+  v_seq bigint;
+BEGIN
+  UPDATE public.profiles
+     SET pack_installs_seq = pack_installs_seq + 1
+   WHERE id = p_owner
+   RETURNING pack_installs_seq INTO v_seq;
+  RETURN COALESCE(v_seq, 0);
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.waves_next_pack_install_seq(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.waves_next_pack_install_seq(uuid) TO service_role;
+
+CREATE FUNCTION public.waves_stamp_pack_install_seq() RETURNS trigger
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+BEGIN
+  NEW.updated_seq := public.waves_next_pack_install_seq(NEW.owner_user_id);
+  RETURN NEW;
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.waves_stamp_pack_install_seq() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.waves_stamp_pack_install_seq() TO service_role;
+
+CREATE TRIGGER pack_installs_stamp_seq BEFORE INSERT OR UPDATE ON public.pack_installs
+  FOR EACH ROW EXECUTE FUNCTION public.waves_stamp_pack_install_seq();
+
+ALTER TABLE public.pack_installs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY pack_installs_own ON public.pack_installs TO authenticated
+  USING ((owner_user_id = public.waves_current_profile_id()))
+  WITH CHECK ((owner_user_id = public.waves_current_profile_id()));
+
+-- No DELETE for `authenticated`: uninstalling is a soft delete, like every other
+-- personal row, so the tombstone can reach the person's other devices.
+GRANT SELECT, INSERT, UPDATE ON TABLE public.pack_installs TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.pack_installs TO service_role;
+
+-- ─────────────────────────────────────────────────── tags learn two things ──
+
+-- Which picker a tag belongs in. The default is what every row written before
+-- today already was, so this changes nothing that exists.
+ALTER TABLE public.category_tags ADD COLUMN axis text DEFAULT 'expense'::text NOT NULL;
+ALTER TABLE public.category_tags
+  ADD CONSTRAINT category_tags_axis_known CHECK ((axis = ANY (ARRAY['expense'::text, 'income'::text])));
+
+-- Where a tag came from. Provenance the catalog can show, never a dependency:
+-- `ON DELETE SET NULL` means deleting the pack leaves the categories standing.
+ALTER TABLE public.category_tags ADD COLUMN pack_id uuid;
+ALTER TABLE ONLY public.category_tags
+    ADD CONSTRAINT category_tags_pack_id_fkey FOREIGN KEY (pack_id)
+    REFERENCES public.packs(id) ON UPDATE CASCADE ON DELETE SET NULL;
+
+COMMENT ON COLUMN public.category_tags.axis IS 'Which picker this tag appears in: a spending category or an income source.';
+COMMENT ON COLUMN public.category_tags.pack_id IS 'The pack that first wrote this tag, for provenance. The tag outlives the pack.';
+
+-- ──────────────────────────────────────────────────────── asking for one ──
+
+-- The other half of "we author them, others ask". A request is a sentence, not
+-- a submission: there is no authoring surface here and nothing a request can put
+-- in front of another user.
+CREATE TABLE public.pack_requests (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    requester_id uuid NOT NULL,
+    body text NOT NULL,
+    status text DEFAULT 'open'::text NOT NULL,
+    decided_by uuid,
+    decided_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT pack_requests_status_known CHECK ((status = ANY (ARRAY['open'::text, 'done'::text, 'declined'::text]))),
+    -- The same shape `member_claims` uses: an undecided row carries no decision.
+    CONSTRAINT pack_requests_decided_shape CHECK (((status = 'open'::text) = (decided_at IS NULL))),
+    CONSTRAINT pack_requests_body_length CHECK ((char_length(body) BETWEEN 1 AND 500))
+);
+
+COMMENT ON TABLE public.pack_requests IS 'Somebody asking for a pack that does not exist yet. Read and decided in the admin console.';
+
+ALTER TABLE ONLY public.pack_requests ADD CONSTRAINT pack_requests_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.pack_requests
+    ADD CONSTRAINT pack_requests_requester_id_fkey FOREIGN KEY (requester_id)
+    REFERENCES public.profiles(id) ON UPDATE CASCADE ON DELETE CASCADE;
+CREATE INDEX pack_requests_status_created_at_idx ON public.pack_requests
+  USING btree (status, created_at DESC);
+
+ALTER TABLE public.pack_requests ENABLE ROW LEVEL SECURITY;
+
+-- Write your own, read your own. No update: a request once sent is not something
+-- to quietly rewrite, and the decision on it is ours to make.
+CREATE POLICY pack_requests_own ON public.pack_requests FOR SELECT TO authenticated
+  USING ((requester_id = public.waves_current_profile_id()));
+CREATE POLICY pack_requests_insert_own ON public.pack_requests FOR INSERT TO authenticated
+  WITH CHECK ((requester_id = public.waves_current_profile_id()));
+
+GRANT SELECT, INSERT ON TABLE public.pack_requests TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.pack_requests TO service_role;

--- a/packages/db/prisma/migrations/20260906130000_seed_category_packs/migration.sql
+++ b/packages/db/prisma/migrations/20260906130000_seed_category_packs/migration.sql
@@ -1,0 +1,103 @@
+-- Five packs, so the shelf is not empty on the day it opens.
+--
+-- A marketplace with nothing in it teaches people not to come back, and the
+-- first person to look will look once. These are the five vocabularies the
+-- built-ins most obviously do not cover: a country's everyday words, and the
+-- four ways of earning and spending that the general list cannot serve without
+-- becoming everybody's problem.
+--
+-- Every icon here is in the curated set (`TAG_ICONS` in @waves/core) and every
+-- tint is one of the six, which is what `parsePack` insists on — these rows go
+-- in through the same gate the console uses, so a typo would surface as a pack
+-- the client silently drops rather than a blank box on somebody's phone. Keep
+-- that true when adding more.
+--
+-- Idempotent on the slug, so re-running this changes nothing.
+
+INSERT INTO public.packs (slug, title, summary, status, version, entries) VALUES
+(
+  'india-everyday',
+  'India · everyday',
+  'The words an Indian household actually uses — the ones a general category list has no room for.',
+  'published',
+  1,
+  '[
+    {"key":"kirana","label":"Kirana","icon":"storefront-outline","tint":"mint","axis":"expense"},
+    {"key":"auto","label":"Auto","icon":"car-outline","tint":"peach","axis":"expense"},
+    {"key":"chit-fund","label":"Chit fund","icon":"people-outline","tint":"lilac","axis":"expense"},
+    {"key":"maid","label":"House help","icon":"person-outline","tint":"sky","axis":"expense"},
+    {"key":"tiffin","label":"Tiffin","icon":"fast-food-outline","tint":"peach","axis":"expense"},
+    {"key":"puja","label":"Puja","icon":"flower-outline","tint":"pink","axis":"expense"},
+    {"key":"recharge","label":"Recharge","icon":"call-outline","tint":"sky","axis":"expense"},
+    {"key":"fd-interest","label":"Deposit interest","icon":"trending-up-outline","tint":"mint","axis":"income"},
+    {"key":"pf","label":"Provident fund","icon":"shield-checkmark-outline","tint":"mint","axis":"income"}
+  ]'::jsonb
+),
+(
+  'freelance',
+  'Freelance',
+  'Invoices in, tools and taxes out — for anybody billing their own clients.',
+  'published',
+  1,
+  '[
+    {"key":"client-invoice","label":"Client invoice","icon":"document-text-outline","tint":"sky","axis":"income"},
+    {"key":"retainer","label":"Retainer","icon":"calendar-outline","tint":"mint","axis":"income"},
+    {"key":"advance","label":"Advance","icon":"cash-outline","tint":"lilac","axis":"income"},
+    {"key":"software","label":"Software","icon":"laptop-outline","tint":"lilac","axis":"expense"},
+    {"key":"equipment","label":"Equipment","icon":"desktop-outline","tint":"sky","axis":"expense"},
+    {"key":"coworking","label":"Coworking","icon":"business-outline","tint":"peach","axis":"expense"},
+    {"key":"tax-set-aside","label":"Tax set aside","icon":"calculator-outline","tint":"coral","axis":"expense"},
+    {"key":"accountant","label":"Accountant","icon":"briefcase-outline","tint":"mint","axis":"expense"}
+  ]'::jsonb
+),
+(
+  'landlord',
+  'Letting a property',
+  'Rent coming in, and everything a property costs to keep.',
+  'published',
+  1,
+  '[
+    {"key":"rent-received","label":"Rent received","icon":"home-outline","tint":"mint","axis":"income"},
+    {"key":"deposit-held","label":"Deposit held","icon":"key-outline","tint":"sky","axis":"income"},
+    {"key":"repairs","label":"Repairs","icon":"hammer-outline","tint":"peach","axis":"expense"},
+    {"key":"maintenance","label":"Maintenance","icon":"construct-outline","tint":"lilac","axis":"expense"},
+    {"key":"property-tax","label":"Property tax","icon":"receipt-outline","tint":"coral","axis":"expense"},
+    {"key":"insurance","label":"Insurance","icon":"shield-checkmark-outline","tint":"sky","axis":"expense"},
+    {"key":"agent-fee","label":"Agent fee","icon":"pricetag-outline","tint":"pink","axis":"expense"}
+  ]'::jsonb
+),
+(
+  'student',
+  'Student',
+  'Fees, books and the small money of term time.',
+  'published',
+  1,
+  '[
+    {"key":"tuition","label":"Tuition","icon":"school-outline","tint":"lilac","axis":"expense"},
+    {"key":"books","label":"Books","icon":"book-outline","tint":"peach","axis":"expense"},
+    {"key":"hostel","label":"Hostel","icon":"bed-outline","tint":"sky","axis":"expense"},
+    {"key":"printing","label":"Printing","icon":"print-outline","tint":"mint","axis":"expense"},
+    {"key":"society","label":"Clubs & societies","icon":"people-outline","tint":"pink","axis":"expense"},
+    {"key":"scholarship","label":"Scholarship","icon":"ribbon-outline","tint":"mint","axis":"income"},
+    {"key":"part-time","label":"Part-time work","icon":"briefcase-outline","tint":"sky","axis":"income"},
+    {"key":"from-family","label":"From family","icon":"heart-outline","tint":"pink","axis":"income"}
+  ]'::jsonb
+),
+(
+  'travel',
+  'A long trip',
+  'The costs a trip has that everyday life does not.',
+  'published',
+  1,
+  '[
+    {"key":"flights","label":"Flights","icon":"airplane-outline","tint":"sky","axis":"expense"},
+    {"key":"visa","label":"Visa","icon":"document-text-outline","tint":"lilac","axis":"expense"},
+    {"key":"travel-insurance","label":"Travel insurance","icon":"umbrella-outline","tint":"mint","axis":"expense"},
+    {"key":"sim","label":"Local SIM","icon":"call-outline","tint":"peach","axis":"expense"},
+    {"key":"laundry","label":"Laundry","icon":"shirt-outline","tint":"sky","axis":"expense"},
+    {"key":"tips","label":"Tips","icon":"happy-outline","tint":"pink","axis":"expense"},
+    {"key":"souvenirs","label":"Souvenirs","icon":"gift-outline","tint":"coral","axis":"expense"},
+    {"key":"tours","label":"Tours","icon":"map-outline","tint":"mint","axis":"expense"}
+  ]'::jsonb
+)
+ON CONFLICT (slug) DO NOTHING;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -158,6 +158,9 @@ model Profile {
   /// Per-owner counter behind the personal-finance scope (A48), covering every
   /// `personal_records` row. Bumped by `waves_next_personal_seq`.
   personalSeq       BigInt   @default(0) @map("personal_seq")
+  /// Per-owner counter behind installed category packs, the captures equivalent
+  /// for `pack_installs`. Bumped by `waves_next_pack_install_seq`.
+  packInstallsSeq   BigInt   @default(0) @map("pack_installs_seq")
   createdAt         DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt         DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
 
@@ -165,6 +168,8 @@ model Profile {
   captures            Capture[]
   categoryTags        CategoryTag[]
   personalRecords     PersonalRecord[]
+  packInstalls        PackInstall[]
+  packRequests        PackRequest[]
   pushTokens          PushToken[]
   notifications       Notification[]
   emailEvents         EmailEvent[]
@@ -967,6 +972,11 @@ model CategoryTag {
   icon        String?
   /// One of the six design-system tints (lilac/pink/mint/peach/sky/coral).
   tint        String?
+  /// Which picker this tag appears in: 'expense' or 'income'.
+  axis        String    @default("expense")
+  /// The pack that first wrote this tag, for provenance. Nulled if that pack is
+  /// deleted — the tag is the person's own by then and outlives it.
+  packId      String?   @map("pack_id") @db.Uuid
   sortOrder   Int       @default(0) @map("sort_order")
   hidden      Boolean   @default(false)
   updatedSeq  BigInt    @default(0) @map("updated_seq")
@@ -975,6 +985,7 @@ model CategoryTag {
   deletedAt   DateTime? @map("deleted_at") @db.Timestamptz(6)
 
   owner Profile @relation(fields: [ownerUserId], references: [id], onDelete: Cascade)
+  pack  Pack?   @relation(fields: [packId], references: [id], onDelete: SetNull)
 
   @@index([ownerUserId, updatedSeq], map: "category_tags_owner_user_id_updated_seq_idx")
   @@map("category_tags")
@@ -1006,6 +1017,80 @@ model PersonalRecord {
 
   @@index([ownerUserId, updatedSeq], map: "personal_records_owner_user_id_updated_seq_idx")
   @@map("personal_records")
+  @@schema("public")
+}
+
+/// An installable set of categories or income sources — a pack (see the
+/// `20260906120000_category_packs` migration). Data, never code: labels, icons
+/// from a curated set, tints from six, validated by `parsePack` in @waves/core
+/// before it is written and again on the client after it is read.
+///
+/// The trust boundary is the RLS, not a sandbox: readable only where
+/// `status = 'published'`, writable only by `service_role`. A pack reaches a
+/// phone because we published it.
+model Pack {
+  id           String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  /// URL-safe and unique; what a link to a pack is made of.
+  slug         String   @unique(map: "packs_slug_idx")
+  title        String
+  summary      String
+  /// Every entry: {key, label, icon, tint, axis}. Opaque to the database.
+  entries      Json     @default("[]")
+  /// 'draft' | 'published' | 'unlisted'. Unlisting withdraws a pack without
+  /// touching anybody who already installed it.
+  status       String   @default("draft")
+  version      Int      @default(1)
+  installCount Int      @default(0) @map("install_count")
+  createdAt    DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt    DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
+
+  installs PackInstall[]
+  tags     CategoryTag[]
+
+  @@index([status, updatedAt(sort: Desc)], map: "packs_status_idx")
+  @@map("packs")
+  @@schema("public")
+}
+
+/// A pack somebody has installed. Owner-scoped and seq-stamped like `Capture`,
+/// so it rides the personal sync scope. Removing the row uninstalls the pack;
+/// the categories it wrote stay, because by then they are the person's own.
+model PackInstall {
+  id          String    @id @db.Uuid
+  ownerUserId String    @map("owner_user_id") @db.Uuid
+  packId      String    @map("pack_id") @db.Uuid
+  /// Which version was installed, so a later one can offer what is new.
+  version     Int       @default(1)
+  updatedSeq  BigInt    @default(0) @map("updated_seq")
+  createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt   DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
+  deletedAt   DateTime? @map("deleted_at") @db.Timestamptz(6)
+
+  owner Profile @relation(fields: [ownerUserId], references: [id], onDelete: Cascade)
+  pack  Pack    @relation(fields: [packId], references: [id], onDelete: Cascade)
+
+  @@index([ownerUserId, updatedSeq], map: "pack_installs_owner_user_id_updated_seq_idx")
+  @@map("pack_installs")
+  @@schema("public")
+}
+
+/// Somebody asking for a pack that does not exist yet — the other half of "we
+/// author them, others ask". A sentence, not a submission: there is no authoring
+/// surface here and nothing a request can put in front of another user.
+model PackRequest {
+  id          String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  requesterId String    @map("requester_id") @db.Uuid
+  body        String
+  /// 'open' | 'done' | 'declined'; an open row carries no decision stamp.
+  status      String    @default("open")
+  decidedBy   String?   @map("decided_by") @db.Uuid
+  decidedAt   DateTime? @map("decided_at") @db.Timestamptz(6)
+  createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+
+  requester Profile @relation(fields: [requesterId], references: [id], onDelete: Cascade)
+
+  @@index([status, createdAt(sort: Desc)], map: "pack_requests_status_created_at_idx")
+  @@map("pack_requests")
   @@schema("public")
 }
 

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -28,6 +28,7 @@ import {
   buildApplyExpenseArgs,
   computeShares,
   GUEST_TRIAL_DAYS,
+  isTagIcon,
   parseSplitParams,
   sanitiseCategoryMeta,
   sanitiseExpenseLocation,
@@ -82,7 +83,9 @@ type MutationKind =
   | 'group_budget.set'
   | 'category_budget.set'
   // The trip's shared exchange rate — group-scoped, admin-gated in its RPC.
-  | 'group_fx_rate.set';
+  | 'group_fx_rate.set'
+  | 'pack.install'
+  | 'pack.uninstall';
 
 /** True for the kinds whose scope is a user, not a group. */
 function isPersonalKind(kind: MutationKind): boolean {
@@ -95,7 +98,9 @@ function isPersonalKind(kind: MutationKind): boolean {
     kind === 'tag.update' ||
     kind === 'tag.delete' ||
     kind === 'personal.upsert' ||
-    kind === 'personal.delete'
+    kind === 'personal.delete' ||
+    kind === 'pack.install' ||
+    kind === 'pack.uninstall'
   );
 }
 
@@ -110,6 +115,12 @@ function categoryTagsScope(profileId: string): string {
  *  the client's `personalScope`; suffixed so it keeps its own cursor. */
 function personalScope(profileId: string): string {
   return `${profileId}:personal`;
+}
+
+/** The personal-scope key for the packs a user has installed. Must match the
+ *  client's `packInstallsScope`; suffixed so it keeps its own cursor. */
+function packInstallsScope(profileId: string): string {
+  return `${profileId}:pack_installs`;
 }
 
 interface MutationEnvelope {
@@ -523,6 +534,10 @@ export class SyncSession {
         return await this.upsertTag(mutation);
       case 'tag.delete':
         return await this.deleteTag(mutation);
+      case 'pack.install':
+        return await this.installPack(mutation);
+      case 'pack.uninstall':
+        return await this.uninstallPack(mutation);
       case 'personal.upsert':
         return await this.upsertPersonal(mutation);
       case 'personal.delete':
@@ -944,6 +959,8 @@ export class SyncSession {
       label?: string | null;
       icon?: string | null;
       tint?: string | null;
+      axis?: string | null;
+      packId?: string | null;
       sortOrder?: number;
       hidden?: boolean;
     };
@@ -955,9 +972,21 @@ export class SyncSession {
     if (!builtinId && !label) {
       throw new HttpError(400, 'VALIDATION_FAILED', 'A custom tag needs a label');
     }
-    const icon = typeof payload.icon === 'string' ? payload.icon.trim().slice(0, 64) : null;
+    // The icon is checked against the curated set, not merely length-capped. For
+    // as long as a picker was the only writer this could not be wrong; a pack is
+    // a second writer, authored elsewhere, and a glyph that does not exist
+    // renders as a blank box on every device that installs it. Refused rather
+    // than repaired, so the mistake stays visible where it was made.
+    const icon = typeof payload.icon === 'string' ? payload.icon.trim() : null;
+    if (icon !== null && !isTagIcon(icon)) {
+      throw new HttpError(400, 'VALIDATION_FAILED', 'Unknown icon');
+    }
     const tint =
       typeof payload.tint === 'string' && TAG_TINTS.has(payload.tint) ? payload.tint : null;
+    // Which picker the tag belongs in. Anything else reads as `expense`, which
+    // is what every tag written before this field existed already was.
+    const axis = payload.axis === 'income' ? 'income' : 'expense';
+    const packId = typeof payload.packId === 'string' ? payload.packId : null;
     // Upsert by id, so a create and its later edits are the same row and a replay
     // is harmless. owner_user_id comes from the identity, never the payload.
     const { error } = await this.caller.from('category_tags').upsert(
@@ -968,6 +997,8 @@ export class SyncSession {
         label,
         icon,
         tint,
+        axis,
+        pack_id: packId,
         sort_order: Number.isFinite(payload.sortOrder)
           ? Math.trunc(payload.sortOrder as number)
           : 0,
@@ -1007,6 +1038,70 @@ export class SyncSession {
         'A personal record may only be written under its own owner',
       );
     }
+  }
+
+  private requirePackScope(mutation: MutationEnvelope): void {
+    if (mutation.groupId !== packInstallsScope(this.profileId)) {
+      throw new HttpError(403, 'NOT_OWNER', 'A pack install belongs to its own owner');
+    }
+  }
+
+  /**
+   * Record that somebody installed a pack.
+   *
+   * The categories themselves are not written here: they arrive as ordinary
+   * `tag.create` mutations queued beside this one, because a packed category is
+   * an ordinary category and giving it a privileged write path would make it
+   * something else. This row only says which pack they came from — enough for
+   * the shelf to show "installed" and for a later version to offer what is new.
+   *
+   * The pack must be one we have published. `packs` is readable by
+   * `authenticated` only where `status = 'published'`, so reading it as the
+   * caller is the check: a draft or an unlisted pack simply is not there.
+   */
+  private async installPack(mutation: MutationEnvelope): Promise<unknown> {
+    this.requirePackScope(mutation);
+    const installId = requireString(mutation.payload.installId, 'installId');
+    const packId = requireString(mutation.payload.packId, 'packId');
+    const version = Number.isFinite(mutation.payload.version)
+      ? Math.max(1, Math.trunc(mutation.payload.version as number))
+      : 1;
+
+    const { data: pack, error: lookupError } = await this.caller
+      .from('packs')
+      .select('id')
+      .eq('id', packId)
+      .maybeSingle();
+    if (lookupError) throw new HttpError(500, 'INTERNAL', lookupError.message);
+    if (!pack) throw new HttpError(404, 'NO_SUCH_PACK', 'No such pack');
+
+    const { error } = await this.caller.from('pack_installs').upsert(
+      {
+        id: installId,
+        owner_user_id: this.profileId,
+        pack_id: packId,
+        version,
+        deleted_at: null,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'id' },
+    );
+    if (error) throw new HttpError(400, 'VALIDATION_FAILED', error.message);
+    return { installId };
+  }
+
+  /** Uninstall. A soft delete, so the tombstone reaches their other devices —
+   *  and only of this row: the categories the pack wrote are the person's own by
+   *  now, and taking them back would rewrite what they have already filed. */
+  private async uninstallPack(mutation: MutationEnvelope): Promise<unknown> {
+    this.requirePackScope(mutation);
+    const installId = requireString(mutation.payload.installId, 'installId');
+    const { error } = await this.caller
+      .from('pack_installs')
+      .update({ deleted_at: new Date().toISOString(), updated_at: new Date().toISOString() })
+      .eq('id', installId);
+    if (error) throw new HttpError(400, 'VALIDATION_FAILED', error.message);
+    return { installId };
   }
 
   private async upsertPersonal(mutation: MutationEnvelope): Promise<unknown> {
@@ -1101,6 +1196,11 @@ async function pull(
   // suffixed key. Must equal `personalScope(profileId)` in @waves/core.
   const pfScope = `${profileId}:personal`;
   groupIds.delete(pfScope);
+
+  // Installed packs ride a fifth personal scope, its own suffixed key. Must
+  // equal `packInstallsScope(profileId)` in @waves/core.
+  const packScope = `${profileId}:pack_installs`;
+  groupIds.delete(packScope);
 
   // Every group's own row in one query rather than one lookup per group. The
   // per-group `maybeSingle` was the first of twelve serial round trips each
@@ -1246,6 +1346,15 @@ async function pull(
       column: 'owner_user_id',
       scope: pfScope,
       as: 'personal_records',
+    },
+    // The packs this person has installed. The packs themselves are not pulled:
+    // a catalogue of what we publish is not the user's data, and mirroring it
+    // would make every shelf browse an offline read of a stale shelf.
+    {
+      table: 'pack_installs',
+      column: 'owner_user_id',
+      scope: packScope,
+      as: 'pack_installs',
     },
   ] as const;
 

--- a/supabase/functions/sync/packs.test.ts
+++ b/supabase/functions/sync/packs.test.ts
@@ -1,0 +1,203 @@
+/**
+ * The two things the pack feature asks of the sync boundary.
+ *
+ * **A tag's icon must be a glyph that exists.** For as long as a picker was the
+ * only writer of a tag this could not be wrong, so `/sync` only capped the
+ * string's length. A pack is a second writer, authored somewhere else, and a
+ * glyph that does not exist renders as a blank box on every device that installs
+ * it — with nothing, anywhere, having said no.
+ *
+ * **An install is only ever of a published pack.** `packs` is readable by
+ * `authenticated` only where `status = 'published'`, so reading it as the caller
+ * *is* the check: a draft or a withdrawn pack is not there to be found. The test
+ * for that is the stub returning null, which is exactly what RLS does.
+ *
+ * Driven with a stubbed Supabase client — no Deno, no network, no database.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { SyncSession } from './index.ts';
+
+const OWNER = 'owner-profile-id';
+const PACK_ID = '99999999-8888-7777-6666-555555555555';
+const INSTALL_ID = '11111111-2222-3333-4444-555555555555';
+const TAG_ID = '22222222-3333-4444-5555-666666666666';
+
+interface CallerOptions {
+  /** What a select of the pack returns — null is what RLS does to a draft. */
+  pack?: { id: string } | null;
+}
+
+function caller(options: CallerOptions = {}) {
+  const upsert = vi.fn(() => Promise.resolve({ error: null }));
+  const update = vi.fn(() => ({ eq: () => Promise.resolve({ error: null }) }));
+  const maybeSingle = vi.fn(() =>
+    Promise.resolve({
+      data: options.pack === undefined ? { id: PACK_ID } : options.pack,
+      error: null,
+    }),
+  );
+  const from = vi.fn((table: string) => {
+    const builder: Record<string, unknown> = { upsert, update };
+    builder.select = () => builder;
+    builder.eq = () => builder;
+    builder.maybeSingle = maybeSingle;
+    return builder;
+  });
+  const rpc = vi.fn(() => Promise.resolve({ data: null, error: null }));
+  return { client: { from, rpc } as never, upsert, update, from };
+}
+
+function service() {
+  const from = vi.fn(() => {
+    const builder: Record<string, unknown> = { insert: () => Promise.resolve({ error: null }) };
+    builder.select = () => builder;
+    builder.eq = () => builder;
+    builder.maybeSingle = () => Promise.resolve({ data: null, error: null });
+    return builder;
+  });
+  return { from } as never;
+}
+
+function mutation(kind: string, groupId: string, payload: Record<string, unknown>) {
+  return {
+    clientMutationId: `${kind}-1`,
+    kind,
+    groupId,
+    seq: 1,
+    clientCreatedAt: '2026-09-06T04:00:00.000Z',
+    payload,
+  } as never;
+}
+
+const tagScope = `${OWNER}:category_tags`;
+const packScope = `${OWNER}:pack_installs`;
+
+const tag = (over: Record<string, unknown> = {}) => ({
+  tagId: TAG_ID,
+  label: 'Chit fund',
+  icon: 'cash-outline',
+  tint: 'mint',
+  sortOrder: 12,
+  hidden: false,
+  ...over,
+});
+
+describe('tag icons at the sync boundary', () => {
+  it('accepts a glyph from the curated set', async () => {
+    const scoped = caller();
+    const session = new SyncSession(scoped.client, service(), OWNER);
+
+    const outcome = await session.apply(mutation('tag.create', tagScope, tag()));
+
+    expect(outcome).toMatchObject({ status: 'applied' });
+    expect(scoped.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ icon: 'cash-outline', axis: 'expense' }),
+      expect.anything(),
+    );
+  });
+
+  it('refuses a glyph that does not exist', async () => {
+    const scoped = caller();
+    const session = new SyncSession(scoped.client, service(), OWNER);
+
+    const outcome = await session.apply(
+      mutation('tag.create', tagScope, tag({ icon: 'chit-fund-outline' })),
+    );
+
+    expect(outcome).toMatchObject({ status: 'rejected', code: 'VALIDATION_FAILED' });
+    expect(scoped.upsert).not.toHaveBeenCalled();
+  });
+
+  it('carries a tag into the picker it belongs in', async () => {
+    const scoped = caller();
+    const session = new SyncSession(scoped.client, service(), OWNER);
+
+    await session.apply(mutation('tag.create', tagScope, tag({ axis: 'income' })));
+
+    expect(scoped.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ axis: 'income' }),
+      expect.anything(),
+    );
+  });
+
+  it('reads an unknown axis as the one every older tag already had', async () => {
+    const scoped = caller();
+    const session = new SyncSession(scoped.client, service(), OWNER);
+
+    await session.apply(mutation('tag.create', tagScope, tag({ axis: 'sideways' })));
+
+    expect(scoped.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ axis: 'expense' }),
+      expect.anything(),
+    );
+  });
+});
+
+describe('installing a pack', () => {
+  it('records the install once the pack is found', async () => {
+    const scoped = caller();
+    const session = new SyncSession(scoped.client, service(), OWNER);
+
+    const outcome = await session.apply(
+      mutation('pack.install', packScope, { installId: INSTALL_ID, packId: PACK_ID, version: 2 }),
+    );
+
+    expect(outcome).toMatchObject({ status: 'applied' });
+    expect(scoped.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: INSTALL_ID,
+        owner_user_id: OWNER,
+        pack_id: PACK_ID,
+        version: 2,
+        deleted_at: null,
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('refuses a pack it cannot see', async () => {
+    // Which is what a draft or an unlisted pack looks like through RLS.
+    const scoped = caller({ pack: null });
+    const session = new SyncSession(scoped.client, service(), OWNER);
+
+    const outcome = await session.apply(
+      mutation('pack.install', packScope, { installId: INSTALL_ID, packId: PACK_ID }),
+    );
+
+    expect(outcome).toMatchObject({ status: 'rejected', code: 'NO_SUCH_PACK' });
+    expect(scoped.upsert).not.toHaveBeenCalled();
+  });
+
+  it('refuses an install written into somebody else’s scope', async () => {
+    const scoped = caller();
+    const session = new SyncSession(scoped.client, service(), OWNER);
+
+    const outcome = await session.apply(
+      mutation('pack.install', 'someone-else:pack_installs', {
+        installId: INSTALL_ID,
+        packId: PACK_ID,
+      }),
+    );
+
+    expect(outcome).toMatchObject({ status: 'rejected', code: 'NOT_OWNER' });
+    expect(scoped.upsert).not.toHaveBeenCalled();
+  });
+
+  it('uninstalls without touching a single category', async () => {
+    const scoped = caller();
+    const session = new SyncSession(scoped.client, service(), OWNER);
+
+    const outcome = await session.apply(
+      mutation('pack.uninstall', packScope, { installId: INSTALL_ID }),
+    );
+
+    expect(outcome).toMatchObject({ status: 'applied' });
+    // A soft delete of the install row, and nothing else written at all.
+    expect(scoped.update).toHaveBeenCalledWith(
+      expect.objectContaining({ deleted_at: expect.any(String) }),
+    );
+    expect(scoped.from).not.toHaveBeenCalledWith('category_tags');
+  });
+});


### PR DESCRIPTION
Builds the plan you approved. Nothing of this existed before — no packs, no catalogue, no install path.

## What it is

A shelf of installable **category and income-source packs**. Five ship with it: India · everyday, Freelance, Letting a property, Student, A long trip — 40 categories between them, across spending and income.

The scope decision that makes it tractable: **a pack is data, not code.** Labels, icons from the curated set, tints from six. There is no sandbox to build and nothing a pack can do to a device beyond appearing in a picker. What is left is a content question and an integrity one, and only the second needed engineering.

## The trust boundary is RLS, not a sandbox

```sql
CREATE POLICY packs_read_published ON public.packs FOR SELECT TO authenticated
  USING ((status = 'published'::text));
```

`authenticated` has **no write privilege on `packs` at all** — not a policy to get around, the privilege simply is not there. A pack reaches a phone because we published it. The install checks this by *reading* the pack as the caller: a draft or an unlisted pack is not there to find.

## Installing is an ordinary write

Installing writes ordinary custom tags into the person's own catalog through the same `tag.create` the editor uses. No new write path, nothing privileged — so **installing works offline**, and every screen that renders a custom tag renders a packed one without knowing the difference.

- **Installing twice is installing once.** Tag ids are derived from (pack, entry), so a double tap, a retry, or a second device writes the same rows.
- **An existing tag is never overwritten.** Install a pack, rename one of its categories to suit you, install a newer version — your name stands.
- **Uninstalling keeps the categories**, and the screen says so in as many words. By then they are the person's own, with expenses filed under them. The same holds for a pack withdrawn after publication: unlisting stops it spreading and touches nobody who has it. Taking their categories back would rewrite somebody's history over a decision that was not theirs.

## A gap this would have opened, closed first

The curated icon list lived in the mobile app while `/sync` accepted **any string up to 64 characters** as an icon. Harmless while a picker was the only writer — a pack is a second writer, authored elsewhere, and a glyph that does not exist renders as a blank box on every device that installs it with nothing anywhere having said no. The list moved to `@waves/core`, `/sync` validates against it, and `parsePack` refuses rather than repairs: a bad icon is not quietly swapped for a pricetag, an unknown tint is not defaulted to sky, and a pack with one unusable entry is refused whole — installing "most of" what somebody chose is not a thing to do quietly.

`parsePack` runs on **both sides**: the console before publishing, the client on what it fetched. A client that trusts the server to have validated is a client that draws a blank box the first time something upstream goes wrong.

The seeded packs go in as raw SQL and so never pass through it — `seededPacks.test.ts` reads the seed file and puts every pack through the same gate, which is what makes a first-party pack as safe as an authored one.

## Also in here

- `category_tags` learns an **axis**, so an income source can never appear in the spend picker — the confusion the axis exists to end. The default keeps every existing row exactly as it was.
- The source picker shows the person's own sources after the fifteen built-ins — theirs second rather than mixed in, so a list somebody has learned does not reorder itself the first time they install something.
- `recurringOccurrenceId`'s hashing extracted to `deterministicId` and reused. The seed string is unchanged, so every occurrence already written keeps its id.

## Console

`/packs` (publish · unlist · edit) and `/pack-requests`. Entries are edited as JSON rather than a row-by-row form — a deliberate trade for a staff tool used by a handful of people, since the validator already catches every mistake a form would have prevented. If somebody outside the team ever authors a pack, that is the first thing to replace. The requests queue shows what was asked and nothing about who asked.

## Gates

`typecheck` 0 · `lint` 0 · core **919** (+37) · edge **156** (+8) · mobile **830** · admin **31** · `check-definer-grants` OK · four locales complete

Both migrations applied to a local Postgres and verified: tables, trigger, constraints, and the five packs present.

## Deploying

**Deploy-gated**, unlike #678: `prisma migrate deploy` + `edge:deploy` + an admin deploy. Not device-tested yet.

## Not in this round

Third-party **authoring** (the review states exist; the submission flow does not), payment of any kind, themes, and automations — a pack that *does* something is a different feature with a different threat model, and folding it in would mean shipping an execution surface to get a category list.

## A correction to something I said earlier

While verifying locally I hit `42703: column u.raw_user_meta_data does not exist` applying `20260905090000_restore_new_user_profile_trigger`, and reported that a fresh database could not be migrated from scratch. **That was wrong.** CI applies every migration cleanly on a fresh Postgres: the repo never creates an `auth.users` stub, so the guard in that migration correctly skips. My local database had a stale five-column `auth.users` left from an earlier session, which made the guard pass and the backfill fail. Nothing to fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a marketplace for browsing, installing, and uninstalling category and income-source packs.
  - Added pack detail views showing included entries, installation status, and install results.
  - Added offline support for pack installation state and retry handling.
  - Added the ability to request new packs.
  - Added an admin area for creating, publishing, editing, and managing packs and pack requests.
  - Custom income sources now appear alongside built-in options.
- **Bug Fixes**
  - Reordering guidance is hidden when no categories exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->