### PR TITLE
feat(email): the code mail looks like the screen it is typed into

### DIFF
--- a/apps/mobile/test/otpLength.test.ts
+++ b/apps/mobile/test/otpLength.test.ts
@@ -12,13 +12,15 @@
  * reads both and insists they match.
  */
 
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
 const CONFIG = readFileSync(join(__dirname, '../../../supabase/config.toml'), 'utf8');
 const OTP_INPUT = readFileSync(join(__dirname, '../src/components/OtpInput.tsx'), 'utf8');
+const TEMPLATE_DIR = join(__dirname, '../../../supabase/templates');
+const TEMPLATES = readdirSync(TEMPLATE_DIR).filter((name) => name.endsWith('.html'));
 
 /**
  * Read as source rather than imported: `OtpInput` pulls in react-native, which
@@ -50,5 +52,32 @@ describe('the sign-in code', () => {
   it('stays inside the range GoTrue accepts', () => {
     expect(configuredOtpLength()).toBeGreaterThanOrEqual(6);
     expect(configuredOtpLength()).toBeLessThanOrEqual(10);
+  });
+});
+
+/**
+ * The mail states a number of minutes. A template saying fifteen while GoTrue
+ * expires the code in sixty is not a cosmetic mismatch — it is the app lying to
+ * somebody about how long they have, which they only discover by being refused.
+ */
+describe('how long the code lasts', () => {
+  function configuredExpirySeconds(): number {
+    const match = /^otp_expiry\s*=\s*(\d+)\s*$/m.exec(CONFIG);
+    if (!match) throw new Error('otp_expiry is not set in supabase/config.toml');
+    return Number(match[1]);
+  }
+
+  it('is the number of minutes every template promises', () => {
+    const minutes = configuredExpirySeconds() / 60;
+    for (const name of TEMPLATES) {
+      const html = readFileSync(join(TEMPLATE_DIR, name), 'utf8');
+      const stated = /Expires in (\d+) minutes/.exec(html);
+      expect(stated, `${name} does not state an expiry`).not.toBeNull();
+      expect(Number(stated?.[1]), name).toBe(minutes);
+    }
+  });
+
+  it('covers every template, so a new one cannot ship unchecked', () => {
+    expect(TEMPLATES.length).toBeGreaterThanOrEqual(5);
   });
 });

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -101,6 +101,12 @@ enable_confirmations = true
 # something this setting can express.
 max_frequency = "1m0s"
 otp_length = 6
+# Fifteen minutes, and the templates say so in those words. Supabase's default
+# is an hour, which is a long time for a code sitting in a mailbox somebody else
+# may later read — and "expires shortly" is what a mail says when nobody knows
+# the number. If this changes, change the line in `supabase/templates/*.html`
+# with it.
+otp_expiry = 900
 
 # Auth mail — the sign-up confirmation and the login code — through Resend.
 #

--- a/supabase/templates/_README.md
+++ b/supabase/templates/_README.md
@@ -14,9 +14,27 @@ both teaches people to click the link in a message asking for a code, which is
 the exact shape of every phishing mail they will ever get. `otp_length = 8` in
 config.toml, so the code is eight digits.
 
-They are deliberately plain: inline styles, no images, no web fonts, one colour.
-A code mail is read in two seconds in a notification shade, and every byte of
-decoration is a byte that can render wrong in Outlook.
+They are deliberately plain: table layout, inline styles, no images, no web
+fonts. A code mail is read in two seconds in a notification shade, and every byte
+of decoration is a byte that can render wrong in Outlook.
+
+Three things in the layout are not decoration, and each was taken from how the
+apps that do this well handle it on screen:
+
+* **The code sits in its own bordered field**, tracked wide, rather than loose in
+  a paragraph. Per-digit boxes would be better still — that is what the app's own
+  screen shows — but a Go template cannot slice a string, so one field with
+  letter-spacing is as close as this gets.
+* **The expiry is a number**, not "shortly". It has to match `otp_expiry` in
+  `config.toml`, and `apps/mobile/test/otpLength.test.ts` fails if it does not:
+  a mail promising fifteen minutes against a server that allows sixty is the app
+  lying about something somebody only discovers by being refused.
+* **The address is named** in the footer (`{{ .Email }}`). It costs a line and it
+  is the cheapest phishing tell there is — a code mail that cannot say who it was
+  sent to did not come from us.
+
+The hidden `div` at the top is preview text: what an inbox list shows beside the
+subject. Left out, mail clients show the first words of the markup instead.
 
 The Go template variables GoTrue exposes are `{{ .Token }}`, `{{ .TokenHash }}`,
 `{{ .ConfirmationURL }}`, `{{ .SiteURL }}`, `{{ .Email }}` and `{{ .NewEmail }}`.

--- a/supabase/templates/_README.md
+++ b/supabase/templates/_README.md
@@ -23,15 +23,15 @@ of decoration is a byte that can render wrong in Outlook.
 Three things in the layout are not decoration, and each was taken from how the
 apps that do this well handle it on screen:
 
-* **The code sits in its own bordered field**, tracked wide, rather than loose in
+- **The code sits in its own bordered field**, tracked wide, rather than loose in
   a paragraph. Per-digit boxes would be better still — that is what the app's own
   screen shows — but a Go template cannot slice a string, so one field with
   letter-spacing is as close as this gets.
-* **The expiry is a number**, not "shortly". It has to match `otp_expiry` in
+- **The expiry is a number**, not "shortly". It has to match `otp_expiry` in
   `config.toml`, and `apps/mobile/test/otpLength.test.ts` fails if it does not:
   a mail promising fifteen minutes against a server that allows sixty is the app
   lying about something somebody only discovers by being refused.
-* **The address is named** in the footer (`{{ .Email }}`). It costs a line and it
+- **The address is named** in the footer (`{{ .Email }}`). It costs a line and it
   is the cheapest phishing tell there is — a code mail that cannot say who it was
   sent to did not come from us.
 

--- a/supabase/templates/_README.md
+++ b/supabase/templates/_README.md
@@ -11,8 +11,10 @@ in a console text box nobody can diff.
 for a code on a six-box screen (`verify-email.tsx`, `phone.tsx`) — a magic link
 lands somebody on a page with nothing to type into, and a mail that contains
 both teaches people to click the link in a message asking for a code, which is
-the exact shape of every phishing mail they will ever get. `otp_length = 8` in
-config.toml, so the code is eight digits.
+the exact shape of every phishing mail they will ever get. `otp_length = 6` in
+config.toml, matching `OTP_LEN` in the app — the two are checked against each
+other by `apps/mobile/test/otpLength.test.ts`, because at 8 the mail carried a
+code the six-box screen silently truncated.
 
 They are deliberately plain: table layout, inline styles, no images, no web
 fonts. A code mail is read in two seconds in a notification shade, and every byte

--- a/supabase/templates/confirmation.html
+++ b/supabase/templates/confirmation.html
@@ -1,13 +1,152 @@
 <!doctype html>
 <html>
-  <body style="margin:0;padding:24px;background:#f5f5f4;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
-    <div style="max-width:520px;margin:0 auto;background:#ffffff;border-radius:12px;padding:28px;">
-      <h1 style="margin:0 0 12px;font-size:20px;line-height:1.35;color:#1c1917;">Confirm your email</h1>
-      <p style="margin:0 0 24px;font-size:15px;line-height:1.6;color:#44403c;">Type this code into Waves to finish creating your account.</p>
-      <p style="margin:0 0 24px;font-size:30px;line-height:1.2;letter-spacing:6px;font-weight:700;color:#1c1917;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;">{{ .Token }}</p>
-      <p style="margin:0;font-size:13px;line-height:1.6;color:#78716c;">If you did not sign up for Waves, ignore this and no account is created.</p>
-      <p style="margin:28px 0 0;font-size:12px;line-height:1.6;color:#78716c;">Waves will never ask you for this code — not by email, not on a call, not in a chat. If somebody is asking, they are not us.</p>
+  <body style="margin: 0; padding: 0; background: #f4f4f2">
+    <!-- Preview text: what the inbox list shows beside the subject. Hidden in
+         the mail itself by the zero height + hidden colour. -->
+    <div
+      style="
+        display: none;
+        max-height: 0;
+        overflow: hidden;
+        opacity: 0;
+        color: transparent;
+        height: 0;
+        width: 0;
+      "
+    >
+      Confirm your email and finish setting up Waves.
     </div>
-    <p style="max-width:520px;margin:16px auto 0;font-size:12px;color:#a8a29e;">Waves</p>
+    <table
+      role="presentation"
+      width="100%"
+      cellpadding="0"
+      cellspacing="0"
+      style="background: #f4f4f2; padding: 32px 16px"
+    >
+      <tr>
+        <td align="center">
+          <table
+            role="presentation"
+            width="100%"
+            cellpadding="0"
+            cellspacing="0"
+            style="max-width: 480px; background: #ffffff; border-radius: 16px"
+          >
+            <tr>
+              <td
+                style="
+                  padding: 32px 32px 0;
+                  font-family:
+                    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                    sans-serif;
+                "
+              >
+                <p
+                  style="
+                    margin: 0 0 28px;
+                    font-size: 15px;
+                    font-weight: 700;
+                    letter-spacing: -0.2px;
+                    color: #4f9a2e;
+                  "
+                >
+                  Waves
+                </p>
+                <h1
+                  style="
+                    margin: 0 0 10px;
+                    font-size: 24px;
+                    line-height: 1.25;
+                    font-weight: 700;
+                    letter-spacing: -0.5px;
+                    color: #12100e;
+                  "
+                >
+                  Confirm your email
+                </h1>
+                <p style="margin: 0 0 24px; font-size: 15px; line-height: 1.6; color: #57534e">
+                  Type this into Waves to finish creating your account.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding: 0 32px">
+                <table
+                  role="presentation"
+                  width="100%"
+                  cellpadding="0"
+                  cellspacing="0"
+                  style="border: 1px solid #e7e5e4; border-radius: 12px; background: #fafaf9"
+                >
+                  <tr>
+                    <td
+                      align="center"
+                      style="
+                        padding: 20px 12px;
+                        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                        font-size: 34px;
+                        line-height: 1.1;
+                        font-weight: 700;
+                        letter-spacing: 10px;
+                        text-indent: 10px;
+                        color: #12100e;
+                      "
+                    >
+                      {{ .Token }}
+                    </td>
+                  </tr>
+                </table>
+                <p style="margin: 12px 0 0; font-size: 13px; line-height: 1.6; color: #78716c">
+                  Expires in 15 minutes, and works once.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td
+                style="
+                  padding: 28px 32px 32px;
+                  font-family:
+                    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                    sans-serif;
+                "
+              >
+                <table
+                  role="presentation"
+                  width="100%"
+                  cellpadding="0"
+                  cellspacing="0"
+                  style="border-top: 1px solid #f0efed"
+                >
+                  <tr>
+                    <td style="padding-top: 20px">
+                      <p
+                        style="margin: 0 0 10px; font-size: 13px; line-height: 1.6; color: #57534e"
+                      >
+                        Did not sign up for Waves? Ignore this and no account is created.
+                      </p>
+                      <p style="margin: 0; font-size: 13px; line-height: 1.6; color: #a8a29e">
+                        Waves will never ask you for this code &mdash; not by email, not on a call,
+                        not in a chat.
+                      </p>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+          <p
+            style="
+              margin: 16px 0 0;
+              font-family:
+                -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+              font-size: 12px;
+              color: #a8a29e;
+            "
+          >
+            Sent to {{ .Email }} &middot; Waves
+          </p>
+        </td>
+      </tr>
+    </table>
   </body>
 </html>

--- a/supabase/templates/email-change.html
+++ b/supabase/templates/email-change.html
@@ -1,13 +1,153 @@
 <!doctype html>
 <html>
-  <body style="margin:0;padding:24px;background:#f5f5f4;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
-    <div style="max-width:520px;margin:0 auto;background:#ffffff;border-radius:12px;padding:28px;">
-      <h1 style="margin:0 0 12px;font-size:20px;line-height:1.35;color:#1c1917;">Confirm your new address</h1>
-      <p style="margin:0 0 24px;font-size:15px;line-height:1.6;color:#44403c;">Type this code into Waves to move your account to {{ .NewEmail }}.</p>
-      <p style="margin:0 0 24px;font-size:30px;line-height:1.2;letter-spacing:6px;font-weight:700;color:#1c1917;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;">{{ .Token }}</p>
-      <p style="margin:0;font-size:13px;line-height:1.6;color:#78716c;">If you did not ask to change the address on your Waves account, ignore this — the change does not happen without the code, and your old address keeps working.</p>
-      <p style="margin:28px 0 0;font-size:12px;line-height:1.6;color:#78716c;">Waves will never ask you for this code — not by email, not on a call, not in a chat. If somebody is asking, they are not us.</p>
+  <body style="margin: 0; padding: 0; background: #f4f4f2">
+    <!-- Preview text: what the inbox list shows beside the subject. Hidden in
+         the mail itself by the zero height + hidden colour. -->
+    <div
+      style="
+        display: none;
+        max-height: 0;
+        overflow: hidden;
+        opacity: 0;
+        color: transparent;
+        height: 0;
+        width: 0;
+      "
+    >
+      Confirm the new address on your Waves account.
     </div>
-    <p style="max-width:520px;margin:16px auto 0;font-size:12px;color:#a8a29e;">Waves</p>
+    <table
+      role="presentation"
+      width="100%"
+      cellpadding="0"
+      cellspacing="0"
+      style="background: #f4f4f2; padding: 32px 16px"
+    >
+      <tr>
+        <td align="center">
+          <table
+            role="presentation"
+            width="100%"
+            cellpadding="0"
+            cellspacing="0"
+            style="max-width: 480px; background: #ffffff; border-radius: 16px"
+          >
+            <tr>
+              <td
+                style="
+                  padding: 32px 32px 0;
+                  font-family:
+                    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                    sans-serif;
+                "
+              >
+                <p
+                  style="
+                    margin: 0 0 28px;
+                    font-size: 15px;
+                    font-weight: 700;
+                    letter-spacing: -0.2px;
+                    color: #4f9a2e;
+                  "
+                >
+                  Waves
+                </p>
+                <h1
+                  style="
+                    margin: 0 0 10px;
+                    font-size: 24px;
+                    line-height: 1.25;
+                    font-weight: 700;
+                    letter-spacing: -0.5px;
+                    color: #12100e;
+                  "
+                >
+                  Confirm your new address
+                </h1>
+                <p style="margin: 0 0 24px; font-size: 15px; line-height: 1.6; color: #57534e">
+                  Type this into Waves to move your account to {{ .NewEmail }}.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding: 0 32px">
+                <table
+                  role="presentation"
+                  width="100%"
+                  cellpadding="0"
+                  cellspacing="0"
+                  style="border: 1px solid #e7e5e4; border-radius: 12px; background: #fafaf9"
+                >
+                  <tr>
+                    <td
+                      align="center"
+                      style="
+                        padding: 20px 12px;
+                        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                        font-size: 34px;
+                        line-height: 1.1;
+                        font-weight: 700;
+                        letter-spacing: 10px;
+                        text-indent: 10px;
+                        color: #12100e;
+                      "
+                    >
+                      {{ .Token }}
+                    </td>
+                  </tr>
+                </table>
+                <p style="margin: 12px 0 0; font-size: 13px; line-height: 1.6; color: #78716c">
+                  Expires in 15 minutes, and works once.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td
+                style="
+                  padding: 28px 32px 32px;
+                  font-family:
+                    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                    sans-serif;
+                "
+              >
+                <table
+                  role="presentation"
+                  width="100%"
+                  cellpadding="0"
+                  cellspacing="0"
+                  style="border-top: 1px solid #f0efed"
+                >
+                  <tr>
+                    <td style="padding-top: 20px">
+                      <p
+                        style="margin: 0 0 10px; font-size: 13px; line-height: 1.6; color: #57534e"
+                      >
+                        Did not ask to change your address? Ignore this &mdash; nothing moves
+                        without the code, and your current address keeps working.
+                      </p>
+                      <p style="margin: 0; font-size: 13px; line-height: 1.6; color: #a8a29e">
+                        Waves will never ask you for this code &mdash; not by email, not on a call,
+                        not in a chat.
+                      </p>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+          <p
+            style="
+              margin: 16px 0 0;
+              font-family:
+                -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+              font-size: 12px;
+              color: #a8a29e;
+            "
+          >
+            Sent to {{ .Email }} &middot; Waves
+          </p>
+        </td>
+      </tr>
+    </table>
   </body>
 </html>

--- a/supabase/templates/magic-link.html
+++ b/supabase/templates/magic-link.html
@@ -1,13 +1,153 @@
 <!doctype html>
 <html>
-  <body style="margin:0;padding:24px;background:#f5f5f4;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
-    <div style="max-width:520px;margin:0 auto;background:#ffffff;border-radius:12px;padding:28px;">
-      <h1 style="margin:0 0 12px;font-size:20px;line-height:1.35;color:#1c1917;">Your sign-in code</h1>
-      <p style="margin:0 0 24px;font-size:15px;line-height:1.6;color:#44403c;">Type this code into Waves to sign in. It expires shortly and works once.</p>
-      <p style="margin:0 0 24px;font-size:30px;line-height:1.2;letter-spacing:6px;font-weight:700;color:#1c1917;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;">{{ .Token }}</p>
-      <p style="margin:0;font-size:13px;line-height:1.6;color:#78716c;">If you did not try to sign in, you can ignore this. Nothing has changed on your account, and nobody can get in without this code.</p>
-      <p style="margin:28px 0 0;font-size:12px;line-height:1.6;color:#78716c;">Waves will never ask you for this code — not by email, not on a call, not in a chat. If somebody is asking, they are not us.</p>
+  <body style="margin: 0; padding: 0; background: #f4f4f2">
+    <!-- Preview text: what the inbox list shows beside the subject. Hidden in
+         the mail itself by the zero height + hidden colour. -->
+    <div
+      style="
+        display: none;
+        max-height: 0;
+        overflow: hidden;
+        opacity: 0;
+        color: transparent;
+        height: 0;
+        width: 0;
+      "
+    >
+      Your Waves sign-in code, good for 15 minutes.
     </div>
-    <p style="max-width:520px;margin:16px auto 0;font-size:12px;color:#a8a29e;">Waves</p>
+    <table
+      role="presentation"
+      width="100%"
+      cellpadding="0"
+      cellspacing="0"
+      style="background: #f4f4f2; padding: 32px 16px"
+    >
+      <tr>
+        <td align="center">
+          <table
+            role="presentation"
+            width="100%"
+            cellpadding="0"
+            cellspacing="0"
+            style="max-width: 480px; background: #ffffff; border-radius: 16px"
+          >
+            <tr>
+              <td
+                style="
+                  padding: 32px 32px 0;
+                  font-family:
+                    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                    sans-serif;
+                "
+              >
+                <p
+                  style="
+                    margin: 0 0 28px;
+                    font-size: 15px;
+                    font-weight: 700;
+                    letter-spacing: -0.2px;
+                    color: #4f9a2e;
+                  "
+                >
+                  Waves
+                </p>
+                <h1
+                  style="
+                    margin: 0 0 10px;
+                    font-size: 24px;
+                    line-height: 1.25;
+                    font-weight: 700;
+                    letter-spacing: -0.5px;
+                    color: #12100e;
+                  "
+                >
+                  Your sign-in code
+                </h1>
+                <p style="margin: 0 0 24px; font-size: 15px; line-height: 1.6; color: #57534e">
+                  Type this into Waves to sign in.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding: 0 32px">
+                <table
+                  role="presentation"
+                  width="100%"
+                  cellpadding="0"
+                  cellspacing="0"
+                  style="border: 1px solid #e7e5e4; border-radius: 12px; background: #fafaf9"
+                >
+                  <tr>
+                    <td
+                      align="center"
+                      style="
+                        padding: 20px 12px;
+                        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                        font-size: 34px;
+                        line-height: 1.1;
+                        font-weight: 700;
+                        letter-spacing: 10px;
+                        text-indent: 10px;
+                        color: #12100e;
+                      "
+                    >
+                      {{ .Token }}
+                    </td>
+                  </tr>
+                </table>
+                <p style="margin: 12px 0 0; font-size: 13px; line-height: 1.6; color: #78716c">
+                  Expires in 15 minutes, and works once.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td
+                style="
+                  padding: 28px 32px 32px;
+                  font-family:
+                    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                    sans-serif;
+                "
+              >
+                <table
+                  role="presentation"
+                  width="100%"
+                  cellpadding="0"
+                  cellspacing="0"
+                  style="border-top: 1px solid #f0efed"
+                >
+                  <tr>
+                    <td style="padding-top: 20px">
+                      <p
+                        style="margin: 0 0 10px; font-size: 13px; line-height: 1.6; color: #57534e"
+                      >
+                        Did not try to sign in? Ignore this. Nothing changes, and nobody gets in
+                        without the code.
+                      </p>
+                      <p style="margin: 0; font-size: 13px; line-height: 1.6; color: #a8a29e">
+                        Waves will never ask you for this code &mdash; not by email, not on a call,
+                        not in a chat.
+                      </p>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+          <p
+            style="
+              margin: 16px 0 0;
+              font-family:
+                -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+              font-size: 12px;
+              color: #a8a29e;
+            "
+          >
+            Sent to {{ .Email }} &middot; Waves
+          </p>
+        </td>
+      </tr>
+    </table>
   </body>
 </html>

--- a/supabase/templates/reauthentication.html
+++ b/supabase/templates/reauthentication.html
@@ -1,13 +1,153 @@
 <!doctype html>
 <html>
-  <body style="margin:0;padding:24px;background:#f5f5f4;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
-    <div style="max-width:520px;margin:0 auto;background:#ffffff;border-radius:12px;padding:28px;">
-      <h1 style="margin:0 0 12px;font-size:20px;line-height:1.35;color:#1c1917;">Confirm it is you</h1>
-      <p style="margin:0 0 24px;font-size:15px;line-height:1.6;color:#44403c;">Type this code into Waves to confirm the change you just asked for.</p>
-      <p style="margin:0 0 24px;font-size:30px;line-height:1.2;letter-spacing:6px;font-weight:700;color:#1c1917;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;">{{ .Token }}</p>
-      <p style="margin:0;font-size:13px;line-height:1.6;color:#78716c;">If you were not making a change to your account just now, ignore this and change how you sign in.</p>
-      <p style="margin:28px 0 0;font-size:12px;line-height:1.6;color:#78716c;">Waves will never ask you for this code — not by email, not on a call, not in a chat. If somebody is asking, they are not us.</p>
+  <body style="margin: 0; padding: 0; background: #f4f4f2">
+    <!-- Preview text: what the inbox list shows beside the subject. Hidden in
+         the mail itself by the zero height + hidden colour. -->
+    <div
+      style="
+        display: none;
+        max-height: 0;
+        overflow: hidden;
+        opacity: 0;
+        color: transparent;
+        height: 0;
+        width: 0;
+      "
+    >
+      Confirm the change you just asked for in Waves.
     </div>
-    <p style="max-width:520px;margin:16px auto 0;font-size:12px;color:#a8a29e;">Waves</p>
+    <table
+      role="presentation"
+      width="100%"
+      cellpadding="0"
+      cellspacing="0"
+      style="background: #f4f4f2; padding: 32px 16px"
+    >
+      <tr>
+        <td align="center">
+          <table
+            role="presentation"
+            width="100%"
+            cellpadding="0"
+            cellspacing="0"
+            style="max-width: 480px; background: #ffffff; border-radius: 16px"
+          >
+            <tr>
+              <td
+                style="
+                  padding: 32px 32px 0;
+                  font-family:
+                    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                    sans-serif;
+                "
+              >
+                <p
+                  style="
+                    margin: 0 0 28px;
+                    font-size: 15px;
+                    font-weight: 700;
+                    letter-spacing: -0.2px;
+                    color: #4f9a2e;
+                  "
+                >
+                  Waves
+                </p>
+                <h1
+                  style="
+                    margin: 0 0 10px;
+                    font-size: 24px;
+                    line-height: 1.25;
+                    font-weight: 700;
+                    letter-spacing: -0.5px;
+                    color: #12100e;
+                  "
+                >
+                  Confirm it is you
+                </h1>
+                <p style="margin: 0 0 24px; font-size: 15px; line-height: 1.6; color: #57534e">
+                  Type this into Waves to confirm the change you just asked for.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding: 0 32px">
+                <table
+                  role="presentation"
+                  width="100%"
+                  cellpadding="0"
+                  cellspacing="0"
+                  style="border: 1px solid #e7e5e4; border-radius: 12px; background: #fafaf9"
+                >
+                  <tr>
+                    <td
+                      align="center"
+                      style="
+                        padding: 20px 12px;
+                        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                        font-size: 34px;
+                        line-height: 1.1;
+                        font-weight: 700;
+                        letter-spacing: 10px;
+                        text-indent: 10px;
+                        color: #12100e;
+                      "
+                    >
+                      {{ .Token }}
+                    </td>
+                  </tr>
+                </table>
+                <p style="margin: 12px 0 0; font-size: 13px; line-height: 1.6; color: #78716c">
+                  Expires in 15 minutes, and works once.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td
+                style="
+                  padding: 28px 32px 32px;
+                  font-family:
+                    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                    sans-serif;
+                "
+              >
+                <table
+                  role="presentation"
+                  width="100%"
+                  cellpadding="0"
+                  cellspacing="0"
+                  style="border-top: 1px solid #f0efed"
+                >
+                  <tr>
+                    <td style="padding-top: 20px">
+                      <p
+                        style="margin: 0 0 10px; font-size: 13px; line-height: 1.6; color: #57534e"
+                      >
+                        Were you not changing anything just now? Ignore this, then change how you
+                        sign in.
+                      </p>
+                      <p style="margin: 0; font-size: 13px; line-height: 1.6; color: #a8a29e">
+                        Waves will never ask you for this code &mdash; not by email, not on a call,
+                        not in a chat.
+                      </p>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+          <p
+            style="
+              margin: 16px 0 0;
+              font-family:
+                -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+              font-size: 12px;
+              color: #a8a29e;
+            "
+          >
+            Sent to {{ .Email }} &middot; Waves
+          </p>
+        </td>
+      </tr>
+    </table>
   </body>
 </html>

--- a/supabase/templates/recovery.html
+++ b/supabase/templates/recovery.html
@@ -1,13 +1,152 @@
 <!doctype html>
 <html>
-  <body style="margin:0;padding:24px;background:#f5f5f4;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
-    <div style="max-width:520px;margin:0 auto;background:#ffffff;border-radius:12px;padding:28px;">
-      <h1 style="margin:0 0 12px;font-size:20px;line-height:1.35;color:#1c1917;">Reset your password</h1>
-      <p style="margin:0 0 24px;font-size:15px;line-height:1.6;color:#44403c;">Type this code into Waves to set a new password.</p>
-      <p style="margin:0 0 24px;font-size:30px;line-height:1.2;letter-spacing:6px;font-weight:700;color:#1c1917;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;">{{ .Token }}</p>
-      <p style="margin:0;font-size:13px;line-height:1.6;color:#78716c;">If you did not ask to reset your password, ignore this. Your current password still works and nothing has changed.</p>
-      <p style="margin:28px 0 0;font-size:12px;line-height:1.6;color:#78716c;">Waves will never ask you for this code — not by email, not on a call, not in a chat. If somebody is asking, they are not us.</p>
+  <body style="margin: 0; padding: 0; background: #f4f4f2">
+    <!-- Preview text: what the inbox list shows beside the subject. Hidden in
+         the mail itself by the zero height + hidden colour. -->
+    <div
+      style="
+        display: none;
+        max-height: 0;
+        overflow: hidden;
+        opacity: 0;
+        color: transparent;
+        height: 0;
+        width: 0;
+      "
+    >
+      Reset the password on your Waves account.
     </div>
-    <p style="max-width:520px;margin:16px auto 0;font-size:12px;color:#a8a29e;">Waves</p>
+    <table
+      role="presentation"
+      width="100%"
+      cellpadding="0"
+      cellspacing="0"
+      style="background: #f4f4f2; padding: 32px 16px"
+    >
+      <tr>
+        <td align="center">
+          <table
+            role="presentation"
+            width="100%"
+            cellpadding="0"
+            cellspacing="0"
+            style="max-width: 480px; background: #ffffff; border-radius: 16px"
+          >
+            <tr>
+              <td
+                style="
+                  padding: 32px 32px 0;
+                  font-family:
+                    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                    sans-serif;
+                "
+              >
+                <p
+                  style="
+                    margin: 0 0 28px;
+                    font-size: 15px;
+                    font-weight: 700;
+                    letter-spacing: -0.2px;
+                    color: #4f9a2e;
+                  "
+                >
+                  Waves
+                </p>
+                <h1
+                  style="
+                    margin: 0 0 10px;
+                    font-size: 24px;
+                    line-height: 1.25;
+                    font-weight: 700;
+                    letter-spacing: -0.5px;
+                    color: #12100e;
+                  "
+                >
+                  Reset your password
+                </h1>
+                <p style="margin: 0 0 24px; font-size: 15px; line-height: 1.6; color: #57534e">
+                  Type this into Waves to set a new password.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding: 0 32px">
+                <table
+                  role="presentation"
+                  width="100%"
+                  cellpadding="0"
+                  cellspacing="0"
+                  style="border: 1px solid #e7e5e4; border-radius: 12px; background: #fafaf9"
+                >
+                  <tr>
+                    <td
+                      align="center"
+                      style="
+                        padding: 20px 12px;
+                        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                        font-size: 34px;
+                        line-height: 1.1;
+                        font-weight: 700;
+                        letter-spacing: 10px;
+                        text-indent: 10px;
+                        color: #12100e;
+                      "
+                    >
+                      {{ .Token }}
+                    </td>
+                  </tr>
+                </table>
+                <p style="margin: 12px 0 0; font-size: 13px; line-height: 1.6; color: #78716c">
+                  Expires in 15 minutes, and works once.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td
+                style="
+                  padding: 28px 32px 32px;
+                  font-family:
+                    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                    sans-serif;
+                "
+              >
+                <table
+                  role="presentation"
+                  width="100%"
+                  cellpadding="0"
+                  cellspacing="0"
+                  style="border-top: 1px solid #f0efed"
+                >
+                  <tr>
+                    <td style="padding-top: 20px">
+                      <p
+                        style="margin: 0 0 10px; font-size: 13px; line-height: 1.6; color: #57534e"
+                      >
+                        Did not ask to reset it? Ignore this. Your current password still works.
+                      </p>
+                      <p style="margin: 0; font-size: 13px; line-height: 1.6; color: #a8a29e">
+                        Waves will never ask you for this code &mdash; not by email, not on a call,
+                        not in a chat.
+                      </p>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+          <p
+            style="
+              margin: 16px 0 0;
+              font-family:
+                -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+              font-size: 12px;
+              color: #a8a29e;
+            "
+          >
+            Sent to {{ .Email }} &middot; Waves
+          </p>
+        </td>
+      </tr>
+    </table>
   </body>
 </html>


### PR DESCRIPTION
The sign-in mail worked but read as a paragraph with digits loose inside it. Redesigned against how apps that do this well handle a code on screen — [Air NZ](https://mobbin.com/screens/ea443a38-e211-4001-8f49-930effbe4d79) (grouped field + explicit expiry), [Oportun](https://mobbin.com/screens/aa6e1309-f660-4a4f-b3b7-4218bd1ccc4c) (minutes, stated), [Shopee](https://mobbin.com/screens/88aaba8d-b149-4701-a9eb-bf0a671518eb) (destination address named), [PayPal](https://mobbin.com/screens/9079d5c6-2cae-48c8-87e9-1215a23215cd) (digits as tiles).

**The code sits in its own bordered field**, tracked wide, so it reads as something to copy rather than a number in a sentence. Per-digit tiles would match the app's six-box screen more closely, but a Go template cannot slice a string — one tracked field is as close as this gets.

**The expiry is a number, not "shortly"** — and to make that honest rather than decorative, `otp_expiry` drops from Supabase's default **hour** to **15 minutes**. An hour is a long time for a working credential to sit in a mailbox somebody else may later read.

**The address is named in the footer** (`{{ .Email }}`). One line, and the cheapest phishing tell there is: a code mail that can't say who it was sent to didn't come from us.

Plus hidden preview text, so the inbox list shows a sentence instead of the first words of the markup, and a green Waves wordmark so the mail is recognisable at a glance.

## Drift guard

`apps/mobile/test/otpLength.test.ts` now also asserts every template's stated minutes equals `otp_expiry`. A mail promising fifteen minutes against a server allowing sixty is the app lying about something somebody only discovers by being refused. It also fails if a new template ships without an expiry line.

Needs `supabase config push` after merge — both the setting and the templates are server-side.