### PR TITLE
fix(voice): keep the and in a spoken description

### DIFF
--- a/apps/mobile/src/lib/voiceExpense.ts
+++ b/apps/mobile/src/lib/voiceExpense.ts
@@ -414,6 +414,23 @@ const STOPWORDS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * A word reduced to the letters and digits that identify it, for set lookups.
+ *
+ * Note that this drops combining marks along with the punctuation: `\p{M}` is
+ * neither `\p{L}` nor `\p{N}`, so "மற்றும்" comes back as "மறறம" and "कॉफी" as
+ * "कफ". Harmless for comparing two tokens with each other — both sides lose the
+ * same marks — but fatal for a *literal* written into a lookup table, which
+ * keeps its marks and can then never be matched. Every set this function is
+ * used against has to be built through it (see NOTE_CONJUNCTIONS below).
+ */
+function noteToken(word: string): string {
+  return word
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]/gu, '');
+}
+
+/**
  * List glue that a description keeps even though it is a stopword everywhere
  * else. "800 rupees for dress and biscuits" is one bill for two things, and the
  * note has to read back the way it was spoken — "dress biscuits" is not a
@@ -423,25 +440,39 @@ const STOPWORDS: ReadonlySet<string> = new Set([
  * The non-English entries are the same word in the app's other locales. They
  * were never stopwords, so they already survived into notes; listing them here
  * only lets the dangling-edge tidy below reach them too.
+ *
+ * Stored as noteToken() output rather than as the words themselves, so the
+ * written form and the looked-up form cannot drift apart. Spelling "மற்றும்"
+ * out here instead would put an entry in the set that no lookup can ever reach.
  */
-const NOTE_CONJUNCTIONS: ReadonlySet<string> = new Set(['and', 'और', 'மற்றும்', 'و']);
-
-/** A word reduced to the letters and digits that identify it, for set lookups. */
-function noteToken(word: string): string {
-  return word
-    .normalize('NFKC')
-    .toLowerCase()
-    .replace(/[^\p{L}\p{N}]/gu, '');
-}
+const NOTE_CONJUNCTIONS: ReadonlySet<string> = new Set(
+  ['and', 'और', 'மற்றும்', 'و'].map(noteToken),
+);
 
 /**
- * A description that starts, ends or doubles on a conjunction, cleaned up.
+ * The glue a description is allowed to keep between two things: the list
+ * punctuation people speak, and nothing else. Anything wider ("then") would be
+ * written into notes that the tidy below has no way to take back out again.
+ *
+ * One class, three uses — what separatorGlue writes back and what the tidy trims
+ * off the ends have to stay the same set, or a mark can be written into a note
+ * that nothing can remove.
+ */
+const NOTE_GLUE_PUNCTUATION = String.raw`[,;]`;
+const IS_NOTE_GLUE_PUNCTUATION = new RegExp(`^${NOTE_GLUE_PUNCTUATION}$`, 'u');
+const LEADING_NOTE_GLUE = new RegExp(`^${NOTE_GLUE_PUNCTUATION}+\\s*`, 'u');
+const TRAILING_NOTE_GLUE = new RegExp(`\\s*${NOTE_GLUE_PUNCTUATION}+$`, 'u');
+
+/**
+ * A description that starts, ends or doubles on glue, cleaned up.
  *
  * Keeping "and" in the note means it can be left stranded once the words around
  * it are taken away — a category phrase lifted out ("category food and dinner"),
  * a member's name removed ("dinner and Ravi"), or a trailing "… and" the speaker
- * never finished. A conjunction joining nothing is not grammar, so it is dropped
- * wherever it no longer sits between two things.
+ * never finished. The same is true of the comma that joined a list: "500 for
+ * dinner, Ravi and Asha" becomes "dinner," once the names move to the split.
+ * Glue joining nothing is not grammar, so it is dropped wherever it no longer
+ * sits between two things.
  */
 function tidyNoteConjunctions(note: string): string {
   const isConjunction = (word: string | undefined): boolean =>
@@ -449,12 +480,22 @@ function tidyNoteConjunctions(note: string): string {
 
   const kept: string[] = [];
   for (const word of note.split(/\s+/u).filter(Boolean)) {
+    // A word that is only punctuation says nothing on its own. It reaches here
+    // when the word it was attached to was taken away, and dropping it keeps a
+    // detached comma from reading differently to an attached one.
+    if (!noteToken(word)) continue;
     if (isConjunction(word) && (kept.length === 0 || isConjunction(kept[kept.length - 1])))
       continue;
     kept.push(word);
   }
   while (kept.length > 0 && isConjunction(kept[kept.length - 1])) kept.pop();
-  return kept.join(' ');
+  if (kept.length === 0) return '';
+
+  // The list punctuation left clinging to the ends once its other half is gone
+  // — "dinner," where the names that followed it are now rows on the split.
+  kept[0] = kept[0].replace(LEADING_NOTE_GLUE, '');
+  kept[kept.length - 1] = kept[kept.length - 1].replace(TRAILING_NOTE_GLUE, '');
+  return kept.filter(Boolean).join(' ');
 }
 
 /** A signed number; validation below accepts only positive values. */
@@ -1748,11 +1789,17 @@ const SEGMENT_SEPARATOR = /(\s*,\s*|\s+and\s+|\s*;\s*|\s+then\s+|\n+)/i;
 /**
  * The mark or word that joined two fragments, written the way it would be typed
  * back into a description: ", " after a comma, " and " around a conjunction.
+ *
+ * Only glue the tidy above can take back out again is ever written back. A line
+ * break says nothing, and "then" narrates a sequence rather than joining a list
+ * — "coffee then tax" is not how anyone describes one bill, and a "then" left
+ * stranded by a name or a category coming out of the note could never be
+ * removed. Both collapse to the plain space the split used to leave behind.
  */
 function separatorGlue(separator: string): string {
   const joiner = separator.replace(/\s+/gu, ' ').trim();
-  if (!joiner) return ' ';
-  return /^[,;]$/u.test(joiner) ? `${joiner} ` : ` ${joiner} `;
+  if (IS_NOTE_GLUE_PUNCTUATION.test(joiner)) return `${joiner} `;
+  return NOTE_CONJUNCTIONS.has(noteToken(joiner)) ? ` ${joiner} ` : ' ';
 }
 
 /**

--- a/apps/mobile/src/lib/voiceExpense.ts
+++ b/apps/mobile/src/lib/voiceExpense.ts
@@ -413,6 +413,50 @@ const STOPWORDS: ReadonlySet<string> = new Set([
   'fils',
 ]);
 
+/**
+ * List glue that a description keeps even though it is a stopword everywhere
+ * else. "800 rupees for dress and biscuits" is one bill for two things, and the
+ * note has to read back the way it was spoken — "dress biscuits" is not a
+ * phrase anyone would have typed. The conjunction stays a stopword for group
+ * and member matching, where it names nothing; only the note holds on to it.
+ *
+ * The non-English entries are the same word in the app's other locales. They
+ * were never stopwords, so they already survived into notes; listing them here
+ * only lets the dangling-edge tidy below reach them too.
+ */
+const NOTE_CONJUNCTIONS: ReadonlySet<string> = new Set(['and', 'और', 'மற்றும்', 'و']);
+
+/** A word reduced to the letters and digits that identify it, for set lookups. */
+function noteToken(word: string): string {
+  return word
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]/gu, '');
+}
+
+/**
+ * A description that starts, ends or doubles on a conjunction, cleaned up.
+ *
+ * Keeping "and" in the note means it can be left stranded once the words around
+ * it are taken away — a category phrase lifted out ("category food and dinner"),
+ * a member's name removed ("dinner and Ravi"), or a trailing "… and" the speaker
+ * never finished. A conjunction joining nothing is not grammar, so it is dropped
+ * wherever it no longer sits between two things.
+ */
+function tidyNoteConjunctions(note: string): string {
+  const isConjunction = (word: string | undefined): boolean =>
+    word !== undefined && NOTE_CONJUNCTIONS.has(noteToken(word));
+
+  const kept: string[] = [];
+  for (const word of note.split(/\s+/u).filter(Boolean)) {
+    if (isConjunction(word) && (kept.length === 0 || isConjunction(kept[kept.length - 1])))
+      continue;
+    kept.push(word);
+  }
+  while (kept.length > 0 && isConjunction(kept[kept.length - 1])) kept.pop();
+  return kept.join(' ');
+}
+
 /** A signed number; validation below accepts only positive values. */
 const SIGNED_AMOUNT_RE = String.raw`[+-]?\s*\d[\d,]*(?:\.\d+)?`;
 
@@ -556,24 +600,24 @@ function buildNote(transcript: string, matchedGroupName: string | null): string 
   const nameTokens = new Set(matchedGroupName ? tokenize(matchedGroupName) : []);
   const currencyWord = new RegExp(`\\b(?:${CURRENCY_WORD_ALT})\\b`, 'gi');
 
-  return transcript
+  const words = transcript
     .replace(SPLIT_WITH_CLAUSE, ' ')
     .replace(currencyWord, ' ')
     .replace(new RegExp(CURRENCY_SYMBOL_RE, 'g'), ' ')
     .replace(/\d[\d,]*(?:\.\d+)?/g, ' ')
     .split(/\s+/)
     .filter((word) => {
-      const token = word
-        .normalize('NFKC')
-        .toLowerCase()
-        .replace(/[^\p{L}\p{N}]/gu, '');
+      const token = noteToken(word);
       if (!token) return false;
-      if (STOPWORDS.has(token)) return false;
+      // The list conjunction is the one stopword a description keeps, so two
+      // things bought on one bill still read as two things.
+      if (STOPWORDS.has(token) && !NOTE_CONJUNCTIONS.has(token)) return false;
       if (nameTokens.has(token)) return false;
       return true;
     })
-    .join(' ')
-    .trim();
+    .join(' ');
+
+  return tidyNoteConjunctions(words);
 }
 
 /**
@@ -673,7 +717,8 @@ export function matchMemberNames(
  * A spoken name is split information, not a description — "dinner with Ravi"
  * describes dinner, and Ravi becomes a row, not a word in the note. Removes
  * every member name word (two letters or more) so the description that reaches
- * the form is just what was spent on.
+ * the form is just what was spent on. Taking a name out can strand the "and"
+ * that led to it ("dinner and Ravi"), so the leftovers are tidied afterwards.
  */
 export function stripMemberNames(
   note: string,
@@ -682,14 +727,15 @@ export function stripMemberNames(
   const nameTokens = new Set(
     members.flatMap((member) => tokenize(member.name)).filter((token) => token.length >= 2),
   );
-  return note
+  const words = note
     .split(/\s+/)
     .filter((word) => {
       const token = word.toLowerCase().replace(/[^\p{L}\p{N}]/gu, '');
       return token !== '' && !nameTokens.has(token);
     })
-    .join(' ')
-    .trim();
+    .join(' ');
+
+  return tidyNoteConjunctions(words);
 }
 
 export function resolveVoiceParticipants(params: {
@@ -779,6 +825,17 @@ function stripCategoryPhrase(text: string): string {
     .replace(CATEGORY_PHRASE, ' ')
     .replace(/[ \t]{2,}/g, ' ')
     .trim();
+}
+
+/**
+ * The last pass over a description before the review screen shows it. Lifting a
+ * category phrase out can leave the conjunction that led to it hanging
+ * ("category food and dinner" → "and dinner"), so the tidy runs after, not
+ * before. Only notes go through here — the split/people text is read by
+ * machine, not by a person, and is left exactly as spoken.
+ */
+function finalizeNote(note: string): string {
+  return tidyNoteConjunctions(stripCategoryPhrase(note));
 }
 
 /* ─────────────────────────────────────────────────────────────────────────
@@ -1682,6 +1739,23 @@ export function detectCreateGroup(transcript: string): { name: string; rest: str
 }
 
 /**
+ * What people put between two spoken expenses. Captured, not discarded, because
+ * a fragment with no amount is folded back into a priced neighbour and the word
+ * that joined them belongs in the description.
+ */
+const SEGMENT_SEPARATOR = /(\s*,\s*|\s+and\s+|\s*;\s*|\s+then\s+|\n+)/i;
+
+/**
+ * The mark or word that joined two fragments, written the way it would be typed
+ * back into a description: ", " after a comma, " and " around a conjunction.
+ */
+function separatorGlue(separator: string): string {
+  const joiner = separator.replace(/\s+/gu, ' ').trim();
+  if (!joiner) return ' ';
+  return /^[,;]$/u.test(joiner) ? `${joiner} ` : ` ${joiner} `;
+}
+
+/**
  * The sentence broken into one piece per expense.
  *
  * People list expenses with commas and "and" ("5 for snacks, 10 for tea and 20
@@ -1690,37 +1764,67 @@ export function detectCreateGroup(transcript: string): { name: string; rest: str
  * than one currency-adjacent amount is split again just before each amount, so
  * a run with no commas still comes apart. Pieces with no amount are dropped by
  * the caller.
+ *
+ * A piece put back together keeps the word it was split on, so a single-price
+ * sentence still reads as one: "800 rupees for dress and biscuits" is one bill
+ * for "dress and biscuits", never for "dress biscuits".
  */
 function segmentExpenses(text: string): string[] {
   // Take out "split among 4" / "4 people" first, so the count is never scanned
   // as an amount and turned into a phantom expense. The caller keeps the count
   // separately (extractSplitCount reads the untouched body), so nothing is lost.
   const withoutCount = text.replace(new RegExp(SPLIT_COUNT.source, 'gi'), ' ');
-  const bySeparator = withoutCount
-    .split(/\s*,\s*|\s+and\s+|\s*;\s*|\s+then\s+|\n+/i)
-    .map((piece) => piece.trim())
-    .filter(Boolean);
+
+  // With a capturing separator, split alternates fragment, separator, fragment.
+  // Each fragment remembers the separator that came before it, so a fold can put
+  // it back. Consecutive separators around an empty fragment ("tea,, 30") keep
+  // the first, which is the one that reads.
+  const parts = withoutCount.split(SEGMENT_SEPARATOR);
+  const fragments: { text: string; separatorBefore: string }[] = [];
+  let carriedSeparator = '';
+  for (let index = 0; index < parts.length; index += 1) {
+    if (index % 2 === 1) {
+      if (!carriedSeparator) carriedSeparator = parts[index];
+      continue;
+    }
+    const piece = parts[index].trim();
+    if (!piece) continue;
+    fragments.push({ text: piece, separatorBefore: carriedSeparator });
+    carriedSeparator = '';
+  }
 
   // A separator only starts a new expense when a *price* follows it: "5 snacks
   // and 10 tea" is two, but "bread and tea 300" is one bill whose note happens
   // to contain "and". So an amountless fragment is not its own expense — it is
   // words belonging to a neighbouring priced one. Fold each into the next priced
   // fragment (a leading label like "bread and…"); any left over at the end joins
-  // the last priced fragment ("…300 and tax"). A wholly amountless transcript
-  // keeps its single fragment, which the caller then drops for having no amount.
+  // the last priced fragment ("…300 and tax"). The joining word is put back with
+  // the fragment so the description stays the sentence that was spoken. A wholly
+  // amountless transcript keeps its single fragment, which the caller then drops
+  // for having no amount.
   const hasAmount = (piece: string): boolean => /\d[\d,]*(?:\.\d+)?/.test(piece);
   const merged: string[] = [];
   let pending = '';
-  for (const piece of bySeparator) {
-    if (hasAmount(piece)) {
-      merged.push(pending ? `${pending} ${piece}` : piece);
+  let pendingSeparator = '';
+  for (const fragment of fragments) {
+    const glue = separatorGlue(fragment.separatorBefore);
+    if (hasAmount(fragment.text)) {
+      merged.push(pending ? `${pending}${glue}${fragment.text}` : fragment.text);
       pending = '';
+      pendingSeparator = '';
+    } else if (pending) {
+      pending = `${pending}${glue}${fragment.text}`;
     } else {
-      pending = pending ? `${pending} ${piece}` : piece;
+      pending = fragment.text;
+      // How this run of amountless words attaches to the priced fragment before
+      // it, kept for the trailing case ("coffee 50 and tax").
+      pendingSeparator = fragment.separatorBefore;
     }
   }
   if (pending) {
-    if (merged.length > 0) merged[merged.length - 1] = `${merged[merged.length - 1]} ${pending}`;
+    if (merged.length > 0)
+      merged[merged.length - 1] =
+        `${merged[merged.length - 1]}${separatorGlue(pendingSeparator)}${pending}`;
     else merged.push(pending);
   }
 
@@ -1824,7 +1928,7 @@ export function parseVoiceExpenses(
       amountMajor,
       amountMinor: toVoiceMinorUnits(amountMajor, currency),
       currency,
-      note: stripCategoryPhrase(buildNote(segment, matchedName)),
+      note: finalizeNote(buildNote(segment, matchedName)),
       category: itemCategory,
     });
   }
@@ -1838,7 +1942,7 @@ export function parseVoiceExpenses(
         amountMinor: one.amountMinor,
         amountMajor: one.amountMajor,
         currency: one.currency,
-        note: stripCategoryPhrase(one.note),
+        note: finalizeNote(one.note),
         category,
       });
     }

--- a/apps/mobile/test/voiceExpense.test.ts
+++ b/apps/mobile/test/voiceExpense.test.ts
@@ -606,14 +606,15 @@ describe('parseVoiceExpenses (several in one breath)', () => {
     expect(result.items[0].category).toBe('food');
   });
 
-  it('keeps the local conjunction in a Hindi or Tamil description', () => {
-    // "और" and "மற்றும்" are never translated into English — the note is shown
-    // back in the language it was spoken, so the local word has to survive as
-    // the English one now does.
+  it('keeps the local conjunction in Hindi, Tamil, or Arabic descriptions', () => {
+    // "और", "மற்றும்" and "و" are never translated into English — the note is
+    // shown back in the language it was spoken, so the local word has to survive
+    // as the English one now does.
     expect(parseVoiceExpenses('500 रुपये चाय और कॉफी', groups).items[0]?.note).toBe('चाय और कॉफी');
     expect(parseVoiceExpenses('500 ரூபாய் தேநீர் மற்றும் காபி', groups).items[0]?.note).toBe(
       'தேநீர் மற்றும் காபி',
     );
+    expect(parseVoiceExpenses('٥٠٠ روبية شاي و قهوة', groups).items[0]?.note).toBe('شاي و قهوة');
   });
 
   it('keeps a lone expense working, with its named group', () => {

--- a/apps/mobile/test/voiceExpense.test.ts
+++ b/apps/mobile/test/voiceExpense.test.ts
@@ -441,6 +441,11 @@ describe('matchMemberNames', () => {
     expect(stripMemberNames('dinner and Ravi', members)).toBe('dinner');
     expect(stripMemberNames('Ravi and dinner', members)).toBe('dinner');
     expect(stripMemberNames('tea and Ravi and coffee', members)).toBe('tea and coffee');
+    // Whatever the sentence was spoken in — the note is never translated.
+    expect(stripMemberNames('चाय और Ravi', members)).toBe('चाय');
+    expect(stripMemberNames('தேநீர் மற்றும் Ravi', members)).toBe('தேநீர்');
+    // And the comma that introduced the name goes with it.
+    expect(stripMemberNames('dinner, Ravi', members)).toBe('dinner');
   });
 
   it('resolves named voice participants and keeps the payer included', () => {
@@ -609,12 +614,63 @@ describe('parseVoiceExpenses (several in one breath)', () => {
   it('keeps the local conjunction in Hindi, Tamil, or Arabic descriptions', () => {
     // "और", "மற்றும்" and "و" are never translated into English — the note is
     // shown back in the language it was spoken, so the local word has to survive
-    // as the English one now does.
+    // as the English one now does. None of the three was ever a stopword, so
+    // this half held before any of this; the dangling case below is the half
+    // that did not.
     expect(parseVoiceExpenses('500 रुपये चाय और कॉफी', groups).items[0]?.note).toBe('चाय और कॉफी');
     expect(parseVoiceExpenses('500 ரூபாய் தேநீர் மற்றும் காபி', groups).items[0]?.note).toBe(
       'தேநீர் மற்றும் காபி',
     );
     expect(parseVoiceExpenses('٥٠٠ روبية شاي و قهوة', groups).items[0]?.note).toBe('شاي و قهوة');
+  });
+
+  it('drops a local conjunction left joining nothing', () => {
+    // The half a mid-sentence assertion cannot see: a conjunction survives in
+    // the middle whether or not the parser knows it is one. A conjunction is
+    // recognised through noteToken(), which strips combining marks, so a Tamil
+    // word spelled out in the lookup set would sit there unreachable and this
+    // would keep its "மற்றும்" for ever.
+    expect(parseVoiceExpenses('500 रुपये चाय और', groups).items[0]?.note).toBe('चाय');
+    expect(parseVoiceExpenses('500 ரூபாய் தேநீர் மற்றும்', groups).items[0]?.note).toBe('தேநீர்');
+    expect(parseVoiceExpenses('٥٠٠ روبية شاي و', groups).items[0]?.note).toBe('شاي');
+    expect(parseVoiceExpenses('500 रुपये चाय और और कॉफी', groups).items[0]?.note).toBe(
+      'चाय और कॉफी',
+    );
+    expect(
+      parseVoiceExpenses('500 ரூபாய் தேநீர் மற்றும் மற்றும் காபி', groups).items[0]?.note,
+    ).toBe('தேநீர் மற்றும் காபி');
+  });
+
+  it('leaves no comma hanging where the words after it became split rows', () => {
+    // "500 for dinner, Ravi and Asha" reaches the form as "dinner, Ravi and
+    // Asha"; the names then become rows on the split, and the comma that
+    // introduced them has nothing left to separate.
+    const note = parseVoiceExpenses('500 for dinner, Ravi and Asha', groups).items[0].note;
+    expect(note).toBe('dinner, Ravi and Asha');
+    expect(
+      stripMemberNames(note, [
+        { id: 'r', name: 'Ravi' },
+        { id: 'a', name: 'Asha' },
+      ]),
+    ).toBe('dinner');
+  });
+
+  it('leaves no comma or semicolon hanging where a category phrase came out', () => {
+    expect(parseVoiceExpenses('400 for dinner, category food', groups).items[0].note).toBe(
+      'dinner',
+    );
+    expect(parseVoiceExpenses('400 for dinner; category food', groups).items[0].note).toBe(
+      'dinner',
+    );
+  });
+
+  it('does not write a spoken "then" into a description', () => {
+    // "then" narrates a sequence rather than joining a list, and one stranded
+    // by a category phrase coming out could never be tidied away again.
+    expect(parseVoiceExpenses('coffee 50 then tax', groups).items[0].note).toBe('coffee tax');
+    expect(parseVoiceExpenses('400 for dinner then category food', groups).items[0].note).toBe(
+      'dinner',
+    );
   });
 
   it('keeps a lone expense working, with its named group', () => {

--- a/apps/mobile/test/voiceExpense.test.ts
+++ b/apps/mobile/test/voiceExpense.test.ts
@@ -6,6 +6,7 @@ import {
   parseVoiceExpense,
   parseVoiceExpenseDate,
   resolveVoiceParticipants,
+  stripMemberNames,
   type VoiceGroupRef,
 } from '@/lib/voiceExpense';
 
@@ -434,6 +435,14 @@ describe('matchMemberNames', () => {
     expect(matchMemberNames('add 500 for dinner', members)).toEqual([]);
   });
 
+  it('does not leave an "and" hanging where a name was removed', () => {
+    // The name becomes a row on the split, not a word in the description, and
+    // the conjunction that introduced it goes with it.
+    expect(stripMemberNames('dinner and Ravi', members)).toBe('dinner');
+    expect(stripMemberNames('Ravi and dinner', members)).toBe('dinner');
+    expect(stripMemberNames('tea and Ravi and coffee', members)).toBe('tea and coffee');
+  });
+
   it('resolves named voice participants and keeps the payer included', () => {
     expect(
       resolveVoiceParticipants({
@@ -519,7 +528,7 @@ describe('parseVoiceExpenses (several in one breath)', () => {
     const result = parseVoiceExpenses('bread and tea 300', groups);
     expect(result.items).toHaveLength(1);
     expect(result.items[0].amountMajor).toBe(300);
-    expect(result.items[0].note).toBe('bread tea');
+    expect(result.items[0].note).toBe('bread and tea');
   });
 
   it('keeps role-like labels together when one shared price follows', () => {
@@ -527,26 +536,84 @@ describe('parseVoiceExpenses (several in one breath)', () => {
 
     expect(result.items).toHaveLength(1);
     expect(result.items[0].amountMajor).toBe(1200);
-    expect(result.items[0].note).toBe('user rider traveller financer');
+    expect(result.items[0].note).toBe('user and rider and traveller and financer');
   });
 
   it('folds a leading label across "and" into the price that follows', () => {
     const result = parseVoiceExpenses('add expense 300 bread and tea', groups);
     expect(result.items).toHaveLength(1);
-    expect(result.items[0].note).toBe('bread tea');
+    expect(result.items[0].note).toBe('bread and tea');
   });
 
   it('attaches a trailing amountless fragment to the last priced item', () => {
     const result = parseVoiceExpenses('coffee 50 and tax', groups);
     expect(result.items).toHaveLength(1);
     expect(result.items[0].amountMajor).toBe(50);
-    expect(result.items[0].note).toBe('coffee tax');
+    expect(result.items[0].note).toBe('coffee and tax');
   });
 
   it('still splits a genuine priced list on "and"', () => {
     const result = parseVoiceExpenses('5 snacks and 10 tea', groups);
     expect(result.items.map((item) => item.amountMajor)).toEqual([5, 10]);
     expect(result.items.map((item) => item.note)).toEqual(['snacks', 'tea']);
+  });
+
+  it('reads two things bought on one bill as one grammatical description', () => {
+    // The reported bug, word for word: "800 rupees for dress and biscuits" is a
+    // single ₹800 expense, and the review screen showed "dress biscuits" — the
+    // conjunction was eaten twice over, once when the amountless "biscuits" was
+    // folded back into the priced fragment and again as a note stopword.
+    const result = parseVoiceExpenses('800 rupees for dress and biscuits', groups);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].amountMajor).toBe(800);
+    expect(result.items[0].currency).toBe('INR');
+    expect(result.items[0].note).toBe('dress and biscuits');
+  });
+
+  it('keeps the conjunction in a one-price description with no currency word', () => {
+    const result = parseVoiceExpenses('500 for tea and coffee', groups);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].amountMajor).toBe(500);
+    expect(result.items[0].note).toBe('tea and coffee');
+  });
+
+  it('still makes two expenses when each half carries its own price', () => {
+    // The near neighbour of the bug: the same sentence with a second amount is
+    // two expenses, and neither description picks up the other's words.
+    const result = parseVoiceExpenses('800 rupees for dress and 200 for biscuits', groups);
+    expect(result.items.map((item) => item.amountMajor)).toEqual([800, 200]);
+    expect(result.items.map((item) => item.note)).toEqual(['dress', 'biscuits']);
+  });
+
+  it('keeps a comma-and-and list readable inside one priced description', () => {
+    const result = parseVoiceExpenses('250 for idli, dosa and vada', groups);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].note).toBe('idli, dosa and vada');
+  });
+
+  it('drops a conjunction the speaker left joining nothing', () => {
+    // "…for dinner and" — the sentence trails off, and a description ending on
+    // "and" reads worse than one without it.
+    const result = parseVoiceExpenses('500 rupees for dinner and', groups);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].note).toBe('dinner');
+  });
+
+  it('drops the conjunction stranded by lifting a category phrase out', () => {
+    const result = parseVoiceExpenses('400 for dinner and category food', groups);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].note).toBe('dinner');
+    expect(result.items[0].category).toBe('food');
+  });
+
+  it('keeps the local conjunction in a Hindi or Tamil description', () => {
+    // "और" and "மற்றும்" are never translated into English — the note is shown
+    // back in the language it was spoken, so the local word has to survive as
+    // the English one now does.
+    expect(parseVoiceExpenses('500 रुपये चाय और कॉफी', groups).items[0]?.note).toBe('चाय और कॉफी');
+    expect(parseVoiceExpenses('500 ரூபாய் தேநீர் மற்றும் காபி', groups).items[0]?.note).toBe(
+      'தேநீர் மற்றும் காபி',
+    );
   });
 
   it('keeps a lone expense working, with its named group', () => {


### PR DESCRIPTION
Speaking "800 rupees for dress and biscuits" and looking at the voice review screen offered one ₹800 expense described as **dress biscuits**. Two things were bought, and the description no longer said so.

## What was happening

The conjunction was thrown away twice, in two different places.

`segmentExpenses` splits a sentence on commas and "and" so that a list of priced things becomes one expense each. A fragment with no amount of its own is not an expense, so it is folded back into a priced neighbour — but the fold rejoined the two halves with a bare space, discarding the word it had split on. "800 rupees for dress and biscuits" came back out as "800 rupees for dress biscuits".

Then `buildNote` filtered the description through the stopword list, where "and" sits alongside "the", "for" and "add". Even a conjunction that had survived the segmenter was removed there.

Reproduced before the change:

```
'800 rupees for dress and biscuits'  →  1 item, ₹800, note "dress biscuits"
'500 for tea and coffee'             →  1 item, 500,  note "tea coffee"
'250 for idli, dosa and vada'        →  1 item, 250,  note "idli dosa vada"
```

Not an over-split: the parser already treated it as a single expense. The defect was purely in the description it handed to the review screen.

## The fix

`SEGMENT_SEPARATOR` now captures what it splits on, and each fragment remembers the separator that preceded it. When an amountless fragment is folded into a priced one, the separator is written back in the form it would be typed — `", "` for a comma, `" and "` for a conjunction — so the rejoined piece reads as the sentence that was spoken.

The note keeps the conjunction as well. "and" remains a stopword for group matching and member matching, where it names nothing and would only add noise; a new `NOTE_CONJUNCTIONS` set carves it out for the description alone.

A conjunction that is kept can later end up joining nothing — a category phrase is lifted out of the note ("400 for dinner and category food"), a member's name is removed by `stripMemberNames` ("dinner and Ravi"), or the speaker simply trailed off ("500 rupees for dinner and"). So a note gets one last pass that drops any conjunction which leads, trails, or sits next to another.

After:

```
'800 rupees for dress and biscuits'        →  1 item, ₹800, note "dress and biscuits"
'500 for tea and coffee'                   →  1 item, 500,  note "tea and coffee"
'250 for idli, dosa and vada'              →  1 item, 250,  note "idli, dosa and vada"
'800 rupees for dress and 200 for biscuits'→  2 items, notes "dress" / "biscuits"
'500 rupees for dinner and'                →  1 item, note "dinner"
```

## Other languages

`NOTE_CONJUNCTIONS` also lists और, மற்றும் and و. Those were never stopwords, so they already survived into notes untouched and are never translated into English; naming them here only lets the dangling-conjunction tidy reach them too. New tests assert a Hindi and a Tamil description keep their own conjunction.

No user-visible strings were added or changed, so there is nothing new to translate.

## Tests

Four existing expectations changed, because they asserted the old ungrammatical notes — `bread tea`, `coffee tax`, `user rider traveller financer`. New cases cover the reported utterance, the one-price neighbour that must stay one expense, the two-price neighbour that must stay two, a comma-and-and list, the three ways a conjunction can be stranded, and the Hindi/Tamil conjunctions. The whole `@waves/mobile` suite passes (873 tests); `pnpm format`, `pnpm lint` and `tsc --noEmit` are clean.

This is JS only, so it ships over the air.
