### PR TITLE
Apple as a way to link an account

### DIFF
--- a/apps/mobile/src/app/settings/account.tsx
+++ b/apps/mobile/src/app/settings/account.tsx
@@ -10,7 +10,7 @@
 import { useRef, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router, useLocalSearchParams } from 'expo-router';
-import { ActivityIndicator, ScrollView, TextInput, View } from 'react-native';
+import { ActivityIndicator, Platform, ScrollView, TextInput, View } from 'react-native';
 
 import {
   Badge,
@@ -72,7 +72,7 @@ function AccountForm() {
   const theme = useTheme();
   const clearance = useTabBarClearance();
   const { t } = useStrings();
-  const { session, profile, isGuest, refresh, updateProfile, withGoogle } = useAuth();
+  const { session, profile, isGuest, refresh, updateProfile, withGoogle, withApple } = useAuth();
 
   // Set when a guest was sent here by a limit rather than arriving on their own
   // (ADR-006 addendum). It only changes the explainer at the top; the linking
@@ -149,7 +149,7 @@ function AccountForm() {
 
   // Which providers already sign this account in, so a linked one shows as done
   // rather than offering to link what is already linked. Adding one goes through
-  // the same `withGoogle` the sign-in screen uses: for somebody
+  // the same `withGoogle`/`withApple` the sign-in screen uses: for somebody
   // already signed in, `planAuth` turns that into a link, never a fresh sign-in
   // that would strand this account (ADR-006).
   const linkedProviders = new Set(
@@ -586,22 +586,35 @@ function AccountForm() {
 
           {/* Linking a social account, so it can sign this same account in later
               on another phone — the OAuth complement to the email/phone above.
-              Only Google today; the row is built to take more. Under the same
-              heading, because it is another way into the same account. */}
+              Under the same heading, because it is another way into the same
+              account.
+
+              Apple is offered on Android too, exactly as the sign-in screen
+              offers it: `withApple` only reaches the native sheet for a fresh
+              sign-in on iOS, and a link is always the browser round trip, so
+              there is nothing platform-specific to hide here. The order follows
+              the sign-in screen's — Apple first on iOS, where its guidelines
+              want it at least as prominent as its neighbours. */}
           <Card style={{ gap: theme.spacing.md }}>
             <Text variant="caption" tone="muted">
               {t.contact.signInMethodsBody}
             </Text>
             <View style={{ gap: theme.spacing.md }}>
-              <ProviderRow
-                name="Google"
-                icon="logo-google"
-                linked={linkedProviders.has('google')}
-                busy={busy}
-                linkLabel={t.contact.link}
-                linkedLabel={t.contact.linked}
-                onLink={() => void link(withGoogle)}
-              />
+              {(Platform.OS === 'ios' ? PROVIDERS_APPLE_FIRST : PROVIDERS_GOOGLE_FIRST).map(
+                (provider) => (
+                  <ProviderRow
+                    key={provider.id}
+                    name={provider.name}
+                    icon={provider.icon}
+                    linked={linkedProviders.has(provider.id)}
+                    busy={busy}
+                    linkLabel={t.contact.link}
+                    linkA11yLabel={t.contact.linkProvider.replace('{provider}', provider.name)}
+                    linkedLabel={t.contact.linked}
+                    onLink={() => void link(provider.id === 'apple' ? withApple : withGoogle)}
+                  />
+                ),
+              )}
             </View>
           </Card>
         </View>
@@ -648,6 +661,17 @@ function GroupLabel({ icon, title }: { icon: keyof typeof Ionicons.glyphMap; tit
 }
 
 /**
+ * The identity providers this screen can attach, as data rather than repeated
+ * markup. `id` is the provider string Supabase stores on `user.identities`, so
+ * it is what decides whether a row is already linked — it must stay spelled the
+ * way the server spells it. Brand names are not translated.
+ */
+const PROVIDER_GOOGLE = { id: 'google', name: 'Google', icon: 'logo-google' } as const;
+const PROVIDER_APPLE = { id: 'apple', name: 'Apple', icon: 'logo-apple' } as const;
+const PROVIDERS_APPLE_FIRST = [PROVIDER_APPLE, PROVIDER_GOOGLE];
+const PROVIDERS_GOOGLE_FIRST = [PROVIDER_GOOGLE, PROVIDER_APPLE];
+
+/**
  * One provider in the "ways to sign in" list: its mark, its name, and either a
  * Linked badge or a button to link it. Icon-and-name so the row reads at a
  * glance; the action says exactly what it does.
@@ -658,14 +682,17 @@ function ProviderRow({
   linked,
   busy,
   linkLabel,
+  linkA11yLabel,
   linkedLabel,
   onLink,
 }: {
   name: string;
-  icon: 'logo-google';
+  icon: 'logo-google' | 'logo-apple';
   linked: boolean;
   busy: boolean;
   linkLabel: string;
+  /** Names the provider aloud, because the visible pill only says "Link". */
+  linkA11yLabel: string;
   linkedLabel: string;
   onLink: () => void;
 }) {
@@ -681,6 +708,7 @@ function ProviderRow({
       ) : (
         <Button
           label={linkLabel}
+          accessibilityLabel={linkA11yLabel}
           size="sm"
           variant="secondary"
           disabled={busy}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1051,6 +1051,13 @@ export interface UiStrings {
     signInMethodsTitle: string;
     signInMethodsBody: string;
     link: string;
+    /**
+     * The spoken label for one provider's Link button. The visible pill says
+     * only "Link", which is right beside the name and wrong on its own: with
+     * two providers listed, a screen reader would otherwise announce two
+     * identical buttons. `{provider}` is the brand name, never translated.
+     */
+    linkProvider: string;
     linked: string;
     footnote: string;
     /** Shown when a guest is sent here by a limit rather than arriving on their own. */
@@ -3385,6 +3392,7 @@ const en: UiStrings = {
     signInMethodsTitle: 'Ways to sign in',
     signInMethodsBody: 'Link an account and you can sign in with it next time, on any phone.',
     link: 'Link',
+    linkProvider: 'Link {provider}',
     linked: 'Linked',
     footnote:
       'Waves never asks for this to let you in, and never shares it with anyone in your groups. People see the name you choose, nothing else.',
@@ -5669,6 +5677,7 @@ const ta: UiStrings = {
     signInMethodsTitle: 'உள்நுழையும் வழிகள்',
     signInMethodsBody: 'ஒரு கணக்கை இணைத்தால், அடுத்த முறை எந்த ஃபோனிலும் அதன் மூலம் உள்நுழையலாம்.',
     link: 'இணை',
+    linkProvider: '{provider} ஐ இணை',
     linked: 'இணைக்கப்பட்டது',
     footnote:
       'உள்ளே விடுவதற்கு Waves இதை ஒருபோதும் கேட்பதில்லை, உங்கள் குழுக்களில் உள்ள யாருடனும் இதைப் பகிர்வதும் இல்லை. நீங்கள் தேர்ந்தெடுத்த பெயரை மட்டுமே மற்றவர்கள் பார்ப்பார்கள்.',
@@ -8006,6 +8015,7 @@ const hi: UiStrings = {
     signInMethodsTitle: 'साइन इन करने के तरीके',
     signInMethodsBody: 'कोई खाता लिंक करें और अगली बार किसी भी फ़ोन पर उससे साइन इन कर सकते हैं।',
     link: 'लिंक करें',
+    linkProvider: '{provider} लिंक करें',
     linked: 'लिंक किया गया',
     footnote:
       'अंदर आने देने के लिए Waves यह कभी नहीं माँगता, और आपके समूह में किसी के साथ इसे साझा नहीं करता। लोग सिर्फ़ वही नाम देखते हैं जो आप चुनते हैं।',
@@ -10323,6 +10333,7 @@ const ar: UiStrings = {
     signInMethodsTitle: 'طرق تسجيل الدخول',
     signInMethodsBody: 'اربط حسابًا لتتمكن من تسجيل الدخول به في المرة القادمة، على أي هاتف.',
     link: 'ربط',
+    linkProvider: 'ربط {provider}',
     linked: 'مرتبط',
     footnote:
       'لا يطلب Waves هذا ليسمح لك بالدخول، ولا يشاركه مع أحد في مجموعاتك. يرى الناس الاسم الذي تختاره، لا غير.',


### PR DESCRIPTION
## What

The "Ways to sign in" card on Your account (`settings/account`) — the screen a guest uses to attach real credentials to the account they already have — offered Google and nothing else. Apple now sits beside it.

## How

No new Apple code. `withApple` in `lib/auth.tsx` already routes through `planAuth`, and for anybody who is signed in — guest or member — that returns `linkIdentity`, which attaches the provider to the **existing** user id. The groups, expenses and balances stay where they are, which is the whole point of ADR-006 and the one thing that must not go wrong here.

The native Apple sheet is deliberately not involved. Supabase has no id-token form of `linkIdentity`, so a link is always the browser round trip regardless of platform — `withApple` only reaches `signInWithIdToken` when `planAuth` says `signInWithOAuth`, which by definition means nobody is signed in. So there is no native module to lazily require on this path, and the row is shown on Android as well as iOS, matching what the sign-in screen already does.

Small things that came with it:

- The two rows are generated from a provider table instead of duplicated markup, ordered Apple-first on iOS and Google-first elsewhere — the same ordering, and the same reason, as the sign-in screen's tiles.
- Each Link button now names its provider to a screen reader. Two buttons both announcing "Link" would be indistinguishable. New string `contact.linkProvider`, translated in en, ta, hi and ar.
- `ProviderRow`'s icon type widened to accept `logo-apple`.

## Files

- `apps/mobile/src/app/settings/account.tsx`
- `apps/mobile/src/i18n/index.ts`

## Checks

`pnpm --filter @waves/mobile typecheck`, `lint` and `format` are clean. The mobile suite is 864/865: `test/watchSendFailure.test.ts` times out under full-suite load on this machine, and it does so identically on `main` with these changes stashed, so it is a pre-existing flake and not from here.

## Not verified

This has not been run on a device or in a simulator — no native build was made, so the flow has never actually been tapped. The linking path itself is unchanged code that Google already exercises; what is untested is Apple's browser round trip specifically.

Apple sign-in also needs the Supabase Apple provider secret configured before any of this can succeed at runtime. Without it the browser round trip will fail at Apple's end, exactly as it would on the sign-in screen today.
