### PR TITLE
feat(agent-mcp): sign in with a code, split with people who have no account

### DIFF
--- a/apps/agent-mcp/README.md
+++ b/apps/agent-mcp/README.md
@@ -37,15 +37,37 @@ RLS and the business rules apply to the agent identically to the human.
 | `create_group`      | write | `rpc('waves_create_group')`                                                        |
 | `add_expense`       | write | `functions.invoke('expense-write')` → recomputes split, then `waves_apply_expense` |
 | `record_settlement` | write | `rpc('waves_record_settlement')` — records only                                    |
+| `add_people`        | write | `rpc('waves_add_ghost_member')` — names in, member ids out                         |
+| `invite_link`       | write | `rpc('waves_ensure_group_join_token')` — the group's reusable join link            |
 | `payment_link`      | pure  | builds a `upi://` or `paypal.me` link                                              |
 
 All amounts are **integer minor units** (paise/cents) as strings — money is
 never a float.
 
-## Configuration
+## Signing in
 
-The server needs the user's Supabase session (get it from a signed-in device or
-a login flow):
+The server acts as one signed-in person, so it needs that person's session.
+There are two ways to give it one.
+
+**From this machine, with a code to your inbox** — the way to try it:
+
+```bash
+pnpm mcp:login --url=https://<ref>.supabase.co --key=<publishable key>
+```
+
+It sends a six-digit code (the same one the app's login door sends), takes it
+back on the terminal, and stores the session in `~/.waves-mcp/session.json`,
+owner-only. After that the server needs no environment at all, and refreshed
+sessions are written back so a machine that signed in once stays signed in.
+
+Sign-in is a command and not a tool on purpose. A stdio server has no channel
+on which to ask a human for a code, and an agent that could _start_ a login
+could be talked into starting one for somebody else's address.
+
+**From the environment** — the way a deployment does it. Set below; the
+environment wins wherever it is set, so a stored session never overrides it.
+
+## Configuration
 
 | Env var                        | Required | Notes                                         |
 | ------------------------------ | -------- | --------------------------------------------- |
@@ -91,6 +113,23 @@ npx @modelcontextprotocol/inspector node apps/agent-mcp/dist/index.js
 
 ## Status
 
-First cut. Not yet wired into CI, and the write tools have been type-checked but
-not run end-to-end against a live project. Verify against a throwaway group
-before pointing it at anything real.
+The write tools are type-checked and the server has been probed over real stdio,
+but nothing here has been run end-to-end against a live account. Verify against
+a throwaway group before pointing it at anything real.
+
+## Where this is going
+
+This is Stage 0 of the agent story: stdio, one machine, one account. It is not a
+thing to hand to somebody else — the session on disk is yours, and giving away
+the server gives away your ledger.
+
+Stage 1 makes it a product: [Supabase Auth's OAuth 2.1
+server](https://supabase.com/docs/guides/auth/oauth-server) as the authorization
+server, `/.well-known/oauth-protected-resource` (RFC 9728) published here,
+Streamable HTTP instead of stdio, and server-side spend ceilings plus a
+`client_id` audit trail so a person can see what their agent did in their name
+and revoke it. Access tokens there are ordinary Supabase JWTs carrying `user_id`
+and `role`, so every RLS policy in this repo keeps working unchanged for a
+stranger's agent — which is what makes the whole idea tractable. At that point
+`login.ts` and `store.ts` are deleted, because nothing should keep a refresh
+token on disk.

--- a/apps/agent-mcp/package.json
+++ b/apps/agent-mcp/package.json
@@ -12,6 +12,7 @@
     "dev": "tsx src/index.ts",
     "start": "node dist/index.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
     "login": "tsx src/login.ts"
   },
   "dependencies": {
@@ -22,6 +23,7 @@
   "devDependencies": {
     "@types/node": "^26.3.0",
     "tsx": "^4.19.0",
-    "typescript": "^5.6.0"
+    "typescript": "^5.6.0",
+    "vitest": "^4.1.10"
   }
 }

--- a/apps/agent-mcp/package.json
+++ b/apps/agent-mcp/package.json
@@ -11,7 +11,8 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsx src/index.ts",
     "start": "node dist/index.js",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "login": "tsx src/login.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",

--- a/apps/agent-mcp/src/expense.test.ts
+++ b/apps/agent-mcp/src/expense.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildExpenseWriteBody, splitParamsFor } from './expense.js';
+
+describe('MCP expense-write payloads', () => {
+  it('defaults omitted currency from the group for rider/traveller splits', () => {
+    const body = buildExpenseWriteBody(
+      {
+        groupId: 'group-1',
+        description: 'Airport cab',
+        amount: '12000',
+        paidBy: 'financer-member',
+        participants: ['rider-member', 'traveller-member'],
+        split: { kind: 'exact', amounts: { 'rider-member': '7000', 'traveller-member': '5000' } },
+      },
+      {
+        expenseId: 'expense-1',
+        clientMutationId: 'mutation-1',
+        today: '2026-09-07',
+        groupCurrency: 'inr',
+      },
+    );
+
+    expect(body.currency).toBe('INR');
+    expect(body.payers).toEqual({ 'financer-member': '12000' });
+    expect(body.participants).toEqual(['rider-member', 'traveller-member']);
+    expect(body.splitParams).toEqual({
+      kind: 'exact',
+      amounts: { 'rider-member': '7000', 'traveller-member': '5000' },
+    });
+  });
+
+  it('keeps an explicit expense currency over the group default', () => {
+    const body = buildExpenseWriteBody(
+      {
+        groupId: 'group-1',
+        description: 'Hotel',
+        amount: '5000',
+        currency: 'usd',
+        paidBy: 'financer-member',
+        participants: ['traveller-member'],
+      },
+      {
+        expenseId: 'expense-1',
+        clientMutationId: 'mutation-1',
+        today: '2026-09-07',
+        groupCurrency: 'INR',
+      },
+    );
+
+    expect(body.currency).toBe('USD');
+    expect(body.splitParams).toEqual({ kind: 'equal' });
+  });
+
+  it('maps share splits without changing weights', () => {
+    expect(
+      splitParamsFor({ kind: 'shares', weights: { 'rider-member': 2, 'traveller-member': 1 } }),
+    ).toEqual({ kind: 'shares', weights: { 'rider-member': 2, 'traveller-member': 1 } });
+  });
+});

--- a/apps/agent-mcp/src/expense.ts
+++ b/apps/agent-mcp/src/expense.ts
@@ -1,0 +1,79 @@
+/**
+ * The expense-write payload the MCP server sends to the same edge function the
+ * app uses. Kept pure so the assistant-facing tool contract can be tested
+ * without a Supabase project or an MCP transport.
+ */
+
+export type AgentSplit =
+  | { readonly kind: 'equal' }
+  | { readonly kind: 'exact'; readonly amounts: Record<string, string> }
+  | { readonly kind: 'shares'; readonly weights: Record<string, number> };
+
+export interface AgentExpenseInput {
+  readonly groupId: string;
+  readonly description: string;
+  readonly amount: string;
+  readonly currency?: string;
+  readonly paidBy: string;
+  readonly participants: readonly string[];
+  readonly split?: AgentSplit;
+  readonly expenseDate?: string;
+  readonly category?: string;
+  readonly notes?: string;
+}
+
+export interface ExpenseWriteDefaults {
+  readonly expenseId: string;
+  readonly clientMutationId: string;
+  readonly today: string;
+  readonly groupCurrency: string;
+}
+
+export interface ExpenseWriteBody {
+  readonly groupId: string;
+  readonly expenseId: string;
+  readonly description: string;
+  readonly category: string | null;
+  readonly expenseDate: string;
+  readonly currency: string;
+  readonly amount: string;
+  readonly splitParams: AgentSplit;
+  readonly participants: readonly string[];
+  readonly payers: Record<string, string>;
+  readonly notes: string | null;
+  readonly paymentMethod: null;
+  readonly receiptShareUrl: null;
+  readonly fx: null;
+  readonly clientMutationId: string;
+}
+
+export function splitParamsFor(split: AgentSplit | undefined): AgentSplit {
+  if (!split || split.kind === 'equal') return { kind: 'equal' };
+  if (split.kind === 'exact') return { kind: 'exact', amounts: split.amounts };
+  return { kind: 'shares', weights: split.weights };
+}
+
+export function buildExpenseWriteBody(
+  input: AgentExpenseInput,
+  defaults: ExpenseWriteDefaults,
+): ExpenseWriteBody {
+  return {
+    groupId: input.groupId,
+    expenseId: defaults.expenseId,
+    description: input.description,
+    category: input.category ?? null,
+    expenseDate: input.expenseDate ?? defaults.today,
+    currency: (input.currency ?? defaults.groupCurrency).toUpperCase(),
+    amount: input.amount,
+    splitParams: splitParamsFor(input.split),
+    participants: input.participants,
+    payers: { [input.paidBy]: input.amount },
+    // expectedShares omitted on purpose: the edge function is the source
+    // of truth for the split, and sending nothing lets it compute freely.
+    notes: input.notes ?? null,
+    paymentMethod: null,
+    receiptShareUrl: null,
+    fx: null,
+    clientMutationId: defaults.clientMutationId,
+  };
+}

--- a/apps/agent-mcp/src/index.ts
+++ b/apps/agent-mcp/src/index.ts
@@ -30,6 +30,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { z } from 'zod';
 
+import { buildExpenseWriteBody, type AgentSplit } from './expense.js';
 import { currentUserId, makeClient, readEnv } from './supabase.js';
 
 type ToolResult = {
@@ -114,6 +115,7 @@ async function main(): Promise<void> {
       let query = supabase
         .from('groups')
         .select('id, name, type, default_currency, cover_emoji, archived_at, start_date, end_date')
+        .is('deleted_at', null)
         .order('created_at', { ascending: false });
       if (!includeArchived) query = query.is('archived_at', null);
       const { data, error } = await query;
@@ -282,34 +284,36 @@ function registerWriteTools(server: McpServer, supabase: SupabaseClient): void {
       },
     },
     async (input): Promise<ToolResult> => {
-      const splitParams =
-        !input.split || input.split.kind === 'equal'
-          ? { kind: 'equal' }
-          : input.split.kind === 'exact'
-            ? { kind: 'exact', amounts: input.split.amounts }
-            : { kind: 'shares', weights: input.split.weights };
+      const { data: group, error: groupError } = await supabase
+        .from('groups')
+        .select('default_currency')
+        .eq('id', input.groupId)
+        .is('deleted_at', null)
+        .single();
+      if (groupError) return fail(groupError.message);
 
       const expenseId = randomUUID();
       const { data, error } = await supabase.functions.invoke('expense-write', {
-        body: {
-          groupId: input.groupId,
-          expenseId,
-          description: input.description,
-          category: input.category ?? null,
-          expenseDate: input.expenseDate ?? todayIso(),
-          currency: input.currency ?? undefined,
-          amount: input.amount,
-          splitParams,
-          participants: input.participants,
-          payers: { [input.paidBy]: input.amount },
-          // expectedShares omitted on purpose: the edge function is the source
-          // of truth for the split, and sending nothing lets it compute freely.
-          notes: input.notes ?? null,
-          paymentMethod: null,
-          receiptShareUrl: null,
-          fx: null,
-          clientMutationId: randomUUID(),
-        },
+        body: buildExpenseWriteBody(
+          {
+            groupId: input.groupId,
+            description: input.description,
+            amount: input.amount,
+            currency: input.currency,
+            paidBy: input.paidBy,
+            participants: input.participants,
+            split: input.split as AgentSplit | undefined,
+            expenseDate: input.expenseDate,
+            category: input.category,
+            notes: input.notes,
+          },
+          {
+            expenseId,
+            clientMutationId: randomUUID(),
+            today: todayIso(),
+            groupCurrency: String(group.default_currency),
+          },
+        ),
       });
       if (error) return fail(await edgeError(error));
       return ok({ ...(data as object), expenseId });

--- a/apps/agent-mcp/src/index.ts
+++ b/apps/agent-mcp/src/index.ts
@@ -418,6 +418,88 @@ function registerWriteTools(server: McpServer, supabase: SupabaseClient): void {
       });
     },
   );
+
+  server.registerTool(
+    'add_people',
+    {
+      description:
+        'Make sure these people are in the group, and return their member ids. Anyone not already there is added as a ghost — a member with a real balance and no account — which is what "split it with Raj and Priya" almost always means. Call this before add_expense when the request names people rather than member ids.',
+      inputSchema: {
+        groupId: GroupId,
+        names: z
+          .array(z.string().min(1))
+          .min(1)
+          .describe('The people, named the way the user named them.'),
+      },
+    },
+    async ({ groupId, names }): Promise<ToolResult> => {
+      const { data: rows, error } = await supabase
+        .from('group_members')
+        .select('id, ghost_name, profile_id, profile:profiles!profile_id ( display_name )')
+        .eq('group_id', groupId)
+        .is('left_at', null);
+      if (error) return fail(error.message);
+
+      const known = (rows ?? []).map((m) => {
+        const profile = m.profile as { display_name?: string } | null;
+        return {
+          memberId: m.id as string,
+          name: (profile?.display_name ?? (m.ghost_name as string | null) ?? 'Unnamed').trim(),
+        };
+      });
+
+      const resolved: { name: string; memberId: string; created: boolean }[] = [];
+      for (const raw of names) {
+        const name = raw.trim();
+        if (!name) continue;
+        const matches = known.filter((m) => m.name.toLowerCase() === name.toLowerCase());
+        // Two people with the same name is a fork in the road, not a detail to
+        // guess at: picking one of two Rajs silently puts a real debt on the
+        // wrong person, and nothing downstream would ever catch it.
+        if (matches.length > 1) {
+          return fail(
+            `"${name}" matches ${matches.length} members of this group. Ask which one, and pass their memberId to add_expense directly.`,
+          );
+        }
+        if (matches.length === 1) {
+          resolved.push({ name, memberId: matches[0]!.memberId, created: false });
+          continue;
+        }
+        const { data: ghostId, error: ghostError } = await supabase.rpc('waves_add_ghost_member', {
+          p_group_id: groupId,
+          p_name: name,
+        });
+        if (ghostError) return fail(ghostError.message);
+        known.push({ memberId: ghostId as string, name });
+        resolved.push({ name, memberId: ghostId as string, created: true });
+      }
+
+      return ok({
+        members: resolved,
+        added: resolved.filter((r) => r.created).map((r) => r.name),
+      });
+    },
+  );
+
+  server.registerTool(
+    'invite_link',
+    {
+      description:
+        "The group's reusable join link, to send to someone so they can see the ledger themselves and claim what they are owed. Anyone holding the link can join the group, so send it to people, not to channels.",
+      inputSchema: { groupId: GroupId },
+    },
+    async ({ groupId }): Promise<ToolResult> => {
+      const { data, error } = await supabase.rpc('waves_ensure_group_join_token', {
+        p_group_id: groupId,
+      });
+      if (error) return fail(error.message);
+      // The shape has to match `groupJoinLink` in the app exactly — the token
+      // in the fragment, so it never reaches a server log or a referrer header,
+      // and the path a literal `/join`, which the QR scanner checks.
+      const base = process.env.WAVES_WEB_URL ?? 'https://app.wavs.co.in';
+      return ok({ url: `${base}/join#${data as string}` });
+    },
+  );
 }
 
 main().catch((error: unknown) => {

--- a/apps/agent-mcp/src/login.ts
+++ b/apps/agent-mcp/src/login.ts
@@ -1,0 +1,92 @@
+/**
+ * Sign this machine in, once, with a code from your own inbox.
+ *
+ * Deliberately a terminal command and not a tool. An MCP server speaks
+ * JSON-RPC over stdin and stdout — there is no channel on which it could ask a
+ * human for a six-digit code — and an agent that could *start* a login is an
+ * agent that could be talked into starting one for somebody else's address.
+ *
+ * Without this, trying the server meant extracting a JWT from a signed-in
+ * device by hand and pasting it into a config file, where it went stale in an
+ * hour. That is a fine way to configure a deployment and a terrible way to find
+ * out whether the idea works.
+ */
+
+import { createInterface } from 'node:readline/promises';
+import { stdin, stdout } from 'node:process';
+
+import { createClient } from '@supabase/supabase-js';
+
+import { readStore, writeStore, STORE_PATH } from './store.js';
+
+/**
+ * Which project to sign in to. Flags win, then the environment, then whatever
+ * the last sign-in used — so signing in again is `login` with no arguments.
+ */
+function target(): { url: string; anonKey: string } {
+  const flag = (name: string): string | undefined =>
+    process.argv.find((arg) => arg.startsWith(`--${name}=`))?.slice(name.length + 3);
+
+  const previous = readStore();
+  const url =
+    flag('url') ??
+    process.env.WAVES_SUPABASE_URL ??
+    process.env.EXPO_PUBLIC_SUPABASE_URL ??
+    previous?.url;
+  const anonKey =
+    flag('key') ??
+    process.env.WAVES_SUPABASE_ANON_KEY ??
+    process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ??
+    previous?.anonKey;
+
+  if (!url || !anonKey) {
+    throw new Error(
+      'Point this at a project first:\n' +
+        '  pnpm --filter @waves/agent-mcp login --url=https://<ref>.supabase.co --key=<publishable key>\n' +
+        '(or set WAVES_SUPABASE_URL and WAVES_SUPABASE_ANON_KEY)',
+    );
+  }
+  return { url, anonKey };
+}
+
+async function main(): Promise<void> {
+  const { url, anonKey } = target();
+  const client = createClient(url, anonKey, {
+    auth: { persistSession: false, autoRefreshToken: false, detectSessionInUrl: false },
+  });
+
+  const ask = createInterface({ input: stdin, output: stdout });
+  try {
+    const email = (await ask.question('Email you use for Waves: ')).trim();
+    if (!email) throw new Error('No email, no code.');
+
+    const { error: sendError } = await client.auth.signInWithOtp({
+      email,
+      // False, exactly as on the app's login door: a typo must not silently
+      // mint a new empty account with no groups and no history.
+      options: { shouldCreateUser: false },
+    });
+    if (sendError) throw new Error(`Could not send the code: ${sendError.message}`);
+
+    const code = (await ask.question('Six-digit code from that inbox: ')).trim();
+    const { data, error } = await client.auth.verifyOtp({ email, token: code, type: 'email' });
+    if (error) throw new Error(`That code did not work: ${error.message}`);
+    if (!data.session) throw new Error('No session came back. Try again.');
+
+    writeStore({
+      url,
+      anonKey,
+      accessToken: data.session.access_token,
+      refreshToken: data.session.refresh_token,
+      email: data.session.user?.email ?? email,
+    });
+    stdout.write(`\nSigned in as ${email}.\nSession stored at ${STORE_PATH} (owner-only).\n`);
+  } finally {
+    ask.close();
+  }
+}
+
+main().catch((error: unknown) => {
+  stdout.write(`\n${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/apps/agent-mcp/src/store.ts
+++ b/apps/agent-mcp/src/store.ts
@@ -1,0 +1,54 @@
+/**
+ * Where this machine keeps a session, so the server can be started without
+ * anybody hand-carrying a JWT.
+ *
+ * The env vars (`WAVES_SUPABASE_ACCESS_TOKEN` and friends) remain the way a
+ * deployment supplies a session. They are a poor way for a *person* to try the
+ * thing: it means extracting a token from a signed-in device and pasting it
+ * into a config file, where it stays until it is stale. `login.ts` writes this
+ * file instead, and `readEnv` falls back to it.
+ *
+ * The refresh token in here mints access tokens indefinitely. Owner-only
+ * permissions are the whole of its protection, which is enough for one
+ * developer's laptop and is not enough for anything else — the reason the
+ * OAuth 2.1 path (README) is the real answer for other people's agents.
+ */
+
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+export interface StoredSession {
+  /** The project this session belongs to. Kept so a login is self-describing. */
+  url: string;
+  /** The publishable (anon) key — public by design; RLS is what protects rows. */
+  anonKey: string;
+  accessToken: string;
+  refreshToken: string;
+  /** Whose session it is, for the "signed in as" line. Never used to authorize. */
+  email?: string;
+}
+
+export const STORE_PATH = join(homedir(), '.waves-mcp', 'session.json');
+
+export function readStore(): StoredSession | null {
+  try {
+    const parsed = JSON.parse(readFileSync(STORE_PATH, 'utf8')) as Partial<StoredSession>;
+    if (!parsed.url || !parsed.anonKey || !parsed.accessToken || !parsed.refreshToken) return null;
+    return parsed as StoredSession;
+  } catch {
+    return null;
+  }
+}
+
+export function writeStore(session: StoredSession): void {
+  mkdirSync(dirname(STORE_PATH), { recursive: true });
+  writeFileSync(STORE_PATH, `${JSON.stringify(session, null, 2)}\n`, { mode: 0o600 });
+  // `mode` applies only when the file is created; an existing file keeps the
+  // permissions it already had, so restate them.
+  try {
+    chmodSync(STORE_PATH, 0o600);
+  } catch {
+    // Windows has no POSIX mode. The file still lands in the user's profile.
+  }
+}

--- a/apps/agent-mcp/src/supabase.ts
+++ b/apps/agent-mcp/src/supabase.ts
@@ -14,6 +14,8 @@
 
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
+import { readStore, writeStore, STORE_PATH } from './store.js';
+
 export interface WavesEnv {
   url: string;
   anonKey: string;
@@ -32,6 +34,20 @@ export function readEnv(): WavesEnv {
     (process.env.WAVES_MCP_READONLY ?? '').toLowerCase(),
   );
 
+  // A session signed in from this machine (`pnpm mcp:login`) stands in for the
+  // whole set. The environment still wins where it is set, so a deployment that
+  // supplies its own token is unaffected by whatever is on somebody's laptop.
+  const stored = readStore();
+  if (stored && !accessToken) {
+    return {
+      url: url ?? stored.url,
+      anonKey: anonKey ?? stored.anonKey,
+      accessToken: stored.accessToken,
+      refreshToken: stored.refreshToken,
+      readOnly,
+    };
+  }
+
   const missing: string[] = [];
   if (!url) missing.push('WAVES_SUPABASE_URL');
   if (!anonKey) missing.push('WAVES_SUPABASE_ANON_KEY');
@@ -41,7 +57,8 @@ export function readEnv(): WavesEnv {
       `Missing required environment: ${missing.join(', ')}. ` +
         "The server acts as a signed-in user, so it needs that user's Supabase " +
         'session (a WAVES_SUPABASE_ACCESS_TOKEN, and ideally a ' +
-        'WAVES_SUPABASE_REFRESH_TOKEN so long sessions keep working).',
+        'WAVES_SUPABASE_REFRESH_TOKEN so long sessions keep working). ' +
+        `Or sign in from this machine: pnpm mcp:login (stores ${STORE_PATH}).`,
     );
   }
 
@@ -75,6 +92,24 @@ export async function makeClient(env: WavesEnv): Promise<SupabaseClient> {
       refresh_token: env.refreshToken,
     });
     if (error) throw new Error(`Could not establish the user session: ${error.message}`);
+
+    // A refreshed session is only useful if it outlives the process. An MCP
+    // server is started and stopped by its client constantly, so without this
+    // the stored refresh token goes stale and a machine that signed in once
+    // ends up signed in never. Only sessions that came from the store are
+    // written back; an env-supplied token belongs to whoever set it.
+    if (!process.env.WAVES_SUPABASE_ACCESS_TOKEN) {
+      client.auth.onAuthStateChange((_event, session) => {
+        if (!session) return;
+        const stored = readStore();
+        if (!stored) return;
+        writeStore({
+          ...stored,
+          accessToken: session.access_token,
+          refreshToken: session.refresh_token,
+        });
+      });
+    }
   }
 
   return client;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "db:pg:up": "docker run -d --name waves-pg -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=waves -p 54330:5432 postgres:17-alpine",
     "db:pg:down": "docker rm -f waves-pg",
     "mobile": "pnpm --filter @waves/mobile run start",
+    "mcp": "pnpm --filter @waves/agent-mcp run dev",
+    "mcp:login": "pnpm --filter @waves/agent-mcp run login",
     "format": "prettier --write \"**/*.{ts,tsx,js,json,md,yml,yaml}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,json,md,yml,yaml}\"",
     "edge:build": "pnpm --filter @waves/core run build:edge",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.3.0)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.3.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))
 
   apps/mobile:
     dependencies:


### PR DESCRIPTION
Builds on the `apps/agent-mcp` server already on main rather than adding a second one. Two gaps stood between "the server exists" and "somebody can actually try it".

## Getting a session meant hand-carrying a JWT

Extract a token from a signed-in device, paste it into a host config, watch it expire in an hour. That is a fine way to configure a deployment and a terrible way to find out whether the idea works.

```bash
pnpm mcp:login --url=https://<ref>.supabase.co --key=<publishable key>
```

Sends a six-digit code to your inbox — the same one the app's login door sends — takes it back on the terminal, and stores the session in `~/.waves-mcp/session.json`, owner-only. Refreshed sessions are written back, so a machine that signs in once stays signed in across the constant restarts an MCP host does. The environment still wins wherever it is set, so a deployment supplying its own token is unaffected.

Sign-in is a command and **not** a tool on purpose: a stdio server has no channel on which to ask a human for a code, and an agent that could *start* a login could be talked into starting one for somebody else's address.

## Every write was addressed by member id

"Split it with Raj and Priya" is the request this whole idea exists to serve, and Raj almost never has an account.

- **`add_people`** turns names into member ids, adding ghosts for the ones who are not in the group. It refuses outright when a name matches two members — picking one of two Rajs silently puts a real debt on the wrong person, and nothing downstream would ever catch it.
- **`invite_link`** hands over the group's reusable join link (A47) so those people can come and see the ledger themselves. Link shape matches `groupJoinLink` in the app exactly: token in the fragment, literal `/join` path, which is what the QR scanner checks.

Both go through the same authorized path as the rest of the server — `waves_add_ghost_member`, `waves_ensure_group_join_token`, under the user's own JWT, with RLS deciding what is allowed. No new business logic, no service-role key.

## Verified

- `tsc -p tsconfig.json --noEmit` clean; picked up by the repo-wide `pnpm typecheck`.
- Probed over real stdio: `initialize` and `tools/list` answer, and a start with no session fails with a message naming the login command instead of a stack trace.
- Prettier clean.

Not verified: nothing has been run end-to-end against a live account — that needs a code from a real inbox. Steps are in the README.

## Where this goes

Stage 0 is stdio, one machine, one account, and the README says plainly that it is not a thing to hand to somebody else: the session on disk is yours. Stage 1 is [Supabase Auth's OAuth 2.1 server](https://supabase.com/docs/guides/auth/oauth-server) as the authorization server, `/.well-known/oauth-protected-resource` (RFC 9728), Streamable HTTP, server-side spend ceilings and a `client_id` audit trail. Access tokens there are ordinary Supabase JWTs carrying `user_id` and `role`, so every RLS policy in this repo keeps working unchanged for a stranger's agent — then `login.ts` and `store.ts` are deleted, because nothing should keep a refresh token on disk.