### PR TITLE
The country picker is a pushed screen, not a bottom modal

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -661,6 +661,7 @@ function AuthGate() {
             <Stack.Screen name="friends/merge" />
             <Stack.Screen name="friends/person/[key]" />
             <Stack.Screen name="contact-picker" options={slide} />
+            <Stack.Screen name="country" options={slide} />
             <Stack.Screen name="scan" options={slide} />
             <Stack.Screen name="personal/transactions" />
             <Stack.Screen name="personal/entry" options={slide} />

--- a/apps/mobile/src/app/country.tsx
+++ b/apps/mobile/src/app/country.tsx
@@ -1,0 +1,168 @@
+/**
+ * Where a group — or a person — settles.
+ *
+ * Not a flag-and-dial-code control: this only decides two things, and saying
+ * which is more useful than a pretty list. **Which payment rails the settle
+ * screen offers**, and what currency a new group starts in. A group in the UAE
+ * gets Aani and dirhams; the same group set to India gets UPI and rupees.
+ *
+ * The list is deliberately short and ordered by market rather than
+ * alphabetically (see `COUNTRIES` in `@waves/core`), because somebody in the
+ * Gulf should not scroll past forty countries to find theirs. "Not set" is a
+ * real, supported answer and stays first: a group with no country falls back to
+ * bank, cash and the cross-border wallets, which is the right behaviour for a
+ * group whose members are in four places.
+ *
+ * A route rather than the `Modal` this used to be. As a modal it rose from the
+ * bottom edge and framed itself by hand, so it was the one full-screen page in
+ * the app that neither slid in from the leading edge nor wore the standard
+ * header — and, missing the bottom inset, its last country sat under the system
+ * navigation bar. As a route it inherits the app's push animation (which follows
+ * the writing direction, so Arabic still arrives from the left) and the same
+ * header, padding and clearance as every other pushed screen. The caller leaves
+ * its intent in `countryPickerBridge` first, because a pushed route cannot
+ * return a value the way the inline callback did.
+ */
+
+import { useEffect, useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router } from 'expo-router';
+import { Pressable, ScrollView, View } from 'react-native';
+
+import { COUNTRIES, countryFlag, railsFor } from '@waves/core';
+import {
+  directionalIcon,
+  IconButton,
+  iconSize,
+  Row,
+  Screen,
+  Text,
+  useScreenClearance,
+  useTheme,
+} from '@waves/ui';
+
+import { useStrings } from '@/i18n';
+
+import { takeCountryRequest } from '@/lib/countryPickerBridge';
+
+export default function CountryScreen(): React.JSX.Element {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const clearance = useScreenClearance();
+
+  // Taken once on mount — this captures the request and clears the bridge in
+  // one step, so the route owns it outright and no re-render or later open can
+  // see a stale request. Nothing else clears it; this screen is the sole owner.
+  const [request] = useState(() => takeCountryRequest());
+
+  // Opened with no pending request (a deep link, a stray navigation) has nothing
+  // to answer — close rather than show a picker whose choice would go nowhere.
+  useEffect(() => {
+    if (!request) router.back();
+  }, [request]);
+
+  const choose = (countryCode: string | null): void => {
+    request?.onPicked(countryCode);
+    router.back();
+  };
+
+  return (
+    <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.misc.whereSettle}</Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
+      <ScrollView
+        style={{ flex: 1 }}
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.lg,
+          // The app draws edge-to-edge, so without the system inset the last
+          // country in the list sits under the navigation bar.
+          paddingBottom: clearance,
+          gap: theme.spacing.sm,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        <Text variant="caption" tone="muted" style={{ paddingBottom: theme.spacing.xs }}>
+          {t.pickers.countryNote}
+        </Text>
+
+        <Choice
+          flag="🌐"
+          label={t.pickers.notSet}
+          hint={t.pickers.notSetRails}
+          selected={(request?.initial ?? null) === null}
+          onPress={() => choose(null)}
+        />
+        {COUNTRIES.map((country) => (
+          <Choice
+            key={country.code}
+            flag={countryFlag(country.code) ?? '🌐'}
+            label={country.name}
+            hint={railsFor(country.code)
+              .slice(0, 3)
+              .map((rail) => rail.label)
+              .join(', ')}
+            selected={request?.initial === country.code}
+            onPress={() => choose(country.code)}
+          />
+        ))}
+      </ScrollView>
+    </Screen>
+  );
+}
+
+function Choice({
+  flag,
+  label,
+  hint,
+  selected,
+  onPress,
+}: {
+  flag: string;
+  label: string;
+  hint: string;
+  selected: boolean;
+  onPress: () => void;
+}) {
+  const theme = useTheme();
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="radio"
+      accessibilityState={{ selected }}
+      style={{
+        paddingVertical: theme.spacing.md,
+        paddingHorizontal: theme.spacing.lg,
+        borderRadius: theme.radius.md,
+        backgroundColor: selected ? theme.color.brandSoft : theme.color.surface,
+      }}
+    >
+      <Row style={{ justifyContent: 'space-between', gap: theme.spacing.md }}>
+        <Text style={{ fontSize: 26 }}>{flag}</Text>
+        <View style={{ flex: 1 }}>
+          <Text variant="subheading">{label}</Text>
+          <Text variant="micro" tone="muted">
+            {hint}
+          </Text>
+        </View>
+        {selected ? (
+          <Text variant="subheading" tone="brand">
+            ✓
+          </Text>
+        ) : null}
+      </Row>
+    </Pressable>
+  );
+}

--- a/apps/mobile/src/components/CountryPicker.tsx
+++ b/apps/mobile/src/components/CountryPicker.tsx
@@ -1,26 +1,27 @@
 /**
- * Where a group settles.
+ * The row that shows where a group — or a person — settles, and opens the
+ * picker.
  *
- * Not a flag-and-dial-code control — this only decides two things, and saying
- * which is more useful than a pretty list: **which payment rails the settle
- * screen offers**, and what currency a new group starts in. A group in the UAE
- * gets Aani and dirhams; the same group set to India gets UPI and rupees.
+ * Not a flag-and-dial-code control: the choice only decides two things, and
+ * saying which is more useful than a pretty list. **Which payment rails the
+ * settle screen offers**, and what currency a new group starts in. A group in
+ * the UAE gets Aani and dirhams; the same group set to India gets UPI and
+ * rupees, so the row says as much under its title.
  *
- * The list is deliberately short and ordered by market rather than
- * alphabetically (see `COUNTRIES` in `@waves/core`), because somebody in the
- * Gulf should not scroll past forty countries to find theirs. "Not set" is a
- * real, supported answer and stays first: a group with no country falls back to
- * bank, cash and the cross-border wallets, which is the right behaviour for a
- * group whose members are in four places.
+ * The list itself lives on the `/country` route rather than in a `Modal` opened
+ * from here, so it arrives with the same push as every other full-screen page.
+ * A pushed route cannot hand a value back the way an inline callback could, so
+ * the answer comes back through `countryPickerBridge`.
  */
 
-import { useState } from 'react';
-import { Modal, Pressable, ScrollView, View } from 'react-native';
+import { router } from 'expo-router';
 
-import { COUNTRIES, countryFlag, countryName, railsFor } from '@waves/core';
-import { Button, Card, ListRow, Row, Screen, Text, useTheme } from '@waves/ui';
+import { countryFlag, countryName, railsFor } from '@waves/core';
+import { Card, ListRow, Text, useTheme } from '@waves/ui';
 
 import { useStrings } from '@/i18n';
+
+import { requestCountry } from '@/lib/countryPickerBridge';
 
 export function CountryRow({
   countryCode,
@@ -31,7 +32,6 @@ export function CountryRow({
 }) {
   const theme = useTheme();
   const { t } = useStrings();
-  const [open, setOpen] = useState(false);
 
   // What this choice actually buys, said in the row rather than in a help page.
   const rails = railsFor(countryCode)
@@ -39,128 +39,28 @@ export function CountryRow({
     .map((rail) => rail.label)
     .join(', ');
 
+  // The intent is stashed before the navigation, not passed as a route param: a
+  // param can carry the country we start from but not the callback that has to
+  // receive the answer.
+  const open = (): void => {
+    requestCountry({ initial: countryCode, onPicked: onChange });
+    router.push('/country');
+  };
+
   return (
-    <>
-      <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
-        <ListRow
-          // A globe stands in for "no country set", where a flag would be a lie.
-          leading={<Text style={{ fontSize: 26 }}>{countryFlag(countryCode) ?? '🌐'}</Text>}
-          title={t.pickers.country}
-          subtitle={t.pickers.settlesWith
-            .replace(
-              '{country}',
-              countryCode ? (countryName(countryCode) ?? countryCode) : t.pickers.notSet,
-            )
-            .replace('{rails}', rails)}
-          onPress={() => setOpen(true)}
-        />
-      </Card>
-
-      <Modal visible={open} animationType="slide" onRequestClose={() => setOpen(false)}>
-        <Screen edges={['top', 'bottom']} inModal>
-          <View
-            style={{
-              paddingHorizontal: theme.spacing.xl,
-              paddingBottom: theme.spacing.lg,
-              gap: theme.spacing.xs,
-            }}
-          >
-            <Text variant="heading">{t.misc.whereSettle}</Text>
-            <Text variant="caption" tone="muted">
-              {t.pickers.countryNote}
-            </Text>
-          </View>
-
-          <ScrollView
-            contentContainerStyle={{
-              paddingHorizontal: theme.spacing.xl,
-              paddingBottom: theme.spacing.xxxl,
-              gap: theme.spacing.sm,
-            }}
-            showsVerticalScrollIndicator={false}
-          >
-            <Choice
-              flag="🌐"
-              label={t.pickers.notSet}
-              hint={t.pickers.notSetRails}
-              selected={countryCode === null}
-              onPress={() => {
-                onChange(null);
-                setOpen(false);
-              }}
-            />
-            {COUNTRIES.map((country) => (
-              <Choice
-                key={country.code}
-                flag={countryFlag(country.code) ?? '🌐'}
-                label={country.name}
-                hint={railsFor(country.code)
-                  .slice(0, 3)
-                  .map((rail) => rail.label)
-                  .join(', ')}
-                selected={countryCode === country.code}
-                onPress={() => {
-                  onChange(country.code);
-                  setOpen(false);
-                }}
-              />
-            ))}
-          </ScrollView>
-
-          <View style={{ paddingHorizontal: theme.spacing.xl, paddingBottom: theme.spacing.lg }}>
-            <Button
-              label={t.common.close}
-              variant="ghost"
-              fullWidth
-              onPress={() => setOpen(false)}
-            />
-          </View>
-        </Screen>
-      </Modal>
-    </>
-  );
-}
-
-function Choice({
-  flag,
-  label,
-  hint,
-  selected,
-  onPress,
-}: {
-  flag: string;
-  label: string;
-  hint: string;
-  selected: boolean;
-  onPress: () => void;
-}) {
-  const theme = useTheme();
-  return (
-    <Pressable
-      onPress={onPress}
-      accessibilityRole="radio"
-      accessibilityState={{ selected }}
-      style={{
-        paddingVertical: theme.spacing.md,
-        paddingHorizontal: theme.spacing.lg,
-        borderRadius: theme.radius.md,
-        backgroundColor: selected ? theme.color.brandSoft : theme.color.surface,
-      }}
-    >
-      <Row style={{ justifyContent: 'space-between', gap: theme.spacing.md }}>
-        <Text style={{ fontSize: 26 }}>{flag}</Text>
-        <View style={{ flex: 1 }}>
-          <Text variant="subheading">{label}</Text>
-          <Text variant="micro" tone="muted">
-            {hint}
-          </Text>
-        </View>
-        {selected ? (
-          <Text variant="subheading" tone="brand">
-            ✓
-          </Text>
-        ) : null}
-      </Row>
-    </Pressable>
+    <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+      <ListRow
+        // A globe stands in for "no country set", where a flag would be a lie.
+        leading={<Text style={{ fontSize: 26 }}>{countryFlag(countryCode) ?? '🌐'}</Text>}
+        title={t.pickers.country}
+        subtitle={t.pickers.settlesWith
+          .replace(
+            '{country}',
+            countryCode ? (countryName(countryCode) ?? countryCode) : t.pickers.notSet,
+          )
+          .replace('{rails}', rails)}
+        onPress={open}
+      />
+    </Card>
   );
 }

--- a/apps/mobile/src/lib/countryPickerBridge.ts
+++ b/apps/mobile/src/lib/countryPickerBridge.ts
@@ -1,0 +1,43 @@
+/**
+ * A one-shot handoff between a row that shows the settling country and the
+ * full-screen country picker.
+ *
+ * The picker used to be a React Native `Modal` opened straight from the row, so
+ * it rose from the bottom edge while every other full-screen page in the app
+ * slides in from the leading edge. Moving it to its own route buys the app's one
+ * navigation motion for free, but a pushed route cannot hand a value back the
+ * way an inline callback could. So the row leaves its intent here first — which
+ * country is set now, and what to do with the answer — and the route reads it
+ * once on open.
+ *
+ * Deliberately a module singleton, not React state: it has to outlive the
+ * navigation that carries the caller off-screen and back. It holds exactly one
+ * request — there is only ever one picker open — and is cleared the moment it is
+ * read, so a stale request can never leak into the next open. This mirrors
+ * `contactPickerBridge`, which solves the same problem for the contact picker.
+ */
+
+export interface CountryRequest {
+  /** The country set right now, so the picker opens with it ticked. */
+  readonly initial: string | null;
+  /** What the caller does with the country chosen, before the picker closes. */
+  readonly onPicked: (countryCode: string | null) => void;
+}
+
+let pending: CountryRequest | null = null;
+
+/** Stash the caller's intent, then navigate to `/country`. */
+export function requestCountry(request: CountryRequest): void {
+  pending = request;
+}
+
+/**
+ * Take the open request and clear it in the same step — the picker reads this
+ * once on mount and thereafter owns the captured request, so nothing carries
+ * over to the next open whether it picks a country or is backed out of.
+ */
+export function takeCountryRequest(): CountryRequest | null {
+  const request = pending;
+  pending = null;
+  return request;
+}


### PR DESCRIPTION
"Where does this group settle?" was the one full-screen page in the app that did not behave like a page.

It was a React Native `Modal` opened inline from the country row (`components/CountryPicker.tsx`), which meant three things went wrong at once:

- **It arrived from the wrong edge.** `animationType="slide"` rises from the bottom, while every other full-screen page in the app slides in from the leading edge — the `ios_from_right` / `ios_from_left` push the root layout declares once for the whole Stack.
- **It framed itself by hand.** No back chevron, a left-aligned heading instead of the centred one every pushed screen wears, and a bare `Close` button pinned to the foot.
- **Its last row hid under the navigation bar.** The scroll container padded the foot with a fixed `xxxl` rather than the system inset, and the app draws edge-to-edge, so on a gesture-pill or three-button phone the final country sat behind the system UI.

It is now a route, `/country`, registered in the root layout beside the other pushed screens. That buys the app's own push animation for free — declared once, and following the writing direction, so Arabic still arrives from the left rather than from a hardcoded side. It also gets the standard header (back chevron, title centred), the same `xl` horizontal padding, and `useScreenClearance()` at the foot so the final row clears the navigation bar.

A pushed route cannot hand a value back the way the inline callback did, so the row leaves its intent in a new `countryPickerBridge` first — which country is set now, and what to do with the answer — and the route takes it once on mount, clearing the bridge in the same step. This is the same one-shot handoff the full-screen contact picker already uses. The bottom `Close` button goes with the modal: back is the header chevron now, as on every other page.

The row itself is unchanged apart from what its tap does, and all three callers (group settings, account settings, paying settings) keep the same `countryCode` / `onChange` contract.

## Testing

No copy changed, so there are no new strings in any of the four locales. `pnpm format`, `pnpm lint` and the mobile typecheck and test suite were run; the only lint warnings are the pre-existing `import/first` ones in `phone.tsx`. Not run on a device.
