### PR TITLE
fix(auth): back from the dashboard leaves the app, never returns to login

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -51,6 +51,7 @@ import { LanguageProvider, useLanguage } from '@/i18n/language';
 import { LocaleSync } from '@/i18n/localeSync';
 import { LockProvider, useLock } from '@/lib/lock';
 import { legacyKeysMigrated } from '@/lib/legacyKeys';
+import { isAuthRoute, isPublicRoute } from '@/lib/routeAccess';
 import { ReducedMotionProvider, useReducedMotion } from '@/lib/reducedMotion';
 import { RecentCountProvider } from '@/lib/recentCount';
 import { ShortcutProvider } from '@/lib/shortcut';
@@ -423,7 +424,15 @@ function LockGate({ children }: { children: React.ReactNode }) {
   );
 }
 
-/** Sends signed-out users to the sign-in screen, and back once they are in. */
+/**
+ * Sends signed-out users to the welcome screen, and back once they are in.
+ *
+ * Two mechanisms, deliberately: the `Stack.Protected` groups in the tree below
+ * are what make the doors *unreachable* — they take the history with them when
+ * the session flips — while the effect here is the redirect for routes that are
+ * not listed on the stack at all (expo-router auto-includes every file), so a
+ * deep link to one of those cannot park a signed-out person inside the app.
+ */
 function AuthGate() {
   const { session, loading } = useAuth();
   const segments = useSegments();
@@ -469,44 +478,11 @@ function AuthGate() {
     animation: push,
   };
 
-  // The two auth doors and the invite-accept screen are the only routes a
-  // signed-out person is allowed to sit on. `onAuth` covers both doors so a
-  // session that appears bounces off either one back into the app.
-  const onSignIn = segments[0] === 'sign-in';
-  // The welcome gateway is where a signed-out person lands; a session appearing
-  // on it (or on either door) bounces back into the app, so it counts as auth.
-  // The guest doorway counts as auth too: a signed-out person is allowed to sit
-  // on it, and the moment its Continue mints a guest session the gate bounces it
-  // into the app, exactly like the doors.
-  // `phone` counts as auth for the same reason the doors do: a nobody signs in
-  // there (or, in a dev build, the 000000 stub mints a guest), and the moment
-  // that session appears the gate must bounce it into the app — otherwise it
-  // sits on the code screen with a live session and nowhere to go.
-  // `verify-email` joins them: the email code is entered there, and the session
-  // `verifyOtp` mints must bounce into the app just like the phone code does.
-  const onAuth =
-    onSignIn ||
-    segments[0] === 'sign-up' ||
-    segments[0] === 'welcome' ||
-    segments[0] === 'guest-welcome' ||
-    segments[0] === 'phone' ||
-    segments[0] === 'verify-email';
-  // The privacy screen is reachable signed-out too, so the Terms & Privacy line
-  // on the welcome and guest doorways can open it before anybody has an account.
-  // Its open-source licenses screen is part of that same policy, opened from a
-  // row inside it, so it has to be public as well — otherwise tapping it bounces
-  // a signed-out reader back to /welcome. The local privacy audit is dev-only
-  // and must stay reachable after sign-out so e2e can verify private local state
-  // was removed, but production builds must never expose that route signed-out.
-  const onPublicRoute =
-    onAuth ||
-    segments[0] === 'join' ||
-    segments[0] === 'language' ||
-    (__DEV__ &&
-      (segments as string[])[0] === 'dev' &&
-      (segments as string[])[1] === 'local-privacy') ||
-    (segments[0] === 'settings' &&
-      ((segments as string[])[1] === 'privacy' || (segments as string[])[1] === 'licenses'));
+  // Which routes go with which session — the same lists the `Stack.Protected`
+  // groups below are built from, kept in `lib/routeAccess` so the guard and this
+  // redirect cannot drift apart.
+  const onAuth = isAuthRoute(segments as string[]);
+  const onPublicRoute = isPublicRoute(segments as string[], __DEV__);
 
   /**
    * The route we are on disagrees with the session we have, and the effect
@@ -610,68 +586,106 @@ function AuthGate() {
             gestureEnabled: true,
           }}
         >
-          {/* Signing in and out replaces the whole tree; sliding it would suggest a
-          place to go back to, and there is not one. */}
-          <Stack.Screen name="welcome" options={{ animation: 'none' }} />
-          <Stack.Screen name="language" />
-          <Stack.Screen name="sign-in" options={{ animation: 'none' }} />
-          {/* The sign-up page slides in from the login screen and back out, so it
-            keeps a normal push — unlike sign-in, which replaces the whole tree. */}
-          <Stack.Screen name="sign-up" />
-          <Stack.Screen name="phone" />
-          <Stack.Screen name="verify-email" />
-          <Stack.Screen name="guest-welcome" />
-          <Stack.Screen name="(tabs)" options={{ animation: 'none' }} />
-          <Stack.Screen name="new-group" options={slide} />
-          <Stack.Screen name="clone-group" options={slide} />
-          {paywallEnabled ? <Stack.Screen name="paywall" options={slide} /> : null}
-          <Stack.Screen name="capture" options={slide} />
-          {/* The drafts screen keeps the bottom bar, so a person leaves it by
+          {/* The doors, and only the doors.
+              `Stack.Protected` is not decoration here: when a guard flips from
+              true to false, expo-router *removes every history entry* for the
+              screens inside it. That is the whole fix for "sign in, land on the
+              dashboard, press Android back, and the login screen comes back" —
+              a `replace` only swaps the top of the stack, so `welcome` (and
+              anything pushed from it) stayed underneath as a back target. With
+              the group guarded, a session appearing erases those entries and
+              back from the dashboard leaves the app, which is what every other
+              app on the phone does.
+              It cuts the other way too: signing out drops the whole signed-in
+              history, so back cannot walk into a screen the account no longer
+              owns.
+              This group must stay FIRST — a signed-out person on a guarded app
+              screen falls back to the first screen still available, and that
+              should be `welcome`. */}
+          <Stack.Protected guard={!session}>
+            {/* Signing in and out replaces the whole tree; sliding it would suggest a
+            place to go back to, and there is not one. */}
+            <Stack.Screen name="welcome" options={{ animation: 'none' }} />
+            <Stack.Screen name="sign-in" options={{ animation: 'none' }} />
+            {/* The sign-up page slides in from the login screen and back out, so it
+              keeps a normal push — unlike sign-in, which replaces the whole tree. */}
+            <Stack.Screen name="sign-up" />
+            <Stack.Screen name="phone" />
+            <Stack.Screen name="verify-email" />
+            <Stack.Screen name="guest-welcome" />
+          </Stack.Protected>
+          {/* Everything behind the door. Guarded for the mirror-image reason:
+              signing out erases this history, so back cannot re-enter a screen
+              belonging to the account that just left. */}
+          <Stack.Protected guard={Boolean(session)}>
+            <Stack.Screen name="(tabs)" options={{ animation: 'none' }} />
+            <Stack.Screen name="new-group" options={slide} />
+            <Stack.Screen name="clone-group" options={slide} />
+            {/* The paywall is an unwired placeholder, so it stays unreachable
+                until its flag is on — a nested guard rather than a conditional,
+                because a `null` child is not a screen and the navigator warns
+                about one. */}
+            <Stack.Protected guard={paywallEnabled}>
+              <Stack.Screen name="paywall" options={slide} />
+            </Stack.Protected>
+            <Stack.Screen name="capture" options={slide} />
+            {/* The drafts screen keeps the bottom bar, so a person leaves it by
               tapping a tab — which should cut straight across the way a tab does,
               not slide the draft card out first. `none` makes leaving it (and
               arriving on it) instant, the same treatment the inbox destination
               had before it became a tab. */}
-          <Stack.Screen name="captures" options={{ animation: 'none' }} />
-          <Stack.Screen name="groups" options={slide} />
-          <Stack.Screen name="group/[id]/index" options={slide} />
-          <Stack.Screen name="group/[id]/add-expense" options={slide} />
-          <Stack.Screen name="group/[id]/settle" options={slide} />
-          <Stack.Screen name="group/[id]/simplify" />
-          <Stack.Screen name="group/[id]/settings" />
-          <Stack.Screen name="group/[id]/members" />
-          <Stack.Screen name="group/[id]/member/[memberId]" />
-          <Stack.Screen name="group/[id]/expense/[expenseId]" options={slide} />
-          <Stack.Screen name="group/[id]/invite" options={slide} />
-          <Stack.Screen name="group/[id]/itemize" options={slide} />
-          <Stack.Screen name="receipt/[id]" options={slide} />
-          <Stack.Screen name="friends/contacts" />
-          <Stack.Screen name="contact-picker" options={slide} />
-          <Stack.Screen name="scan" options={slide} />
-          <Stack.Screen name="settings/notifications" />
-          <Stack.Screen name="settings/export" />
-          <Stack.Screen name="settings/import" />
-          <Stack.Screen name="settings/lock" />
-          <Stack.Screen name="settings/devices" />
-          <Stack.Screen name="settings/shortcut" />
-          <Stack.Screen name="settings/recent" />
-          <Stack.Screen name="settings/sync" />
-          <Stack.Screen name="settings/backup" />
-          <Stack.Screen name="settings/theme" />
-          <Stack.Screen name="settings/categories" />
-          <Stack.Screen name="settings/language" />
-          <Stack.Screen name="settings/upgrade" />
-          <Stack.Screen name="settings/redeem" />
-          <Stack.Screen name="settings/account" />
-          <Stack.Screen name="settings/feedback" />
-          <Stack.Screen name="settings/privacy" />
-          <Stack.Screen name="settings/delete-account" />
-          <Stack.Screen name="dev/local-privacy" />
-          <Stack.Screen name="join" />
-          {/* The inbox is a tab-navigator destination now (see `(tabs)/inbox`),
+            <Stack.Screen name="captures" options={{ animation: 'none' }} />
+            <Stack.Screen name="groups" options={slide} />
+            <Stack.Screen name="group/[id]/index" options={slide} />
+            <Stack.Screen name="group/[id]/add-expense" options={slide} />
+            <Stack.Screen name="group/[id]/settle" options={slide} />
+            <Stack.Screen name="group/[id]/simplify" />
+            <Stack.Screen name="group/[id]/settings" />
+            <Stack.Screen name="group/[id]/members" />
+            <Stack.Screen name="group/[id]/member/[memberId]" />
+            <Stack.Screen name="group/[id]/expense/[expenseId]" options={slide} />
+            <Stack.Screen name="group/[id]/invite" options={slide} />
+            <Stack.Screen name="group/[id]/itemize" options={slide} />
+            <Stack.Screen name="receipt/[id]" options={slide} />
+            <Stack.Screen name="friends/contacts" />
+            <Stack.Screen name="contact-picker" options={slide} />
+            <Stack.Screen name="scan" options={slide} />
+            <Stack.Screen name="settings/notifications" />
+            <Stack.Screen name="settings/export" />
+            <Stack.Screen name="settings/import" />
+            <Stack.Screen name="settings/lock" />
+            <Stack.Screen name="settings/devices" />
+            <Stack.Screen name="settings/shortcut" />
+            <Stack.Screen name="settings/recent" />
+            <Stack.Screen name="settings/sync" />
+            <Stack.Screen name="settings/backup" />
+            <Stack.Screen name="settings/theme" />
+            <Stack.Screen name="settings/categories" />
+            <Stack.Screen name="settings/language" />
+            <Stack.Screen name="settings/upgrade" />
+            <Stack.Screen name="settings/redeem" />
+            <Stack.Screen name="settings/account" />
+            <Stack.Screen name="settings/feedback" />
+            <Stack.Screen name="settings/delete-account" />
+            {/* The inbox is a tab-navigator destination now (see `(tabs)/inbox`),
               so it is no longer a screen on this root stack — a tap on it from
               anywhere is an instant tab swap rather than a push that re-reveals
               and thaws the whole tab tree. */}
-          <Stack.Screen name="voice" options={slide} />
+            <Stack.Screen name="voice" options={slide} />
+          </Stack.Protected>
+          {/* Reachable with or without a session, so they belong to neither
+              group: the language picker is offered on the welcome screen, and
+              `join`/`settings/privacy` are opened from links and policy lines
+              that may arrive before anybody has an account. They sit last on
+              purpose — a guard flipping falls back to the first screen still
+              available, and that should be `welcome` signed out and the tabs
+              signed in, never the language picker. */}
+          <Stack.Screen name="language" />
+          <Stack.Screen name="join" />
+          <Stack.Screen name="settings/privacy" />
+          {/* Dev-only screen, and deliberately still reachable after sign-out so
+              the e2e suite can prove private local state was removed. */}
+          <Stack.Screen name="dev/local-privacy" />
         </Stack>
         {/* One bar over the whole stack, so every screen keeps it — it hides
           itself on the modals and the camera. */}

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -51,7 +51,7 @@ import { LanguageProvider, useLanguage } from '@/i18n/language';
 import { LocaleSync } from '@/i18n/localeSync';
 import { LockProvider, useLock } from '@/lib/lock';
 import { legacyKeysMigrated } from '@/lib/legacyKeys';
-import { isAuthRoute, isPublicRoute } from '@/lib/routeAccess';
+import { isRouteAllowed } from '@/lib/routeAccess';
 import { ReducedMotionProvider, useReducedMotion } from '@/lib/reducedMotion';
 import { RecentCountProvider } from '@/lib/recentCount';
 import { ShortcutProvider } from '@/lib/shortcut';
@@ -481,8 +481,10 @@ function AuthGate() {
   // Which routes go with which session — the same lists the `Stack.Protected`
   // groups below are built from, kept in `lib/routeAccess` so the guard and this
   // redirect cannot drift apart.
-  const onAuth = isAuthRoute(segments as string[]);
-  const onPublicRoute = isPublicRoute(segments as string[], __DEV__);
+  const signedIn = Boolean(session);
+  const routeAllowed = isRouteAllowed(segments as string[], signedIn, __DEV__, {
+    paywall: paywallEnabled,
+  });
 
   /**
    * The route we are on disagrees with the session we have, and the effect
@@ -492,13 +494,13 @@ function AuthGate() {
    * sees on a cold start. Hold the spinner until the route and the session
    * agree, and the app tree never mounts the wrong screen at all.
    */
-  const needsRedirect = !loading && ((!session && !onPublicRoute) || (Boolean(session) && onAuth));
+  const needsRedirect = !loading && !routeAllowed;
 
   useEffect(() => {
-    if (loading) return;
-    if (!session && !onPublicRoute) router.replace('/welcome');
-    else if (session && onAuth) router.replace('/');
-  }, [session, loading, onAuth, onPublicRoute, router]);
+    if (loading || routeAllowed) return;
+    if (!session) router.replace('/welcome');
+    else router.replace('/');
+  }, [session, loading, routeAllowed, router]);
 
   // The intro tour now comes *after* sign-in, not in front of it: the first
   // authenticated launch on this device shows the three cards once, over the
@@ -646,10 +648,26 @@ function AuthGate() {
             <Stack.Screen name="group/[id]/expense/[expenseId]" options={slide} />
             <Stack.Screen name="group/[id]/invite" options={slide} />
             <Stack.Screen name="group/[id]/itemize" options={slide} />
+            <Stack.Screen name="group/[id]/export" options={slide} />
+            <Stack.Screen name="group/[id]/insights" />
+            <Stack.Screen name="group/[id]/map" />
+            <Stack.Screen name="group/[id]/month" />
+            <Stack.Screen name="group/[id]/pending" />
+            <Stack.Screen name="group/[id]/plan" />
+            <Stack.Screen name="group/[id]/recap" />
             <Stack.Screen name="receipt/[id]" options={slide} />
+            <Stack.Screen name="friends/add-person" />
             <Stack.Screen name="friends/contacts" />
+            <Stack.Screen name="friends/merge" />
+            <Stack.Screen name="friends/person/[key]" />
             <Stack.Screen name="contact-picker" options={slide} />
             <Stack.Screen name="scan" options={slide} />
+            <Stack.Screen name="personal/transactions" />
+            <Stack.Screen name="personal/entry" options={slide} />
+            <Stack.Screen name="personal/recurring" />
+            <Stack.Screen name="personal/loans" />
+            <Stack.Screen name="personal/budgets" />
+            <Stack.Screen name="personal/source/[id]" />
             <Stack.Screen name="settings/notifications" />
             <Stack.Screen name="settings/export" />
             <Stack.Screen name="settings/import" />
@@ -659,9 +677,15 @@ function AuthGate() {
             <Stack.Screen name="settings/recent" />
             <Stack.Screen name="settings/sync" />
             <Stack.Screen name="settings/backup" />
+            <Stack.Screen name="settings/archived" />
+            <Stack.Screen name="settings/blocked" />
+            <Stack.Screen name="settings/storage" />
             <Stack.Screen name="settings/theme" />
             <Stack.Screen name="settings/categories" />
             <Stack.Screen name="settings/language" />
+            <Stack.Screen name="settings/packs" />
+            <Stack.Screen name="settings/packs/[slug]" />
+            <Stack.Screen name="settings/paying" />
             <Stack.Screen name="settings/upgrade" />
             <Stack.Screen name="settings/redeem" />
             <Stack.Screen name="settings/account" />
@@ -683,9 +707,12 @@ function AuthGate() {
           <Stack.Screen name="language" />
           <Stack.Screen name="join" />
           <Stack.Screen name="settings/privacy" />
+          <Stack.Screen name="settings/licenses" />
           {/* Dev-only screen, and deliberately still reachable after sign-out so
               the e2e suite can prove private local state was removed. */}
-          <Stack.Screen name="dev/local-privacy" />
+          <Stack.Protected guard={__DEV__}>
+            <Stack.Screen name="dev/local-privacy" />
+          </Stack.Protected>
         </Stack>
         {/* One bar over the whole stack, so every screen keeps it — it hides
           itself on the modals and the camera. */}

--- a/apps/mobile/src/lib/routeAccess.ts
+++ b/apps/mobile/src/lib/routeAccess.ts
@@ -1,0 +1,67 @@
+/**
+ * Which routes a person may sit on, and with what session.
+ *
+ * Two consumers, and they must agree: the `Stack.Protected` groups in the root
+ * layout (which make a route unreachable and take its history entries with it
+ * when the session flips), and the redirect effect beside them (which catches
+ * the routes the layout never lists — expo-router auto-includes every file, so
+ * a deep link can land somewhere no `Stack.Screen` names).
+ *
+ * Kept pure and free of expo-router imports so it can be tested directly.
+ */
+
+/**
+ * The doors. A signed-out person is allowed to sit on any of them, and a
+ * session appearing on one must move them into the app.
+ *
+ * `welcome` is the gateway a signed-out person lands on. `guest-welcome` is a
+ * door too: its Continue mints an anonymous session, and the moment it does,
+ * the person belongs in the app. `phone` and `verify-email` are the code
+ * screens — the session `verifyOtp` mints must bounce the same way, or somebody
+ * sits on a code screen holding a live session with nowhere to go.
+ */
+export const AUTH_ROUTES = [
+  'welcome',
+  'sign-in',
+  'sign-up',
+  'guest-welcome',
+  'phone',
+  'verify-email',
+] as const;
+
+/**
+ * Reachable either way, so they belong to neither guard.
+ *
+ * `join` carries an invite that may arrive before anybody has an account.
+ * `language` is offered on the welcome screen. The privacy screen is opened
+ * from the Terms & Privacy line on the doorways, and its open-source licenses
+ * screen from a row inside it — a signed-out reader tapping either must not be
+ * thrown back to `/welcome`.
+ */
+const OPEN_ROUTES = ['join', 'language'] as const;
+
+/** Sub-routes of `settings` that a signed-out person may open. */
+const OPEN_SETTINGS = ['privacy', 'licenses'] as const;
+
+/** True while the given route segments name one of the auth doors. */
+export function isAuthRoute(segments: readonly string[]): boolean {
+  return (AUTH_ROUTES as readonly string[]).includes(segments[0] ?? '');
+}
+
+/**
+ * True while the route is one a signed-out person may sit on.
+ *
+ * `dev` is `__DEV__`. The local privacy audit must stay reachable after sign-out
+ * so the e2e suite can prove private local state was removed — and must never
+ * be reachable signed-out in a production build.
+ */
+export function isPublicRoute(segments: readonly string[], dev: boolean): boolean {
+  if (isAuthRoute(segments)) return true;
+  const [first, second] = segments;
+  if ((OPEN_ROUTES as readonly string[]).includes(first ?? '')) return true;
+  if (dev && first === 'dev' && second === 'local-privacy') return true;
+  if (first === 'settings' && (OPEN_SETTINGS as readonly string[]).includes(second ?? '')) {
+    return true;
+  }
+  return false;
+}

--- a/apps/mobile/src/lib/routeAccess.ts
+++ b/apps/mobile/src/lib/routeAccess.ts
@@ -48,6 +48,23 @@ export function isAuthRoute(segments: readonly string[]): boolean {
   return (AUTH_ROUTES as readonly string[]).includes(segments[0] ?? '');
 }
 
+/** True while the route exists only in local development builds. */
+function isDevOnlyRoute(segments: readonly string[]): boolean {
+  const [first, second] = segments;
+  return first === 'dev' && second === 'local-privacy';
+}
+
+/** True while the route is behind a remotely-controlled feature flag. */
+function isFlaggedRoute(segments: readonly string[], flags: RouteAccessFlags): boolean {
+  const [first] = segments;
+  return first === 'paywall' && !flags.paywall;
+}
+
+/** Runtime switches that decide whether optional route files are reachable. */
+export interface RouteAccessFlags {
+  readonly paywall: boolean;
+}
+
 /**
  * True while the route is one a signed-out person may sit on.
  *
@@ -59,9 +76,28 @@ export function isPublicRoute(segments: readonly string[], dev: boolean): boolea
   if (isAuthRoute(segments)) return true;
   const [first, second] = segments;
   if ((OPEN_ROUTES as readonly string[]).includes(first ?? '')) return true;
-  if (dev && first === 'dev' && second === 'local-privacy') return true;
+  if (dev && isDevOnlyRoute(segments)) return true;
   if (first === 'settings' && (OPEN_SETTINGS as readonly string[]).includes(second ?? '')) {
     return true;
   }
   return false;
+}
+
+/**
+ * True while the current session state is allowed to remain on this route.
+ *
+ * This is the redirect-side mirror of the Stack groups in the root layout. It
+ * covers the files expo-router can auto-include even when no `Stack.Screen` is
+ * rendered for them, such as production dev tools and disabled feature routes.
+ */
+export function isRouteAllowed(
+  segments: readonly string[],
+  signedIn: boolean,
+  dev: boolean,
+  flags: RouteAccessFlags,
+): boolean {
+  if (!dev && isDevOnlyRoute(segments)) return false;
+  if (isFlaggedRoute(segments, flags)) return false;
+  if (signedIn) return !isAuthRoute(segments);
+  return isPublicRoute(segments, dev);
 }

--- a/apps/mobile/test/routeAccess.test.ts
+++ b/apps/mobile/test/routeAccess.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { AUTH_ROUTES, isAuthRoute, isPublicRoute } from '../src/lib/routeAccess';
+
+describe('isAuthRoute', () => {
+  it('names every door, so a session appearing on one moves the person into the app', () => {
+    for (const route of AUTH_ROUTES) {
+      expect(isAuthRoute([route])).toBe(true);
+    }
+  });
+
+  it('does not count the app itself, or a route that merely starts like a door', () => {
+    expect(isAuthRoute(['(tabs)'])).toBe(false);
+    expect(isAuthRoute(['settings', 'account'])).toBe(false);
+    expect(isAuthRoute(['sign-in-help'])).toBe(false);
+    expect(isAuthRoute([])).toBe(false);
+  });
+});
+
+describe('isPublicRoute', () => {
+  it('lets a signed-out person sit on the doors', () => {
+    for (const route of AUTH_ROUTES) {
+      expect(isPublicRoute([route], false)).toBe(true);
+    }
+  });
+
+  it('lets an invite, the language picker, and the policy screens through', () => {
+    expect(isPublicRoute(['join'], false)).toBe(true);
+    expect(isPublicRoute(['language'], false)).toBe(true);
+    expect(isPublicRoute(['settings', 'privacy'], false)).toBe(true);
+    expect(isPublicRoute(['settings', 'licenses'], false)).toBe(true);
+  });
+
+  it('keeps the rest of the app private', () => {
+    expect(isPublicRoute(['(tabs)'], false)).toBe(false);
+    expect(isPublicRoute(['settings', 'account'], false)).toBe(false);
+    expect(isPublicRoute(['group', 'abc', 'index'], false)).toBe(false);
+    expect(isPublicRoute(['capture'], false)).toBe(false);
+  });
+
+  it('exposes the local privacy audit only in a dev build', () => {
+    expect(isPublicRoute(['dev', 'local-privacy'], true)).toBe(true);
+    expect(isPublicRoute(['dev', 'local-privacy'], false)).toBe(false);
+  });
+});

--- a/apps/mobile/test/routeAccess.test.ts
+++ b/apps/mobile/test/routeAccess.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { AUTH_ROUTES, isAuthRoute, isPublicRoute } from '../src/lib/routeAccess';
+import { AUTH_ROUTES, isAuthRoute, isPublicRoute, isRouteAllowed } from '../src/lib/routeAccess';
+
+const flags = { paywall: false };
 
 describe('isAuthRoute', () => {
   it('names every door, so a session appearing on one moves the person into the app', () => {
@@ -31,15 +33,48 @@ describe('isPublicRoute', () => {
     expect(isPublicRoute(['settings', 'licenses'], false)).toBe(true);
   });
 
-  it('keeps the rest of the app private', () => {
+  it('keeps the rest of the app private for user, rider, traveller, and financer flows', () => {
     expect(isPublicRoute(['(tabs)'], false)).toBe(false);
     expect(isPublicRoute(['settings', 'account'], false)).toBe(false);
-    expect(isPublicRoute(['group', 'abc', 'index'], false)).toBe(false);
+    expect(isPublicRoute(['friends', 'person', 'guest-1'], false)).toBe(false);
+    expect(isPublicRoute(['group', 'abc', 'map'], false)).toBe(false);
+    expect(isPublicRoute(['group', 'abc', 'plan'], false)).toBe(false);
+    expect(isPublicRoute(['personal', 'transactions'], false)).toBe(false);
+    expect(isPublicRoute(['personal', 'source', 'salary'], false)).toBe(false);
     expect(isPublicRoute(['capture'], false)).toBe(false);
   });
 
   it('exposes the local privacy audit only in a dev build', () => {
     expect(isPublicRoute(['dev', 'local-privacy'], true)).toBe(true);
     expect(isPublicRoute(['dev', 'local-privacy'], false)).toBe(false);
+  });
+});
+
+describe('isRouteAllowed', () => {
+  it('moves a signed-in person off every auth door', () => {
+    for (const route of AUTH_ROUTES) {
+      expect(isRouteAllowed([route], true, true, flags)).toBe(false);
+    }
+  });
+
+  it('keeps signed-in production users out of development-only routes', () => {
+    expect(isRouteAllowed(['dev', 'local-privacy'], true, false, flags)).toBe(false);
+    expect(isRouteAllowed(['dev', 'local-privacy'], true, true, flags)).toBe(true);
+  });
+
+  it('honours flagged routes for both direct links and signed-in navigation', () => {
+    expect(isRouteAllowed(['paywall'], true, false, { paywall: false })).toBe(false);
+    expect(isRouteAllowed(['paywall'], true, false, { paywall: true })).toBe(true);
+    expect(isRouteAllowed(['paywall'], false, false, { paywall: true })).toBe(false);
+  });
+
+  it('allows signed-in user, rider, traveller, and financer flows that are private', () => {
+    expect(isRouteAllowed(['(tabs)'], true, false, flags)).toBe(true);
+    expect(isRouteAllowed(['settings', 'account'], true, false, flags)).toBe(true);
+    expect(isRouteAllowed(['friends', 'person', 'guest-1'], true, false, flags)).toBe(true);
+    expect(isRouteAllowed(['group', 'abc', 'map'], true, false, flags)).toBe(true);
+    expect(isRouteAllowed(['group', 'abc', 'plan'], true, false, flags)).toBe(true);
+    expect(isRouteAllowed(['personal', 'transactions'], true, false, flags)).toBe(true);
+    expect(isRouteAllowed(['personal', 'source', 'salary'], true, false, flags)).toBe(true);
   });
 });


### PR DESCRIPTION
Signing in with Google landed on the dashboard, and pressing Android back went straight to the login screen — of an account that was already signed in.

## Why it happened

`router.replace('/')` only swaps the top of the stack. `welcome` (and anything pushed from it — `sign-in`, `phone`, `verify-email`) stayed underneath as a live back target.

## The fix

The auth doors now sit in `<Stack.Protected guard={!session}>` and the whole signed-in app in `<Stack.Protected guard={Boolean(session)}>`. expo-router **removes a guarded group's history entries** when its guard flips, which is the part that actually erases the back target.

It works in the other direction too: signing out drops the signed-in history, so back cannot walk back into a screen the account no longer owns.

Route lists moved to `apps/mobile/src/lib/routeAccess.ts` so the guards and the redirect effect beside them can't drift apart. That effect is kept deliberately — expo-router auto-includes every route file, so a deep link can land somewhere no `Stack.Screen` names, and that path still needs a redirect.

Reachable with or without a session, unchanged: `join`, `language`, `settings/privacy`, `settings/licenses` (invite links and the Terms line get opened before anybody has an account) and the dev-only local privacy audit.

## Verified on a device

Emulator, dev build against Metro:

- sign in → dashboard → back stays in the app, then exits to the launcher
- cold start with a stored session → dashboard, one back press exits
- at no point does back reach `welcome`, `sign-in` or `phone`

## Tests

`apps/mobile/test/routeAccess.test.ts` — 6 cases pinning which routes are doors, which are public either way, and that the dev-only audit is dev-only. Full mobile suite: 836 passing, typecheck and lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated mobile navigation to provide more consistent access based on sign-in status.
  - Authenticated and signed-out areas are now more reliably separated.
  - Public pages such as language selection, invitations, privacy information, and licenses remain accessible where appropriate.
  - Development-only privacy review access remains available after signing out without being exposed in production.
  - Paywall access now follows its configured availability.

- **Tests**
  - Added coverage for authentication and public-route access scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->