### PR TITLE
fix(email): a digest says why it arrived without naming a group

### DIFF
--- a/packages/core/src/notifications/copy.ts
+++ b/packages/core/src/notifications/copy.ts
@@ -107,6 +107,13 @@ export interface EmailChrome {
   readonly securityReason: string;
   /** Button on a security mail — straight to the list of signed-in devices. */
   readonly securityAction: string;
+  /**
+   * The footer reason on a digest, which has no group to name — it is a summary
+   * of all of them. Without it `why` interpolates its `{group}` placeholder with
+   * the fallback and produces "You are getting this because of Waves on Waves",
+   * which is what shipped for one day.
+   */
+  readonly digestReason: string;
   readonly unsubscribe: string;
   readonly signature: string;
 }
@@ -218,6 +225,7 @@ const en: CopyStrings = {
     promoReason: 'You are getting this because you use Waves.',
     securityReason: 'You are getting this because somebody signed in to your Waves account.',
     securityAction: 'Review your devices',
+    digestReason: 'You are getting this because you turned on the weekly digest.',
     unsubscribe: 'Stop emails like this',
     signature: 'Waves',
   },
@@ -324,6 +332,7 @@ const ta: CopyStrings = {
     promoReason: 'நீங்கள் Waves-ஐப் பயன்படுத்துவதால் இந்த மின்னஞ்சல் வந்துள்ளது.',
     securityReason: 'உங்கள் Waves கணக்கில் யாரோ உள்நுழைந்ததால் இந்த மின்னஞ்சல் வந்துள்ளது.',
     securityAction: 'உங்கள் சாதனங்களைப் பார்க்கவும்',
+    digestReason: 'வாராந்திர சுருக்கத்தை நீங்கள் இயக்கியதால் இந்த மின்னஞ்சல் வந்துள்ளது.',
     unsubscribe: 'இதுபோன்ற மின்னஞ்சல்களை நிறுத்தவும்',
     signature: 'Waves',
   },
@@ -427,6 +436,7 @@ const hi: CopyStrings = {
     promoReason: 'यह मेल इसलिए आया है क्योंकि आप Waves इस्तेमाल करते हैं।',
     securityReason: 'यह मेल इसलिए आया है क्योंकि किसी ने आपके Waves खाते में साइन इन किया।',
     securityAction: 'अपने डिवाइस देखें',
+    digestReason: 'यह मेल इसलिए आया है क्योंकि आपने साप्ताहिक सारांश चालू किया है।',
     unsubscribe: 'ऐसे मेल बंद करें',
     signature: 'Waves',
   },
@@ -530,6 +540,7 @@ const ar: CopyStrings = {
     promoReason: 'وصلك هذا البريد لأنك تستخدم Waves.',
     securityReason: 'وصلك هذا البريد لأن أحدهم سجّل الدخول إلى حسابك في Waves.',
     securityAction: 'راجع أجهزتك',
+    digestReason: 'وصلك هذا البريد لأنك فعّلت الملخص الأسبوعي.',
     unsubscribe: 'أوقف هذه الرسائل',
     signature: 'Waves',
   },

--- a/packages/core/src/notifications/email.ts
+++ b/packages/core/src/notifications/email.ts
@@ -241,9 +241,20 @@ export function buildEmail(row: EmailableNotification, options: EmailOptions): B
       ? copy.email.confirmAction
       : copy.email.openAction;
   const link = webLinkFor(row.deepLink, options.webUrl);
+  // Why this arrived, and the answer is different for each shape of mail. A
+  // digest summarises every group, so naming one is impossible; a security
+  // notice is about the account, not a ledger. Only mail that *is* about a group
+  // gets the group line — and when such a row reaches here with no group name
+  // (`waves_notify` allows a null group), the honest fallback is "you use
+  // Waves", not the app's own name dropped into the `{group}` slot, which read
+  // as "You are getting this because of Waves on Waves."
   const why = security
     ? copy.email.securityReason
-    : interpolate(copy.email.why, { group: row.groupName ?? copy.email.signature });
+    : template === EmailTemplate.Digest
+      ? copy.email.digestReason
+      : row.groupName
+        ? interpolate(copy.email.why, { group: row.groupName })
+        : copy.email.promoReason;
   const direction = RIGHT_TO_LEFT.has(language) ? 'rtl' : 'ltr';
 
   return {

--- a/packages/core/test/email.test.ts
+++ b/packages/core/test/email.test.ts
@@ -392,3 +392,28 @@ describe('a security mail', () => {
     expect(built?.html).toContain('Stop emails like this');
   });
 });
+
+describe('why a mail arrived', () => {
+  it('tells a digest reader it was the weekly digest, not a group', () => {
+    const built = buildEmail(
+      { ...ROW, kind: 'digest_weekly', groupName: null, facts: { count: '4' } },
+      OPTIONS,
+    );
+    // Shipped once as "You are getting this because of Waves on Waves." — the
+    // group placeholder filled with the signature, because a digest has no
+    // group to name.
+    expect(built?.text).toContain('you turned on the weekly digest');
+    expect(built?.text).not.toContain('Waves on Waves');
+  });
+
+  it('falls back to "you use Waves" for a group mail that arrived without one', () => {
+    const built = buildEmail({ ...ROW, groupName: null }, OPTIONS);
+    expect(built?.text).toContain('because you use Waves');
+    expect(built?.text).not.toContain('Waves on Waves');
+  });
+
+  it('still names the group when there is one', () => {
+    const built = buildEmail(ROW, OPTIONS);
+    expect(built?.text).toContain('because of Goa trip on Waves');
+  });
+});


### PR DESCRIPTION
Post-merge review of #682, by rendering the mail instead of reading the code. The weekly digest's footer came out as:

> You are getting this because of **Waves on Waves**.

`copy.email.why` interpolates `{group}`, and a digest has no group — it summarises all of them. `row.groupName ?? copy.email.signature` filled the slot with the app's own name.

Three shapes of mail, three answers:

| mail | footer |
|---|---|
| digest | You are getting this because you turned on the weekly digest. |
| security (sign-in alert) | You are getting this because somebody signed in to your Waves account. |
| group mail | You are getting this because of {group} on Waves. |

A group mail that arrives without a group name (`waves_notify` permits a null group) now falls back to the already-translated "because you use Waves" rather than to the signature.

`digestReason` added in all four locales.

Three tests cover the footer directly — it was invisible to every existing test, all of which check the subject. Same blind spot that let `New sign-in on {device}` reach a real inbox yesterday.

Nothing to redeploy but the edge functions; no migration, no config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Email notifications now provide clearer explanations for why they were sent.
  * Weekly digest emails identify the digest cadence instead of referencing a group.
  * Group-related emails name the relevant group when available.
  * Emails without a group now use a general explanation.
  * Added weekly-digest reason text for English, Tamil, Hindi, and Arabic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->