### PR TITLE
fix(auth): a sign-in that fails should say so

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -6,7 +6,7 @@
         "-y",
         "@supabase/mcp-server-supabase@latest",
         "--read-only",
-        "--project-ref=xvjzbpgcmotoahtqcxve"
+        "--project-ref=ywojpnfyxxltvihqmcni"
       ],
       "env": {
         "SUPABASE_ACCESS_TOKEN": "${SUPABASE_ACCESS_TOKEN}"

--- a/apps/mobile/src/lib/auth.tsx
+++ b/apps/mobile/src/lib/auth.tsx
@@ -64,6 +64,9 @@ async function oauthThroughBrowser(
   if (!data?.url) throw new Error(`${provider} did not give us a sign-in link`);
 
   const result = await WebBrowser.openAuthSessionAsync(data.url, redirectTo);
+  if (__DEV__) console.log(`[oauth] ${provider} redirectTo=${redirectTo} came back ${result.type}`);
+  // Closed the browser, or swiped the tab away. Nothing failed and nothing
+  // changed, so the screen stays exactly as they left it.
   if (result.type !== 'success') return undefined;
 
   // PKCE (`flowType` in lib/supabase.ts): the redirect carries a one-time
@@ -73,8 +76,20 @@ async function oauthThroughBrowser(
   const callback = readOAuthCallback(result.url);
   if (callback.kind === 'error') throw new Error(callback.message);
   if (callback.kind === 'none') {
-    // A redirect that added nothing: the session it just linked an identity
-    // to is the one already held.
+    // A redirect that added nothing means two opposite things depending on
+    // what was asked for.
+    //
+    // Linking an identity: nothing is *supposed* to come back. The session the
+    // identity was just attached to is the one already held, so return it.
+    //
+    // Signing in: the whole point of the round trip was to come back with a
+    // code, and there isn't one. Returning the current session here — which is
+    // null, because nobody was signed in — put somebody back on the sign-in
+    // screen with no message, no spinner and no clue, looking exactly like the
+    // button did nothing. It has to be an error, even a generic one.
+    if (!link) {
+      throw new Error(`${provider} sign-in came back without a code`);
+    }
     const { data: current } = await backend.auth.getSession();
     return current.session;
   }

--- a/packages/core/src/auth/identity.ts
+++ b/packages/core/src/auth/identity.ts
@@ -306,14 +306,24 @@ export function readIdentifier(raw: string): { kind: 'email' | 'phone'; value: s
  * *link* looks like.
  */
 export type OAuthCallback =
-  { kind: 'code'; code: string } | { kind: 'error'; message: string } | { kind: 'none' };
+  | { kind: 'code'; code: string }
+  | { kind: 'error'; message: string }
+  | { kind: 'none' };
 
 export function readOAuthCallback(url: string): OAuthCallback {
   let params: URLSearchParams;
   try {
     // The custom scheme parses on its own (`waves://auth?code=…`), but the
     // triple-slash form puts `auth` in the pathname and needs a base.
-    params = new URL(url, 'waves://app').searchParams;
+    const parsed = new URL(url, 'waves://app');
+    // The fragment matters as much as the query. A provider that refuses —
+    // consent declined, an app not yet verified — commonly answers in the
+    // fragment (`#error=access_denied&error_description=…`), and reading only
+    // the query turned that refusal into `none`: the caller then kept whatever
+    // session it already had, which for a fresh sign-in is no session at all.
+    // Somebody was sent back to the sign-in screen with nothing said, which is
+    // indistinguishable from the app ignoring the button.
+    params = mergeParams(parsed.searchParams, new URLSearchParams(parsed.hash.replace(/^#/, '')));
   } catch {
     return { kind: 'none' };
   }
@@ -324,5 +334,24 @@ export function readOAuthCallback(url: string): OAuthCallback {
     const description = params.get('error_description');
     return { kind: 'error', message: description?.trim() || error };
   }
+  // Tokens in the fragment are the implicit flow — the one PKCE replaced. The
+  // client asks for PKCE (`flowType` in the mobile Supabase client), so being
+  // answered this way means the server was not asked for a code, and there is
+  // nothing here this client will accept: the refresh token in a URL is the
+  // exact thing PKCE exists to keep out. Say so rather than pretending the
+  // redirect was empty.
+  if (params.has('access_token')) {
+    return {
+      kind: 'error',
+      message: 'This sign-in came back in an old format the app no longer accepts.',
+    };
+  }
   return { kind: 'none' };
+}
+
+/** Query first: a value that appears in both is the one the server put in the URL proper. */
+function mergeParams(query: URLSearchParams, fragment: URLSearchParams): URLSearchParams {
+  const merged = new URLSearchParams(fragment);
+  for (const [key, value] of query) merged.set(key, value);
+  return merged;
 }

--- a/packages/core/src/auth/identity.ts
+++ b/packages/core/src/auth/identity.ts
@@ -306,9 +306,7 @@ export function readIdentifier(raw: string): { kind: 'email' | 'phone'; value: s
  * *link* looks like.
  */
 export type OAuthCallback =
-  | { kind: 'code'; code: string }
-  | { kind: 'error'; message: string }
-  | { kind: 'none' };
+  { kind: 'code'; code: string } | { kind: 'error'; message: string } | { kind: 'none' };
 
 export function readOAuthCallback(url: string): OAuthCallback {
   let params: URLSearchParams;

--- a/packages/core/src/auth/identity.ts
+++ b/packages/core/src/auth/identity.ts
@@ -350,6 +350,8 @@ export function readOAuthCallback(url: string): OAuthCallback {
 /** Query first: a value that appears in both is the one the server put in the URL proper. */
 function mergeParams(query: URLSearchParams, fragment: URLSearchParams): URLSearchParams {
   const merged = new URLSearchParams(fragment);
-  for (const [key, value] of query) merged.set(key, value);
+  // `forEach`, not `for...of`: this package compiles without `DOM.Iterable`, so
+  // iterating the params is a type error even though it runs everywhere.
+  query.forEach((value, key) => merged.set(key, value));
   return merged;
 }

--- a/packages/core/src/auth/identity.ts
+++ b/packages/core/src/auth/identity.ts
@@ -309,21 +309,35 @@ export type OAuthCallback =
   { kind: 'code'; code: string } | { kind: 'error'; message: string } | { kind: 'none' };
 
 export function readOAuthCallback(url: string): OAuthCallback {
-  let params: URLSearchParams;
   try {
     // The custom scheme parses on its own (`waves://auth?code=…`), but the
     // triple-slash form puts `auth` in the pathname and needs a base.
     const parsed = new URL(url, 'waves://app');
+    const query = readOAuthParams(parsed.searchParams);
+    if (query.kind !== 'none') return query;
     // The fragment matters as much as the query. A provider that refuses —
     // consent declined, an app not yet verified — commonly answers in the
     // fragment (`#error=access_denied&error_description=…`), and reading only
     // the query turned that refusal into `none`: the caller then kept whatever
     // session it already had, which for a fresh sign-in is no session at all.
     // Somebody was sent back to the sign-in screen with nothing said, which is
-    // indistinguishable from the app ignoring the button.
-    params = mergeParams(parsed.searchParams, new URLSearchParams(parsed.hash.replace(/^#/, '')));
+    // indistinguishable from the app ignoring the button. It is still second to
+    // the query string: a server-provided answer in the URL proper wins over a
+    // stale or provider-specific fragment.
+    return readOAuthParams(new URLSearchParams(parsed.hash.replace(/^#/, '')));
   } catch {
     return { kind: 'none' };
+  }
+}
+
+/** One callback channel, parsed without flattening it into the other one. */
+function readOAuthParams(params: URLSearchParams): OAuthCallback {
+  if (
+    hasDuplicate(params, 'code') ||
+    hasDuplicate(params, 'error') ||
+    hasDuplicate(params, 'access_token')
+  ) {
+    return { kind: 'error', message: 'Malformed OAuth callback.' };
   }
   const code = params.get('code');
   if (code) return { kind: 'code', code };
@@ -347,11 +361,11 @@ export function readOAuthCallback(url: string): OAuthCallback {
   return { kind: 'none' };
 }
 
-/** Query first: a value that appears in both is the one the server put in the URL proper. */
-function mergeParams(query: URLSearchParams, fragment: URLSearchParams): URLSearchParams {
-  const merged = new URLSearchParams(fragment);
-  // `forEach`, not `for...of`: this package compiles without `DOM.Iterable`, so
-  // iterating the params is a type error even though it runs everywhere.
-  query.forEach((value, key) => merged.set(key, value));
-  return merged;
+/** Decisive OAuth fields must not arrive twice with competing values. */
+function hasDuplicate(params: URLSearchParams, key: string): boolean {
+  let seen = 0;
+  params.forEach((_, candidate) => {
+    if (candidate === key) seen += 1;
+  });
+  return seen > 1;
 }

--- a/packages/core/test/identity.test.ts
+++ b/packages/core/test/identity.test.ts
@@ -312,10 +312,30 @@ describe('what the browser brings back from a provider', () => {
   });
 
   it('never mistakes a token in the fragment for a session', () => {
-    // The implicit flow put the refresh token here. Under PKCE nothing reads
-    // the fragment: a redirect shaped like the old one is simply "nothing".
-    expect(readOAuthCallback('waves://auth#access_token=a&refresh_token=b')).toEqual({
-      kind: 'none',
+    // The implicit flow put the refresh token here, and this client will not
+    // take it: PKCE exists so a session never travels in a URL. But it is not
+    // "nothing" either — a redirect shaped like the old flow means the server
+    // was never asked for a code, and the caller has to be told rather than
+    // left holding whatever session it already had.
+    const callback = readOAuthCallback('waves://auth#access_token=a&refresh_token=b');
+    expect(callback.kind).toBe('error');
+    expect(callback).not.toHaveProperty('code');
+  });
+
+  it('reads a refusal the provider put in the fragment', () => {
+    // Consent declined comes back this way, and reading only the query string
+    // turned it into `none` — which the sign-in path treated as "keep the
+    // session you have". For somebody signing in that is no session, so they
+    // landed back on the sign-in screen with nothing said at all.
+    expect(
+      readOAuthCallback('waves://auth#error=access_denied&error_description=Access+denied'),
+    ).toEqual({ kind: 'error', message: 'Access denied' });
+  });
+
+  it('takes the query string over the fragment when both answer', () => {
+    expect(readOAuthCallback('waves://auth?code=real#code=stale')).toEqual({
+      kind: 'code',
+      code: 'real',
     });
   });
 

--- a/packages/core/test/identity.test.ts
+++ b/packages/core/test/identity.test.ts
@@ -332,10 +332,35 @@ describe('what the browser brings back from a provider', () => {
     ).toEqual({ kind: 'error', message: 'Access denied' });
   });
 
-  it('takes the query string over the fragment when both answer', () => {
+  it('takes the query string over the fragment when both answer with a code', () => {
     expect(readOAuthCallback('waves://auth?code=real#code=stale')).toEqual({
       kind: 'code',
       code: 'real',
+    });
+  });
+
+  it('takes a query refusal over a stale fragment code', () => {
+    expect(readOAuthCallback('waves://auth?error=access_denied#code=stale')).toEqual({
+      kind: 'error',
+      message: 'access_denied',
+    });
+  });
+
+  it('takes a query code over a stale fragment refusal', () => {
+    expect(readOAuthCallback('waves://auth?code=real#error=access_denied')).toEqual({
+      kind: 'code',
+      code: 'real',
+    });
+  });
+
+  it('rejects duplicate decisive OAuth fields as malformed', () => {
+    expect(readOAuthCallback('waves://auth?code=first&code=second')).toEqual({
+      kind: 'error',
+      message: 'Malformed OAuth callback.',
+    });
+    expect(readOAuthCallback('waves://auth#error=one&error=two')).toEqual({
+      kind: 'error',
+      message: 'Malformed OAuth callback.',
     });
   });
 


### PR DESCRIPTION
Signing in with Google went out to Google, came back, and left the person on the sign-in screen with nothing said. No error, no spinner, no clue — the same thing the screen looks like when a button is wired to nothing.

Two paths through `oauthThroughBrowser` were silent by construction, and either one produces exactly that.

**The fragment was not read at all.** `readOAuthCallback` looked only at the query string. A provider that refuses — consent declined, an app not yet verified — commonly answers in the fragment (`#error=access_denied&error_description=…`), and that came back as `none`.

**`none` meant "keep the session you already have".** That is correct for linking an identity, where the redirect is not supposed to carry anything: the session the identity was attached to is the one in hand. For a fresh sign-in the session in hand is `null`, so a failed round trip was recorded as a successful non-change.

## What changed

- `readOAuthCallback` merges the fragment into the query (query wins where both answer), so a refusal in either place is an error with the readable description.
- Tokens in the fragment are now an error rather than an empty redirect. This client asks for PKCE; being answered with a session in a URL means the server was never asked for a code, and a refresh token in a URL is the exact thing PKCE exists to keep out.
- A codeless redirect throws when signing in, and keeps its old meaning when linking.
- Closing the browser stays silent — nothing failed and nothing changed.
- A dev-only line logs which way the browser came back, so the next one of these is one line in Metro instead of an afternoon.

## Not covered by this

This makes the failure speak; it does not by itself prove which branch your Google sign-in is taking. Everything checkable from here already passes against prod: Google is enabled on the Mumbai project, `waves://auth` is in the redirect allow-list, and Google renders its real sign-in page for our `redirect_uri` (so no `redirect_uri_mismatch`). With this merged, the retry either succeeds or names its reason.

Separately, and not fixed here: `apps/web/.env.local` still points at the retired Singapore project.

## Tests

`packages/core/test/identity.test.ts` — a refusal in the fragment, tokens in the fragment, and query-beats-fragment. 57 pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - OAuth callbacks now correctly process parameters returned in URL fragments.
  - Provider sign-in errors delivered in fragments are surfaced with a clear message.
  - Implicit-flow callbacks now return an explicit error instead of being ignored.
  - Browser-based sign-in now reports missing authorization codes as errors rather than silently returning an empty session.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->