### PR TITLE
fix(auth): the emailed code is six digits, the length the app can accept

### DIFF
--- a/apps/mobile/test/otpLength.test.ts
+++ b/apps/mobile/test/otpLength.test.ts
@@ -1,0 +1,54 @@
+/**
+ * The code screen and the server have to agree on how many digits there are.
+ *
+ * They did not, and the failure was quiet in the worst way: `otp_length = 8` in
+ * `supabase/config.toml` against `OTP_LEN = 6` in the app. The mail arrived, the
+ * digits in it were correct, and the six-box screen silently sliced the code to
+ * its first six characters — so signing in by email could not be completed on a
+ * phone at all, and nothing anywhere said why.
+ *
+ * Neither value can be derived from the other (one is a TOML file the Supabase
+ * CLI pushes, the other a TypeScript constant compiled into the app), so this
+ * reads both and insists they match.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const CONFIG = readFileSync(join(__dirname, '../../../supabase/config.toml'), 'utf8');
+const OTP_INPUT = readFileSync(join(__dirname, '../src/components/OtpInput.tsx'), 'utf8');
+
+/**
+ * Read as source rather than imported: `OtpInput` pulls in react-native, which
+ * this node-environment suite cannot parse. The constant is a plain literal, so
+ * reading it is exact.
+ */
+function appOtpLength(): number {
+  const match = /export const OTP_LEN\s*=\s*(\d+)/.exec(OTP_INPUT);
+  if (!match) throw new Error('OTP_LEN is not a plain literal in OtpInput.tsx any more');
+  return Number(match[1]);
+}
+
+/** The `otp_length` under `[auth.email]`, as the CLI would read it. */
+function configuredOtpLength(): number {
+  const match = /^otp_length\s*=\s*(\d+)\s*$/m.exec(CONFIG);
+  if (!match) throw new Error('otp_length is not set in supabase/config.toml');
+  return Number(match[1]);
+}
+
+describe('the sign-in code', () => {
+  it('is the same length on the server and in the app', () => {
+    expect(configuredOtpLength()).toBe(appOtpLength());
+  });
+
+  /**
+   * GoTrue refuses anything outside 6–10. Below the floor the value is not
+   * rejected loudly — it is a config push that does not do what it says.
+   */
+  it('stays inside the range GoTrue accepts', () => {
+    expect(configuredOtpLength()).toBeGreaterThanOrEqual(6);
+    expect(configuredOtpLength()).toBeLessThanOrEqual(10);
+  });
+});

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -87,11 +87,20 @@ enable_signup = true
 # means addresses are guessable by design. `config push` sends this file to the
 # hosted project, so a local convenience here is a live account takeover.
 enable_confirmations = true
-# A minute between mails, and eight digits. Both are Supabase's hosted defaults;
-# 1s and six digits are what a local stack does not care about and a real one
-# does — that is a mailbox flood and a code worth guessing.
+# A minute between mails, and six digits. The frequency is Supabase's hosted
+# default; 1s is what a local stack does not care about and a real one does —
+# that is a mailbox flood.
+#
+# **`otp_length` must equal `OTP_LEN` in `apps/mobile/src/components/OtpInput.tsx`**,
+# and `test/otpLength.test.ts` fails if they drift. At 8 it shipped a code the
+# app could not accept: the code screen has six boxes and slices anything longer,
+# so the mail arrived, the digits were right, and email sign-in still could not
+# be completed on a phone.
+#
+# Six is also the floor — GoTrue accepts 6 to 10, so a shorter code is not
+# something this setting can express.
 max_frequency = "1m0s"
-otp_length = 8
+otp_length = 6
 
 # Auth mail — the sign-up confirmation and the login code — through Resend.
 #


### PR DESCRIPTION
Reported from a real mailbox: the sign-in code arrived as **93525891** — eight digits. The code screen has **six** boxes and `OtpInput` slices anything longer, so email sign-in could not be completed on a phone. The mail arrived, the digits were right, and the screen silently dropped the last two.

`otp_length = 8` in `supabase/config.toml` against `OTP_LEN = 6` in `apps/mobile/src/components/OtpInput.tsx`. Now both six.

**Five is not available.** GoTrue accepts `otp_length` between 6 and 10, so six is the floor — and it's the length the app was already built for.

`apps/mobile/test/otpLength.test.ts` reads both values and fails if they drift again. Neither can be derived from the other (one is a TOML file the CLI pushes, the other a constant compiled into the binary), and it reads `OtpInput.tsx` as text rather than importing it, because the import pulls react-native into a node-environment suite.

Needs `supabase config push` after merge — the setting is server-side.