### PR TITLE
feat(backup): ask Google for Drive the only way Android still allows

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,23 +400,42 @@ Three decisions worth knowing:
 
 Drive needs **its own OAuth clients**, which the app does not otherwise have:
 sign-in goes through Supabase's hosted Google flow and holds no Google client id
-of its own. In the Google Cloud console, on a project with the Drive API
-enabled: create an OAuth client per platform (Android bound to
-`app.waves.mobile` plus the signing SHA-1 — one for debug, one for release; iOS
-bound to the bundle id), add `.../auth/drive.appdata` to the consent screen, and
-set:
+of its own.
 
-| Variable                                     | Where              | What it does                   |
-| -------------------------------------------- | ------------------ | ------------------------------ |
-| `EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_ANDROID` | `apps/mobile/.env` | the Android OAuth client       |
-| `EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_IOS`     | `apps/mobile/.env` | the iOS OAuth client           |
-| `EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_WEB`     | `apps/mobile/.env` | the fallback for anything else |
+Consent is asked for by Play services, not by a browser tab. Google
+[withdrew custom URI schemes](https://developers.google.com/identity/protocols/oauth2/native-app)
+for Android clients — any app can claim a scheme and catch the redirect — so
+there is no `waves://` redirect left to register, and no Android client id to put
+in the bundle either: Android apps are identified by their package name and
+signing certificate. That is also why a debug-signed build and a release-signed
+build need one client each.
 
-These are not secrets — a native OAuth client has none, which is why the flow is
-PKCE — but they name a Google project, so they are read from the environment
-rather than committed. With none set the app builds and runs; the backup screen
-says the destination is unavailable in this build rather than opening a consent
-page Google would reject.
+In the Google Cloud console, on a project with the Drive API enabled:
+
+1. Create an **Android** OAuth client per signing key, bound to
+   `app.waves.mobile` plus that key's SHA-1
+   (`keytool -list -v -keystore ~/.android/debug.keystore -storepass android`
+   for the debug one). Nothing references its id; registering it is the point.
+2. Create an **iOS** client bound to the bundle id, if you build for iOS.
+3. Add `.../auth/drive.appdata` to the consent screen.
+4. Set the two ids the SDK does need:
+
+| Variable                                 | Where              | What it does                               |
+| ---------------------------------------- | ------------------ | ------------------------------------------ |
+| `EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_WEB` | `apps/mobile/.env` | names the Cloud project — required on both |
+| `EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_IOS` | `apps/mobile/.env` | the iOS client, and its URL scheme         |
+
+These are not secrets — none of these flows has a client secret, which is the
+whole reason they are usable on a phone — but they name a Google project, so
+they are read from the environment rather than committed. Both are read at
+**build** time, so changing one means rebuilding the app, not restarting it.
+With neither set the app builds and runs; the backup screen says the destination
+is unavailable in this build rather than opening a consent page Google would
+reject.
+
+Play services keeps the grant and issues an access token about an hour long,
+so there is no refresh token on the phone: a renewal asks it again, silently,
+for as long as the person leaves the access granted in their Google account.
 
 A `drive.appdata` app stays in testing until the consent screen is verified;
 until then only accounts added as test users can link one.

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -68,6 +68,30 @@ function googleMapsKey(platform: 'android' | 'ios'): string | undefined {
   return perPlatform || process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY || undefined;
 }
 
+/**
+ * The Drive-backup sign-in plugin, for iOS builds that have a client id.
+ *
+ * Android needs nothing here: the native module autolinks, and Google matches
+ * the app by package name and signing certificate rather than by anything
+ * written into the binary. iOS is matched by bundle id instead, and its SDK
+ * takes the consent result back through a URL scheme derived from the client
+ * id — `123-abc.apps.googleusercontent.com` becomes
+ * `com.googleusercontent.apps.123-abc` — which has to be in the Info.plist
+ * before the app is built.
+ *
+ * The plugin is added only when that id is set, because its own validation
+ * throws without one, and an unconfigured clone must still be able to prebuild.
+ */
+function googleSignInPlugin(): [string, { iosUrlScheme: string }] | undefined {
+  const iosClientId = process.env.EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_IOS;
+  if (!iosClientId) return undefined;
+  const bare = iosClientId.replace(/\.apps\.googleusercontent\.com$/, '');
+  return [
+    '@react-native-google-signin/google-signin',
+    { iosUrlScheme: `com.googleusercontent.apps.${bare}` },
+  ];
+}
+
 export default (): ExpoConfig => {
   const config = appJson.expo as ExpoConfig;
 
@@ -90,14 +114,19 @@ export default (): ExpoConfig => {
       : config.ios,
   };
 
+  const drive = googleSignInPlugin();
+  const withDrive: ExpoConfig = drive
+    ? { ...withPush, plugins: [...(withPush.plugins ?? []), drive] }
+    : withPush;
+
   const organization = process.env.SENTRY_ORG;
   const project = process.env.SENTRY_PROJECT;
-  if (!organization || !project) return withPush;
+  if (!organization || !project) return withDrive;
 
   return {
-    ...withPush,
+    ...withDrive,
     plugins: [
-      ...(withPush.plugins ?? []),
+      ...(withDrive.plugins ?? []),
       [
         '@sentry/react-native/expo',
         { organization, project, url: process.env.SENTRY_URL ?? 'https://sentry.io/' },

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -13,6 +13,7 @@
     "@noble/ciphers": "^2.3.0",
     "@react-native-async-storage/async-storage": "3.1.1",
     "@react-native-community/datetimepicker": "9.1.0",
+    "@react-native-google-signin/google-signin": "^16.1.5",
     "@react-native-ml-kit/text-recognition": "^2.0.0",
     "@sentry/react-native": "~8.22.0",
     "@shopify/flash-list": "2.3.2",

--- a/apps/mobile/src/app/+native-intent.ts
+++ b/apps/mobile/src/app/+native-intent.ts
@@ -31,15 +31,15 @@ export function redirectSystemPath({ path }: { path: string; initial: boolean })
     if (url.hostname === 'auth' || firstSegment === 'auth') {
       return '/';
     }
-    // The Drive-backup consent redirects to `waves://oauthredirect`, and the
-    // same double delivery happens: `promptAsync` has already taken the code
-    // and swapped it, so the intent carries nothing left to do — but there is
-    // no `/oauthredirect` screen either, and letting the router match it lands
-    // on "Unmatched Route" the moment somebody links their Drive. Unlike
-    // sign-in, sending this one to the root would be wrong: the person is
-    // standing on the backup screen and expects to still be there, so it goes
-    // back to the screen that started the flow. A `navigate` to a route already
-    // in the stack returns to it rather than pushing a second copy.
+    // Drive-backup consent used to redirect to `waves://oauthredirect`. It no
+    // longer does — Google withdrew custom URI schemes for Android clients, so
+    // that consent is now asked for by Play services with no redirect at all
+    // (see `lib/cloud/nativeGoogle.ts`). The guard stays because the link can
+    // still arrive: a phone carrying an older build's pending intent, or
+    // anything else that has the scheme. Letting the router match it lands on
+    // "Unmatched Route", so it goes to the screen the flow belonged to rather
+    // than to the root. A `navigate` to a route already in the stack returns to
+    // it rather than pushing a second copy.
     if (url.hostname === 'oauthredirect' || firstSegment === 'oauthredirect') {
       return '/settings/backup';
     }

--- a/apps/mobile/src/lib/cloud/config.ts
+++ b/apps/mobile/src/lib/cloud/config.ts
@@ -1,20 +1,25 @@
 /**
- * Which OAuth client this build presents, and whether it has one at all.
+ * Which Google Cloud project this build's Drive backup belongs to.
  *
  * Drive needs its own client ids — the app's *login* goes through Supabase's
  * hosted Google flow and never holds a Google client id of its own, so nothing
- * here is shared with sign-in. Google binds a native OAuth client to a platform
- * identity: Android to the package name plus the signing SHA-1, iOS to the
- * bundle id. One id therefore cannot serve both, and the release and debug
- * Android builds need separate ones because they are signed with different
- * keys.
+ * here is shared with sign-in.
  *
- * The ids are not secret — a native OAuth client has no secret, which is why
- * this app uses PKCE — but they name a Google Cloud project that belongs to
- * whoever is building, so they are read from the environment rather than
- * committed. `EXPO_PUBLIC_*` is inlined by Metro at build time, which is why
- * each one is spelled out statically below: a computed `process.env[key]` is
- * not substituted and would read as undefined in a release bundle.
+ * There are two ids, and neither of them is an Android one. That is not an
+ * omission: Google identifies an Android app by its package name and signing
+ * certificate, checked by Play services against a client registered for that
+ * pair, so there is nothing for the bundle to carry. What the SDK does need is
+ *
+ *   * a **web** client id, which names the Cloud project the consent belongs to
+ *     — no browser is involved and no server is called, it is an identifier;
+ *   * an **iOS** client id, because Apple builds are matched by bundle id.
+ *
+ * Neither is secret — these flows have no client secret, which is the whole
+ * point of them on a phone — but they name a project belonging to whoever is
+ * building, so they are read from the environment rather than committed.
+ * `EXPO_PUBLIC_*` is inlined by Metro at build time, which is why each one is
+ * spelled out statically below: a computed `process.env[key]` is not
+ * substituted and would read as undefined in a release bundle.
  *
  * With none set the app builds and runs; the backup screen says the destination
  * is unavailable in this build instead of opening a consent page that would be
@@ -25,25 +30,40 @@ import { Platform } from 'react-native';
 
 import type { CloudProviderId } from './types';
 
-/** The Drive OAuth client for the platform this build is running on. */
-function googleDriveClientId(): string | undefined {
-  const id = Platform.select({
-    android: process.env.EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_ANDROID,
-    ios: process.env.EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_IOS,
-    default: process.env.EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_WEB,
-  });
+/** The Cloud project's web client id. Required on every platform. */
+export function webClientId(): string {
+  const id = process.env.EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_WEB;
+  if (!id) throw new Error('no Google web client id configured for Drive');
+  return id;
+}
+
+/** The iOS client id, for the one platform that is matched by bundle id. */
+function iosClientId(): string | undefined {
+  const id = process.env.EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_IOS;
   return id && id.length > 0 ? id : undefined;
 }
 
 export function clientId(provider: CloudProviderId): string {
-  const id = provider === 'gdrive' ? googleDriveClientId() : undefined;
+  const id = provider === 'gdrive' ? iosClientId() : undefined;
   // Callers gate on `isConfigured` first; reaching here without an id is a
   // programming error, not a user-facing state, so it throws rather than
-  // sending an empty `client_id` to a consent page.
-  if (!id) throw new Error(`no OAuth client id configured for ${provider}`);
+  // handing the SDK an empty string.
+  if (!id) throw new Error(`no iOS OAuth client id configured for ${provider}`);
   return id;
 }
 
+/**
+ * True when this build names a project Drive consent can be asked for.
+ *
+ * Android needs only the web client id, because the app itself is identified by
+ * its signature. iOS needs both. The web platform has neither flow — Google's
+ * browser clients require a secret, and a secret in a page is not a secret —
+ * so Drive backup is simply not offered there.
+ */
 export function isConfigured(provider: CloudProviderId): boolean {
-  return provider === 'gdrive' && googleDriveClientId() !== undefined;
+  if (provider !== 'gdrive') return false;
+  const web = process.env.EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_WEB;
+  if (!web || web.length === 0) return false;
+  if (Platform.OS === 'web') return false;
+  return Platform.OS === 'ios' ? iosClientId() !== undefined : true;
 }

--- a/apps/mobile/src/lib/cloud/googleDrive.ts
+++ b/apps/mobile/src/lib/cloud/googleDrive.ts
@@ -20,33 +20,24 @@
  * accumulates and a restore never has to choose between candidates.
  */
 
-import { asAuthFailure, authorize, isExpired, refresh, type OAuthConfig } from './oauth';
-import { requestJson, requestRaw, requestText } from './http';
-import { clientId, isConfigured as clientConfigured } from './config';
+import { isExpired } from './oauth';
+import { CloudHttpError, requestJson, requestRaw, requestText } from './http';
+import { isConfigured as clientConfigured } from './config';
+import {
+  nativeAuthAvailable,
+  nativeAuthorize,
+  nativeReauthorize,
+  nativeRevoke,
+} from './nativeGoogle';
 import type { CloudFile, CloudProvider, CloudTokens } from './types';
 
-const DISCOVERY = {
-  authorizationEndpoint: 'https://accounts.google.com/o/oauth2/v2/auth',
-  tokenEndpoint: 'https://oauth2.googleapis.com/token',
-  revocationEndpoint: 'https://oauth2.googleapis.com/revoke',
-};
+/** Where a grant is handed back when somebody unlinks. */
+const REVOCATION_ENDPOINT = 'https://oauth2.googleapis.com/revoke';
 
 /** The hidden per-app folder. Not an id we look up — Drive accepts the alias. */
 const APP_DATA = 'appDataFolder';
 /** The fields worth asking for; Drive returns only what it is asked for. */
 const FILE_FIELDS = 'id,name,size,modifiedTime';
-
-function config(): OAuthConfig {
-  return {
-    clientId: clientId('gdrive'),
-    scopes: ['https://www.googleapis.com/auth/drive.appdata'],
-    discovery: DISCOVERY,
-    // `offline` plus a forced consent is what makes Google hand back a refresh
-    // token; without it an automatic backup would stop working an hour after
-    // the person connected, and they would find out weeks later.
-    extraParams: { access_type: 'offline', prompt: 'consent' },
-  };
-}
 
 function authHeader(tokens: CloudTokens): Record<string, string> {
   return { Authorization: `Bearer ${tokens.accessToken}` };
@@ -67,27 +58,32 @@ function toFile(raw: Record<string, unknown>): CloudFile {
 export const googleDrive: CloudProvider = {
   id: 'gdrive',
   label: 'Google Drive',
-  isConfigured: () => clientConfigured('gdrive'),
-  connect: () => authorize(config()),
+  // Both halves have to hold: a project to ask consent for, and a build that
+  // carries the module able to ask.
+  isConfigured: () => clientConfigured('gdrive') && nativeAuthAvailable(),
+  connect: () => nativeAuthorize(),
 
   /**
-   * Fresh tokens, refreshing first when the access token is stale.
+   * A token good to use now, asked for again when the one held is stale.
    *
-   * A refresh Google rejects because the grant is gone — revoked in the user's
-   * account settings, consent withdrawn, the app removed — is turned into the
-   * same 401 a Drive API call would produce, so the one caller-side predicate
-   * (`isAuthFailure`) recognises it. Everything else is left as it is: a token
-   * endpoint that timed out is a transport failure, and treating it as a dead
-   * link would sign the person out of their own backup over a bad minute of
-   * signal.
+   * There is no refresh token to present — Play services keeps the grant — so
+   * "refreshing" is asking for the scopes a second time. That is silent while
+   * the consent stands, and it is exactly what stops standing when somebody
+   * revokes access in their Google account settings: Google then has a decision
+   * to put to them, which cannot be done from a background backup, and the
+   * request comes back with nothing.
+   *
+   * Nothing is the same dead grant a rejected refresh used to be, so it becomes
+   * the same 401 a Drive call would produce and the one caller-side predicate
+   * (`isAuthFailure`) recognises it. Anything else thrown here is a transport
+   * failure and is left alone: treating a bad minute of signal as a dead link
+   * would unlink somebody from their own backup.
    */
   async ensureValid(tokens: CloudTokens): Promise<CloudTokens> {
     if (!isExpired(tokens)) return tokens;
-    try {
-      return await refresh(config(), tokens);
-    } catch (error) {
-      throw asAuthFailure(error) ?? error;
-    }
+    const renewed = await nativeReauthorize(tokens);
+    if (!renewed) throw new CloudHttpError(401, 'the Drive authorization is no longer granted');
+    return renewed;
   },
 
   /**
@@ -186,14 +182,20 @@ export const googleDrive: CloudProvider = {
 
   /**
    * Hand the grant back when somebody unlinks, so "disconnect" means it in
-   * Google's account settings too and not only in this app's keystore. The
-   * refresh token is the one worth revoking — revoking it kills the access
-   * token with it.
+   * Google's account settings too and not only in this app's keystore.
+   *
+   * Two things have to happen, and the local one is not optional: revoking at
+   * Google kills the grant, but Play services would keep handing out the token
+   * it has already cached until that token expires on its own.
    */
   async revoke(tokens: CloudTokens): Promise<void> {
+    // Play services can do this properly — it drops its cached token and tells
+    // Google in one go. The HTTP call below is the fallback for a build that
+    // somehow has tokens without the module that made them.
+    if (await nativeRevoke(tokens)) return;
     const token = tokens.refreshToken ?? tokens.accessToken;
     if (!token) return;
-    await fetch(DISCOVERY.revocationEndpoint, {
+    await fetch(REVOCATION_ENDPOINT, {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: `token=${encodeURIComponent(token)}`,

--- a/apps/mobile/src/lib/cloud/googleDrive.ts
+++ b/apps/mobile/src/lib/cloud/googleDrive.ts
@@ -191,8 +191,14 @@ export const googleDrive: CloudProvider = {
   async revoke(tokens: CloudTokens): Promise<void> {
     // Play services can do this properly — it drops its cached token and tells
     // Google in one go. The HTTP call below is the fallback for a build that
-    // somehow has tokens without the module that made them.
-    if (await nativeRevoke(tokens)) return;
+    // somehow has tokens without the module that made them, or for a partial
+    // native failure while unlinking: disconnect is best-effort, but if one path
+    // to Google failed and another remains, take it.
+    try {
+      if (await nativeRevoke(tokens)) return;
+    } catch {
+      // Fall through to HTTP revoke below.
+    }
     const token = tokens.refreshToken ?? tokens.accessToken;
     if (!token) return;
     await fetch(REVOCATION_ENDPOINT, {

--- a/apps/mobile/src/lib/cloud/nativeGoogle.ts
+++ b/apps/mobile/src/lib/cloud/nativeGoogle.ts
@@ -1,0 +1,225 @@
+/**
+ * Google authorization the only way Android still allows it.
+ *
+ * The browser flow this file replaces asked Google for a code and had it
+ * redirected back to `waves://oauthredirect`. Google has since withdrawn that
+ * mechanism outright — "custom URI schemes are no longer supported on Android
+ * and Chrome apps", because any other app can claim the same scheme and catch
+ * the redirect. There is no client id that makes it work again; the consent
+ * page is refused before the person ever sees it.
+ *
+ * What replaces it is Google's own sheet, presented by Play services. There is
+ * no redirect at all, so there is nothing for another app to intercept: the
+ * token is handed to *this* app because the OS knows which app asked, matching
+ * the package name and the signing certificate against an OAuth client
+ * registered for exactly that pair. That check is why no Android client id is
+ * written down anywhere in this repo — the identity is the signature, not a
+ * string in the bundle — and why a debug-signed build and a release-signed
+ * build need separate clients registered.
+ *
+ * What is lost: a refresh token of our own. Play services keeps the grant and
+ * hands out an access token good for about an hour, so renewing one is asking
+ * it again rather than presenting a refresh token. That ask is silent while the
+ * consent stands, which is what lets a backup run without interrupting anybody
+ * — and what stops working the moment somebody revokes access in their Google
+ * account, which is exactly the behaviour that setting is supposed to have.
+ */
+
+import { Platform } from 'react-native';
+
+import { clientId, webClientId } from './config';
+import type { CloudTokens } from './types';
+
+type SigninModule = typeof import('@react-native-google-signin/google-signin');
+
+/**
+ * The native module, or null on a build that does not carry it.
+ *
+ * Required lazily behind a catch, like every other native module here: a JS
+ * bundle can reach a binary older than the dependency (an OTA update onto a
+ * previous native build is the ordinary way this happens), and a bare import
+ * would take the whole app down at launch rather than disabling one row in
+ * settings.
+ */
+let cached: SigninModule | null | undefined;
+
+function load(): SigninModule | null {
+  if (cached !== undefined) return cached;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    cached = require('@react-native-google-signin/google-signin') as SigninModule;
+  } catch {
+    cached = null;
+  }
+  return cached;
+}
+
+/** True when this build can present Google's sheet at all. */
+export function nativeAuthAvailable(): boolean {
+  return Platform.OS !== 'web' && load() !== null;
+}
+
+/**
+ * Stand a fake SDK in, for tests.
+ *
+ * The real one is reached through `require` so that a bundle running on an
+ * older binary degrades instead of crashing — and `require` is exactly what a
+ * test runner cannot satisfy, so without this seam every path below would be
+ * untestable except the one where the module is missing.
+ */
+export function setSigninModuleForTests(module: SigninModule | null): void {
+  cached = module;
+  configured = false;
+}
+
+/**
+ * Google's access tokens last an hour and the SDK does not say when this one
+ * was minted. Five minutes are given back so a token cannot expire between the
+ * check and the upload that follows it.
+ */
+const ACCESS_TOKEN_TTL_MS = 55 * 60_000;
+
+/** The one scope this app ever asks Google for. */
+const SCOPES = ['https://www.googleapis.com/auth/drive.appdata'];
+
+let configured = false;
+
+/**
+ * Hand the SDK its client ids and the scope, once.
+ *
+ * `webClientId` is required even though no browser is involved and no server of
+ * ours is called: it names the Google Cloud project the consent belongs to. The
+ * iOS client id is separate because Apple builds are matched by bundle id
+ * rather than by signature.
+ *
+ * `offlineAccess` stays off deliberately. Turning it on returns a code meant to
+ * be exchanged for a refresh token *by a server holding the client secret*;
+ * this app has no such server, and a refresh token on the phone would outlive
+ * the grant the person thinks they gave.
+ */
+function configure(module: SigninModule): void {
+  if (configured) return;
+  module.GoogleSignin.configure({
+    webClientId: webClientId(),
+    scopes: SCOPES,
+    offlineAccess: false,
+    ...(Platform.OS === 'ios' ? { iosClientId: clientId('gdrive') } : {}),
+  });
+  configured = true;
+}
+
+/** The module, configured — or a thrown failure the caller turns into a sentence. */
+function ready(): SigninModule {
+  const module = load();
+  if (!module) throw new Error('the Google authorization module is missing from this build');
+  configure(module);
+  return module;
+}
+
+function tokensFrom(accessToken: string): CloudTokens {
+  return {
+    accessToken,
+    // Play services holds the grant; there is no refresh token to keep, and
+    // pretending otherwise would have `isExpired` wait for a refresh that could
+    // never happen.
+    refreshToken: null,
+    expiresAt: Date.now() + ACCESS_TOKEN_TTL_MS,
+  };
+}
+
+/**
+ * Ask for the scope, presenting Google's sheet.
+ *
+ * Resolves to null when the person dismissed it — a decision, not a failure,
+ * and the screen must not report an error they made on purpose.
+ */
+export async function nativeAuthorize(): Promise<CloudTokens | null> {
+  const module = ready();
+  try {
+    // Play services can be absent (an emulator built without Google APIs) or
+    // too old. Checking first turns that into one clear failure rather than an
+    // opaque one from inside the sheet.
+    await module.GoogleSignin.hasPlayServices({ showPlayServicesUpdateDialog: true });
+    const response = await module.GoogleSignin.signIn();
+    if (!module.isSuccessResponse(response)) return null;
+    // `signIn` reports who they are; the token to call Drive with is a separate
+    // question, and this is the call that answers it.
+    const tokens = await module.GoogleSignin.getTokens();
+    return tokensFrom(tokens.accessToken);
+  } catch (error) {
+    if (isCancellation(module, error)) return null;
+    throw error;
+  }
+}
+
+/**
+ * A token good to use now, for a grant that already stands.
+ *
+ * No sheet: `getTokens` renews silently while the consent holds. The old token
+ * is dropped from Play services' cache first, because without that Android
+ * happily hands back the same expired string and the next Drive call fails with
+ * the 401 this was meant to avoid.
+ *
+ * Null means the grant is gone — revoked in their Google account, or the
+ * account removed from the phone — and the caller turns that into the same
+ * "link it again" the screen already knows how to say.
+ */
+export async function nativeReauthorize(previous: CloudTokens): Promise<CloudTokens | null> {
+  const module = ready();
+  await forget(module, previous.accessToken);
+  try {
+    const restored = await module.GoogleSignin.signInSilently();
+    // Not `isSuccessResponse`: a silent attempt answers with its own
+    // "nobody is signed in" case, which that guard does not accept.
+    if (restored.type !== 'success') return null;
+    const tokens = await module.GoogleSignin.getTokens();
+    return tokensFrom(tokens.accessToken);
+  } catch (error) {
+    // Sign-in required, cancelled, anything the SDK raises when it cannot do
+    // this without asking: the grant is not usable now, and asking belongs to
+    // the person tapping Connect rather than to a backup running behind them.
+    if (isGone(module, error)) return null;
+    throw error;
+  }
+}
+
+/** Drop a token from Play services' cache. Best effort: a failure changes nothing. */
+async function forget(module: SigninModule, accessToken: string): Promise<void> {
+  if (Platform.OS !== 'android' || !accessToken) return;
+  await module.GoogleSignin.clearCachedAccessToken(accessToken).catch(() => undefined);
+}
+
+/**
+ * Give the grant back on unlink, so "disconnect" means it in Google's account
+ * settings and not only in this app's keystore.
+ *
+ * Returns false when this build cannot do it, so the caller can fall back to
+ * revoking over HTTP rather than quietly leaving the grant standing.
+ */
+export async function nativeRevoke(tokens: CloudTokens): Promise<boolean> {
+  const module = load();
+  if (!module) return false;
+  await forget(module, tokens.accessToken);
+  await module.GoogleSignin.revokeAccess();
+  await module.GoogleSignin.signOut().catch(() => undefined);
+  return true;
+}
+
+/**
+ * Whether a rejection means "they closed it", which every caller treats as a
+ * cancel rather than an error. The code is read through the library's own type
+ * guard, because a rejection is not guaranteed to be an object at all.
+ */
+function isCancellation(module: SigninModule, error: unknown): boolean {
+  if (!module.isErrorWithCode(error)) return false;
+  return error.code === module.statusCodes.SIGN_IN_CANCELLED;
+}
+
+/** Whether a silent renewal failed because there is nothing to renew. */
+function isGone(module: SigninModule, error: unknown): boolean {
+  if (!module.isErrorWithCode(error)) return false;
+  return (
+    error.code === module.statusCodes.SIGN_IN_REQUIRED ||
+    error.code === module.statusCodes.SIGN_IN_CANCELLED
+  );
+}

--- a/apps/mobile/src/lib/cloud/oauth.ts
+++ b/apps/mobile/src/lib/cloud/oauth.ts
@@ -1,113 +1,22 @@
 /**
- * The OAuth dance every personal-cloud provider shares.
+ * What is left of the OAuth dance once the dance itself moved.
  *
- * Authorization code + PKCE, the only flow that is honest on a phone: there is
- * nowhere safe to keep a client secret in a binary somebody can unzip, so the
- * proof is a verifier the app generates per attempt and never sends until the
- * code comes back. Each provider supplies its endpoints, its scopes and the
- * couple of extra query params it wants; the flow itself lives here once.
+ * This file used to run authorization-code-plus-PKCE in a browser tab and take
+ * the redirect back on the app's own `waves://oauthredirect` scheme. Google
+ * withdrew that mechanism on Android — a custom scheme can be claimed by any
+ * app on the phone, so the redirect was never really addressed to us — and the
+ * flow now goes through Play services instead (see `nativeGoogle.ts`), which
+ * has no redirect to intercept at all.
  *
- * The redirect comes back to the app's own `waves://` scheme — the same
- * mechanism the Supabase sign-in already uses, on its own `oauthredirect` path
- * so the two are never confused. `+native-intent.ts` explains what happens to
- * the copy of that link the OS *also* delivers as an app intent.
+ * What survives is the two judgements that flow needed and the new one still
+ * does: whether a token is too old to use, and whether a failure means the
+ * grant is gone or merely that the network is. Both are decisions about tokens
+ * rather than about how they were obtained, which is why they outlived the
+ * transport.
  */
-
-import {
-  AuthRequest,
-  exchangeCodeAsync,
-  makeRedirectUri,
-  refreshAsync,
-  type AuthDiscoveryDocument,
-  type TokenResponse,
-} from 'expo-auth-session';
-import * as WebBrowser from 'expo-web-browser';
 
 import { CloudHttpError } from './http';
 import type { CloudTokens } from './types';
-
-// Lets the auth popup hand its result back and close itself when the app is
-// re-focused after the redirect. A no-op on native, required on web.
-WebBrowser.maybeCompleteAuthSession();
-
-/** The endpoints for one provider. `revocationEndpoint` is optional. */
-export interface OAuthEndpoints extends AuthDiscoveryDocument {
-  readonly authorizationEndpoint: string;
-  readonly tokenEndpoint: string;
-}
-
-export interface OAuthConfig {
-  readonly clientId: string;
-  readonly scopes: readonly string[];
-  readonly discovery: OAuthEndpoints;
-  /** Provider-specific query params, e.g. Google's `access_type=offline`. */
-  readonly extraParams?: Record<string, string>;
-}
-
-/** The one path every provider redirects to — distinct from `auth` sign-in. */
-export function redirectUri(): string {
-  return makeRedirectUri({ scheme: 'waves', path: 'oauthredirect' });
-}
-
-function toTokens(response: TokenResponse, previousRefresh?: string | null): CloudTokens {
-  return {
-    accessToken: response.accessToken,
-    // A refresh returns a new refresh token only sometimes; keep the old one
-    // when it doesn't, or the next refresh has nothing to present.
-    refreshToken: response.refreshToken ?? previousRefresh ?? null,
-    expiresAt: response.expiresIn ? Date.now() + response.expiresIn * 1000 : null,
-  };
-}
-
-/**
- * Run the interactive flow. Resolves to tokens, or null if the person closed
- * the browser without granting — a cancel, not an error, and the caller must
- * treat it as one rather than showing a failure they caused on purpose.
- */
-export async function authorize(config: OAuthConfig): Promise<CloudTokens | null> {
-  const request = new AuthRequest({
-    clientId: config.clientId,
-    scopes: [...config.scopes],
-    redirectUri: redirectUri(),
-    usePKCE: true,
-    extraParams: config.extraParams,
-  });
-
-  const result = await request.promptAsync(config.discovery);
-  if (result.type !== 'success' || !result.params.code) return null;
-
-  const token = await exchangeCodeAsync(
-    {
-      clientId: config.clientId,
-      code: result.params.code,
-      redirectUri: redirectUri(),
-      // PKCE proof: the verifier behind the challenge sent in the auth request.
-      extraParams: { code_verifier: request.codeVerifier ?? '' },
-    },
-    config.discovery,
-  );
-
-  return toTokens(token);
-}
-
-/**
- * Trade a refresh token for a fresh access token. Returns the input unchanged
- * when there is no refresh token to use — the caller then re-authorises.
- */
-export async function refresh(config: OAuthConfig, tokens: CloudTokens): Promise<CloudTokens> {
-  if (!tokens.refreshToken) return tokens;
-  const token = await refreshAsync(
-    {
-      clientId: config.clientId,
-      refreshToken: tokens.refreshToken,
-      // `prompt=consent` belongs to the interactive leg only; sending it on a
-      // refresh is meaningless at best and rejected at worst.
-      extraParams: undefined,
-    },
-    config.discovery,
-  );
-  return toTokens(token, tokens.refreshToken);
-}
 
 /**
  * The OAuth error codes that mean the grant is gone and only a new consent will
@@ -129,10 +38,10 @@ const DEAD_GRANT_CODES = new Set([
  * produces, or null when the failure was not about the grant.
  *
  * The point is that one predicate — `isAuthFailure` — covers both halves of the
- * provider. Without this, a refresh rejected because the user revoked access in
- * their Google account settings throws a `TokenError` that nothing recognises,
- * and the caller ends up reporting "nothing is linked" while the dead tokens sit
- * on disk. The screen then offers the wrong remedy for the rest of time.
+ * provider. Without this, a refusal because the user revoked access in their
+ * Google account settings throws an error that nothing recognises, and the
+ * caller ends up reporting "nothing is linked" while the dead tokens sit on
+ * disk. The screen then offers the wrong remedy for the rest of time.
  */
 export function asAuthFailure(error: unknown): CloudHttpError | null {
   // A rejection is not guaranteed to be an object at all, and a thrown

--- a/apps/mobile/test/driveNativeAuth.test.ts
+++ b/apps/mobile/test/driveNativeAuth.test.ts
@@ -19,8 +19,15 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const platform = { OS: 'android' };
+
 vi.mock('react-native', () => ({
-  Platform: { OS: 'android', select: (o: Record<string, unknown>) => o.android ?? o.default },
+  Platform: {
+    get OS() {
+      return platform.OS;
+    },
+    select: (o: Record<string, unknown>) => o[platform.OS] ?? o.default,
+  },
 }));
 
 const { googleDrive } = await import('../src/lib/cloud/googleDrive');
@@ -36,10 +43,17 @@ interface FakeState {
   signIn: 'success' | 'cancelled' | 'throws-cancelled';
   /** What a silent renewal finds. */
   silent: 'success' | 'nobody' | 'required';
+  /** Whether native revoke completes or throws after a partial Play-services failure. */
+  revoke: 'success' | 'throws';
   accessToken: string;
 }
 
-const state: FakeState = { signIn: 'success', silent: 'success', accessToken: 'token-1' };
+const state: FakeState = {
+  signIn: 'success',
+  silent: 'success',
+  revoke: 'success',
+  accessToken: 'token-1',
+};
 const calls = {
   signIn: vi.fn(),
   signInSilently: vi.fn(),
@@ -47,6 +61,7 @@ const calls = {
   cleared: vi.fn(),
   revoked: vi.fn(),
   configured: vi.fn(),
+  fetch: vi.fn(),
 };
 
 function cancelled(code: string): Error & { code: string } {
@@ -81,6 +96,7 @@ function fakeModule() {
       },
       async revokeAccess() {
         calls.revoked();
+        if (state.revoke === 'throws') throw new Error('native revoke failed');
         return null;
       },
       async signOut() {
@@ -96,9 +112,13 @@ function fakeModule() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  platform.OS = 'android';
   state.signIn = 'success';
   state.silent = 'success';
+  state.revoke = 'success';
   state.accessToken = 'token-1';
+  calls.fetch.mockResolvedValue({ ok: true, text: async () => '' });
+  vi.stubGlobal('fetch', calls.fetch);
   process.env.EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_WEB = '1234.apps.googleusercontent.com';
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   setSigninModuleForTests(fakeModule() as any);
@@ -185,6 +205,38 @@ describe('unlinking', () => {
     });
     expect(calls.revoked).toHaveBeenCalled();
     expect(calls.cleared).toHaveBeenCalledWith('token-1');
+    expect(calls.fetch).not.toHaveBeenCalled();
+  });
+
+  it('falls back to HTTP revoke when native revoke fails partway through', async () => {
+    state.revoke = 'throws';
+    await googleDrive.revoke?.({
+      accessToken: 'token-1',
+      refreshToken: null,
+      expiresAt: Date.now(),
+    });
+
+    expect(calls.revoked).toHaveBeenCalled();
+    expect(calls.fetch).toHaveBeenCalledWith('https://oauth2.googleapis.com/revoke', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: 'token=token-1',
+    });
+  });
+
+  it('falls back to HTTP revoke when tokens exist but the native module does not', async () => {
+    setSigninModuleForTests(null);
+    await googleDrive.revoke?.({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiresAt: Date.now(),
+    });
+
+    expect(calls.fetch).toHaveBeenCalledWith('https://oauth2.googleapis.com/revoke', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: 'token=refresh-token',
+    });
   });
 });
 
@@ -200,5 +252,30 @@ describe('whether the row is offered at all', () => {
     // The project is still named; the phone simply cannot ask.
     expect(isConfigured('gdrive')).toBe(true);
     expect(googleDrive.isConfigured()).toBe(false);
+  });
+
+  it('is not offered on web even when a project is named', () => {
+    platform.OS = 'web';
+    expect(isConfigured('gdrive')).toBe(false);
+    expect(googleDrive.isConfigured()).toBe(false);
+  });
+
+  it('requires the iOS client id on iOS builds', () => {
+    platform.OS = 'ios';
+    delete process.env.EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_IOS;
+    expect(isConfigured('gdrive')).toBe(false);
+    expect(googleDrive.isConfigured()).toBe(false);
+  });
+
+  it('configures the iOS client id only on iOS builds', async () => {
+    platform.OS = 'ios';
+    process.env.EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_IOS = 'ios-client.apps.googleusercontent.com';
+    expect(isConfigured('gdrive')).toBe(true);
+
+    await googleDrive.connect();
+
+    expect(calls.configured).toHaveBeenCalledWith(
+      expect.objectContaining({ iosClientId: 'ios-client.apps.googleusercontent.com' }),
+    );
   });
 });

--- a/apps/mobile/test/driveNativeAuth.test.ts
+++ b/apps/mobile/test/driveNativeAuth.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Drive authorization, now that Google's browser redirect is gone on Android.
+ *
+ * The flow this replaces could be reasoned about from the URL: a code came back
+ * to `waves://oauthredirect`, was exchanged for a refresh token, and the refresh
+ * token renewed itself for as long as the grant stood. None of that exists any
+ * more. Play services holds the grant, hands out an access token that lasts
+ * about an hour, and says nothing about when it was minted.
+ *
+ * So the properties worth pinning down are the ones that changed shape:
+ *
+ *   * a renewal is **silent** — a backup running in the background must never
+ *     put a sheet in front of somebody who did not ask for one;
+ *   * a grant that is gone reads as **401**, the same thing a Drive call would
+ *     say, because that is the one signal the engine acts on;
+ *   * a dismissed sheet is **not an error**, because they meant it;
+ *   * unlinking tells **Google**, not only this phone's keystore.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'android', select: (o: Record<string, unknown>) => o.android ?? o.default },
+}));
+
+const { googleDrive } = await import('../src/lib/cloud/googleDrive');
+const { setSigninModuleForTests } = await import('../src/lib/cloud/nativeGoogle');
+const { isConfigured } = await import('../src/lib/cloud/config');
+const { CloudHttpError } = await import('../src/lib/cloud/http');
+
+const SIGN_IN_CANCELLED = 'SIGN_IN_CANCELLED';
+const SIGN_IN_REQUIRED = 'SIGN_IN_REQUIRED';
+
+interface FakeState {
+  /** What the interactive sheet does. */
+  signIn: 'success' | 'cancelled' | 'throws-cancelled';
+  /** What a silent renewal finds. */
+  silent: 'success' | 'nobody' | 'required';
+  accessToken: string;
+}
+
+const state: FakeState = { signIn: 'success', silent: 'success', accessToken: 'token-1' };
+const calls = {
+  signIn: vi.fn(),
+  signInSilently: vi.fn(),
+  getTokens: vi.fn(),
+  cleared: vi.fn(),
+  revoked: vi.fn(),
+  configured: vi.fn(),
+};
+
+function cancelled(code: string): Error & { code: string } {
+  return Object.assign(new Error('cancelled'), { code });
+}
+
+/** Only the surface `nativeGoogle` actually touches. */
+function fakeModule() {
+  return {
+    GoogleSignin: {
+      configure: (params: unknown) => calls.configured(params),
+      hasPlayServices: async () => true,
+      async signIn() {
+        calls.signIn();
+        if (state.signIn === 'throws-cancelled') throw cancelled(SIGN_IN_CANCELLED);
+        if (state.signIn === 'cancelled') return { type: 'cancelled', data: null };
+        return { type: 'success', data: { user: { email: 'someone@example.com' } } };
+      },
+      async signInSilently() {
+        calls.signInSilently();
+        if (state.silent === 'required') throw cancelled(SIGN_IN_REQUIRED);
+        if (state.silent === 'nobody') return { type: 'noSavedCredentialFound', data: null };
+        return { type: 'success', data: { user: { email: 'someone@example.com' } } };
+      },
+      async getTokens() {
+        calls.getTokens();
+        return { idToken: 'id', accessToken: state.accessToken };
+      },
+      async clearCachedAccessToken(token: string) {
+        calls.cleared(token);
+        return null;
+      },
+      async revokeAccess() {
+        calls.revoked();
+        return null;
+      },
+      async signOut() {
+        return null;
+      },
+    },
+    isSuccessResponse: (response: { type: string }) => response.type === 'success',
+    isErrorWithCode: (error: unknown) =>
+      typeof error === 'object' && error !== null && 'code' in error,
+    statusCodes: { SIGN_IN_CANCELLED, SIGN_IN_REQUIRED },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.signIn = 'success';
+  state.silent = 'success';
+  state.accessToken = 'token-1';
+  process.env.EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_WEB = '1234.apps.googleusercontent.com';
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  setSigninModuleForTests(fakeModule() as any);
+});
+
+describe('asking for consent', () => {
+  it('hands back a token that expires, and no refresh token to renew it with', async () => {
+    const tokens = await googleDrive.connect();
+    expect(tokens?.accessToken).toBe('token-1');
+    // The absence matters: `isExpired` waits for a refresh when one exists, and
+    // there is nothing here that could ever perform it.
+    expect(tokens?.refreshToken).toBeNull();
+    expect(tokens?.expiresAt).toBeGreaterThan(Date.now());
+    // Under an hour, because Google's are an hour and this one is already older
+    // than the moment it was asked for.
+    expect(tokens?.expiresAt).toBeLessThanOrEqual(Date.now() + 60 * 60_000);
+  });
+
+  it('names the project it is asking on behalf of', async () => {
+    await googleDrive.connect();
+    expect(calls.configured).toHaveBeenCalledWith(
+      expect.objectContaining({
+        webClientId: '1234.apps.googleusercontent.com',
+        scopes: ['https://www.googleapis.com/auth/drive.appdata'],
+        // A code meant for a server holding a client secret. There is no such
+        // server, and asking for one would put a longer-lived grant on a phone.
+        offlineAccess: false,
+      }),
+    );
+  });
+
+  it('treats a dismissed sheet as a decision, not a failure', async () => {
+    state.signIn = 'cancelled';
+    await expect(googleDrive.connect()).resolves.toBeNull();
+  });
+
+  it('treats a cancellation raised as an error the same way', async () => {
+    // Android reports this by rejecting rather than resolving.
+    state.signIn = 'throws-cancelled';
+    await expect(googleDrive.connect()).resolves.toBeNull();
+  });
+});
+
+describe('renewing an expired token', () => {
+  const expired = { accessToken: 'token-1', refreshToken: null, expiresAt: Date.now() - 1_000 };
+
+  it('does it without a sheet', async () => {
+    state.accessToken = 'token-2';
+    const renewed = await googleDrive.ensureValid(expired);
+    expect(renewed.accessToken).toBe('token-2');
+    expect(calls.signInSilently).toHaveBeenCalled();
+    expect(calls.signIn).not.toHaveBeenCalled();
+  });
+
+  it('drops the stale token first, or Android returns it again', async () => {
+    await googleDrive.ensureValid(expired);
+    expect(calls.cleared).toHaveBeenCalledWith('token-1');
+  });
+
+  it('leaves a token that is still good alone', async () => {
+    const fresh = { accessToken: 'token-1', refreshToken: null, expiresAt: Date.now() + 600_000 };
+    await expect(googleDrive.ensureValid(fresh)).resolves.toBe(fresh);
+    expect(calls.getTokens).not.toHaveBeenCalled();
+  });
+
+  it('reports a revoked grant as a 401, which is what the engine acts on', async () => {
+    state.silent = 'nobody';
+    await expect(googleDrive.ensureValid(expired)).rejects.toBeInstanceOf(CloudHttpError);
+    await expect(googleDrive.ensureValid(expired)).rejects.toMatchObject({ status: 401 });
+  });
+
+  it('says the same when Google wants the person to sign in again', async () => {
+    state.silent = 'required';
+    await expect(googleDrive.ensureValid(expired)).rejects.toMatchObject({ status: 401 });
+  });
+});
+
+describe('unlinking', () => {
+  it('gives the grant back to Google rather than only forgetting it here', async () => {
+    await googleDrive.revoke?.({
+      accessToken: 'token-1',
+      refreshToken: null,
+      expiresAt: Date.now(),
+    });
+    expect(calls.revoked).toHaveBeenCalled();
+    expect(calls.cleared).toHaveBeenCalledWith('token-1');
+  });
+});
+
+describe('whether the row is offered at all', () => {
+  it('is not, on a build that names no project', () => {
+    delete process.env.EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_WEB;
+    expect(isConfigured('gdrive')).toBe(false);
+    expect(googleDrive.isConfigured()).toBe(false);
+  });
+
+  it('is not, on a build whose binary predates the module', () => {
+    setSigninModuleForTests(null);
+    // The project is still named; the phone simply cannot ask.
+    expect(isConfigured('gdrive')).toBe(true);
+    expect(googleDrive.isConfigured()).toBe(false);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       '@react-native-community/datetimepicker':
         specifier: 9.1.0
         version: 9.1.0(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      '@react-native-google-signin/google-signin':
+        specifier: ^16.1.5
+        version: 16.1.5(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
       '@react-native-ml-kit/text-recognition':
         specifier: ^2.0.0
         version: 2.0.0(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
@@ -2268,6 +2271,16 @@ packages:
       expo:
         optional: true
       react-native-windows:
+        optional: true
+
+  '@react-native-google-signin/google-signin@16.1.5':
+    resolution: {integrity: sha512-9rmMwACzHK9Cbd0Yp7efg5uWgiYoLwmNAJh4gRCuMcSQH+qplpK7E4d1Q4tbsD8M9jvvVtRX2Z0AP9wwBKmPrQ==}
+    peerDependencies:
+      expo: '>=52.0.40'
+      react: '*'
+      react-native: '*'
+    peerDependenciesMeta:
+      expo:
         optional: true
 
   '@react-native-masked-view/masked-view@0.3.2':
@@ -9422,6 +9435,13 @@ snapshots:
     optionalDependencies:
       expo: 57.0.18(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.14)(expo-router@57.0.17)(react-dom@19.2.8(react@19.2.8))(react-native-web@0.21.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
 
+  '@react-native-google-signin/google-signin@16.1.5(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)':
+    dependencies:
+      react: 19.2.8
+      react-native: 0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1)
+    optionalDependencies:
+      expo: 57.0.18(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.14)(expo-router@57.0.17)(react-dom@19.2.8(react@19.2.8))(react-native-web@0.21.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+
   '@react-native-masked-view/masked-view@0.3.2(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)':
     dependencies:
       react: 19.2.8
@@ -11728,7 +11748,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.66.0(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.66.0(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
The Drive-backup row in settings has always read "Backup is not available in this build", and the assumption was that somebody just had to create an OAuth client and set `EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_ANDROID`.

That would not have worked. Google [withdrew custom URI schemes](https://developers.google.com/identity/protocols/oauth2/native-app) for Android OAuth clients — "no longer supported on Android and Chrome apps" — because any app on the phone can claim `waves://` and catch the redirect. No client id brings the browser flow back; the consent page is refused before the person sees it.

## What changes

Consent now comes from Play services (`@react-native-google-signin/google-signin`), which has no redirect to intercept. The token reaches *this* app because the OS knows which app asked, matching the package name and signing certificate against a client registered for that pair — which is why nothing in the bundle carries an Android client id, and why debug-signed and release-signed builds need one client each.

Renewal changes shape with it. There is no refresh token of our own: Play services holds the grant and issues an access token good for about an hour, so `ensureValid` asks again instead of presenting one. Silent while consent stands, so a scheduled backup never puts a sheet in front of anybody — and dead the moment they revoke access in their Google account, which is what that setting is for. A silent ask that returns nothing becomes the same 401 the engine already acts on: *re-link*, not "nothing was ever linked".

`offlineAccess` stays off: it returns a code meant for a server holding the client secret, there is no such server, and a refresh token on the phone would outlive the grant the person thinks they gave.

The browser half of `cloud/oauth.ts` goes. What survives is the two judgements that outlived the transport — whether a token is too old to use, and whether a failure means the grant is gone or only the network.

## Console work this still needs

Nothing here has run against a real Google account, because the clients do not exist yet. In the Cloud project with the Drive API enabled: an **Android** client per signing key (`app.waves.mobile` + SHA-1), an **iOS** client if building for Apple, `.../auth/drive.appdata` on the consent screen, and `EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_WEB` set to that project's web client id. README has the full list.

## Verification

- `vitest run` in `apps/mobile`: 860 passed, including 12 new ones that stand a fake SDK in through a seam (the module is reached by `require` so an OTA onto an older binary degrades to one disabled row instead of crashing; `require` is exactly what a test runner cannot answer).
- `tsc --noEmit`, `pnpm lint`, `pnpm format` clean.
- `./gradlew assembleRelease` — BUILD SUCCESSFUL, so the new native module autolinks.
- Not run on a device against a real Google account.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Google Drive sign-in now uses native Google authentication on Android, avoiding browser redirects and custom URI schemes.
  - Drive access can renew silently and revoke permissions through the native sign-in experience.
  - Older app versions continue to handle previously received redirect links safely.

- **Documentation**
  - Updated setup instructions for web and iOS client IDs, Android signing certificates, build-time configuration, and token behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->