### PR TITLE
feat(welcome): put the waves where they can be seen

### DIFF
--- a/apps/mobile/src/app/welcome.tsx
+++ b/apps/mobile/src/app/welcome.tsx
@@ -330,10 +330,20 @@ function HeaderGlyph({
  * seamlessly. Motion-gated: with animation off the waves are still drawn (the
  * flat wash gets its shape) but hold still.
  */
+/**
+ * Baselines are a fraction of screen height, and they sit in the open green
+ * between the hero (which ends around 0.42) and the legal line above the
+ * providers (around 0.68). That gap is the only place the crests are actually
+ * *seen*: lower down they ran behind the buttons and the app named Waves showed
+ * none. Each band still fills to the bottom of the screen, so the tint under
+ * the controls is unchanged — only the crest lines moved up into the open.
+ * Keep the topmost crest (baseline − amplitude) below 0.42 so it never rides
+ * into the headline.
+ */
 const WAVES = [
-  { amplitude: 0.05, baseline: 0.62, color: '#FFFFFF14', seconds: 9 },
-  { amplitude: 0.07, baseline: 0.72, color: '#4F9A2E4D', seconds: 13 },
-  { amplitude: 0.06, baseline: 0.82, color: '#FFFFFF12', seconds: 17 },
+  { amplitude: 0.05, baseline: 0.47, color: '#FFFFFF1F', seconds: 9 },
+  { amplitude: 0.07, baseline: 0.56, color: '#4F9A2E5C', seconds: 13 },
+  { amplitude: 0.06, baseline: 0.65, color: '#FFFFFF1A', seconds: 17 },
 ] as const;
 
 /**


### PR DESCRIPTION
The wave field on the welcome screen sat at 0.62 / 0.72 / 0.82 of screen height — which is exactly where the provider buttons are. The crests ran behind "Continue with Google" and the social tiles, so an app called Waves showed none.

Moved to **0.47 / 0.56 / 0.65**: the open green between the headline and the legal line, which is the only band where a crest is actually visible. Each layer still fills to the bottom of the screen, so the tint behind the controls is unchanged — only the crest lines moved up.

The two white layers went `#FFFFFF14`→`#1F` and `#FFFFFF12`→`#1A`, and the green one `4D`→`5C`, now that they are something to look at rather than something to feel. Motion, wavelength and the seamless loop are untouched.

The topmost crest (`baseline − amplitude` = 0.42) stays below the headline; there's a comment on the constant saying so, because that is the invariant somebody will break next time these numbers get nudged.

Screenshotted on an emulator before and after.