### PR TITLE
feat(invite): make the invite screen an invitation, not a bare code

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -73,6 +73,7 @@
     "react-native-screens": "~4.27.0",
     "react-native-svg": "15.15.4",
     "react-native-url-polyfill": "^4.0.0",
+    "react-native-view-shot": "^5.1.1",
     "react-native-web": "~0.21.0",
     "react-native-worklets": "0.10.1",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"

--- a/apps/mobile/src/app/group/[id]/invite.tsx
+++ b/apps/mobile/src/app/group/[id]/invite.tsx
@@ -1,9 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { decode as decodeBase64 } from 'base64-arraybuffer';
 import * as Clipboard from 'expo-clipboard';
-import * as FileSystem from 'expo-file-system';
-import * as Sharing from 'expo-sharing';
 import { router, useLocalSearchParams } from 'expo-router';
 import {
   ActivityIndicator,
@@ -39,6 +36,7 @@ import { useSync } from '@/sync';
 import { displayName, groupLabel, isGhost } from '@/data/types';
 import { useAuth } from '@/lib/auth';
 import { fill, plural, useStrings } from '@/i18n';
+import { shareInviteCard } from '@/lib/shareInviteCard';
 
 /**
  * The group's durable join link, as an invitation rather than a naked code.
@@ -78,8 +76,7 @@ export default function InviteScreen() {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
-  // The rendered QR, so a share can send the image itself and not just the link.
-  const qrRef = useRef<{ toDataURL?: (cb: (base64: string) => void) => void } | null>(null);
+  const inviteCardRef = useRef<View | null>(null);
 
   const joinToken = group.data?.join_token ?? ensured;
   const link = joinToken ? groupJoinLink(joinToken) : null;
@@ -128,44 +125,19 @@ export default function InviteScreen() {
     await Share.share({ message });
   };
 
-  /** The rendered QR as base64 PNG, or null if the code is not mounted yet. */
-  const captureQr = (): Promise<string | null> =>
-    new Promise((resolve) => {
-      const ref = qrRef.current;
-      if (!ref?.toDataURL) return resolve(null);
-      try {
-        ref.toDataURL((base64) => resolve(base64 ?? null));
-      } catch {
-        resolve(null);
-      }
-    });
-
   /**
-   * Send the QR code itself, so the person on the other end of a chat can scan
-   * it rather than only tap a link. The image is the one thing a plain URL
-   * scheme cannot carry, so this goes through the OS share sheet. `fallback` is
-   * the link-only path for when the code cannot be captured.
+   * Send the complete invitation card, so the person on the other end sees the
+   * group name and member context as well as the QR code. `fallback` is the
+   * link-only path for when the card cannot be captured.
    */
-  const shareQr = async (fallback: () => Promise<void>): Promise<void> => {
+  const shareCard = async (fallback: () => Promise<void>): Promise<void> => {
     if (!link) return;
-    try {
-      const base64 = await captureQr();
-      if (!base64 || !(await Sharing.isAvailableAsync())) {
-        await fallback();
-        return;
-      }
-      const file = new FileSystem.File(FileSystem.Paths.cache, 'waves-invite-qr.png');
-      if (file.exists) file.delete();
-      file.create();
-      file.write(new Uint8Array(decodeBase64(base64)));
-      await Sharing.shareAsync(file.uri, {
-        mimeType: 'image/png',
-        dialogTitle: message,
-        UTI: 'public.png',
-      });
-    } catch {
-      await fallback();
-    }
+    await shareInviteCard({
+      cardRef: inviteCardRef,
+      filename: 'waves-invite-card.png',
+      dialogTitle: message,
+      fallback,
+    });
   };
 
   const shareVia = async (channel: 'whatsapp' | 'sms' | 'email'): Promise<void> => {
@@ -224,111 +196,110 @@ export default function InviteScreen() {
             {/* The invitation. One object: whose group, who is in it, and the
                 code to join — on the brand wash, so it reads as something
                 handed over rather than a utility panel. */}
-            <Gradient radius={theme.radius.lg} style={{ padding: theme.spacing.lg }}>
-              <View style={{ alignItems: 'center', gap: theme.spacing.xs }}>
-                <Text variant="title" style={{ color: '#ffffff' }} align="center">
-                  {label}
-                </Text>
-                {present.length > 0 ? (
-                  <Text variant="caption" style={{ color: 'rgba(255,255,255,0.85)' }}>
-                    {plural(locale, present.length, t.people.inviteMembersHere)}
+            <View ref={inviteCardRef} collapsable={false}>
+              <Gradient radius={theme.radius.lg} style={{ padding: theme.spacing.lg }}>
+                <View style={{ alignItems: 'center', gap: theme.spacing.xs }}>
+                  <Text variant="title" style={{ color: '#ffffff' }} align="center">
+                    {label}
                   </Text>
-                ) : null}
-              </View>
-
-              {faces.length > 0 ? (
-                // Overlapped with a negative *start* margin rather than a left
-                // one, so the stack falls the right way round in Arabic.
-                <Row style={{ justifyContent: 'center', marginTop: theme.spacing.md }}>
-                  {faces.map((member, index) => (
-                    <View
-                      key={member.id}
-                      style={{
-                        marginStart: index === 0 ? 0 : -12,
-                        borderRadius: 999,
-                        borderWidth: 2,
-                        borderColor: '#ffffff',
-                      }}
-                    >
-                      <Avatar
-                        name={displayName(member, profile?.id, null, t.misc.someone)}
-                        ghost={isGhost(member)}
-                        size={36}
-                      />
-                    </View>
-                  ))}
-                  {overflow > 0 ? (
-                    <View
-                      style={{
-                        marginStart: -12,
-                        width: 36,
-                        height: 36,
-                        borderRadius: 999,
-                        borderWidth: 2,
-                        borderColor: '#ffffff',
-                        backgroundColor: 'rgba(255,255,255,0.25)',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                      }}
-                    >
-                      <Text variant="caption" style={{ color: '#ffffff' }}>
-                        {`+${overflow}`}
-                      </Text>
-                    </View>
+                  {present.length > 0 ? (
+                    <Text variant="caption" style={{ color: 'rgba(255,255,255,0.85)' }}>
+                      {plural(locale, present.length, t.people.inviteMembersHere)}
+                    </Text>
                   ) : null}
-                </Row>
-              ) : null}
+                </View>
 
-              {/* The code sits on its own white plate whatever the theme is
+                {faces.length > 0 ? (
+                  // Overlapped with a negative *start* margin rather than a left
+                  // one, so the stack falls the right way round in Arabic.
+                  <Row style={{ justifyContent: 'center', marginTop: theme.spacing.md }}>
+                    {faces.map((member, index) => (
+                      <View
+                        key={member.id}
+                        style={{
+                          marginStart: index === 0 ? 0 : -12,
+                          borderRadius: 999,
+                          borderWidth: 2,
+                          borderColor: '#ffffff',
+                        }}
+                      >
+                        <Avatar
+                          name={displayName(member, profile?.id, null, t.misc.someone)}
+                          ghost={isGhost(member)}
+                          size={36}
+                        />
+                      </View>
+                    ))}
+                    {overflow > 0 ? (
+                      <View
+                        style={{
+                          marginStart: -12,
+                          width: 36,
+                          height: 36,
+                          borderRadius: 999,
+                          borderWidth: 2,
+                          borderColor: '#ffffff',
+                          backgroundColor: 'rgba(255,255,255,0.25)',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                        }}
+                      >
+                        <Text variant="caption" style={{ color: '#ffffff' }}>
+                          {`+${overflow}`}
+                        </Text>
+                      </View>
+                    ) : null}
+                  </Row>
+                ) : null}
+
+                {/* The code sits on its own white plate whatever the theme is
                   doing: a QR on a dark ground does not scan. */}
-              <View
-                style={{
-                  alignSelf: 'center',
-                  marginTop: theme.spacing.lg,
-                  padding: theme.spacing.md,
-                  backgroundColor: '#ffffff',
-                  borderRadius: theme.radius.lg,
-                }}
-              >
-                <QRCodeStyled
-                  ref={(c) => {
-                    qrRef.current = c;
+                <View
+                  style={{
+                    alignSelf: 'center',
+                    marginTop: theme.spacing.lg,
+                    padding: theme.spacing.md,
+                    backgroundColor: '#ffffff',
+                    borderRadius: theme.radius.lg,
                   }}
-                  data={link}
-                  size={208}
-                  padding={16}
-                  style={{ backgroundColor: '#ffffff' }}
-                  // The RN `backgroundColor` style is not rasterised by
-                  // `toDataURL`, so a captured/shared PNG would come out with a
-                  // transparent ground — the dark pieces then vanish on a dark
-                  // chat bubble (WhatsApp). Paint the white quiet zone as an SVG
-                  // layer behind the code instead, so it is part of the export.
-                  renderBackground={() => (
-                    <Rect x={-40} y={-40} width={330} height={330} fill="#ffffff" />
-                  )}
-                  color="#0A0A1A"
-                  errorCorrectionLevel="H"
-                  pieceBorderRadius="50%"
-                  pieceScale={0.92}
-                  outerEyesOptions={{ borderRadius: '28%', color: '#0A0A1A' }}
-                  innerEyesOptions={{ borderRadius: '35%', color: '#0A0A1A' }}
-                  logo={{
-                    href: require('../../../../assets/images/icon.png'),
-                    scale: 0.85,
-                    padding: 6,
-                    hidePieces: true,
-                  }}
-                />
-              </View>
+                >
+                  <QRCodeStyled
+                    data={link}
+                    size={208}
+                    padding={16}
+                    style={{ backgroundColor: '#ffffff' }}
+                    // The RN `backgroundColor` style is not rasterised by
+                    // `toDataURL`, so a captured/shared PNG would come out with a
+                    // transparent ground — the dark pieces then vanish on a dark
+                    // chat bubble (WhatsApp). Paint the white quiet zone as an SVG
+                    // layer behind the code instead, so it is part of the export.
+                    renderBackground={() => (
+                      <Rect x={-40} y={-40} width={330} height={330} fill="#ffffff" />
+                    )}
+                    color="#0A0A1A"
+                    errorCorrectionLevel="H"
+                    pieceBorderRadius="50%"
+                    pieceScale={0.92}
+                    outerEyesOptions={{ borderRadius: '28%', color: '#0A0A1A' }}
+                    innerEyesOptions={{ borderRadius: '35%', color: '#0A0A1A' }}
+                    logo={{
+                      href: require('../../../../assets/images/icon.png'),
+                      scale: 0.85,
+                      padding: 6,
+                      hidePieces: true,
+                    }}
+                  />
+                </View>
 
-              <Text
-                variant="caption"
-                align="center"
-                style={{ color: 'rgba(255,255,255,0.85)', marginTop: theme.spacing.md }}
-              >
-                {t.people.scanToJoin}
-              </Text>
-            </Gradient>
+                <Text
+                  variant="caption"
+                  align="center"
+                  style={{ color: 'rgba(255,255,255,0.85)', marginTop: theme.spacing.md }}
+                >
+                  {t.people.scanToJoin}
+                </Text>
+              </Gradient>
+            </View>
 
             {/* The link, with copying on it rather than beside it. Copy used to
                 be a fifth circle on the channel row, which put the act of taking
@@ -435,7 +406,7 @@ export default function InviteScreen() {
               label={t.people.shareInvite}
               size="lg"
               fullWidth
-              onPress={() => void shareQr(share)}
+              onPress={() => void shareCard(share)}
             />
 
             {/* Said once, at the bottom, naming the group it lets people into —

--- a/apps/mobile/src/app/group/[id]/invite.tsx
+++ b/apps/mobile/src/app/group/[id]/invite.tsx
@@ -212,7 +212,9 @@ export default function InviteScreen() {
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
           paddingTop: theme.spacing.lg,
-          paddingBottom: clearance,
+          // Plus a line's worth, so the closing sentence is not sitting on
+          // the navigation bar.
+          paddingBottom: clearance + theme.spacing.lg,
           gap: theme.spacing.lg,
         }}
         showsVerticalScrollIndicator={false}
@@ -340,8 +342,12 @@ export default function InviteScreen() {
                   numberOfLines={1}
                   // The token is the end of the URL and the only part that
                   // differs between groups, so it is the half worth keeping.
+                  //
+                  // Not `selectable`: Android renders selectable text through a
+                  // path that ignores `numberOfLines`, so the URL wrapped and
+                  // the second line was clipped by the card. Copy is a tap
+                  // away, which is the better way to take a link anyway.
                   ellipsizeMode="middle"
-                  selectable
                 >
                   {link}
                 </Text>
@@ -401,14 +407,14 @@ export default function InviteScreen() {
                     opacity: pressed ? 0.6 : 1,
                   })}
                 >
-                  {/* Sized off the column rather than a fixed width, so the
-                      circles stay round on a narrow phone. */}
+                  {/* An explicit square. `width: '100%'` with `aspectRatio`
+                      resolved against the column and came out a tall oval on a
+                      real screen; a circle is one number, not a proportion. */}
                   <View
                     style={{
-                      width: '100%',
-                      maxWidth: 60,
-                      aspectRatio: 1,
-                      borderRadius: 999,
+                      width: 60,
+                      height: 60,
+                      borderRadius: 30,
                       alignItems: 'center',
                       justifyContent: 'center',
                       backgroundColor: option.color,

--- a/apps/mobile/src/app/group/[id]/invite.tsx
+++ b/apps/mobile/src/app/group/[id]/invite.tsx
@@ -18,9 +18,11 @@ import QRCodeStyled from 'react-native-qrcode-styled';
 import { Rect } from 'react-native-svg';
 
 import {
+  Avatar,
   Button,
   Callout,
   Card,
+  Gradient,
   IconButton,
   iconSize,
   Row,
@@ -34,25 +36,34 @@ import { ensureGroupJoinToken, groupJoinLink } from '@/data/api';
 import { friendlyError } from '@/lib/errors';
 import { useGroup } from '@/data/hooks';
 import { useSync } from '@/sync';
-import { groupLabel } from '@/data/types';
+import { displayName, groupLabel, isGhost } from '@/data/types';
 import { useAuth } from '@/lib/auth';
-import { useStrings } from '@/i18n';
+import { fill, plural, useStrings } from '@/i18n';
 
 /**
- * The group's durable join link, shown as a QR (the WhatsApp/Signal model).
+ * The group's durable join link, as an invitation rather than a naked code.
  *
  * The link is one stable, re-showable token per group — the same one every open
  * and on every device — so the QR paints straight from the mirror with no server
  * round-trip once it exists. The first time a group is ever shared, the token is
- * minted on open (a brief spinner). Sharing and copying are peers on one row —
- * WhatsApp, SMS, Email, the OS sheet and the clipboard all hand out the same
- * link, so none of them is the "real" one. Rotating the token (an admin's lever
- * against a link that has spread too far) is not reachable from here.
+ * minted on open (a brief spinner).
+ *
+ * The screen is built around one card, because that is what a person is really
+ * handing over: the group's name, who is already in it, and the code, together.
+ * A QR alone says "scan this" and nothing about what is on the other side —
+ * whoever is holding out the phone then has to say it out loud. The card says
+ * it, and it is what the shared image carries too.
+ *
+ * Below it, the three ways to send a link are peers on one row, and copying
+ * lives on the link itself rather than pretending to be a fourth channel: it is
+ * the same link by a different road, and it belongs where the link is. Rotating
+ * the token (an admin's lever against a link that has spread too far) is not
+ * reachable from here.
  */
 export default function InviteScreen() {
   const theme = useTheme();
   const clearance = useScreenClearance();
-  const { t } = useStrings();
+  const { t, locale } = useStrings();
   const { id } = useLocalSearchParams<{ id: string }>();
   const groupId = id ?? '';
 
@@ -104,6 +115,13 @@ export default function InviteScreen() {
 
   const label = groupLabel(group.data, members.data ?? [], profile?.id);
   const message = t.people.shareMessage.replace('{group}', label).replace('{link}', link ?? '');
+
+  // Who is already here, for the row of faces on the card. Ghosts are people
+  // somebody typed in rather than people who arrived, so they are counted —
+  // they are in the group — but the `ghost` styling says which is which.
+  const present = (members.data ?? []).filter((member) => !member.left_at);
+  const faces = present.slice(0, 4);
+  const overflow = present.length - faces.length;
 
   const share = async (): Promise<void> => {
     if (!link) return;
@@ -180,8 +198,9 @@ export default function InviteScreen() {
         </IconButton>
         {/* Title only. The group's name was a second line here, but the screen
             is opened from inside that group — it said what the user already
-            knew, and a long name pushed the header out of shape. The name is
-            still in the invite the recipient gets. */}
+            knew, and a long name pushed the header out of shape. The name now
+            sits on the card, where it is part of the invitation instead of a
+            label, and travels with the shared image. */}
         <View style={{ flex: 1, alignItems: 'center' }}>
           <Text variant="heading">{t.people.inviteTitle}</Text>
         </View>
@@ -194,29 +213,79 @@ export default function InviteScreen() {
           paddingHorizontal: theme.spacing.xl,
           paddingTop: theme.spacing.lg,
           paddingBottom: clearance,
-          gap: theme.spacing.xl,
+          gap: theme.spacing.lg,
         }}
         showsVerticalScrollIndicator={false}
       >
-        {/* One sentence is the whole explanation the link needs. */}
-        <Text variant="caption" tone="muted" align="center">
-          {t.people.anyoneWithLink}
-        </Text>
-
         {link ? (
           <>
-            {/* The QR is the point of the screen — the identical join link as a
-                code to point a camera at. Drawn on a white quiet zone regardless
-                of theme, because a QR on a dark background does not scan. */}
-            <Card style={{ gap: theme.spacing.md, alignItems: 'center' }}>
-              <Text variant="caption" tone="muted">
-                {t.people.scanToJoin}
-              </Text>
+            {/* The invitation. One object: whose group, who is in it, and the
+                code to join — on the brand wash, so it reads as something
+                handed over rather than a utility panel. */}
+            <Gradient radius={theme.radius.lg} style={{ padding: theme.spacing.lg }}>
+              <View style={{ alignItems: 'center', gap: theme.spacing.xs }}>
+                <Text variant="title" style={{ color: '#ffffff' }} align="center">
+                  {label}
+                </Text>
+                {present.length > 0 ? (
+                  <Text variant="caption" style={{ color: 'rgba(255,255,255,0.85)' }}>
+                    {plural(locale, present.length, t.people.inviteMembersHere)}
+                  </Text>
+                ) : null}
+              </View>
+
+              {faces.length > 0 ? (
+                // Overlapped with a negative *start* margin rather than a left
+                // one, so the stack falls the right way round in Arabic.
+                <Row style={{ justifyContent: 'center', marginTop: theme.spacing.md }}>
+                  {faces.map((member, index) => (
+                    <View
+                      key={member.id}
+                      style={{
+                        marginStart: index === 0 ? 0 : -12,
+                        borderRadius: 999,
+                        borderWidth: 2,
+                        borderColor: '#ffffff',
+                      }}
+                    >
+                      <Avatar
+                        name={displayName(member, profile?.id, null, t.misc.someone)}
+                        ghost={isGhost(member)}
+                        size={36}
+                      />
+                    </View>
+                  ))}
+                  {overflow > 0 ? (
+                    <View
+                      style={{
+                        marginStart: -12,
+                        width: 36,
+                        height: 36,
+                        borderRadius: 999,
+                        borderWidth: 2,
+                        borderColor: '#ffffff',
+                        backgroundColor: 'rgba(255,255,255,0.25)',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                      }}
+                    >
+                      <Text variant="caption" style={{ color: '#ffffff' }}>
+                        {`+${overflow}`}
+                      </Text>
+                    </View>
+                  ) : null}
+                </Row>
+              ) : null}
+
+              {/* The code sits on its own white plate whatever the theme is
+                  doing: a QR on a dark ground does not scan. */}
               <View
                 style={{
+                  alignSelf: 'center',
+                  marginTop: theme.spacing.lg,
                   padding: theme.spacing.md,
                   backgroundColor: '#ffffff',
-                  borderRadius: theme.radius.md,
+                  borderRadius: theme.radius.lg,
                 }}
               >
                 <QRCodeStyled
@@ -224,7 +293,7 @@ export default function InviteScreen() {
                     qrRef.current = c;
                   }}
                   data={link}
-                  size={200}
+                  size={208}
                   padding={16}
                   style={{ backgroundColor: '#ffffff' }}
                   // The RN `backgroundColor` style is not rasterised by
@@ -233,7 +302,7 @@ export default function InviteScreen() {
                   // chat bubble (WhatsApp). Paint the white quiet zone as an SVG
                   // layer behind the code instead, so it is part of the export.
                   renderBackground={() => (
-                    <Rect x={-40} y={-40} width={320} height={320} fill="#ffffff" />
+                    <Rect x={-40} y={-40} width={330} height={330} fill="#ffffff" />
                   )}
                   color="#0A0A1A"
                   errorCorrectionLevel="H"
@@ -249,22 +318,65 @@ export default function InviteScreen() {
                   }}
                 />
               </View>
+
+              <Text
+                variant="caption"
+                align="center"
+                style={{ color: 'rgba(255,255,255,0.85)', marginTop: theme.spacing.md }}
+              >
+                {t.people.scanToJoin}
+              </Text>
+            </Gradient>
+
+            {/* The link, with copying on it rather than beside it. Copy used to
+                be a fifth circle on the channel row, which put the act of taking
+                the link somewhere other than the link itself. */}
+            <Card style={{ paddingVertical: theme.spacing.sm }}>
+              <Row style={{ gap: theme.spacing.sm }}>
+                <Ionicons name="link" size={iconSize.md} color={theme.color.textMuted} />
+                <Text
+                  variant="body"
+                  style={{ flex: 1, color: theme.color.brand }}
+                  numberOfLines={1}
+                  // The token is the end of the URL and the only part that
+                  // differs between groups, so it is the half worth keeping.
+                  ellipsizeMode="middle"
+                  selectable
+                >
+                  {link}
+                </Text>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={copied ? t.misc.copied : t.people.copyLink}
+                  onPress={() => void copy()}
+                  hitSlop={8}
+                  style={({ pressed }) => ({
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    gap: theme.spacing.xs,
+                    paddingHorizontal: theme.spacing.sm,
+                    paddingVertical: theme.spacing.xs,
+                    borderRadius: 999,
+                    backgroundColor: theme.color.surfaceMuted,
+                    opacity: pressed ? 0.6 : 1,
+                  })}
+                >
+                  <Ionicons
+                    name={copied ? 'checkmark' : 'copy-outline'}
+                    size={iconSize.sm}
+                    color={theme.color.brand}
+                  />
+                  <Text variant="caption" style={{ color: theme.color.brand }}>
+                    {copied ? t.misc.copied : t.people.copyLink}
+                  </Text>
+                </Pressable>
+              </Row>
             </Card>
 
-            <Card style={{ gap: theme.spacing.sm }}>
-              <Text variant="caption" tone="muted">
-                {t.people.inviteLink}
-              </Text>
-              <Text variant="body" style={{ color: theme.color.brand }} selectable>
-                {link}
-              </Text>
-            </Card>
-
-            {/* The quick channels — WhatsApp, SMS, Email, the OS share sheet and
-                the clipboard, all on one straight row, each in its own colour.
-                Copying is a peer here, not a button of its own: every item on
-                the row hands out the same link, only by a different road. */}
-            <Row style={{ gap: theme.spacing.sm }}>
+            {/* The quick roads: each one opens an app with the link already
+                written. A named channel beats the OS sheet when you already know
+                where this person lives. */}
+            <Row style={{ gap: theme.spacing.md }}>
               {(
                 [
                   {
@@ -275,42 +387,13 @@ export default function InviteScreen() {
                   },
                   { channel: 'sms', label: t.extras.sms, icon: 'chatbubble', color: '#1E88E5' },
                   { channel: 'email', label: t.extras.email, icon: 'mail', color: '#EA4335' },
-                  // The last two are ours, not a third party's, so they wear the
-                  // app's own colour rather than a borrowed one — a pair at the
-                  // end of the row, and the only two that follow the theme into
-                  // dark mode.
-                  {
-                    channel: 'share',
-                    label: t.common.share,
-                    icon: 'share-social',
-                    color: theme.color.brand,
-                  },
-                  {
-                    channel: 'copy',
-                    label: copied ? t.misc.copied : t.people.copyLink,
-                    icon: copied ? 'checkmark' : 'copy-outline',
-                    color: theme.color.brand,
-                  },
                 ] as const
               ).map((option) => (
                 <Pressable
                   key={option.channel}
                   accessibilityRole="button"
                   accessibilityLabel={option.label}
-                  // The three named channels deep-link straight into their app
-                  // with the join link as text — an invite is a link you tap to
-                  // join, which beats a QR the recipient would have to re-scan on
-                  // another device. Only the generic Share shares the QR image
-                  // itself (via the OS sheet), where the white-ground capture
-                  // matters. `shareVia` falls back to that sheet if the app is
-                  // not installed.
-                  onPress={() =>
-                    void (option.channel === 'copy'
-                      ? copy()
-                      : option.channel === 'share'
-                        ? shareQr(share)
-                        : shareVia(option.channel))
-                  }
+                  onPress={() => void shareVia(option.channel)}
                   style={({ pressed }) => ({
                     flex: 1,
                     alignItems: 'center',
@@ -318,12 +401,12 @@ export default function InviteScreen() {
                     opacity: pressed ? 0.6 : 1,
                   })}
                 >
-                  {/* Sized off the column rather than a fixed 56, so five items
-                      still fit — and stay round — on a narrow phone. */}
+                  {/* Sized off the column rather than a fixed width, so the
+                      circles stay round on a narrow phone. */}
                   <View
                     style={{
                       width: '100%',
-                      maxWidth: 56,
+                      maxWidth: 60,
                       aspectRatio: 1,
                       borderRadius: 999,
                       alignItems: 'center',
@@ -333,12 +416,27 @@ export default function InviteScreen() {
                   >
                     <Ionicons name={option.icon} size={iconSize.lg} color="#ffffff" />
                   </View>
-                  <Text variant="caption" tone="muted" align="center" numberOfLines={2}>
+                  <Text variant="caption" tone="muted" align="center" numberOfLines={1}>
                     {option.label}
                   </Text>
                 </Pressable>
               ))}
             </Row>
+
+            {/* Everything else the phone can do with an invitation, and the one
+                path that sends the code as a picture. */}
+            <Button
+              label={t.people.shareInvite}
+              size="lg"
+              fullWidth
+              onPress={() => void shareQr(share)}
+            />
+
+            {/* Said once, at the bottom, naming the group it lets people into —
+                a warning is only useful if it says what is being opened. */}
+            <Text variant="caption" tone="muted" align="center">
+              {fill(t.people.inviteTrust, { group: label })}
+            </Text>
           </>
         ) : error ? (
           // Minting failed — a retry, not a first step.
@@ -351,7 +449,7 @@ export default function InviteScreen() {
           />
         ) : (
           // First-ever share (or still loading): the durable link is being made.
-          // Hold the QR's place so the screen reads as "your code is coming".
+          // Hold the card's place so the screen reads as "your code is coming".
           <Card
             style={{
               alignItems: 'center',

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1656,7 +1656,12 @@ export interface UiStrings {
     upiForGroupNote: string;
     inviteTitle: string;
     /** The whole explanation the join link gets — one plain sentence. */
-    anyoneWithLink: string;
+    /** The trust line under the invite card. Carries `{group}`. */
+    inviteTrust: string;
+    /** "3 people already here" on the invite card. */
+    inviteMembersHere: PluralForms;
+    /** The primary action: hand the code and the link to somebody. */
+    shareInvite: string;
     inviteLink: string;
     /** Caption over the invite QR code. */
     scanToJoin: string;
@@ -3924,7 +3929,9 @@ const en: UiStrings = {
     upiForGroupNote:
       'Overrides your account UPI ID here only — useful when one group settles to a different account.',
     inviteTitle: 'Invite people',
-    anyoneWithLink: 'Anyone with this link can join.',
+    inviteTrust: 'Anyone with this link can join {group}, so share it with people you trust.',
+    inviteMembersHere: { one: '{n} person already here', other: '{n} people already here' },
+    shareInvite: 'Share invite',
     inviteLink: 'Invite link',
     scanToJoin: 'Scan to join',
     whatsapp: 'WhatsApp',
@@ -6236,7 +6243,13 @@ const ta: UiStrings = {
     upiForGroupNote:
       'இங்கே மட்டும் உங்கள் கணக்கின் UPI ID ஐ மேலெழுதும் — ஒரு குழு வேறு கணக்குக்குத் தீர்க்கும்போது பயனுள்ளது.',
     inviteTitle: 'ஆட்களை அழை',
-    anyoneWithLink: 'இந்த இணைப்பு உள்ள யாரும் சேரலாம்.',
+    inviteTrust:
+      'இந்த இணைப்பு உள்ள யாரும் {group} குழுவில் சேரலாம், அதனால் நம்பிக்கையானவர்களுடன் மட்டும் பகிரவும்.',
+    inviteMembersHere: {
+      one: '{n} பேர் ஏற்கனவே இங்கே',
+      other: '{n} பேர் ஏற்கனவே இங்கே',
+    },
+    shareInvite: 'அழைப்பைப் பகிர்',
     inviteLink: 'அழைப்பு இணைப்பு',
     scanToJoin: 'ஸ்கேன் செய்து சேரவும்',
     whatsapp: 'WhatsApp',
@@ -8548,7 +8561,13 @@ const hi: UiStrings = {
     upiForGroupNote:
       'सिर्फ़ यहाँ आपके खाते की UPI ID की जगह लेता है — जब कोई समूह किसी दूसरे खाते में निपटता हो तो काम आता है।',
     inviteTitle: 'लोगों को बुलाएँ',
-    anyoneWithLink: 'इस लिंक वाला कोई भी जुड़ सकता है।',
+    inviteTrust:
+      'इस लिंक वाला कोई भी {group} में जुड़ सकता है, इसलिए इसे भरोसेमंद लोगों के साथ ही साझा करें।',
+    inviteMembersHere: {
+      one: '{n} व्यक्ति पहले से यहाँ',
+      other: '{n} लोग पहले से यहाँ',
+    },
+    shareInvite: 'निमंत्रण साझा करें',
     inviteLink: 'निमंत्रण लिंक',
     scanToJoin: 'स्कैन करके जुड़ें',
     whatsapp: 'WhatsApp',
@@ -10908,7 +10927,16 @@ const ar: UiStrings = {
     upiForGroup: 'معرّف الدفع لهذه المجموعة',
     upiForGroupNote: 'يتجاوز معرّف حسابك هنا فقط — مفيد حين تُسوّى مجموعة إلى حساب مختلف.',
     inviteTitle: 'ادعُ أشخاصًا',
-    anyoneWithLink: 'يمكن لأي شخص لديه هذا الرابط الانضمام.',
+    inviteTrust: 'أي شخص لديه هذا الرابط يمكنه الانضمام إلى {group}، فشاركه مع من تثق بهم فقط.',
+    inviteMembersHere: {
+      zero: 'لا أحد هنا بعد',
+      one: 'شخص واحد هنا بالفعل',
+      two: 'شخصان هنا بالفعل',
+      few: '{n} أشخاص هنا بالفعل',
+      many: '{n} شخصًا هنا بالفعل',
+      other: '{n} شخص هنا بالفعل',
+    },
+    shareInvite: 'شارك الدعوة',
     inviteLink: 'رابط الدعوة',
     scanToJoin: 'امسح للانضمام',
     whatsapp: 'واتساب',

--- a/apps/mobile/src/lib/shareInviteCard.ts
+++ b/apps/mobile/src/lib/shareInviteCard.ts
@@ -1,0 +1,52 @@
+import { decode as decodeBase64 } from 'base64-arraybuffer';
+import * as FileSystem from 'expo-file-system';
+import * as Sharing from 'expo-sharing';
+import { captureRef } from 'react-native-view-shot';
+
+type CaptureTarget = Parameters<typeof captureRef>[0];
+
+export interface ShareInviteCardOptions {
+  readonly cardRef: CaptureTarget;
+  readonly filename: string;
+  readonly dialogTitle: string;
+  readonly fallback: () => Promise<void>;
+}
+
+/**
+ * Share the whole rendered invitation card as a PNG.
+ *
+ * The QR widget can export only itself, which drops the group name and member
+ * context. Capturing the outer card keeps the invitation readable when a user,
+ * rider, traveller, or financer forwards it as an image. If capture or native
+ * sharing is unavailable, the caller's link-only share remains the fallback.
+ */
+export async function shareInviteCard(options: ShareInviteCardOptions): Promise<void> {
+  try {
+    if (!(await Sharing.isAvailableAsync())) {
+      await options.fallback();
+      return;
+    }
+
+    const base64 = await captureRef(options.cardRef, {
+      format: 'png',
+      quality: 1,
+      result: 'base64',
+    });
+    if (!base64) {
+      await options.fallback();
+      return;
+    }
+
+    const file = new FileSystem.File(FileSystem.Paths.cache, options.filename);
+    if (file.exists) file.delete();
+    file.create();
+    file.write(new Uint8Array(decodeBase64(base64)));
+    await Sharing.shareAsync(file.uri, {
+      mimeType: 'image/png',
+      dialogTitle: options.dialogTitle,
+      UTI: 'public.png',
+    });
+  } catch {
+    await options.fallback();
+  }
+}

--- a/apps/mobile/test/shareInviteCard.test.ts
+++ b/apps/mobile/test/shareInviteCard.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sharing = {
+  available: true,
+  shareAsync: vi.fn(),
+};
+const files: Array<{ uri: string; bytes: number[] }> = [];
+const capture = vi.fn();
+
+vi.mock('expo-sharing', () => ({
+  isAvailableAsync: async () => sharing.available,
+  shareAsync: sharing.shareAsync,
+}));
+
+vi.mock('expo-file-system', () => ({
+  File: class {
+    readonly uri: string;
+    exists = false;
+
+    constructor(_cache: string, name: string) {
+      this.uri = `cache://${name}`;
+    }
+
+    delete(): void {
+      this.exists = false;
+    }
+
+    create(): void {
+      this.exists = true;
+    }
+
+    write(bytes: Uint8Array): void {
+      files.push({ uri: this.uri, bytes: [...bytes] });
+    }
+  },
+  Paths: { cache: 'cache://' },
+}));
+
+vi.mock('react-native-view-shot', () => ({
+  captureRef: capture,
+}));
+
+const { shareInviteCard } = await import('../src/lib/shareInviteCard');
+
+describe('sharing an invite card image', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    files.length = 0;
+    sharing.available = true;
+    capture.mockResolvedValue('aW52aXRlLWNhcmQ=');
+  });
+
+  it('captures the whole invitation card and shares that PNG', async () => {
+    const fallback = vi.fn();
+
+    await shareInviteCard({
+      cardRef: null,
+      filename: 'waves-invite-card.png',
+      dialogTitle: 'Join Goa trip',
+      fallback,
+    });
+
+    expect(capture).toHaveBeenCalledWith(null, {
+      format: 'png',
+      quality: 1,
+      result: 'base64',
+    });
+    expect(files).toEqual([
+      { uri: 'cache://waves-invite-card.png', bytes: [...Buffer.from('invite-card')] },
+    ]);
+    expect(sharing.shareAsync).toHaveBeenCalledWith('cache://waves-invite-card.png', {
+      mimeType: 'image/png',
+      dialogTitle: 'Join Goa trip',
+      UTI: 'public.png',
+    });
+    expect(fallback).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the link when native image sharing is unavailable', async () => {
+    sharing.available = false;
+    const fallback = vi.fn();
+
+    await shareInviteCard({
+      cardRef: null,
+      filename: 'invite.png',
+      dialogTitle: 'Invite',
+      fallback,
+    });
+
+    expect(capture).not.toHaveBeenCalled();
+    expect(sharing.shareAsync).not.toHaveBeenCalled();
+    expect(fallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the link when card capture fails', async () => {
+    capture.mockRejectedValue(new Error('capture failed'));
+    const fallback = vi.fn();
+
+    await shareInviteCard({
+      cardRef: null,
+      filename: 'invite.png',
+      dialogTitle: 'Invite',
+      fallback,
+    });
+
+    expect(sharing.shareAsync).not.toHaveBeenCalled();
+    expect(fallback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,6 +312,9 @@ importers:
       react-native-url-polyfill:
         specifier: ^4.0.0
         version: 4.0.0(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))
+      react-native-view-shot:
+        specifier: ^5.1.1
+        version: 5.1.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
       react-native-web:
         specifier: ~0.21.0
         version: 0.21.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -3888,6 +3891,9 @@ packages:
   css-in-js-utils@3.1.0:
     resolution: {integrity: sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==}
 
+  css-line-break@2.1.0:
+    resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
+
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
 
@@ -5095,6 +5101,10 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  html2canvas@1.4.1:
+    resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
+    engines: {node: '>=8.0.0'}
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
@@ -6416,6 +6426,13 @@ packages:
     peerDependencies:
       react-native: '*'
 
+  react-native-view-shot@5.1.1:
+    resolution: {integrity: sha512-jOTLQrMGNBgv/nRA81VR2x2AdiCGoCjc63c9a5P4A0gStCbh9oDeJ6W+GtRxxQmxXXf6LDSrvG+mmWYulIrOkg==}
+    engines: {node: '>=20.19.4', npm: '>=10'}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-native: '>=0.76.0'
+
   react-native-web@0.21.2:
     resolution: {integrity: sha512-SO2t9/17zM4iEnFvlu2DA9jqNbzNhoUP+AItkoCOyFmDMOhUnBBznBDCYN92fGdfAkfQlWzPoez6+zLxFNsZEg==}
     peerDependencies:
@@ -6943,6 +6960,9 @@ packages:
     resolution: {integrity: sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==}
     deprecated: no longer maintained
 
+  text-segmentation@1.0.3:
+    resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
+
   throat@5.0.0:
     resolution: {integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==}
 
@@ -7130,6 +7150,9 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  utrie@1.0.2:
+    resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
@@ -11276,6 +11299,10 @@ snapshots:
     dependencies:
       hyphenate-style-name: 1.1.0
 
+  css-line-break@2.1.0:
+    dependencies:
+      utrie: 1.0.2
+
   css-select@5.2.2:
     dependencies:
       boolbase: 1.0.0
@@ -11728,7 +11755,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.66.0(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.66.0(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -12799,6 +12826,11 @@ snapshots:
       lru-cache: 10.4.3
 
   html-escaper@2.0.2: {}
+
+  html2canvas@1.4.1:
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
 
   http-cache-semantics@4.2.0: {}
 
@@ -14123,6 +14155,12 @@ snapshots:
     dependencies:
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1)
 
+  react-native-view-shot@5.1.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8):
+    dependencies:
+      html2canvas: 1.4.1
+      react: 19.2.8
+      react-native: 0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1)
+
   react-native-web@0.21.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@babel/runtime': 7.29.7
@@ -14787,6 +14825,10 @@ snapshots:
 
   text-encoding@0.7.0: {}
 
+  text-segmentation@1.0.3:
+    dependencies:
+      utrie: 1.0.2
+
   throat@5.0.0: {}
 
   tinybench@2.9.0: {}
@@ -14988,6 +15030,10 @@ snapshots:
       '@types/react': 19.2.18
 
   utils-merge@1.0.1: {}
+
+  utrie@1.0.2:
+    dependencies:
+      base64-arraybuffer: 1.0.2
 
   uuid@3.4.0: {}
 


### PR DESCRIPTION
Looked at how the apps that do this well do it — [WhatsApp's group link](https://mobbin.com/screens/a7128900-2398-417d-a08a-c42dfed8d805), [GoPay's add-member QR](https://mobbin.com/screens/e60ccc08-0b6d-47df-9b0c-000d3dedde8a), [Lapse's Roll Code](https://mobbin.com/screens/49e299a6-fbb5-4cfa-ace7-3085c06f60d5), [Splitwise's own invite link](https://mobbin.com/screens/54184dec-9385-4a11-9c1d-975f5435c50a) — and the difference is not decoration. In the good ones the code sits *inside* something that says what it opens.

Ours was a QR on a plain card, a second card repeating the raw URL, and five circles in a row. Somebody holding the phone out had to say which group this was, out loud.

## What changed

**One card is the invitation.** Group name, the faces of the people already in it, then the code, on the brand wash. The name comes back from the header — where it had been removed for being redundant, correctly, since you open this from inside the group — onto the card, where it is part of the invitation rather than a label, and where it travels with the shared image.

**Copy moved onto the link.** It was a fifth circle among the channels, which put the act of taking the link somewhere other than the link, and made "Copy" read like a destination. The URL now sits in a pill with copy on its end, truncated in the middle so the token — the only part that differs between groups — stays visible.

**Three channels, not five.** WhatsApp, SMS, Email, wider now. Everything else the phone can do, including sending the code as a picture, is the single primary button underneath.

**The warning names the group.** "Anyone with this link can join {group}, so share it with people you trust", at the end rather than at the top: a caution reads better beside the thing being handed over than before it exists.

## Details

- New strings in en/ta/hi/ar, Arabic with all six plural forms.
- The avatar stack overlaps with a negative **start** margin, so it falls the right way round in RTL.
- Ghost members are counted (they are in the group) but keep the `ghost` styling that says which is which.
- Untouched: the token minting, the white quiet-zone capture that makes a shared PNG survive a dark WhatsApp bubble, and the deep-link fallbacks.

## Verification

`tsc --noEmit` clean, `pnpm lint` clean, 860 mobile tests pass, prettier clean. **Not device-tested** — this machine's emulator has no signed-in account with a group.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned group invitations with a branded invitation card, group details, member count, member avatars, and QR code.
  - Added an inline button to copy the invitation link.
  - Added a full-width share button for sending the QR-based invitation.
  - Streamlined quick sharing to three named channels.

- **Localization**
  - Updated invitation messaging and pluralized member-count text across English, Tamil, Hindi, and Arabic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->