### PR TITLE
fix(auth): finish a sign-in that outlived the app that started it

### DIFF
--- a/apps/mobile/src/lib/auth.tsx
+++ b/apps/mobile/src/lib/auth.tsx
@@ -3,6 +3,7 @@ import { Platform } from 'react-native';
 import type { Session } from '@/lib/backend';
 import { makeRedirectUri } from 'expo-auth-session';
 import * as Crypto from 'expo-crypto';
+import * as Linking from 'expo-linking';
 import * as WebBrowser from 'expo-web-browser';
 
 import {
@@ -17,6 +18,7 @@ import {
 } from '@waves/core';
 
 import { identifyForReporting, reportHandled } from './observability';
+import { claimCode } from './oauthClaim';
 import { refreshPushToken, revokePushToken } from './push';
 import { backend } from './backend';
 
@@ -30,6 +32,21 @@ function viewerFrom(session: Session | null): Viewer {
   return session.user.is_anonymous === true
     ? { kind: 'guest', userId: session.user.id }
     : { kind: 'user', userId: session.user.id };
+}
+
+/**
+ * Redeem the code in a callback URL, if it has one nobody has claimed yet.
+ *
+ * `undefined` means there was nothing here to do — no code, or somebody else
+ * already took it. That is not a failure and must not be reported as one.
+ */
+async function claimOAuthCode(url: string | null): Promise<Session | null | undefined> {
+  if (!url) return undefined;
+  const callback = readOAuthCallback(url);
+  if (callback.kind !== 'code' || !claimCode(callback.code)) return undefined;
+  const { data, error } = await backend.auth.exchangeCodeForSession(callback.code);
+  if (error) throw error;
+  return data.session;
 }
 
 /**
@@ -94,11 +111,14 @@ async function oauthThroughBrowser(
     return current.session;
   }
 
-  const { data: signedIn, error: sessionError } = await backend.auth.exchangeCodeForSession(
-    callback.code,
-  );
-  if (sessionError) throw sessionError;
-  return signedIn.session;
+  // Through the same claim as the deep-link route, so whichever of the two
+  // gets there first is the one that spends the code.
+  const claimed = await claimOAuthCode(result.url);
+  if (claimed !== undefined) return claimed;
+  // Somebody else already redeemed it — the link handler, most likely, on an
+  // app that was restarted mid-sign-in. Their session is the one to keep.
+  const { data: current } = await backend.auth.getSession();
+  return current.session;
 }
 
 /**
@@ -436,6 +456,49 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // render-time clear, and nothing to go stale.
   const profile = profileState.owner === currentUserId ? profileState.profile : null;
   const profileSettled = profileState.owner === currentUserId && profileState.settled;
+
+  /**
+   * Finish a sign-in that outlived the process which started it.
+   *
+   * `oauthThroughBrowser` awaits the browser and redeems the code itself, and
+   * that is the normal path. It only works while this process is alive — and
+   * on a phone it frequently is not: Android is free to kill a backgrounded
+   * app, and while Chrome is in front showing a consent screen, Waves is a
+   * backgrounded app. Several OEM builds do it eagerly. When that happens the
+   * awaiting promise dies with the process, `waves://auth?code=…` arrives at a
+   * cold start with nobody listening, and somebody who really did sign in with
+   * Google lands back on the welcome screen. The screen recording that found
+   * this shows it plainly: the splash plays a second time, then the door.
+   *
+   * The verifier is in the keystore, not in memory, so the fresh process can
+   * still redeem the code — it just has to notice it. This is the noticing:
+   * the launch URL, and every link that arrives afterwards.
+   */
+  useEffect(() => {
+    let active = true;
+
+    const finish = (url: string | null): void => {
+      void claimOAuthCode(url)
+        .then((next) => {
+          if (active && next) setSession(next);
+        })
+        .catch((caught) => {
+          // An expired or already-spent code is the ordinary shape of a
+          // duplicate delivery, not something to put on screen.
+          reportHandled(caught, 'auth.linkCallback');
+        });
+    };
+
+    void Linking.getInitialURL()
+      .then(finish)
+      .catch(() => undefined);
+    const subscription = Linking.addEventListener('url', ({ url }) => finish(url));
+
+    return () => {
+      active = false;
+      subscription.remove();
+    };
+  }, []);
 
   // A crash report carries the account id and nothing else about who it is —
   // enough to tell one person hitting a bug fifty times from fifty people.

--- a/apps/mobile/src/lib/oauthClaim.ts
+++ b/apps/mobile/src/lib/oauthClaim.ts
@@ -1,0 +1,29 @@
+/**
+ * Which authorization codes this process has already spent.
+ *
+ * An OAuth code is single-use, and the callback carrying it can reach the app
+ * twice by two unrelated routes: `WebBrowser.openAuthSessionAsync` hands it to
+ * the call awaiting it, and Android also delivers the same URL as an app
+ * intent. Both are legitimate — on a process that survived the round trip the
+ * first wins, and on one Android killed mid-sign-in only the second exists.
+ *
+ * So neither can be removed, and both must not redeem. Whoever claims first
+ * redeems; everybody else is told there was nothing to do, which is different
+ * from being told it failed.
+ *
+ * Kept free of react-native imports so it can be tested in a plain node suite.
+ */
+
+const claimed = new Set<string>();
+
+/** True the first time a code is seen, false every time after. */
+export function claimCode(code: string): boolean {
+  if (claimed.has(code)) return false;
+  claimed.add(code);
+  return true;
+}
+
+/** Test seam. Nothing in the app calls this: the set is per-process by design. */
+export function resetClaimedCodes(): void {
+  claimed.clear();
+}

--- a/apps/mobile/src/lib/oauthClaim.ts
+++ b/apps/mobile/src/lib/oauthClaim.ts
@@ -14,16 +14,41 @@
  * Kept free of react-native imports so it can be tested in a plain node suite.
  */
 
-const claimed = new Set<string>();
+const CLAIM_TTL_MS = 10 * 60 * 1000;
+const MAX_CLAIMED_CODES = 256;
 
-/** True the first time a code is seen, false every time after. */
+const claimed = new Map<string, number>();
+let now = (): number => Date.now();
+
+/** True the first time a code is seen, false while it is still in the replay window. */
 export function claimCode(code: string): boolean {
+  pruneClaimedCodes(now());
   if (claimed.has(code)) return false;
-  claimed.add(code);
+  claimed.set(code, now());
+  pruneClaimedCodes(now());
   return true;
 }
 
-/** Test seam. Nothing in the app calls this: the set is per-process by design. */
+/** Test seam. Nothing in the app calls this: the registry is per-process by design. */
 export function resetClaimedCodes(): void {
   claimed.clear();
+  now = () => Date.now();
+}
+
+/** Test seam for expiry and eviction. */
+export function setClaimedCodeClock(clock: () => number): void {
+  now = clock;
+}
+
+function pruneClaimedCodes(current: number): void {
+  for (const [code, claimedAt] of claimed) {
+    if (current - claimedAt <= CLAIM_TTL_MS) break;
+    claimed.delete(code);
+  }
+
+  while (claimed.size > MAX_CLAIMED_CODES) {
+    const oldest = claimed.keys().next().value as string | undefined;
+    if (!oldest) return;
+    claimed.delete(oldest);
+  }
 }

--- a/apps/mobile/test/oauthClaim.test.ts
+++ b/apps/mobile/test/oauthClaim.test.ts
@@ -6,11 +6,15 @@
 
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { claimCode, resetClaimedCodes } from '../src/lib/oauthClaim';
+import { claimCode, resetClaimedCodes, setClaimedCodeClock } from '../src/lib/oauthClaim';
 
 describe('claiming an authorization code', () => {
+  let now: number;
+
   beforeEach(() => {
     resetClaimedCodes();
+    now = 1_000;
+    setClaimedCodeClock(() => now);
   });
 
   it('is granted once and refused afterwards', () => {
@@ -22,5 +26,25 @@ describe('claiming an authorization code', () => {
   it('keeps codes apart, so a second sign-in is not refused', () => {
     expect(claimCode('first')).toBe(true);
     expect(claimCode('second')).toBe(true);
+  });
+
+  it('forgets stale codes after the replay window', () => {
+    expect(claimCode('abc-123')).toBe(true);
+    now += 10 * 60 * 1000;
+    expect(claimCode('abc-123')).toBe(false);
+    now += 1;
+    expect(claimCode('abc-123')).toBe(true);
+  });
+
+  it('evicts the oldest codes when distinct callbacks flood the process', () => {
+    expect(claimCode('oldest')).toBe(true);
+    for (let index = 0; index < 256; index += 1) {
+      expect(claimCode(`flood-${index}`)).toBe(true);
+    }
+
+    // The oldest entry was evicted to keep the registry bounded, while the most
+    // recent callback remains protected against the legitimate duplicate route.
+    expect(claimCode('oldest')).toBe(true);
+    expect(claimCode('flood-255')).toBe(false);
   });
 });

--- a/apps/mobile/test/oauthClaim.test.ts
+++ b/apps/mobile/test/oauthClaim.test.ts
@@ -1,0 +1,26 @@
+/**
+ * The callback carrying an authorization code can reach the app twice, and the
+ * code can only be spent once. This is the rule that decides which arrival
+ * spends it — see `src/lib/oauthClaim.ts` for why both arrivals exist.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { claimCode, resetClaimedCodes } from '../src/lib/oauthClaim';
+
+describe('claiming an authorization code', () => {
+  beforeEach(() => {
+    resetClaimedCodes();
+  });
+
+  it('is granted once and refused afterwards', () => {
+    expect(claimCode('abc-123')).toBe(true);
+    expect(claimCode('abc-123')).toBe(false);
+    expect(claimCode('abc-123')).toBe(false);
+  });
+
+  it('keeps codes apart, so a second sign-in is not refused', () => {
+    expect(claimCode('first')).toBe(true);
+    expect(claimCode('second')).toBe(true);
+  });
+});


### PR DESCRIPTION
A screen recording of Google sign-in failing shows what is actually happening, and it is not what the code assumed.

Chrome opens and stays blank for a second — which is fine, a signed-in Chrome with consent already granted redirects without ever painting. Then **the Waves splash plays a second time**, and the welcome screen comes back. The app was killed and cold-started.

That is ordinary Android. While Chrome is in front showing a consent screen, Waves is a backgrounded app, and several OEM builds reclaim one eagerly. But the entire sign-in lived inside a promise in that process: `openAuthSessionAsync` awaits the browser and redeems the code itself. Kill the process and the promise dies with it — `waves://auth?code=…` then arrives at a cold start with nobody listening. The app had **no `getInitialURL` and no `url` listener at all**, and `+native-intent.ts` rewrites the link to `/`, dropping the code on the floor. Somebody who genuinely completed a Google sign-in lands back on the door.

`launchMode` is already `singleTask`, so this is not a task or intent-filter problem. The process simply is not there any more.

## The fix

The PKCE verifier lives in the keystore, not in memory, so a fresh process can still redeem the code. It only had to notice it. `AuthProvider` now reads the launch URL and listens for every link after it, and puts both through the same redemption the in-process path uses.

Both routes stay, because each covers what the other cannot: on a process that survived the round trip the awaiting call gets there first; on one Android killed mid-sign-in the link handler is all there is. Since a code is single-use, `claimCode` decides which arrival spends it — the loser is told there was nothing to do, which is deliberately not the same as being told it failed.

This also fixes the ordinary case of somebody switching apps during the consent screen, which had the same shape and the same silent ending.

## Tests

`apps/mobile/test/oauthClaim.test.ts` — a code is claimable once, and separate codes stay independent so a second sign-in is not refused. Full mobile suite green: 846 tests, 67 files. `tsc --noEmit` clean.

Not verified on a device — that needs the phone from the recording. The dev-only `[oauth] …` line from #688 will say which route completed it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved mobile OAuth sign-in reliability by preventing authorization codes from being processed more than once.
  - Added support for OAuth deep links when the app launches or receives links while running.
  - Preserved the current session when another handler has already completed sign-in.
  - Improved session recovery after app process restarts.
  - Added reporting for duplicate deep-link deliveries.

- **Tests**
  - Added coverage for one-time authorization-code handling and independent sign-ins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->