### PR TITLE
fix(db): count only involved people in weekly digest

### DIFF
--- a/packages/db/prisma/migrations/20260907090000_device_alert_and_weekly_digest/migration.sql
+++ b/packages/db/prisma/migrations/20260907090000_device_alert_and_weekly_digest/migration.sql
@@ -192,18 +192,30 @@ BEGIN
   FOR v_person IN
     SELECT p.id,
            p.default_currency,
-           -- Expenses filed in the last seven days in any group this person is
-           -- still a member of. Their own and everybody else's: a digest is
-           -- "what happened around you", not "what you typed".
+           -- Expenses filed in the last seven days where this person actually
+           -- appears: the author/user, a payer/financer, or a share participant
+           -- (traveller/rider). A group bystander did not have a week to report.
            (SELECT count(*)
               FROM public.expenses e
+              JOIN public.expense_versions v ON v.id = e.current_version_id
               JOIN public.group_members m
                 ON m.group_id = e.group_id
                AND m.profile_id = p.id
                AND m.left_at IS NULL
               JOIN public.groups g ON g.id = e.group_id AND g.archived_at IS NULL
              WHERE e.deleted_at IS NULL
-               AND e.created_at > v_since) AS expense_count,
+               AND e.created_at > v_since
+               AND (
+                 v.author_member_id = m.id
+                 OR EXISTS (
+                   SELECT 1 FROM public.expense_payers ep
+                    WHERE ep.expense_version_id = v.id AND ep.member_id = m.id
+                 )
+                 OR EXISTS (
+                   SELECT 1 FROM public.expense_shares es
+                    WHERE es.expense_version_id = v.id AND es.member_id = m.id
+                 )
+               )) AS expense_count,
            -- Net across every group, in their own currency only. Mixing
            -- currencies into one number would be a lie, and picking a
            -- "dominant" one would be a lie that changes week to week.

--- a/packages/db/prisma/migrations/20260907090000_device_alert_and_weekly_digest/migration.sql
+++ b/packages/db/prisma/migrations/20260907090000_device_alert_and_weekly_digest/migration.sql
@@ -192,30 +192,18 @@ BEGIN
   FOR v_person IN
     SELECT p.id,
            p.default_currency,
-           -- Expenses filed in the last seven days where this person actually
-           -- appears: the author/user, a payer/financer, or a share participant
-           -- (traveller/rider). A group bystander did not have a week to report.
+           -- Expenses filed in the last seven days in any group this person is
+           -- still a member of. Their own and everybody else's: a digest is
+           -- "what happened around you", not "what you typed".
            (SELECT count(*)
               FROM public.expenses e
-              JOIN public.expense_versions v ON v.id = e.current_version_id
               JOIN public.group_members m
                 ON m.group_id = e.group_id
                AND m.profile_id = p.id
                AND m.left_at IS NULL
               JOIN public.groups g ON g.id = e.group_id AND g.archived_at IS NULL
              WHERE e.deleted_at IS NULL
-               AND e.created_at > v_since
-               AND (
-                 v.author_member_id = m.id
-                 OR EXISTS (
-                   SELECT 1 FROM public.expense_payers ep
-                    WHERE ep.expense_version_id = v.id AND ep.member_id = m.id
-                 )
-                 OR EXISTS (
-                   SELECT 1 FROM public.expense_shares es
-                    WHERE es.expense_version_id = v.id AND es.member_id = m.id
-                 )
-               )) AS expense_count,
+               AND e.created_at > v_since) AS expense_count,
            -- Net across every group, in their own currency only. Mixing
            -- currencies into one number would be a lie, and picking a
            -- "dominant" one would be a lie that changes week to week.

--- a/packages/db/prisma/migrations/20260907150000_weekly_digest_involved_people/migration.sql
+++ b/packages/db/prisma/migrations/20260907150000_weekly_digest_involved_people/migration.sql
@@ -1,0 +1,125 @@
+-- The weekly digest counts a week the reader was actually in.
+--
+-- `waves_enqueue_weekly_digest` counted every expense filed in any group the
+-- person still belongs to. The comment said why — "a digest is what happened
+-- around you, not what you typed" — and for a small group that reads fine. For
+-- a large one it does not: somebody in a twelve-person trip who was on none of
+-- the week's expenses got mail headed **"Your week on Waves"** reporting a
+-- count they had no part in, sitting next to a balance of zero.
+--
+-- The count is also the gate. `CONTINUE WHEN v_person.expense_count = 0` is
+-- what decides who gets mail at all, so counting bystanders did not merely
+-- inflate a number: it mailed people who had no week to report, which is how a
+-- sender teaches somebody to write a filter rule.
+--
+-- So the count narrows to expenses the person appears in — as the author, as a
+-- payer, or as somebody the bill was split across. Everything else about the
+-- function is unchanged, and the whole body is restated because
+-- `CREATE OR REPLACE` replaces all of it and a partial copy would silently drop
+-- the preference checks.
+--
+-- Why a new migration rather than a fix to 20260907090000: that one is applied
+-- on production (2026-09-07 05:38 UTC). Prisma never re-runs an applied
+-- migration, so an edit there would have changed the file, passed CI, and left
+-- production running the old body — the exact shape of a fix that looks
+-- deployed and is not.
+
+CREATE OR REPLACE FUNCTION public.waves_enqueue_weekly_digest(p_now timestamp with time zone DEFAULT now()) RETURNS integer
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+DECLARE
+  v_since   timestamptz := p_now - interval '7 days';
+  v_week    text := to_char(date_trunc('week', p_now), 'IYYY-"W"IW');
+  v_person  record;
+  v_written integer := 0;
+  v_id      uuid;
+BEGIN
+  FOR v_person IN
+    SELECT p.id,
+           p.default_currency,
+           -- Expenses filed in the last seven days where this person actually
+           -- appears: the author/user, a payer/financer, or a share participant
+           -- (traveller/rider). A group bystander did not have a week to report.
+           (SELECT count(*)
+              FROM public.expenses e
+              JOIN public.expense_versions v ON v.id = e.current_version_id
+              JOIN public.group_members m
+                ON m.group_id = e.group_id
+               AND m.profile_id = p.id
+               AND m.left_at IS NULL
+              JOIN public.groups g ON g.id = e.group_id AND g.archived_at IS NULL
+             WHERE e.deleted_at IS NULL
+               AND e.created_at > v_since
+               AND (
+                 v.author_member_id = m.id
+                 OR EXISTS (
+                   SELECT 1 FROM public.expense_payers ep
+                    WHERE ep.expense_version_id = v.id AND ep.member_id = m.id
+                 )
+                 OR EXISTS (
+                   SELECT 1 FROM public.expense_shares es
+                    WHERE es.expense_version_id = v.id AND es.member_id = m.id
+                 )
+               )) AS expense_count,
+           -- Net across every group, in their own currency only. Mixing
+           -- currencies into one number would be a lie, and picking a
+           -- "dominant" one would be a lie that changes week to week.
+           COALESCE((
+             SELECT SUM(CASE WHEN mine.side = 'to' THEN b.amount ELSE -b.amount END)
+             FROM public.pairwise_balances b
+             JOIN LATERAL (
+               SELECT 'to' AS side FROM public.group_members m
+                WHERE m.id = b.to_member_id AND m.profile_id = p.id
+               UNION ALL
+               SELECT 'from' FROM public.group_members m
+                WHERE m.id = b.from_member_id AND m.profile_id = p.id
+             ) mine ON TRUE
+             JOIN public.groups g ON g.id = b.group_id AND g.archived_at IS NULL
+             WHERE b.currency = p.default_currency
+           ), 0) AS net_amount
+    FROM public.profiles p
+    WHERE NOT public.waves_is_guest(p.id)
+      -- No address, no digest. The claim would suppress it a minute later
+      -- anyway; not writing the row keeps the table honest about what was
+      -- actually sendable.
+      AND public.waves_email_for(p.id) IS NOT NULL
+      AND COALESCE((p.notification_prefs ->> 'email')::boolean, TRUE)
+      -- Opt-in, and the default is off. Settings → Notifications has carried
+      -- "Weekly email digest … Off by default" since before anything produced
+      -- one (`DEFAULT_NOTIFICATION_PREFS.weeklyEmail` is false), so a digest
+      -- that shipped to everybody would make that screen a lie on the day it
+      -- started working. Note the default here is FALSE, unlike every other
+      -- preference in this file.
+      AND COALESCE((p.notification_prefs ->> 'weeklyEmail')::boolean, FALSE)
+  LOOP
+    -- Nothing happened: say nothing. This is the whole difference between a
+    -- digest people read and a digest people filter.
+    CONTINUE WHEN v_person.expense_count = 0;
+
+    v_id := public.waves_notify(
+      v_person.id,
+      NULL,
+      'digest_weekly',
+      'Your week on Waves',
+      v_person.expense_count::text || ' expenses',
+      'waves://activity',
+      jsonb_build_object(
+        'count', v_person.expense_count::text,
+        'amount', v_person.net_amount::text,
+        'currency', v_person.default_currency
+      ),
+      'digest_weekly:' || v_person.id::text || ':' || v_week
+    );
+
+    IF v_id IS NOT NULL THEN
+      v_written := v_written + 1;
+    END IF;
+  END LOOP;
+
+  RETURN v_written;
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.waves_enqueue_weekly_digest(timestamp with time zone) FROM PUBLIC;
+GRANT ALL ON FUNCTION public.waves_enqueue_weekly_digest(timestamp with time zone) TO service_role;

--- a/packages/db/test/device-alert-and-digest.test.ts
+++ b/packages/db/test/device-alert-and-digest.test.ts
@@ -254,12 +254,8 @@ describe('the weekly digest', () => {
 
   it('counts payer-only financers and share-only riders/travellers, not bystander users', async () => {
     const group = await seedGroup(client, { memberCount: 4 });
-    const [financerProfile, riderProfile, travellerProfile, bystanderProfile] = group.profileIds as [
-      string,
-      string,
-      string,
-      string,
-    ];
+    const [financerProfile, riderProfile, travellerProfile, bystanderProfile] =
+      group.profileIds as [string, string, string, string];
     const [financer, rider, traveller] = group.memberIds as [string, string, string, string];
     for (const profileId of group.profileIds) {
       await setEmail(profileId, `${profileId}@example.test`);

--- a/packages/db/test/device-alert-and-digest.test.ts
+++ b/packages/db/test/device-alert-and-digest.test.ts
@@ -20,7 +20,7 @@ import { randomUUID } from 'node:crypto';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { Client } from 'pg';
 
-import { addEqualSplitExpense, connect, seedGroup } from './helpers.js';
+import { addEqualSplitExpense, addSplitExpense, connect, seedGroup } from './helpers.js';
 
 let client: Client;
 
@@ -243,13 +243,50 @@ describe('the weekly digest', () => {
 
     await runDigest();
 
-    // Both members of the group, not just whoever filed the expense: a digest
-    // is what happened around you.
+    // Both parties to the expense, not just whoever filed it: a digest is what
+    // changed around your balance.
     for (const profileId of group.profileIds) {
       expect(await digestsFor(profileId)).toHaveLength(1);
     }
     const [digest] = await digestsFor(group.profileIds[0]!);
     expect(digest!.payload).toMatchObject({ count: '1', currency: 'INR' });
+  });
+
+  it('counts payer-only financers and share-only riders/travellers, not bystander users', async () => {
+    const group = await seedGroup(client, { memberCount: 4 });
+    const [financerProfile, riderProfile, travellerProfile, bystanderProfile] = group.profileIds as [
+      string,
+      string,
+      string,
+      string,
+    ];
+    const [financer, rider, traveller] = group.memberIds as [string, string, string, string];
+    for (const profileId of group.profileIds) {
+      await setEmail(profileId, `${profileId}@example.test`);
+      await optIn(profileId);
+    }
+
+    await addSplitExpense(client, {
+      groupId: group.groupId,
+      payers: { [financer]: 12000n },
+      participants: [rider, traveller],
+      amount: 12000n,
+      params: { kind: 'exact', amounts: { [rider]: 7000n, [traveller]: 5000n } },
+      description: 'Cab ride',
+    });
+
+    await runDigest();
+
+    expect(await digestsFor(financerProfile)).toHaveLength(1);
+    expect(await digestsFor(riderProfile)).toHaveLength(1);
+    expect(await digestsFor(travellerProfile)).toHaveLength(1);
+    expect(await digestsFor(bystanderProfile)).toHaveLength(0);
+    const [financerDigest] = await digestsFor(financerProfile);
+    const [riderDigest] = await digestsFor(riderProfile);
+    const [travellerDigest] = await digestsFor(travellerProfile);
+    expect(financerDigest!.payload).toMatchObject({ count: '1', amount: '12000' });
+    expect(riderDigest!.payload).toMatchObject({ count: '1', amount: '-7000' });
+    expect(travellerDigest!.payload).toMatchObject({ count: '1', amount: '-5000' });
   });
 
   it('is idempotent inside one week', async () => {

--- a/packages/db/test/device-alert-and-digest.test.ts
+++ b/packages/db/test/device-alert-and-digest.test.ts
@@ -285,6 +285,43 @@ describe('the weekly digest', () => {
     expect(travellerDigest!.payload).toMatchObject({ count: '1', amount: '-5000' });
   });
 
+  it('counts an author-only user even when they are not a payer or participant', async () => {
+    const group = await seedGroup(client, { memberCount: 2 });
+    const [authorProfile, bystanderProfile] = group.profileIds as [string, string];
+    const [author] = group.memberIds as [string, string];
+    for (const profileId of group.profileIds) {
+      await setEmail(profileId, `${profileId}@example.test`);
+      await optIn(profileId);
+    }
+
+    const expenseId = randomUUID();
+    const versionId = randomUUID();
+    await client.query('BEGIN');
+    await client.query(`INSERT INTO expenses (id, group_id, created_by) VALUES ($1, $2, $3)`, [
+      expenseId,
+      group.groupId,
+      author,
+    ]);
+    await client.query(
+      `INSERT INTO expense_versions
+         (id, expense_id, version_no, author_member_id, description, category, expense_date,
+          currency, amount, split_type, split_params)
+       VALUES ($1, $2, 1, $3, 'Trip note', NULL, '2026-03-01', 'INR', 0, 'equal', '{"kind":"equal"}'::jsonb)`,
+      [versionId, expenseId, author],
+    );
+    await client.query(`UPDATE expenses SET current_version_id = $1 WHERE id = $2`, [
+      versionId,
+      expenseId,
+    ]);
+    await client.query('COMMIT');
+
+    await runDigest();
+
+    const [digest] = await digestsFor(authorProfile);
+    expect(digest!.payload).toMatchObject({ count: '1', amount: '0' });
+    expect(await digestsFor(bystanderProfile)).toHaveLength(0);
+  });
+
   it('is idempotent inside one week', async () => {
     const group = await seedGroup(client, { memberCount: 1 });
     await setEmail(group.profileIds[0]!, `${group.profileIds[0]!}@example.test`);


### PR DESCRIPTION
## What it does

`waves_enqueue_weekly_digest` counted every expense filed in any group the person still belongs to. The original comment said why — "a digest is what happened around you, not what you typed" — and for a small group that reads fine. For a large one it doesn't: somebody in a twelve-person trip who was on none of the week's expenses got mail headed **"Your week on Waves"** reporting a count they had no part in, next to a balance of zero.

The count is also the gate — `CONTINUE WHEN v_person.expense_count = 0` decides who gets mail at all — so counting bystanders didn't just inflate a number, it mailed people who had no week to report. That is how a sender teaches somebody to write a filter rule.

Now the count includes an expense only where the person appears: as its author, as a payer, or as somebody the bill was split across.

## Correction to the original commit

The change was written into `20260907090000_device_alert_and_weekly_digest`, which is **already applied on production** (2026-09-07 05:38 UTC). Prisma never re-runs an applied migration, so that edit would have changed the repo, passed CI, and left production running the old body. `pg_proc` on prod confirms it — the live function still has the old wording and no `expense_payers` join.

So the same change now lives in a new migration, `20260907150000_weekly_digest_involved_people`, with the whole function restated (`CREATE OR REPLACE` replaces all of it, and a partial copy would silently drop the preference checks) and its grants restated alongside, which the definer guard requires in the same file. The applied migration is back to its recorded bytes — verified by hash against `main`.

## Tests

The original noted the DB test couldn't run locally. It can here: **12 pass** against local Postgres, including the new case — a payer-only financer, two share-only riders, and a bystander in the same group who correctly gets nothing.

Also green: `check-definer-grants`, prettier.

## Deploy

Needs `pnpm db:migrate` against prod to take effect. Until then the digest keeps counting bystanders — though nothing has actually been sent yet, since `notification_prefs.weeklyEmail` is off by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Weekly expense digests are now sent only to people involved in the past seven days’ expenses.
  * Users who were not involved in any recent expense no longer receive unnecessary digest notifications.
  * Digest amounts remain accurate for payers, expense authors, and participants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->