### PR TITLE
feat(agent): a ceiling on what an assistant may write, and a record of it

### DIFF
--- a/packages/db/prisma/migrations/20260907140000_agent_writes_and_caps/migration.sql
+++ b/packages/db/prisma/migrations/20260907140000_agent_writes_and_caps/migration.sql
@@ -235,3 +235,103 @@ $$;
 
 REVOKE ALL ON FUNCTION public.waves_my_agent_writes(integer) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.waves_my_agent_writes(integer) TO authenticated;
+
+-- Settlements are money writes too. The MCP tool records them directly through
+-- this RPC, so apply the same agent ceiling and audit trail as expense-write.
+CREATE OR REPLACE FUNCTION public.waves_record_settlement(p_group_id uuid, p_from_member_id uuid, p_to_member_id uuid, p_amount bigint, p_method text, p_currency character DEFAULT NULL::bpchar, p_note text DEFAULT NULL::text, p_allocations jsonb DEFAULT '[]'::jsonb, p_client_mutation_id uuid DEFAULT NULL::uuid, p_rail text DEFAULT NULL::text) RETURNS uuid
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+DECLARE
+  v_settlement_id uuid;
+  v_currency      char(3);
+  v_actor         uuid;
+  v_allocation    jsonb;
+  v_rail          text := COALESCE(NULLIF(btrim(p_rail), ''), p_method);
+BEGIN
+  IF NOT public.is_group_member(p_group_id) THEN
+    RAISE EXCEPTION 'NOT_A_MEMBER: you are not in this group'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Resolve the caller's own member id up front: it is both the authorization
+  -- check below and the actor on the activity entry further down.
+  v_actor := public.waves_my_member_id(p_group_id);
+  IF v_actor IS NULL OR v_actor NOT IN (p_from_member_id, p_to_member_id) THEN
+    RAISE EXCEPTION 'NOT_A_PARTY: you can only record a settlement you are part of'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Both parties must be members of THIS group. The FKs only prove the ids are
+  -- real `group_members` rows, not that they belong here — without this a member
+  -- could name a party from another group, and auto-confirm would later write an
+  -- offsetting balance against a member nobody in this group can see, erasing
+  -- their own debt while the per-group sum still totals zero.
+  IF NOT EXISTS (
+        SELECT 1 FROM public.group_members gm
+        WHERE gm.id = p_from_member_id AND gm.group_id = p_group_id
+      )
+     OR NOT EXISTS (
+        SELECT 1 FROM public.group_members gm
+        WHERE gm.id = p_to_member_id AND gm.group_id = p_group_id
+      ) THEN
+    RAISE EXCEPTION 'UNKNOWN_MEMBER: both parties must be members of this group'
+      USING ERRCODE = 'foreign_key_violation';
+  END IF;
+
+  IF p_amount <= 0 THEN
+    RAISE EXCEPTION 'INVALID_AMOUNT: settle a positive amount' USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Replaying the same mutation must not create a second settlement (ADR-005),
+  -- and must not spend an agent's daily ceiling again.
+  IF p_client_mutation_id IS NOT NULL THEN
+    SELECT id INTO v_settlement_id
+    FROM public.settlements WHERE client_mutation_id = p_client_mutation_id;
+    IF v_settlement_id IS NOT NULL THEN
+      RETURN v_settlement_id;
+    END IF;
+  END IF;
+
+  SELECT COALESCE(p_currency, default_currency) INTO v_currency
+  FROM public.groups WHERE id = p_group_id;
+
+  PERFORM public.waves_assert_agent_cap(p_amount);
+
+  INSERT INTO public.settlements
+    (group_id, from_member_id, to_member_id, currency, amount, method, rail, status, note,
+     client_mutation_id)
+  VALUES
+    (p_group_id, p_from_member_id, p_to_member_id, upper(v_currency), p_amount,
+     CASE WHEN p_method IN ('upi', 'cash', 'bank', 'other') THEN p_method ELSE 'other' END
+       ::"SettlementMethod",
+     v_rail, 'initiated', p_note, p_client_mutation_id)
+  RETURNING id INTO v_settlement_id;
+
+  FOR v_allocation IN SELECT * FROM jsonb_array_elements(COALESCE(p_allocations, '[]'::jsonb))
+  LOOP
+    INSERT INTO public.settlement_allocations (settlement_id, expense_id, amount)
+    VALUES (
+      v_settlement_id,
+      (v_allocation ->> 'expenseId')::uuid,
+      (v_allocation ->> 'amount')::bigint
+    )
+    ON CONFLICT (settlement_id, expense_id)
+    DO UPDATE SET amount = public.settlement_allocations.amount + EXCLUDED.amount;
+  END LOOP;
+
+  INSERT INTO public.activity_log (group_id, actor_member_id, verb, object_type, object_id, payload)
+  VALUES (p_group_id, v_actor, 'settled', 'settlement', v_settlement_id,
+          jsonb_build_object('amount', p_amount, 'currency', v_currency,
+                             'method', p_method, 'rail', v_rail));
+
+  PERFORM public.waves_record_agent_write(
+    'settlement.record', p_group_id, v_settlement_id, p_amount, upper(v_currency)
+  );
+
+  RETURN v_settlement_id;
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.waves_record_settlement(p_group_id uuid, p_from_member_id uuid, p_to_member_id uuid, p_amount bigint, p_method text, p_currency character, p_note text, p_allocations jsonb, p_client_mutation_id uuid, p_rail text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.waves_record_settlement(p_group_id uuid, p_from_member_id uuid, p_to_member_id uuid, p_amount bigint, p_method text, p_currency character, p_note text, p_allocations jsonb, p_client_mutation_id uuid, p_rail text) TO authenticated, service_role;

--- a/packages/db/prisma/migrations/20260907140000_agent_writes_and_caps/migration.sql
+++ b/packages/db/prisma/migrations/20260907140000_agent_writes_and_caps/migration.sql
@@ -1,0 +1,237 @@
+-- An agent writing to somebody's ledger, bounded and on the record.
+--
+-- The MCP server (`apps/agent-mcp`) lets an AI agent act as a signed-in person:
+-- it holds that person's JWT and calls the same RPCs the app calls, so RLS
+-- already decides what it may touch. RLS answers "whose data" and answers it
+-- well. It does not answer either of the two questions an agent raises that a
+-- human tapping buttons does not:
+--
+--   * **How much.** A person mistypes an amount once and sees it. A model
+--     mistypes it and retries, and the ledger is a shared record of what other
+--     people owe. There is no ceiling anywhere today: not in the MCP server,
+--     not in the edge function, not in the RPCs.
+--   * **Who did it.** Every write an agent makes is indistinguishable from one
+--     the person made by hand. There is no way to look at a group and ask what
+--     was done on your behalf while you were not looking, and no way to decide
+--     you would rather it had not been.
+--
+-- Both answers hang off one fact: an access token minted for a third-party
+-- client through Supabase's OAuth 2.1 server carries a `client_id` claim, and
+-- one minted for the app itself does not. That claim is in the verified JWT, so
+-- the database can read it directly and nothing in between can forge it. The
+-- app's own writes are untouched by everything here — no claim, no ceiling, no
+-- audit row — which is why this can land before the OAuth server is turned on
+-- and simply do nothing until it is.
+
+-- ─────────────────────────────────────────────────── who is doing the writing ──
+
+-- The OAuth client id from the caller's own token, or NULL for the app itself.
+--
+-- Read from the request's verified claims — the same settings
+-- `waves_current_profile_id` reads `sub` from — so it is not something a caller
+-- can set. It is deliberately a function rather than an argument: passing the
+-- client id in would make it a claim by the caller about the caller, which is
+-- the one thing it must not be.
+--
+-- Not `auth.jwt()`: that lives in Supabase's own schema, and this has to work
+-- on a plain Postgres too (the CI test database has a stub `auth`, and the
+-- self-host stack has no GoTrue schema at all). The settings are set by
+-- PostgREST, not by GoTrue, so reading them directly is both more portable and
+-- exactly as trustworthy.
+CREATE OR REPLACE FUNCTION public.waves_agent_client_id() RETURNS text
+    LANGUAGE sql STABLE
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+  SELECT nullif(
+    btrim(
+      coalesce(
+        current_setting('request.jwt.claim.client_id', true),
+        (nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'client_id'),
+        ''
+      )
+    ),
+    ''
+  );
+$$;
+
+REVOKE ALL ON FUNCTION public.waves_agent_client_id() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.waves_agent_client_id() TO authenticated, service_role;
+
+-- ──────────────────────────────────────────────────────────── the record ──
+
+CREATE TABLE IF NOT EXISTS public.agent_writes (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    profile_id uuid NOT NULL,
+    -- The OAuth client, e.g. a desktop assistant. Kept verbatim so a person can
+    -- tell one agent from another when deciding which to stop trusting.
+    client_id text NOT NULL,
+    -- What was done, in the app's words rather than the table's: expense.add,
+    -- expense.edit, expense.delete, settlement.record.
+    action text NOT NULL,
+    group_id uuid,
+    object_id uuid,
+    -- Minor units, and nullable: not every agent action moves an amount.
+    amount_minor bigint,
+    currency character(3),
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT agent_writes_pkey PRIMARY KEY (id),
+    CONSTRAINT agent_writes_action_shape CHECK ((action ~ '^[a-z][a-z_]*\.[a-z][a-z_]*$')),
+    CONSTRAINT agent_writes_amount_nonneg CHECK ((amount_minor IS NULL) OR (amount_minor >= 0)),
+    CONSTRAINT agent_writes_profile_id_fkey FOREIGN KEY (profile_id)
+      REFERENCES public.profiles(id) ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+-- The daily ceiling asks "how much has this person's agents written today",
+-- which is this index exactly.
+CREATE INDEX IF NOT EXISTS agent_writes_profile_created_idx
+  ON public.agent_writes (profile_id, created_at DESC);
+
+ALTER TABLE public.agent_writes ENABLE ROW LEVEL SECURITY;
+
+-- A person reads what was done in their name and nothing else. There is no
+-- INSERT policy on purpose: rows are written only by the SECURITY DEFINER
+-- function below, so an agent cannot forge its own audit trail — or, more to
+-- the point, cannot write a row claiming a different client_id than its token
+-- carries.
+DROP POLICY IF EXISTS agent_writes_own_read ON public.agent_writes;
+CREATE POLICY agent_writes_own_read ON public.agent_writes
+  FOR SELECT TO authenticated
+  USING (profile_id = public.waves_current_profile_id());
+
+-- ───────────────────────────────────────────────────────────── the ceiling ──
+
+-- Two knobs, both admin-editable at runtime like every other limit in this app
+-- (`app_config`, first used for the receipt cap). Minor units: 5,000,000 paise
+-- is ₹50,000 for one expense, and 20,000,000 is ₹200,000 in a day.
+--
+-- These are starting values, not a considered policy. They exist so that the
+-- answer to "what stops a loop" is a number somebody can raise deliberately
+-- rather than "nothing".
+INSERT INTO public.app_config (key, value, description) VALUES
+  ('agent_expense_cap_minor', 5000000,
+   'Largest single expense an OAuth agent may write, in minor units. The app itself is not affected.'),
+  ('agent_daily_cap_minor', 20000000,
+   'Total an OAuth agent may write for one person in 24 hours, in minor units.')
+ON CONFLICT (key) DO NOTHING;
+
+-- Refuse an agent write that is too large, or that takes the day past its
+-- total. Silent for the app itself.
+--
+-- SECURITY DEFINER because it reads `app_config` and the whole audit table,
+-- neither of which a person may read in full — and because the answer must not
+-- depend on what the caller can see.
+CREATE OR REPLACE FUNCTION public.waves_assert_agent_cap(p_amount_minor bigint)
+RETURNS void
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+DECLARE
+  v_client   text := public.waves_agent_client_id();
+  v_profile  uuid := public.waves_current_profile_id();
+  v_per_call bigint;
+  v_per_day  bigint;
+  v_today    bigint;
+BEGIN
+  -- Not an agent: the app, doing what the person asked with their thumb on the
+  -- screen. Nothing here applies to it.
+  IF v_client IS NULL OR v_profile IS NULL OR p_amount_minor IS NULL THEN
+    RETURN;
+  END IF;
+
+  SELECT value INTO v_per_call FROM public.app_config WHERE key = 'agent_expense_cap_minor';
+  SELECT value INTO v_per_day  FROM public.app_config WHERE key = 'agent_daily_cap_minor';
+  -- A missing knob must not read as "no limit". If somebody deletes the row,
+  -- the conservative reading is the one that refuses.
+  v_per_call := coalesce(v_per_call, 5000000);
+  v_per_day  := coalesce(v_per_day, 20000000);
+
+  IF p_amount_minor > v_per_call THEN
+    RAISE EXCEPTION 'AGENT_CAP_SINGLE: an assistant cannot write an expense this large (% > %)',
+      p_amount_minor, v_per_call
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  SELECT coalesce(sum(amount_minor), 0) INTO v_today
+    FROM public.agent_writes
+   WHERE profile_id = v_profile
+     AND created_at > now() - interval '24 hours';
+
+  IF v_today + p_amount_minor > v_per_day THEN
+    RAISE EXCEPTION 'AGENT_CAP_DAILY: this would take today past what an assistant may write (% + % > %)',
+      v_today, p_amount_minor, v_per_day
+      USING ERRCODE = 'check_violation';
+  END IF;
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.waves_assert_agent_cap(bigint) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.waves_assert_agent_cap(bigint) TO authenticated, service_role;
+
+-- ────────────────────────────────────────────────────────── writing it down ──
+
+-- Record that an agent did something. A no-op for the app, so callers do not
+-- have to ask which they are.
+--
+-- Returns the row id, or NULL when there was nothing to record.
+CREATE OR REPLACE FUNCTION public.waves_record_agent_write(
+  p_action       text,
+  p_group_id     uuid DEFAULT NULL,
+  p_object_id    uuid DEFAULT NULL,
+  p_amount_minor bigint DEFAULT NULL,
+  p_currency     character DEFAULT NULL
+) RETURNS uuid
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+DECLARE
+  v_client  text := public.waves_agent_client_id();
+  v_profile uuid := public.waves_current_profile_id();
+  v_id      uuid;
+BEGIN
+  IF v_client IS NULL OR v_profile IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  INSERT INTO public.agent_writes
+    (profile_id, client_id, action, group_id, object_id, amount_minor, currency)
+  VALUES
+    (v_profile, v_client, p_action, p_group_id, p_object_id, p_amount_minor, p_currency)
+  RETURNING id INTO v_id;
+
+  RETURN v_id;
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.waves_record_agent_write(text, uuid, uuid, bigint, character) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.waves_record_agent_write(text, uuid, uuid, bigint, character)
+  TO authenticated, service_role;
+
+-- What was done in my name, newest first — the answer to "what has it been
+-- doing", and the list somebody reads before deciding to revoke a client.
+CREATE OR REPLACE FUNCTION public.waves_my_agent_writes(p_limit integer DEFAULT 50)
+RETURNS TABLE(
+  id uuid,
+  client_id text,
+  action text,
+  group_id uuid,
+  object_id uuid,
+  amount_minor bigint,
+  currency character,
+  created_at timestamp with time zone
+)
+    LANGUAGE sql STABLE
+    SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+  SELECT w.id, w.client_id, w.action, w.group_id, w.object_id,
+         w.amount_minor, w.currency, w.created_at
+    FROM public.agent_writes w
+   WHERE w.profile_id = public.waves_current_profile_id()
+   ORDER BY w.created_at DESC
+   LIMIT least(greatest(coalesce(p_limit, 50), 1), 200);
+$$;
+
+REVOKE ALL ON FUNCTION public.waves_my_agent_writes(integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.waves_my_agent_writes(integer) TO authenticated;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -170,6 +170,7 @@ model Profile {
   personalRecords     PersonalRecord[]
   packInstalls        PackInstall[]
   packRequests        PackRequest[]
+  agentWrites         AgentWrite[]
   pushTokens          PushToken[]
   notifications       Notification[]
   emailEvents         EmailEvent[]
@@ -1664,6 +1665,38 @@ model RateLimitSetting {
 /// lives here (see 20260818160000_receipt_cap). One row per limit. Readable by
 /// clients (it is configuration, not data about a person); written by the
 /// service role alone, so a limit a client could raise is not a limit.
+/// What an AI agent did in somebody's name.
+///
+/// A write made through the MCP server (`apps/agent-mcp`) with a third-party
+/// OAuth token, which carries a `client_id` claim the app's own tokens do not.
+/// It exists to answer two questions RLS cannot: how much an assistant may
+/// write (the ceiling reads this table for today's total) and what it has
+/// already written, so a person can look and decide to revoke a client.
+///
+/// Rows are inserted only by `waves_record_agent_write` — there is no INSERT
+/// policy, so an agent cannot forge its own trail or attribute a write to a
+/// different client than its token names.
+model AgentWrite {
+  id          String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  profileId   String    @map("profile_id") @db.Uuid
+  /// The OAuth client, kept verbatim so one assistant can be told from another.
+  clientId    String    @map("client_id")
+  /// In the app's words: expense.add, expense.edit, expense.delete, settlement.record.
+  action      String
+  groupId     String?   @map("group_id") @db.Uuid
+  objectId    String?   @map("object_id") @db.Uuid
+  /// Minor units. Null for actions that move no amount.
+  amountMinor BigInt?   @map("amount_minor")
+  currency    String?   @db.Char(3)
+  createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+
+  profile     Profile   @relation(fields: [profileId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+
+  @@index([profileId, createdAt(sort: Desc)], map: "agent_writes_profile_created_idx")
+  @@map("agent_writes")
+  @@schema("public")
+}
+
 model AppConfig {
   key         String   @id
   value       Int

--- a/packages/db/test/agent-writes.test.ts
+++ b/packages/db/test/agent-writes.test.ts
@@ -18,7 +18,7 @@ import { randomUUID } from 'node:crypto';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Client } from 'pg';
 
-import { asRole, connect } from './helpers.js';
+import { asRole, connect, seedGroup } from './helpers.js';
 
 let client: Client;
 let profileId: string;
@@ -128,6 +128,84 @@ describe('the ceiling across a day', () => {
         [profileId],
       );
       expect(count.rows[0].n).toBe(0);
+    });
+  });
+});
+
+describe('settlements written by an agent', () => {
+  it('caps and records a financer paying a rider back', async () => {
+    const group = await seedGroup(client, { memberCount: 2, name: 'Airport cab' });
+    const [financerProfile, riderProfile] = group.profileIds as [string, string];
+    const [financer, rider] = group.memberIds as [string, string];
+
+    await asRole(client, 'authenticated', asAgent(financerProfile, 'settlement-bot'), async () => {
+      const mutationId = randomUUID();
+      const { rows } = await client.query(
+        `SELECT waves_record_settlement($1, $2, $3, 7000, 'upi', 'INR', NULL, '[]'::jsonb, $4) AS id`,
+        [group.groupId, financer, rider, mutationId],
+      );
+      expect(rows[0].id).toBeTruthy();
+
+      const audit = await client.query(
+        `SELECT client_id, action, group_id, object_id, amount_minor, currency
+           FROM agent_writes WHERE profile_id = $1`,
+        [financerProfile],
+      );
+      expect(audit.rows).toHaveLength(1);
+      expect(audit.rows[0]).toMatchObject({
+        client_id: 'settlement-bot',
+        action: 'settlement.record',
+        group_id: group.groupId,
+        object_id: rows[0].id,
+        currency: 'INR',
+      });
+      expect(String(audit.rows[0].amount_minor)).toBe('7000');
+    });
+
+    await asRole(client, 'authenticated', asAgent(riderProfile), async () => {
+      const audit = await client.query(`SELECT * FROM agent_writes`);
+      expect(audit.rows).toHaveLength(0);
+    });
+  });
+
+  it('refuses an agent settlement over the cap', async () => {
+    const group = await seedGroup(client, { memberCount: 2, name: 'Over cap cab' });
+    const [financerProfile] = group.profileIds as [string, string];
+    const [financer, rider] = group.memberIds as [string, string];
+
+    await asRole(client, 'authenticated', asAgent(financerProfile), async () => {
+      await expect(
+        client.query(
+          `SELECT waves_record_settlement($1, $2, $3, 5000001, 'upi', 'INR', NULL, '[]'::jsonb, $4)`,
+          [group.groupId, financer, rider, randomUUID()],
+        ),
+      ).rejects.toThrow(/AGENT_CAP_SINGLE/);
+    });
+  });
+
+  it('does not count a replayed agent settlement twice', async () => {
+    const group = await seedGroup(client, { memberCount: 2, name: 'Replay cab' });
+    const [financerProfile] = group.profileIds as [string, string];
+    const [financer, rider] = group.memberIds as [string, string];
+
+    await asRole(client, 'authenticated', asAgent(financerProfile), async () => {
+      const mutationId = randomUUID();
+      const first = await client.query(
+        `SELECT waves_record_settlement($1, $2, $3, 4000, 'upi', 'INR', NULL, '[]'::jsonb, $4) AS id`,
+        [group.groupId, financer, rider, mutationId],
+      );
+      const second = await client.query(
+        `SELECT waves_record_settlement($1, $2, $3, 4000, 'upi', 'INR', NULL, '[]'::jsonb, $4) AS id`,
+        [group.groupId, financer, rider, mutationId],
+      );
+      expect(second.rows[0].id).toBe(first.rows[0].id);
+
+      const audit = await client.query(
+        `SELECT count(*)::int AS n, coalesce(sum(amount_minor), 0)::text AS total
+           FROM agent_writes WHERE profile_id = $1 AND action = 'settlement.record'`,
+        [financerProfile],
+      );
+      expect(audit.rows[0]).toMatchObject({ n: 1, total: '4000' });
     });
   });
 });

--- a/packages/db/test/agent-writes.test.ts
+++ b/packages/db/test/agent-writes.test.ts
@@ -1,0 +1,210 @@
+/**
+ * What an AI agent may write, and what it leaves behind.
+ *
+ * RLS decides whose data an agent can touch, and decides it well — it holds a
+ * real person's token, so it sees what that person sees. These are the two
+ * questions it does not answer, and both turn on one bit: a token minted for a
+ * third-party client through Supabase's OAuth server carries `client_id`, and
+ * the app's own token does not.
+ *
+ * The property that matters most here is the negative one. Every ceiling and
+ * every audit row must be invisible to the app itself — a person tapping a
+ * button is not an assistant, and a limit that leaked onto them would be a
+ * silent refusal of their own money.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { asRole, connect } from './helpers.js';
+
+let client: Client;
+let profileId: string;
+
+beforeAll(async () => {
+  client = await connect();
+  profileId = randomUUID();
+  await client.query(
+    `INSERT INTO profiles (id, display_name, default_currency) VALUES ($1, 'Agent owner', 'INR')`,
+    [profileId],
+  );
+});
+
+afterAll(async () => {
+  if (profileId) await client.query(`DELETE FROM profiles WHERE id = $1`, [profileId]);
+  await client?.end();
+});
+
+/** Claims as the app mints them: a person, with no third-party client. */
+const asApp = (sub: string) => ({ role: 'authenticated', sub });
+/** Claims as Supabase's OAuth server mints them for somebody's assistant. */
+const asAgent = (sub: string, clientId = 'desktop-assistant') => ({
+  role: 'authenticated',
+  sub,
+  client_id: clientId,
+});
+
+describe('telling an agent from the app', () => {
+  it('sees the client id an OAuth token carries', async () => {
+    const found = await asRole(client, 'authenticated', asAgent(profileId), async () => {
+      const result = await client.query(`SELECT waves_agent_client_id() AS id`);
+      return result.rows[0].id;
+    });
+    expect(found).toBe('desktop-assistant');
+  });
+
+  it('sees nothing for the app, which is what makes all of this opt-in', async () => {
+    const found = await asRole(client, 'authenticated', asApp(profileId), async () => {
+      const result = await client.query(`SELECT waves_agent_client_id() AS id`);
+      return result.rows[0].id;
+    });
+    expect(found).toBeNull();
+  });
+});
+
+describe('the ceiling on a single expense', () => {
+  it('refuses an agent write past the per-expense cap', async () => {
+    await asRole(client, 'authenticated', asAgent(profileId), async () => {
+      // The seeded cap is 5,000,000 minor units.
+      await expect(
+        client.query(`SELECT waves_assert_agent_cap($1::bigint)`, ['5000001']),
+      ).rejects.toThrow(/AGENT_CAP_SINGLE/);
+    });
+  });
+
+  it('allows one exactly at the cap, because a limit is a limit', async () => {
+    await asRole(client, 'authenticated', asAgent(profileId), async () => {
+      await expect(
+        client.query(`SELECT waves_assert_agent_cap($1::bigint)`, ['5000000']),
+      ).resolves.toBeTruthy();
+    });
+  });
+
+  it('does not apply to the app, at any amount', async () => {
+    await asRole(client, 'authenticated', asApp(profileId), async () => {
+      await expect(
+        client.query(`SELECT waves_assert_agent_cap($1::bigint)`, ['999999999']),
+      ).resolves.toBeTruthy();
+    });
+  });
+});
+
+describe('the ceiling across a day', () => {
+  it('counts what this person’s agents have already written', async () => {
+    await asRole(client, 'authenticated', asAgent(profileId), async () => {
+      // Four writes of 4,000,000 = 16,000,000 against a 20,000,000 daily cap.
+      for (let index = 0; index < 4; index += 1) {
+        await client.query(
+          `SELECT waves_record_agent_write('expense.add', NULL, NULL, $1::bigint)`,
+          ['4000000'],
+        );
+      }
+
+      // 16,000,000 + 4,000,000 = 20,000,000 — exactly the cap, so allowed.
+      await expect(
+        client.query(`SELECT waves_assert_agent_cap($1::bigint)`, ['4000000']),
+      ).resolves.toBeTruthy();
+
+      // One unit more is the day's total exceeded, not this expense's size.
+      await expect(
+        client.query(`SELECT waves_assert_agent_cap($1::bigint)`, ['4000001']),
+      ).rejects.toThrow(/AGENT_CAP_DAILY/);
+    });
+  });
+
+  it('does not count the person’s own writes towards it', async () => {
+    await asRole(client, 'authenticated', asApp(profileId), async () => {
+      // The app writes nothing to the trail, so there is nothing to count.
+      for (let index = 0; index < 10; index += 1) {
+        await client.query(
+          `SELECT waves_record_agent_write('expense.add', NULL, NULL, $1::bigint)`,
+          ['9000000'],
+        );
+      }
+      const count = await client.query(
+        `SELECT count(*)::int AS n FROM agent_writes WHERE profile_id = $1`,
+        [profileId],
+      );
+      expect(count.rows[0].n).toBe(0);
+    });
+  });
+});
+
+describe('the record of what an agent did', () => {
+  it('stamps the client id from the token, not from the caller', async () => {
+    const row = await asRole(
+      client,
+      'authenticated',
+      asAgent(profileId, 'some-assistant'),
+      async () => {
+        const groupId = randomUUID();
+        await client.query(
+          `INSERT INTO groups (id, name, type, default_currency, created_by)
+         VALUES ($1, 'Goa', 'trip', 'INR', $2)`,
+          [groupId, profileId],
+        );
+        await client.query(
+          `SELECT waves_record_agent_write('expense.add', $1::uuid, NULL, $2::bigint, 'INR')`,
+          [groupId, '125000'],
+        );
+        const result = await client.query(
+          `SELECT client_id, action, amount_minor, currency FROM agent_writes WHERE profile_id = $1`,
+          [profileId],
+        );
+        return result.rows[0];
+      },
+    );
+
+    expect(row.client_id).toBe('some-assistant');
+    expect(row.action).toBe('expense.add');
+    expect(String(row.amount_minor)).toBe('125000');
+    expect(row.currency).toBe('INR');
+  });
+
+  it('is readable by the person it was made for', async () => {
+    const rows = await asRole(client, 'authenticated', asAgent(profileId), async () => {
+      await client.query(`SELECT waves_record_agent_write('settlement.record')`);
+      const result = await client.query(`SELECT * FROM waves_my_agent_writes(10)`);
+      return result.rows;
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].action).toBe('settlement.record');
+  });
+
+  it('is not readable by anybody else', async () => {
+    const other = randomUUID();
+    await client.query(
+      `INSERT INTO profiles (id, display_name, default_currency) VALUES ($1, 'Someone else', 'INR')`,
+      [other],
+    );
+    try {
+      const rows = await asRole(client, 'authenticated', asAgent(profileId), async () => {
+        await client.query(`SELECT waves_record_agent_write('expense.add')`);
+        // Same transaction, a different person asking.
+        await client.query(`SELECT set_config('request.jwt.claims', $1, true)`, [
+          JSON.stringify(asAgent(other)),
+        ]);
+        const result = await client.query(`SELECT * FROM agent_writes`);
+        return result.rows;
+      });
+      expect(rows).toHaveLength(0);
+    } finally {
+      await client.query(`DELETE FROM profiles WHERE id = $1`, [other]);
+    }
+  });
+
+  it('cannot be forged: there is no way to insert a row directly', async () => {
+    await asRole(client, 'authenticated', asAgent(profileId), async () => {
+      // The point is that an agent cannot write a trail claiming a different
+      // client, or quietly file no trail at all for what it just did.
+      await expect(
+        client.query(
+          `INSERT INTO agent_writes (profile_id, client_id, action) VALUES ($1, 'pretending', 'expense.add')`,
+          [profileId],
+        ),
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/supabase/functions/_shared/agent.ts
+++ b/supabase/functions/_shared/agent.ts
@@ -1,0 +1,80 @@
+/**
+ * The two things that are true of an AI agent's write and not of a person's.
+ *
+ * An agent acts through `apps/agent-mcp` holding a real user's token, so RLS
+ * and the RPC boundary already decide what it may touch — and they decide it
+ * correctly. What they do not decide is *how much* (a person mistypes an amount
+ * once and sees it; a model mistypes it and retries) or leave any trace that
+ * the write was not made by hand.
+ *
+ * Both hang off one fact: a token minted for a third-party client through
+ * Supabase's OAuth 2.1 server carries a `client_id` claim, and one minted for
+ * the app does not. The claim is read *in the database*, from the verified JWT
+ * — see `waves_agent_client_id`. Nothing here decides who the caller is, which
+ * is why nothing here can be tricked about it. Both calls go through the caller
+ * client, never the service one: with the service role there is no user token
+ * to read, so the ceiling would silently never apply.
+ *
+ * For the app itself both functions are no-ops, which is what lets this ship
+ * before the OAuth server is switched on.
+ */
+
+import { HttpError, type SupabaseClient } from './auth.ts';
+
+/**
+ * Refuse a write that is beyond what an assistant may do — too large on its
+ * own, or enough to take the day past its total.
+ *
+ * The database raises `AGENT_CAP_SINGLE` / `AGENT_CAP_DAILY`; both become a 403
+ * carrying that code, because a model reading "forbidden" learns nothing and a
+ * model reading the code can tell the person which limit it hit.
+ */
+export async function assertAgentCap(
+  caller: SupabaseClient,
+  amountMinor: bigint | null,
+): Promise<void> {
+  if (amountMinor === null) return;
+  const { error } = await caller.rpc('waves_assert_agent_cap', {
+    p_amount_minor: amountMinor.toString(),
+  });
+  if (!error) return;
+  const code = /\b(AGENT_CAP_[A-Z]+)\b/.exec(error.message)?.[1];
+  if (code) {
+    throw new HttpError(403, code, error.message.replace(/^[A-Z_]+:\s*/, ''));
+  }
+  throw new HttpError(500, 'AGENT_CAP_CHECK_FAILED', error.message);
+}
+
+/**
+ * Note that an agent did this, so the person can see it later and decide
+ * whether they want that client to keep acting for them.
+ *
+ * A failure here is swallowed on purpose. The write it describes has already
+ * happened; refusing the response because the note could not be filed would
+ * turn a bookkeeping problem into a caller that retries and writes it twice.
+ */
+export async function recordAgentWrite(
+  caller: SupabaseClient,
+  entry: {
+    action: string;
+    groupId?: string | null;
+    objectId?: string | null;
+    amountMinor?: bigint | null;
+    currency?: string | null;
+  },
+): Promise<void> {
+  try {
+    await caller.rpc('waves_record_agent_write', {
+      p_action: entry.action,
+      p_group_id: entry.groupId ?? null,
+      p_object_id: entry.objectId ?? null,
+      p_amount_minor:
+        entry.amountMinor === null || entry.amountMinor === undefined
+          ? null
+          : entry.amountMinor.toString(),
+      p_currency: entry.currency ?? null,
+    });
+  } catch {
+    // Deliberately silent — see above.
+  }
+}

--- a/supabase/functions/expense-write/index.ts
+++ b/supabase/functions/expense-write/index.ts
@@ -31,6 +31,7 @@ import {
   requireMembership,
 } from '../_shared/auth.ts';
 import { enforceRateLimit } from '../_shared/rateLimit.ts';
+import { assertAgentCap, recordAgentWrite } from '../_shared/agent.ts';
 
 interface ExpenseWriteRequest {
   groupId: string;
@@ -113,6 +114,13 @@ serveWithCors(async (request) => {
 
     const amount = parseMinor(body.amount, 'amount');
     if (amount < 0n) throw new HttpError(400, 'INVALID_AMOUNT', 'Amount cannot be negative');
+
+    // Before anything is written, and only for an agent: the app's own writes
+    // do not reach a ceiling here. After the replay check above, so retrying a
+    // mutation that already landed is still free — an agent retries on a
+    // timeout, and refusing the retry would leave it believing the expense was
+    // never written.
+    await assertAgentCap(caller, amount);
 
     const payers = Object.entries(body.payers ?? {}).map(
       ([id, value]) => [id, parseMinor(value, 'payer amount')] as const,
@@ -212,6 +220,15 @@ serveWithCors(async (request) => {
       versionNo: number;
       replayed: boolean;
     };
+
+    // The ledger has it; note who really asked for it. A no-op for the app.
+    await recordAgentWrite(caller, {
+      action: body.expenseId ? 'expense.edit' : 'expense.add',
+      groupId: body.groupId,
+      objectId: result.expenseId,
+      amountMinor: amount,
+      currency: body.currency,
+    });
 
     return json({
       ...result,


### PR DESCRIPTION
Items 5 and 6 of the pending list. RLS decides *whose* ledger an agent can touch and decides it well — the MCP server holds a real person's token, so it sees exactly what they see. It does not answer either of the two questions an agent raises that a person tapping buttons does not.

**How much.** Somebody mistypes an amount once and sees it on screen. A model mistypes it and retries, and this is a shared record of what other people owe. There was no ceiling anywhere: not in the MCP server, not in the edge function, not in an RPC.

**Who did it.** Every agent write was indistinguishable from a manual one. No way to ask what was done in your name while you weren't looking, and no way to decide you'd rather it hadn't been.

## The one fact both hang off

A token minted for a third-party client through [Supabase's OAuth 2.1 server](https://supabase.com/docs/guides/auth/oauth-server) carries a `client_id` claim; the app's own token does not. `waves_agent_client_id()` reads it from the request's verified claims — never passed in as an argument, which would make it a claim by the caller about the caller.

Not `auth.jwt()`: those claims are set by PostgREST, so reading them directly also works on the CI stub `auth` schema and on the self-host stack, which has no GoTrue schema at all.

## What landed

- **`agent_writes`** — what an assistant did, readable by the person it was done for and nobody else. **No INSERT policy at all**: rows come only from a definer function, so an agent cannot file a trail naming a different client, or quietly file none for what it just did.
- **`waves_assert_agent_cap`** — refuses a write beyond a per-expense ceiling, or one that takes the last 24 hours past a daily total. Both are `app_config` knobs an admin can raise at runtime (the pattern the receipt cap established); both default closed if the row is missing, because a deleted knob must not read as "no limit".
- **`waves_my_agent_writes`** — the list somebody reads before deciding to revoke a client.
- **`expense-write`** asks before writing and records after — *after* the replay check, so an agent retrying a mutation that already landed is still free. An agent retries on timeout, and refusing the retry would leave it believing nothing was written.

Recording failures are swallowed on purpose: the write already happened, and failing the response over a bookkeeping problem produces a caller that retries and writes it twice.

**For the app, all of it is a no-op** — no claim, no ceiling, no row. That is what lets this land before the OAuth server is switched on and do nothing at all until it is.

## Tests

`packages/db/test/agent-writes.test.ts`, 11 tests, run against local Postgres: the claim is seen for an agent and absent for the app; the per-expense cap refuses one unit over and allows exactly at the limit; the daily cap counts prior agent writes and refuses the one that crosses; the app is unaffected at any amount and writes no rows; the client id is stamped from the token; the trail is readable by its owner, invisible to anyone else, and cannot be inserted into directly.

Also green: 157 edge-function tests, 35 definer-boundary and anon-surface tests, `check-definer-grants`, and `prisma migrate diff` reports no drift.

## Deploy

Migration is **not** applied to prod yet, and the edge function isn't redeployed. Both are inert until the OAuth server is on, so they can go out whenever — say the word.