### PR TITLE
feat(voice): manage the phone's offline speech models in Settings

### DIFF
--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -475,6 +475,15 @@ function ProfileForm() {
               label: t.account.notifications,
               route: '/settings/notifications',
             },
+            // The mic's own settings sit with the rest of "how the app speaks to
+            // you", not under Data: what is managed here is a language, and the
+            // person who needs it is the person whose mic went silent.
+            {
+              icon: 'mic-outline',
+              label: t.offlineVoice.row,
+              hint: t.offlineVoice.rowHint,
+              route: '/settings/offline-voice',
+            },
             {
               icon: 'watch-outline',
               label: t.recent.title,

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -683,6 +683,7 @@ function AuthGate() {
           <Stack.Screen name="settings/import" />
           <Stack.Screen name="settings/lock" />
           <Stack.Screen name="settings/devices" />
+          <Stack.Screen name="settings/offline-voice" />
           <Stack.Screen name="settings/recent" />
           <Stack.Screen name="settings/sync" />
           <Stack.Screen name="settings/backup" />

--- a/apps/mobile/src/app/settings/offline-voice.tsx
+++ b/apps/mobile/src/app/settings/offline-voice.tsx
@@ -20,13 +20,19 @@
  *  - **Android 13** cannot download in the background at all: the request opens
  *    the system's own dialog and resolves immediately, so the row says the phone
  *    has taken over and offers a refresh for when it is done.
- *  - **Android 12 and below** report no locales and refuse the download outright.
- *  - **iOS** has no download API whatsoever, and its `installedLocales` is just
- *    its supported list repeated — so iPhone gets an explanation of where the
- *    setting lives and no button that would lie about what it does.
+ *  - **Android 12 and below** name no locales and reject the download outright,
+ *    so no button is drawn and a notice points at Android's own settings.
+ *  - **iPhone** has no download API whatsoever, *and* cannot be asked what it
+ *    holds — its module returns the supported list under both names, so every
+ *    locale it can recognise at all would come back ticked. Drawing those ticks
+ *    would be the silence bug arriving through the UI: somebody reads "Tamil —
+ *    on this phone", trusts it, and the mic answers nothing, with no button here
+ *    to recover with. So iPhone gets the four languages the mic asks for, no
+ *    claim about any of them, and the one thing a person can actually do —
+ *    where in Settings the dictation languages live.
  */
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { FlashList } from '@shopify/flash-list';
 import { useQuery } from '@tanstack/react-query';
@@ -56,6 +62,19 @@ import { useReducedMotion } from '@/lib/reducedMotion';
 import { speechModels } from '@/lib/speechModels';
 
 /**
+ * How long a download may run before the screen stops claiming to know.
+ *
+ * On Android 14+ the promise settles from a `ModelDownloadListener`, and nothing
+ * guarantees that listener ever fires. A promise that never settles would leave
+ * the bar sliding forever behind a lock nothing can clear and a button nothing
+ * can re-enable — the row would be dead for the life of the screen. So after a
+ * while the row stops asserting and becomes tappable again. Generous, because a
+ * model is a real download on a real connection and finishing late is normal; a
+ * late answer still overwrites what this leaves behind.
+ */
+const DOWNLOAD_WATCHDOG_MS = 3 * 60_000;
+
+/**
  * What a row is doing since it was last tapped.
  *
  * `working` is the only state that draws a bar. The rest are sentences the
@@ -68,17 +87,27 @@ interface RowProgress {
 }
 
 /**
- * The language a tag names, in the reader's own language, or null.
+ * `Intl.DisplayNames` per app language, built at most once each.
  *
- * `Intl.DisplayNames` is present in Hermes builds with full ICU and absent in
- * others, and a locale list is worth showing either way — so a missing
- * implementation (or a tag it cannot parse) falls back to the bare tag rather
- * than throwing inside a list renderer.
+ * The constructor is absent from the Hermes build this app ships — `intlPolyfill`
+ * backfills `RelativeTimeFormat` and its prerequisites, not this one — so on most
+ * phones every lookup here returns null and a row is named by its bare tag. Held
+ * in a module-level cache because the alternative is constructing a formatter
+ * inside a list renderer, once per row, on every render.
  */
+const displayNames = new Map<string, Intl.DisplayNames | null>();
+
+/** The language a tag names, in the reader's own language, or null. */
 function localeName(tag: string, locale: string): string | null {
+  if (!displayNames.has(locale)) {
+    try {
+      displayNames.set(locale, new Intl.DisplayNames([locale], { type: 'language' }));
+    } catch {
+      displayNames.set(locale, null);
+    }
+  }
   try {
-    const names = new Intl.DisplayNames([locale], { type: 'language' });
-    const name = names.of(tag.replace(/_/g, '-'));
+    const name = displayNames.get(locale)?.of(tag.replace(/_/g, '-'));
     return name && name !== tag ? name : null;
   } catch {
     return null;
@@ -98,58 +127,125 @@ export default function OfflineVoiceScreen() {
   const { t, locale } = useStrings();
   const [progress, setProgress] = useState<Record<string, RowProgress>>({});
 
-  // The phone's own lists. A read, never a write: nothing here downloads
-  // anything until a row is tapped. Disabled outright when the native module is
-  // missing, so an older binary shows its explanation instead of a spinner that
-  // resolves to nothing.
-  const locales = useQuery({
-    queryKey: ['speech-locales'],
-    queryFn: () => speechModels?.listLocales() ?? Promise.resolve(null),
-    enabled: speechModels !== null,
-  });
+  // Which tags have a native download in flight, and every watchdog still
+  // pending. Refs, not state: the lock has to be readable and writable *now*, in
+  // the tap handler, before any render has committed (see `download`).
+  //
+  // The lock holds a token per run rather than the bare tag, so a run that ends
+  // late — after its own watchdog gave up and a second attempt started — cannot
+  // release somebody else's lock on the way out.
+  const inFlight = useRef(new Map<string, symbol>());
+  const watchdogs = useRef(new Set<ReturnType<typeof setTimeout>>());
+  const mounted = useRef(true);
+
+  useEffect(() => {
+    const timers = watchdogs.current;
+    return () => {
+      mounted.current = false;
+      for (const timer of timers) clearTimeout(timer);
+      timers.clear();
+    };
+  }, []);
 
   const supportsOnDevice = speechModels?.supportsOnDevice() ?? false;
   const canDownload = speechModels?.canDownload() ?? false;
+  const reportsInstalled = speechModels?.reportsInstalled() ?? false;
+
+  // The phone's own lists. A read, never a write: nothing here downloads
+  // anything until a row is tapped. Not asked at all when the native module is
+  // missing (an older binary shows its explanation instead of a spinner that
+  // resolves to nothing), nor on a phone whose answer means nothing — iPhone
+  // returns its supported list under both names, and nothing on this screen
+  // reads it.
+  const locales = useQuery({
+    queryKey: ['speech-locales'],
+    queryFn: () => speechModels?.listLocales() ?? Promise.resolve(null),
+    enabled: speechModels !== null && reportsInstalled,
+  });
+
   const models = offlineVoiceModels(
     LANGUAGES,
     deviceLocale(),
     locales.data?.locales,
     locales.data?.installedLocales,
+    reportsInstalled ? 'reported' : 'unknowable',
   );
 
+  const setRow = (tag: string, row: RowProgress): void => {
+    if (!mounted.current) return;
+    setProgress((current) => ({ ...current, [tag]: row }));
+  };
+
   const download = async (model: OfflineVoiceModel): Promise<void> => {
-    if (!speechModels || progress[model.tag]?.phase === 'working') return;
-    setProgress((current) => ({
-      ...current,
-      [model.tag]: { phase: 'working', message: t.offlineVoice.downloading },
-    }));
+    // The lock is a ref rather than a read of `progress`, because two taps
+    // inside one frame share a render closure: a state read there sees the
+    // same "not working" both times, and `disabled` has not been committed yet
+    // either. Both taps would reach the native call.
+    if (!speechModels || inFlight.current.has(model.tag)) return;
+    const run = Symbol(model.tag);
+    const release = (): void => {
+      if (inFlight.current.get(model.tag) === run) inFlight.current.delete(model.tag);
+    };
+    inFlight.current.set(model.tag, run);
+    setRow(model.tag, { phase: 'working', message: t.offlineVoice.downloading });
+
+    const watchdog = setTimeout(() => {
+      watchdogs.current.delete(watchdog);
+      release();
+      setRow(model.tag, { phase: 'settled', message: t.offlineVoice.stillWorking });
+    }, DOWNLOAD_WATCHDOG_MS);
+    watchdogs.current.add(watchdog);
+
     try {
       const status = await speechModels.download(model.tag);
-      setProgress((current) => ({
-        ...current,
-        [model.tag]: {
-          phase: 'settled',
-          message:
-            status === 'download_success'
-              ? t.offlineVoice.ready
-              : status === 'download_scheduled'
-                ? t.offlineVoice.scheduled
-                : t.offlineVoice.dialogOpened,
-        },
-      }));
+      setRow(model.tag, {
+        phase: 'settled',
+        message:
+          status === 'download_success'
+            ? t.offlineVoice.ready
+            : status === 'download_scheduled'
+              ? t.offlineVoice.scheduled
+              : t.offlineVoice.dialogOpened,
+      });
       // Only a completed download changes what the phone holds; re-reading after
       // a dialog or a queued job would just redraw the same "not downloaded".
       if (status === 'download_success') await locales.refetch();
     } catch (caught) {
-      setProgress((current) => ({
-        ...current,
-        [model.tag]: {
-          phase: 'failed',
-          message: refusedAsUnsupported(caught) ? t.offlineVoice.tooOld : t.offlineVoice.failed,
-        },
-      }));
+      setRow(model.tag, {
+        phase: 'failed',
+        message: refusedAsUnsupported(caught) ? t.offlineVoice.tooOld : t.offlineVoice.failed,
+      });
+    } finally {
+      clearTimeout(watchdog);
+      watchdogs.current.delete(watchdog);
+      release();
     }
   };
+
+  const showList = speechModels !== null && supportsOnDevice;
+  // A phone that answered, and named nothing at all. Worth saying out loud: the
+  // app rows below are then the only ones on the screen, and their absence of
+  // company is the phone's doing rather than a list still loading.
+  const namedNothing =
+    locales.isSuccess &&
+    (locales.data?.locales.length ?? 0) === 0 &&
+    (locales.data?.installedLocales.length ?? 0) === 0;
+
+  // One notice at a time, most disqualifying first. Each says what this
+  // particular phone can do, and none of them promises a download that will not
+  // happen.
+  const notice: { tone: 'warning' | 'info'; text: string } | null =
+    speechModels === null
+      ? { tone: 'warning', text: t.offlineVoice.unavailable }
+      : !supportsOnDevice
+        ? { tone: 'warning', text: t.offlineVoice.noOnDevice }
+        : Platform.OS === 'ios'
+          ? { tone: 'info', text: t.offlineVoice.iosNote }
+          : !canDownload
+            ? { tone: 'warning', text: t.offlineVoice.tooOld }
+            : namedNothing
+              ? { tone: 'info', text: t.offlineVoice.empty }
+              : null;
 
   // One flat list of headers and rows rather than three lists in a scroll view:
   // the "other languages" group is every locale the recogniser knows, which on
@@ -200,14 +296,21 @@ export default function OfflineVoiceScreen() {
         </View>
         {/* A model can also arrive from outside the app — the Android 13 dialog,
             or a download the system queued for Wi-Fi — and nothing tells us when
-            it lands. This is how somebody sees it appear. */}
-        <IconButton label={t.offlineVoice.refresh} onPress={() => void locales.refetch()}>
-          <Ionicons name="refresh" size={iconSize.md} color={theme.color.text} />
-        </IconButton>
+            it lands. This is how somebody sees it appear. It is only offered
+            where there is a list to re-read: on a phone that reports nothing,
+            refreshing would redraw the same four rows and mean nothing. The
+            spacer keeps the title centred in its absence. */}
+        {reportsInstalled ? (
+          <IconButton label={t.offlineVoice.refresh} onPress={() => void locales.refetch()}>
+            <Ionicons name="refresh" size={iconSize.md} color={theme.color.text} />
+          </IconButton>
+        ) : (
+          <View style={{ width: 44 }} />
+        )}
       </Row>
 
       <FlashList<ListItem>
-        data={speechModels === null || !supportsOnDevice ? [] : items}
+        data={showList ? items : []}
         keyExtractor={(item) => `${item.kind}-${item.key}`}
         extraData={[locale, theme.scheme, progress, locales.dataUpdatedAt]}
         drawDistance={1500}
@@ -221,13 +324,7 @@ export default function OfflineVoiceScreen() {
             <Text variant="body" tone="muted">
               {t.offlineVoice.intro}
             </Text>
-            {speechModels === null ? (
-              <Callout tone="warning">{t.offlineVoice.unavailable}</Callout>
-            ) : !supportsOnDevice ? (
-              <Callout tone="warning">{t.offlineVoice.noOnDevice}</Callout>
-            ) : Platform.OS === 'ios' ? (
-              <Callout tone="info">{t.offlineVoice.iosNote}</Callout>
-            ) : null}
+            {notice ? <Callout tone={notice.tone}>{notice.text}</Callout> : null}
             {locales.isError ? (
               <Card style={{ gap: theme.spacing.sm }}>
                 <Text variant="subheading">{t.loadError}</Text>
@@ -238,15 +335,6 @@ export default function OfflineVoiceScreen() {
               </Card>
             ) : null}
           </View>
-        }
-        ListEmptyComponent={
-          // Only reachable once the module is there and can work offline: the
-          // two cases above already say their piece in the header.
-          speechModels !== null && supportsOnDevice && !locales.isLoading ? (
-            <Text variant="body" tone="muted">
-              {t.offlineVoice.empty}
-            </Text>
-          ) : null
         }
         renderItem={({ item }) =>
           item.kind === 'header' ? (
@@ -305,13 +393,15 @@ function ModelRow({
 
   // An app language is named in its own script, because somebody looking for
   // Tamil is scanning for the shape of Tamil. Anything else falls back to the
-  // phone's name for the tag, and then to the tag itself.
-  const title = model.language
-    ? LANGUAGE_NAMES[model.language].own
-    : (localeName(model.tag, locale) ?? model.tag);
+  // phone's name for the tag — and, when the phone has no name to give, to the
+  // tag alone rather than the tag printed twice.
+  const named = model.language ? LANGUAGE_NAMES[model.language].own : localeName(model.tag, locale);
+  const title = named ?? model.tag;
   const subtitle = model.language
     ? `${LANGUAGE_NAMES[model.language].english} · ${model.tag}`
-    : model.tag;
+    : named
+      ? model.tag
+      : null;
   const working = progress?.phase === 'working';
 
   return (
@@ -321,23 +411,30 @@ function ModelRow({
           <Text variant="subheading" numberOfLines={1}>
             {title}
           </Text>
-          <Text variant="caption" tone="muted" numberOfLines={1}>
-            {subtitle}
-          </Text>
+          {subtitle ? (
+            <Text variant="caption" tone="muted" numberOfLines={1}>
+              {subtitle}
+            </Text>
+          ) : null}
         </View>
-        {model.installed ? (
+        {/* `unknown` draws nothing at all. A phone that cannot be asked what it
+            holds gets no tick and no button — the notice in the header says
+            where its dictation languages actually come from. */}
+        {model.state === 'installed' ? (
           <Badge label={t.offlineVoice.installed} tone="positive" />
-        ) : canDownload ? (
-          <Button
-            label={t.offlineVoice.download}
-            size="sm"
-            variant="secondary"
-            disabled={working}
-            onPress={onDownload}
-          />
-        ) : (
-          <Badge label={t.offlineVoice.notInstalled} tone="neutral" />
-        )}
+        ) : model.state === 'missing' ? (
+          canDownload ? (
+            <Button
+              label={t.offlineVoice.download}
+              size="sm"
+              variant="secondary"
+              disabled={working}
+              onPress={onDownload}
+            />
+          ) : (
+            <Badge label={t.offlineVoice.notInstalled} tone="neutral" />
+          )
+        ) : null}
       </Row>
 
       {progress ? (

--- a/apps/mobile/src/app/settings/offline-voice.tsx
+++ b/apps/mobile/src/app/settings/offline-voice.tsx
@@ -1,0 +1,355 @@
+/**
+ * The speech models this phone holds, and the one screen that adds to them.
+ *
+ * Voice quick-add asks for on-device recognition only when a model for the
+ * language is actually installed — asking for one that is not there returns
+ * silence, which is the quiet failure `dictation.ts` documents at length. Until
+ * now the only cure was a network recogniser, and on some OEM ROMs that service
+ * is dead: the mic hears you and answers nothing, with no way out inside the
+ * app. Downloading a model was something a person had to go and find in Android
+ * settings, which is to say something almost nobody found.
+ *
+ * So the download lives here instead. What the platform actually allows is
+ * narrower than it looks, and the screen says so rather than pretending:
+ *
+ *  - **Android 14+** fetches a model on request. The native side is handed a
+ *    percentage by `ModelDownloadListener.onProgress`, but the library drops it
+ *    on the floor — nothing reaches JS but a promise that settles. So the bar is
+ *    indeterminate and the copy says the phone is working, rather than animating
+ *    a number nobody measured.
+ *  - **Android 13** cannot download in the background at all: the request opens
+ *    the system's own dialog and resolves immediately, so the row says the phone
+ *    has taken over and offers a refresh for when it is done.
+ *  - **Android 12 and below** report no locales and refuse the download outright.
+ *  - **iOS** has no download API whatsoever, and its `installedLocales` is just
+ *    its supported list repeated — so iPhone gets an explanation of where the
+ *    setting lives and no button that would lie about what it does.
+ */
+
+import { useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { FlashList } from '@shopify/flash-list';
+import { useQuery } from '@tanstack/react-query';
+import { router } from 'expo-router';
+import { Platform, View } from 'react-native';
+
+import {
+  Badge,
+  Button,
+  Callout,
+  Card,
+  directionalIcon,
+  IconButton,
+  iconSize,
+  ProgressBar,
+  Row,
+  Screen,
+  SectionHeader,
+  Text,
+  useScreenClearance,
+  useTheme,
+} from '@waves/ui';
+
+import { deviceLocale, LANGUAGE_NAMES, LANGUAGES, useStrings } from '@/i18n';
+import { offlineVoiceModels, type OfflineVoiceModel } from '@/lib/dictation';
+import { useReducedMotion } from '@/lib/reducedMotion';
+import { speechModels } from '@/lib/speechModels';
+
+/**
+ * What a row is doing since it was last tapped.
+ *
+ * `working` is the only state that draws a bar. The rest are sentences the
+ * phone's own answer earned — including `failed`, which is a fact about this
+ * device and not an error worth a red screen.
+ */
+interface RowProgress {
+  readonly phase: 'working' | 'settled' | 'failed';
+  readonly message: string;
+}
+
+/**
+ * The language a tag names, in the reader's own language, or null.
+ *
+ * `Intl.DisplayNames` is present in Hermes builds with full ICU and absent in
+ * others, and a locale list is worth showing either way — so a missing
+ * implementation (or a tag it cannot parse) falls back to the bare tag rather
+ * than throwing inside a list renderer.
+ */
+function localeName(tag: string, locale: string): string | null {
+  try {
+    const names = new Intl.DisplayNames([locale], { type: 'language' });
+    const name = names.of(tag.replace(/_/g, '-'));
+    return name && name !== tag ? name : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Whether a rejected download was the platform refusing, not the network. */
+function refusedAsUnsupported(caught: unknown): boolean {
+  const code = (caught as { code?: unknown } | null)?.code;
+  return code === 'not_supported';
+}
+
+export default function OfflineVoiceScreen() {
+  const theme = useTheme();
+  const clearance = useScreenClearance();
+  const reduceMotion = useReducedMotion();
+  const { t, locale } = useStrings();
+  const [progress, setProgress] = useState<Record<string, RowProgress>>({});
+
+  // The phone's own lists. A read, never a write: nothing here downloads
+  // anything until a row is tapped. Disabled outright when the native module is
+  // missing, so an older binary shows its explanation instead of a spinner that
+  // resolves to nothing.
+  const locales = useQuery({
+    queryKey: ['speech-locales'],
+    queryFn: () => speechModels?.listLocales() ?? Promise.resolve(null),
+    enabled: speechModels !== null,
+  });
+
+  const supportsOnDevice = speechModels?.supportsOnDevice() ?? false;
+  const canDownload = speechModels?.canDownload() ?? false;
+  const models = offlineVoiceModels(
+    LANGUAGES,
+    deviceLocale(),
+    locales.data?.locales,
+    locales.data?.installedLocales,
+  );
+
+  const download = async (model: OfflineVoiceModel): Promise<void> => {
+    if (!speechModels || progress[model.tag]?.phase === 'working') return;
+    setProgress((current) => ({
+      ...current,
+      [model.tag]: { phase: 'working', message: t.offlineVoice.downloading },
+    }));
+    try {
+      const status = await speechModels.download(model.tag);
+      setProgress((current) => ({
+        ...current,
+        [model.tag]: {
+          phase: 'settled',
+          message:
+            status === 'download_success'
+              ? t.offlineVoice.ready
+              : status === 'download_scheduled'
+                ? t.offlineVoice.scheduled
+                : t.offlineVoice.dialogOpened,
+        },
+      }));
+      // Only a completed download changes what the phone holds; re-reading after
+      // a dialog or a queued job would just redraw the same "not downloaded".
+      if (status === 'download_success') await locales.refetch();
+    } catch (caught) {
+      setProgress((current) => ({
+        ...current,
+        [model.tag]: {
+          phase: 'failed',
+          message: refusedAsUnsupported(caught) ? t.offlineVoice.tooOld : t.offlineVoice.failed,
+        },
+      }));
+    }
+  };
+
+  // One flat list of headers and rows rather than three lists in a scroll view:
+  // the "other languages" group is every locale the recogniser knows, which on
+  // Android runs to dozens, and only a virtualised list keeps that cheap.
+  const items: ListItem[] = [
+    {
+      kind: 'header',
+      key: 'app',
+      title: t.offlineVoice.appSection,
+      hint: t.offlineVoice.appSectionHint,
+    },
+    ...models.app.map((model): ListItem => ({ kind: 'model', key: model.tag, model })),
+    ...(models.alsoInstalled.length > 0
+      ? [{ kind: 'header' as const, key: 'installed', title: t.offlineVoice.alsoInstalled }]
+      : []),
+    ...models.alsoInstalled.map((model): ListItem => ({ kind: 'model', key: model.tag, model })),
+    ...(models.downloadable.length > 0
+      ? [
+          {
+            kind: 'header' as const,
+            key: 'other',
+            title: t.offlineVoice.otherLanguages,
+            hint: canDownload ? t.offlineVoice.otherLanguagesHint : undefined,
+          },
+        ]
+      : []),
+    ...models.downloadable.map((model): ListItem => ({ kind: 'model', key: model.tag, model })),
+  ];
+
+  return (
+    <Screen>
+      <Row
+        style={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.md,
+          alignItems: 'center',
+        }}
+      >
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.offlineVoice.title}</Text>
+        </View>
+        {/* A model can also arrive from outside the app — the Android 13 dialog,
+            or a download the system queued for Wi-Fi — and nothing tells us when
+            it lands. This is how somebody sees it appear. */}
+        <IconButton label={t.offlineVoice.refresh} onPress={() => void locales.refetch()}>
+          <Ionicons name="refresh" size={iconSize.md} color={theme.color.text} />
+        </IconButton>
+      </Row>
+
+      <FlashList<ListItem>
+        data={speechModels === null || !supportsOnDevice ? [] : items}
+        keyExtractor={(item) => `${item.kind}-${item.key}`}
+        extraData={[locale, theme.scheme, progress, locales.dataUpdatedAt]}
+        drawDistance={1500}
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: clearance,
+        }}
+        showsVerticalScrollIndicator={false}
+        ListHeaderComponent={
+          <View style={{ gap: theme.spacing.md, paddingVertical: theme.spacing.lg }}>
+            <Text variant="body" tone="muted">
+              {t.offlineVoice.intro}
+            </Text>
+            {speechModels === null ? (
+              <Callout tone="warning">{t.offlineVoice.unavailable}</Callout>
+            ) : !supportsOnDevice ? (
+              <Callout tone="warning">{t.offlineVoice.noOnDevice}</Callout>
+            ) : Platform.OS === 'ios' ? (
+              <Callout tone="info">{t.offlineVoice.iosNote}</Callout>
+            ) : null}
+            {locales.isError ? (
+              <Card style={{ gap: theme.spacing.sm }}>
+                <Text variant="subheading">{t.loadError}</Text>
+                <Text variant="body" tone="muted">
+                  {t.loadErrorBody}
+                </Text>
+                <Button label={t.retry} fullWidth onPress={() => void locales.refetch()} />
+              </Card>
+            ) : null}
+          </View>
+        }
+        ListEmptyComponent={
+          // Only reachable once the module is there and can work offline: the
+          // two cases above already say their piece in the header.
+          speechModels !== null && supportsOnDevice && !locales.isLoading ? (
+            <Text variant="body" tone="muted">
+              {t.offlineVoice.empty}
+            </Text>
+          ) : null
+        }
+        renderItem={({ item }) =>
+          item.kind === 'header' ? (
+            <View style={{ paddingTop: theme.spacing.lg }}>
+              <SectionHeader title={item.title} />
+              {item.hint ? (
+                <Text
+                  variant="caption"
+                  tone="muted"
+                  style={{ marginTop: -theme.spacing.sm, marginBottom: theme.spacing.md }}
+                >
+                  {item.hint}
+                </Text>
+              ) : null}
+            </View>
+          ) : (
+            <ModelRow
+              model={item.model}
+              progress={progress[item.model.tag]}
+              canDownload={canDownload}
+              reduceMotion={reduceMotion}
+              onDownload={() => void download(item.model)}
+            />
+          )
+        }
+        ListFooterComponent={
+          <Text variant="micro" tone="muted" style={{ paddingVertical: theme.spacing.xl }}>
+            {t.offlineVoice.footnote}
+          </Text>
+        }
+      />
+    </Screen>
+  );
+}
+
+/** A section heading or one model — the two things the list draws. */
+type ListItem =
+  | { kind: 'header'; key: string; title: string; hint?: string }
+  | { kind: 'model'; key: string; model: OfflineVoiceModel };
+
+function ModelRow({
+  model,
+  progress,
+  canDownload,
+  reduceMotion,
+  onDownload,
+}: {
+  model: OfflineVoiceModel;
+  progress: RowProgress | undefined;
+  canDownload: boolean;
+  reduceMotion: boolean;
+  onDownload: () => void;
+}) {
+  const theme = useTheme();
+  const { t, locale } = useStrings();
+
+  // An app language is named in its own script, because somebody looking for
+  // Tamil is scanning for the shape of Tamil. Anything else falls back to the
+  // phone's name for the tag, and then to the tag itself.
+  const title = model.language
+    ? LANGUAGE_NAMES[model.language].own
+    : (localeName(model.tag, locale) ?? model.tag);
+  const subtitle = model.language
+    ? `${LANGUAGE_NAMES[model.language].english} · ${model.tag}`
+    : model.tag;
+  const working = progress?.phase === 'working';
+
+  return (
+    <Card style={{ marginBottom: theme.spacing.md, gap: theme.spacing.md }}>
+      <Row style={{ gap: theme.spacing.md }}>
+        <View style={{ flex: 1, gap: 2 }}>
+          <Text variant="subheading" numberOfLines={1}>
+            {title}
+          </Text>
+          <Text variant="caption" tone="muted" numberOfLines={1}>
+            {subtitle}
+          </Text>
+        </View>
+        {model.installed ? (
+          <Badge label={t.offlineVoice.installed} tone="positive" />
+        ) : canDownload ? (
+          <Button
+            label={t.offlineVoice.download}
+            size="sm"
+            variant="secondary"
+            disabled={working}
+            onPress={onDownload}
+          />
+        ) : (
+          <Badge label={t.offlineVoice.notInstalled} tone="neutral" />
+        )}
+      </Row>
+
+      {progress ? (
+        <View style={{ gap: theme.spacing.sm }}>
+          <Text variant="caption" tone={progress.phase === 'failed' ? 'negative' : 'muted'}>
+            {working ? `${progress.message} ${t.offlineVoice.noProgress}` : progress.message}
+          </Text>
+          {/* Indeterminate on purpose: Android hands the app a percentage and
+              the library never passes it on, so there is no number to draw. */}
+          {working ? <ProgressBar animated={!reduceMotion} /> : null}
+        </View>
+      ) : null}
+    </Card>
+  );
+}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -988,6 +988,56 @@ export interface UiStrings {
     /** The button on the answer card that reopens the mic for another question. */
     askAgain: string;
   };
+  /**
+   * The on-device speech models, and the one screen that manages them.
+   *
+   * On Android the models are a separate download the phone owns; until one is
+   * there the mic falls back to the network recogniser, which is dead on some
+   * OEM ROMs. This screen brings that download inside the app instead of asking
+   * somebody to go hunting through Android settings for it.
+   */
+  offlineVoice: {
+    /** Settings-row label, and the screen's own title. */
+    row: string;
+    title: string;
+    /** Settings-row subtitle. */
+    rowHint: string;
+    intro: string;
+    /** The models Waves itself asks for — one per app language. */
+    appSection: string;
+    appSectionHint: string;
+    /** Models already on the phone that no app language claims. */
+    alsoInstalled: string;
+    /** Everything else the recogniser knows about. */
+    otherLanguages: string;
+    otherLanguagesHint: string;
+    /** Per-row state. */
+    installed: string;
+    notInstalled: string;
+    download: string;
+    /** Under a row while the phone fetches a model. Android hands the app no
+     *  percentage — the bar is indeterminate and this says why. */
+    downloading: string;
+    noProgress: string;
+    /** The three things a finished download call can mean. */
+    ready: string;
+    dialogOpened: string;
+    scheduled: string;
+    failed: string;
+    /** Android 12 and below can neither list installed models nor fetch one. */
+    tooOld: string;
+    /** iOS installs its dictation languages itself; there is nothing to tap. */
+    iosNote: string;
+    /** An older binary whose native speech module is missing entirely. */
+    unavailable: string;
+    /** A recogniser that only ever works over the network. */
+    noOnDevice: string;
+    /** Re-reads the phone's lists, so a download finished elsewhere shows up. */
+    refresh: string;
+    /** The phone named no languages at all. */
+    empty: string;
+    footnote: string;
+  };
   /** Notification preferences, and what the phone will and will not allow. */
   notifications: {
     title: string;
@@ -3336,6 +3386,39 @@ const en: UiStrings = {
     ansNoPerson: "Couldn't find {name}",
     askAgain: 'Ask again',
   },
+  offlineVoice: {
+    row: 'Offline voice',
+    title: 'Offline voice',
+    rowHint: 'Speech models kept on this phone',
+    intro:
+      'With a language downloaded, the mic works with no connection — and keeps working on phones whose online speech service is broken.',
+    appSection: 'Waves languages',
+    appSectionHint: 'These are the ones the mic asks for.',
+    alsoInstalled: 'Also on this phone',
+    otherLanguages: 'Other languages',
+    otherLanguagesHint: 'Your phone can fetch any of these.',
+    installed: 'On this phone',
+    notInstalled: 'Not downloaded',
+    download: 'Download',
+    downloading: 'Your phone is downloading this.',
+    noProgress: 'Android doesn’t say how far along it is.',
+    ready: 'Downloaded. The mic can use it now.',
+    dialogOpened:
+      'Your phone has taken over with its own download screen. Finish there, then come back and refresh.',
+    scheduled: 'Queued. Your phone will finish it, usually once you’re on Wi‑Fi.',
+    failed: 'Your phone couldn’t download that one.',
+    tooOld:
+      'This phone’s Android is too old to download models from inside an app. Search Android settings for “voice” to add one.',
+    iosNote:
+      'iPhone downloads its dictation languages itself. Add one under Settings › General › Keyboard › Dictation Languages and the mic will use it.',
+    unavailable: 'This build can’t reach the speech models.',
+    noOnDevice:
+      'This phone can’t recognise speech without a connection, so there’s nothing to download.',
+    refresh: 'Refresh',
+    empty: 'Your phone didn’t name any languages.',
+    footnote:
+      'The models belong to your phone, not to Waves. With one installed, what you say is turned into text on the device and never leaves it.',
+  },
   notifications: {
     title: 'Notifications',
     neverSpam:
@@ -5613,6 +5696,39 @@ const ta: UiStrings = {
     ansGroupSettled: '{group} இல் அனைத்தும் தீர்க்கப்பட்டது',
     ansNoPerson: '{name} கிடைக்கவில்லை',
     askAgain: 'மீண்டும் கேள்',
+  },
+  offlineVoice: {
+    row: 'ஆஃப்லைன் குரல்',
+    title: 'ஆஃப்லைன் குரல்',
+    rowHint: 'இந்த ஃபோனில் வைத்திருக்கும் பேச்சு மாதிரிகள்',
+    intro:
+      'ஒரு மொழியைப் பதிவிறக்கிய பிறகு இணைப்பு இல்லாமலும் மைக் வேலை செய்யும் — ஆன்லைன் பேச்சுச் சேவை செயலிழந்த ஃபோன்களிலும் தொடர்ந்து வேலை செய்யும்.',
+    appSection: 'Waves மொழிகள்',
+    appSectionHint: 'மைக் கேட்பது இவற்றைத்தான்.',
+    alsoInstalled: 'இந்த ஃபோனில் ஏற்கெனவே உள்ளவை',
+    otherLanguages: 'மற்ற மொழிகள்',
+    otherLanguagesHint: 'இவற்றில் எதையும் உங்கள் ஃபோன் கொண்டுவரும்.',
+    installed: 'ஃபோனில் உள்ளது',
+    notInstalled: 'பதிவிறக்கப்படவில்லை',
+    download: 'பதிவிறக்கு',
+    downloading: 'உங்கள் ஃபோன் இதைப் பதிவிறக்குகிறது.',
+    noProgress: 'எவ்வளவு முடிந்தது என்பதை Android சொல்வதில்லை.',
+    ready: 'பதிவிறக்கப்பட்டது. மைக் இப்போது இதைப் பயன்படுத்தும்.',
+    dialogOpened:
+      'உங்கள் ஃபோன் தன் சொந்தப் பதிவிறக்கத் திரையைத் திறந்துவிட்டது. அங்கே முடித்துவிட்டு, திரும்பி வந்து புதுப்பிக்கவும்.',
+    scheduled: 'வரிசையில் உள்ளது. பொதுவாக Wi‑Fi இணைப்பில் உங்கள் ஃபோன் இதை முடிக்கும்.',
+    failed: 'அதை உங்கள் ஃபோனால் பதிவிறக்க முடியவில்லை.',
+    tooOld:
+      'செயலிக்குள் இருந்து மாதிரிகளைப் பதிவிறக்க இந்த ஃபோனின் Android மிகவும் பழையது. Android அமைப்புகளில் “voice” எனத் தேடி ஒன்றைச் சேர்க்கவும்.',
+    iosNote:
+      'iPhone தன் டிக்டேஷன் மொழிகளைத் தானே பதிவிறக்கும். Settings › General › Keyboard › Dictation Languages இல் ஒன்றைச் சேர்த்தால் மைக் அதைப் பயன்படுத்தும்.',
+    unavailable: 'இந்தப் பதிப்பால் பேச்சு மாதிரிகளை அணுக முடியாது.',
+    noOnDevice:
+      'இணைப்பு இல்லாமல் பேச்சை இந்த ஃபோனால் அடையாளம் காண முடியாது, எனவே பதிவிறக்க எதுவும் இல்லை.',
+    refresh: 'புதுப்பி',
+    empty: 'உங்கள் ஃபோன் எந்த மொழியையும் சொல்லவில்லை.',
+    footnote:
+      'மாதிரிகள் உங்கள் ஃபோனுடையவை, Waves உடையவை அல்ல. ஒன்று இருந்தால், நீங்கள் பேசுவது ஃபோனிலேயே உரையாக மாறும், வெளியே செல்லாது.',
   },
   notifications: {
     title: 'அறிவிப்புகள்',
@@ -7956,6 +8072,38 @@ const hi: UiStrings = {
     ansNoPerson: '{name} नहीं मिला',
     askAgain: 'फिर पूछें',
   },
+  offlineVoice: {
+    row: 'ऑफ़लाइन आवाज़',
+    title: 'ऑफ़लाइन आवाज़',
+    rowHint: 'इस फ़ोन पर रखे स्पीच मॉडल',
+    intro:
+      'कोई भाषा डाउनलोड कर लेने पर माइक बिना कनेक्शन के भी काम करता है — और उन फ़ोनों पर भी चलता रहता है जिनकी ऑनलाइन स्पीच सेवा ख़राब है।',
+    appSection: 'Waves की भाषाएँ',
+    appSectionHint: 'माइक यही माँगता है।',
+    alsoInstalled: 'इस फ़ोन पर पहले से मौजूद',
+    otherLanguages: 'दूसरी भाषाएँ',
+    otherLanguagesHint: 'इनमें से कोई भी आपका फ़ोन ला सकता है।',
+    installed: 'फ़ोन पर मौजूद',
+    notInstalled: 'डाउनलोड नहीं है',
+    download: 'डाउनलोड करें',
+    downloading: 'आपका फ़ोन इसे डाउनलोड कर रहा है।',
+    noProgress: 'Android यह नहीं बताता कि कितना हुआ।',
+    ready: 'डाउनलोड हो गया। माइक अब इसे इस्तेमाल कर सकता है।',
+    dialogOpened:
+      'आपके फ़ोन ने अपनी डाउनलोड स्क्रीन खोल दी है। वहीं पूरा करें, फिर लौटकर ताज़ा करें।',
+    scheduled: 'क़तार में है। आपका फ़ोन इसे पूरा कर देगा, आम तौर पर Wi‑Fi पर।',
+    failed: 'आपका फ़ोन उसे डाउनलोड नहीं कर सका।',
+    tooOld:
+      'ऐप के भीतर से मॉडल डाउनलोड करने के लिए इस फ़ोन का Android बहुत पुराना है। Android सेटिंग्स में “voice” खोजकर एक जोड़ें।',
+    iosNote:
+      'iPhone अपनी डिक्टेशन भाषाएँ ख़ुद डाउनलोड करता है। Settings › General › Keyboard › Dictation Languages में एक जोड़ें, माइक उसे इस्तेमाल करने लगेगा।',
+    unavailable: 'यह बिल्ड स्पीच मॉडल तक नहीं पहुँच सकता।',
+    noOnDevice: 'यह फ़ोन बिना कनेक्शन के बोली नहीं पहचान सकता, इसलिए डाउनलोड करने को कुछ नहीं है।',
+    refresh: 'ताज़ा करें',
+    empty: 'आपके फ़ोन ने कोई भाषा नहीं बताई।',
+    footnote:
+      'मॉडल आपके फ़ोन के हैं, Waves के नहीं। एक मौजूद हो तो आप जो कहते हैं वह फ़ोन पर ही लिखाई में बदलता है और बाहर नहीं जाता।',
+  },
   notifications: {
     title: 'सूचनाएँ',
     neverSpam:
@@ -10276,6 +10424,37 @@ const ar: UiStrings = {
     ansGroupSettled: 'تمت التسوية بالكامل في {group}',
     ansNoPerson: 'تعذر العثور على {name}',
     askAgain: 'اسأل مرة أخرى',
+  },
+  offlineVoice: {
+    row: 'الصوت دون اتصال',
+    title: 'الصوت دون اتصال',
+    rowHint: 'نماذج الكلام المحفوظة على هذا الهاتف',
+    intro:
+      'بعد تنزيل لغة يعمل الميكروفون دون اتصال — ويظل يعمل على الهواتف التي تعطّلت فيها خدمة الكلام عبر الإنترنت.',
+    appSection: 'لغات Waves',
+    appSectionHint: 'هذه ما يطلبه الميكروفون.',
+    alsoInstalled: 'موجودة على هذا الهاتف',
+    otherLanguages: 'لغات أخرى',
+    otherLanguagesHint: 'يستطيع هاتفك جلب أيٍّ منها.',
+    installed: 'على الهاتف',
+    notInstalled: 'غير مُنزَّلة',
+    download: 'تنزيل',
+    downloading: 'هاتفك ينزّل هذا الآن.',
+    noProgress: 'لا يخبر Android بمقدار ما اكتمل.',
+    ready: 'اكتمل التنزيل. يمكن للميكروفون استخدامه الآن.',
+    dialogOpened: 'فتح هاتفك شاشة التنزيل الخاصة به. أكمِل هناك ثم عُد وحدِّث القائمة.',
+    scheduled: 'في الانتظار. سيُكمل هاتفك التنزيل، غالبًا عند اتصاله بشبكة Wi‑Fi.',
+    failed: 'تعذّر على هاتفك تنزيل ذلك.',
+    tooOld:
+      'إصدار Android على هذا الهاتف أقدم من أن ينزّل النماذج من داخل التطبيق. ابحث عن «voice» في إعدادات Android وأضف واحدة.',
+    iosNote:
+      'ينزّل iPhone لغات الإملاء بنفسه. أضف لغة من Settings ‹ General ‹ Keyboard ‹ Dictation Languages وسيستخدمها الميكروفون.',
+    unavailable: 'لا يستطيع هذا الإصدار الوصول إلى نماذج الكلام.',
+    noOnDevice: 'لا يستطيع هذا الهاتف التعرّف على الكلام دون اتصال، فلا شيء لتنزيله.',
+    refresh: 'تحديث',
+    empty: 'لم يذكر هاتفك أي لغة.',
+    footnote:
+      'النماذج ملك لهاتفك لا لـ Waves. وبوجود واحدة يتحوّل ما تقوله إلى نص على الجهاز ولا يغادره.',
   },
   notifications: {
     title: 'الإشعارات',

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1024,6 +1024,9 @@ export interface UiStrings {
     dialogOpened: string;
     scheduled: string;
     failed: string;
+    /** A download still unanswered long after it began — Android's listener may
+     *  simply never fire, and the row stops asserting rather than spin forever. */
+    stillWorking: string;
     /** Android 12 and below can neither list installed models nor fetch one. */
     tooOld: string;
     /** iOS installs its dictation languages itself; there is nothing to tap. */
@@ -1034,7 +1037,8 @@ export interface UiStrings {
     noOnDevice: string;
     /** Re-reads the phone's lists, so a download finished elsewhere shows up. */
     refresh: string;
-    /** The phone named no languages at all. */
+    /** The phone answered, and named no languages at all — so the app's own are
+     *  the only rows on the screen. */
     empty: string;
     footnote: string;
   };
@@ -3407,15 +3411,18 @@ const en: UiStrings = {
       'Your phone has taken over with its own download screen. Finish there, then come back and refresh.',
     scheduled: 'Queued. Your phone will finish it, usually once you’re on Wi‑Fi.',
     failed: 'Your phone couldn’t download that one.',
+    stillWorking:
+      'Your phone hasn’t said whether this finished. Give it a while, then refresh to see if it landed.',
     tooOld:
       'This phone’s Android is too old to download models from inside an app. Search Android settings for “voice” to add one.',
     iosNote:
-      'iPhone downloads its dictation languages itself. Add one under Settings › General › Keyboard › Dictation Languages and the mic will use it.',
+      'iPhone downloads its dictation languages itself, and won’t say which ones it already has. Add one under Settings › General › Keyboard › Dictation Languages and the mic will use it.',
     unavailable: 'This build can’t reach the speech models.',
     noOnDevice:
       'This phone can’t recognise speech without a connection, so there’s nothing to download.',
     refresh: 'Refresh',
-    empty: 'Your phone didn’t name any languages.',
+    empty:
+      'Your phone didn’t name any languages it can recognise, so only the ones Waves asks for are listed. A download may still work.',
     footnote:
       'The models belong to your phone, not to Waves. With one installed, what you say is turned into text on the device and never leaves it.',
   },
@@ -5718,15 +5725,18 @@ const ta: UiStrings = {
       'உங்கள் ஃபோன் தன் சொந்தப் பதிவிறக்கத் திரையைத் திறந்துவிட்டது. அங்கே முடித்துவிட்டு, திரும்பி வந்து புதுப்பிக்கவும்.',
     scheduled: 'வரிசையில் உள்ளது. பொதுவாக Wi‑Fi இணைப்பில் உங்கள் ஃபோன் இதை முடிக்கும்.',
     failed: 'அதை உங்கள் ஃபோனால் பதிவிறக்க முடியவில்லை.',
+    stillWorking:
+      'இது முடிந்ததா என்பதை உங்கள் ஃபோன் இன்னும் சொல்லவில்லை. கொஞ்சம் நேரம் கழித்து, வந்து சேர்ந்ததா எனப் புதுப்பித்துப் பாருங்கள்.',
     tooOld:
       'செயலிக்குள் இருந்து மாதிரிகளைப் பதிவிறக்க இந்த ஃபோனின் Android மிகவும் பழையது. Android அமைப்புகளில் “voice” எனத் தேடி ஒன்றைச் சேர்க்கவும்.',
     iosNote:
-      'iPhone தன் டிக்டேஷன் மொழிகளைத் தானே பதிவிறக்கும். Settings › General › Keyboard › Dictation Languages இல் ஒன்றைச் சேர்த்தால் மைக் அதைப் பயன்படுத்தும்.',
+      'iPhone தன் டிக்டேஷன் மொழிகளைத் தானே பதிவிறக்கும்; எவை ஏற்கெனவே உள்ளன என்பதைச் சொல்லாது. Settings › General › Keyboard › Dictation Languages இல் ஒன்றைச் சேர்த்தால் மைக் அதைப் பயன்படுத்தும்.',
     unavailable: 'இந்தப் பதிப்பால் பேச்சு மாதிரிகளை அணுக முடியாது.',
     noOnDevice:
       'இணைப்பு இல்லாமல் பேச்சை இந்த ஃபோனால் அடையாளம் காண முடியாது, எனவே பதிவிறக்க எதுவும் இல்லை.',
     refresh: 'புதுப்பி',
-    empty: 'உங்கள் ஃபோன் எந்த மொழியையும் சொல்லவில்லை.',
+    empty:
+      'தான் அடையாளம் காணக்கூடிய மொழிகள் எதையும் உங்கள் ஃபோன் சொல்லவில்லை, எனவே Waves கேட்பவை மட்டுமே பட்டியலில் உள்ளன. பதிவிறக்கம் இன்னும் வேலை செய்யக்கூடும்.',
     footnote:
       'மாதிரிகள் உங்கள் ஃபோனுடையவை, Waves உடையவை அல்ல. ஒன்று இருந்தால், நீங்கள் பேசுவது ஃபோனிலேயே உரையாக மாறும், வெளியே செல்லாது.',
   },
@@ -8093,14 +8103,17 @@ const hi: UiStrings = {
       'आपके फ़ोन ने अपनी डाउनलोड स्क्रीन खोल दी है। वहीं पूरा करें, फिर लौटकर ताज़ा करें।',
     scheduled: 'क़तार में है। आपका फ़ोन इसे पूरा कर देगा, आम तौर पर Wi‑Fi पर।',
     failed: 'आपका फ़ोन उसे डाउनलोड नहीं कर सका।',
+    stillWorking:
+      'आपके फ़ोन ने अब तक नहीं बताया कि यह पूरा हुआ या नहीं। थोड़ी देर बाद ताज़ा करके देखें कि आया या नहीं।',
     tooOld:
       'ऐप के भीतर से मॉडल डाउनलोड करने के लिए इस फ़ोन का Android बहुत पुराना है। Android सेटिंग्स में “voice” खोजकर एक जोड़ें।',
     iosNote:
-      'iPhone अपनी डिक्टेशन भाषाएँ ख़ुद डाउनलोड करता है। Settings › General › Keyboard › Dictation Languages में एक जोड़ें, माइक उसे इस्तेमाल करने लगेगा।',
+      'iPhone अपनी डिक्टेशन भाषाएँ ख़ुद डाउनलोड करता है, और यह नहीं बताता कि कौन-सी पहले से मौजूद हैं। Settings › General › Keyboard › Dictation Languages में एक जोड़ें, माइक उसे इस्तेमाल करने लगेगा।',
     unavailable: 'यह बिल्ड स्पीच मॉडल तक नहीं पहुँच सकता।',
     noOnDevice: 'यह फ़ोन बिना कनेक्शन के बोली नहीं पहचान सकता, इसलिए डाउनलोड करने को कुछ नहीं है।',
     refresh: 'ताज़ा करें',
-    empty: 'आपके फ़ोन ने कोई भाषा नहीं बताई।',
+    empty:
+      'आपके फ़ोन ने ऐसी कोई भाषा नहीं बताई जिसे वह पहचान सके, इसलिए सिर्फ़ वही सूचीबद्ध हैं जो Waves माँगता है। डाउनलोड फिर भी काम कर सकता है।',
     footnote:
       'मॉडल आपके फ़ोन के हैं, Waves के नहीं। एक मौजूद हो तो आप जो कहते हैं वह फ़ोन पर ही लिखाई में बदलता है और बाहर नहीं जाता।',
   },
@@ -10445,14 +10458,17 @@ const ar: UiStrings = {
     dialogOpened: 'فتح هاتفك شاشة التنزيل الخاصة به. أكمِل هناك ثم عُد وحدِّث القائمة.',
     scheduled: 'في الانتظار. سيُكمل هاتفك التنزيل، غالبًا عند اتصاله بشبكة Wi‑Fi.',
     failed: 'تعذّر على هاتفك تنزيل ذلك.',
+    stillWorking:
+      'لم يقل هاتفك بعدُ إن كان هذا قد اكتمل. امهله قليلًا ثم حدِّث القائمة لترى إن كان قد وصل.',
     tooOld:
       'إصدار Android على هذا الهاتف أقدم من أن ينزّل النماذج من داخل التطبيق. ابحث عن «voice» في إعدادات Android وأضف واحدة.',
     iosNote:
-      'ينزّل iPhone لغات الإملاء بنفسه. أضف لغة من Settings ‹ General ‹ Keyboard ‹ Dictation Languages وسيستخدمها الميكروفون.',
+      'ينزّل iPhone لغات الإملاء بنفسه، ولا يقول أيّها موجود لديه بالفعل. أضف لغة من Settings ‹ General ‹ Keyboard ‹ Dictation Languages وسيستخدمها الميكروفون.',
     unavailable: 'لا يستطيع هذا الإصدار الوصول إلى نماذج الكلام.',
     noOnDevice: 'لا يستطيع هذا الهاتف التعرّف على الكلام دون اتصال، فلا شيء لتنزيله.',
     refresh: 'تحديث',
-    empty: 'لم يذكر هاتفك أي لغة.',
+    empty:
+      'لم يذكر هاتفك أي لغة يستطيع التعرّف عليها، لذا لا تظهر سوى اللغات التي يطلبها Waves. وقد ينجح التنزيل رغم ذلك.',
     footnote:
       'النماذج ملك لهاتفك لا لـ Waves. وبوجود واحدة يتحوّل ما تقوله إلى نص على الجهاز ولا يغادره.',
   },

--- a/apps/mobile/src/lib/dictation.ts
+++ b/apps/mobile/src/lib/dictation.ts
@@ -86,6 +86,92 @@ export function onDeviceLocaleInstalled(
   });
 }
 
+/** One on-device speech model, as the offline-voice screen lists it. */
+export interface OfflineVoiceModel {
+  /** The BCP-47 tag the recogniser is asked for, and the tag a download names. */
+  readonly tag: string;
+  /**
+   * The app language this model serves, or null for a model the phone offers
+   * that Waves itself never asks for. The screen names an app language in its
+   * own script; anything else can only be named by its tag.
+   */
+  readonly language: Language | null;
+  /** Whether the phone already holds this model. */
+  readonly installed: boolean;
+}
+
+/** The three groups the offline-voice screen shows, in the order it shows them. */
+export interface OfflineVoiceModels {
+  /** One row per app language, present or not — these are the ones Waves uses. */
+  readonly app: OfflineVoiceModel[];
+  /** Models already on the phone that no app language claims. */
+  readonly alsoInstalled: OfflineVoiceModel[];
+  /** Everything else the recogniser says it knows about, and so could fetch. */
+  readonly downloadable: OfflineVoiceModel[];
+}
+
+/** Lower-cased, dash-separated — the one shape tags are compared in. */
+function normaliseTag(tag: string): string {
+  return tag.trim().replace(/_/g, '-').toLowerCase();
+}
+
+/**
+ * The model list, built from what the app needs and what the phone reports.
+ *
+ * Kept pure (no native module, no React) for the same reason the rest of this
+ * file is: the interesting part is the bookkeeping, and the bookkeeping is easy
+ * to get wrong in ways a device would only reveal by staying silent.
+ *
+ * The app's four languages always lead, in the app's own order, whether or not
+ * their model is installed — they are the rows somebody came here to fix, and a
+ * missing one has to be visible to be downloadable. Their installed state goes
+ * through {@link onDeviceLocaleInstalled} rather than a plain membership test,
+ * because that is the matcher the mic itself uses: a phone listing a bare `en`
+ * really does cover `en-IN`, and a phone listing only `en-US` really does not.
+ *
+ * Everything else the phone names is split by whether it is already there. That
+ * split is not cosmetic — an installed model is a fact about the phone, while a
+ * merely supported one is an offer, and putting them in one list would invite a
+ * download of something already present.
+ *
+ * A tag an app row already names is dropped from both other groups so the same
+ * model cannot be listed (or downloaded) twice.
+ */
+export function offlineVoiceModels(
+  languages: readonly Language[],
+  deviceLocale: string,
+  supported: readonly string[] | null | undefined,
+  installed: readonly string[] | null | undefined,
+): OfflineVoiceModels {
+  const installedTags = installed ?? [];
+  const app: OfflineVoiceModel[] = languages.map((language) => {
+    const tag = speechLocale(language, deviceLocale);
+    return { tag, language, installed: onDeviceLocaleInstalled(tag, installedTags) };
+  });
+  const claimed = new Set(app.map((model) => normaliseTag(model.tag)));
+
+  const alsoInstalled: OfflineVoiceModel[] = [];
+  const downloadable: OfflineVoiceModel[] = [];
+  // The phone may name a tag in `installedLocales` that never appears in
+  // `locales`, so both lists are walked; `seen` keeps a tag to one row.
+  const seen = new Set(claimed);
+  for (const raw of [...installedTags, ...(supported ?? [])]) {
+    const tag = raw.trim();
+    const key = normaliseTag(tag);
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    const isInstalled = installedTags.some((entry) => normaliseTag(entry) === key);
+    (isInstalled ? alsoInstalled : downloadable).push({
+      tag,
+      language: null,
+      installed: isInstalled,
+    });
+  }
+
+  const byTag = (a: OfflineVoiceModel, b: OfflineVoiceModel): number => a.tag.localeCompare(b.tag);
+  return { app, alsoInstalled: alsoInstalled.sort(byTag), downloadable: downloadable.sort(byTag) };
+}
+
 /**
  * What the field should read while somebody is speaking.
  *

--- a/apps/mobile/src/lib/dictation.ts
+++ b/apps/mobile/src/lib/dictation.ts
@@ -86,6 +86,23 @@ export function onDeviceLocaleInstalled(
   });
 }
 
+/**
+ * Whether a phone can be asked which models it actually holds.
+ *
+ * Android answers this properly: `installedLocales` is a real list of models on
+ * the device, separate from the ones it merely supports. iOS does not — its
+ * module assigns the supported list to the installed one verbatim, so every
+ * locale iOS can recognise at all comes back as "installed" whether or not its
+ * dictation language has ever been downloaded. Believing that answer is the old
+ * silence bug wearing a tick: the screen would promise a model the recogniser
+ * then fails to find. So the phone that cannot be asked is marked `unknowable`
+ * and the screen says nothing about installed state at all.
+ */
+export type InstalledKnowledge = 'reported' | 'unknowable';
+
+/** Whether the phone holds a model — or whether it can even be asked. */
+export type OfflineVoiceModelState = 'installed' | 'missing' | 'unknown';
+
 /** One on-device speech model, as the offline-voice screen lists it. */
 export interface OfflineVoiceModel {
   /** The BCP-47 tag the recogniser is asked for, and the tag a download names. */
@@ -96,17 +113,24 @@ export interface OfflineVoiceModel {
    * own script; anything else can only be named by its tag.
    */
   readonly language: Language | null;
-  /** Whether the phone already holds this model. */
-  readonly installed: boolean;
+  /** Whether the phone holds this model, or `unknown` when it cannot say. */
+  readonly state: OfflineVoiceModelState;
 }
 
 /** The three groups the offline-voice screen shows, in the order it shows them. */
 export interface OfflineVoiceModels {
   /** One row per app language, present or not — these are the ones Waves uses. */
   readonly app: OfflineVoiceModel[];
-  /** Models already on the phone that no app language claims. */
+  /**
+   * Models already on the phone that no app language claims. Empty on a phone
+   * that cannot be asked what it holds — see {@link InstalledKnowledge}.
+   */
   readonly alsoInstalled: OfflineVoiceModel[];
-  /** Everything else the recogniser says it knows about, and so could fetch. */
+  /**
+   * Everything else the recogniser says it knows about, and so could fetch.
+   * Also empty when the phone cannot be asked: without a trustworthy installed
+   * list there is no way to tell an offer from something already there.
+   */
   readonly downloadable: OfflineVoiceModel[];
 }
 
@@ -134,37 +158,57 @@ function normaliseTag(tag: string): string {
  * merely supported one is an offer, and putting them in one list would invite a
  * download of something already present.
  *
- * A tag an app row already names is dropped from both other groups so the same
- * model cannot be listed (or downloaded) twice.
+ * A tag an app row already *covers* is dropped from both other groups, which is
+ * a wider test than an exact match and has to be: the phone's usual way of
+ * saying it holds generic English is the bare tag `en`, which is not the `en-IN`
+ * an app row names but is the very same model, and listing both puts one model
+ * on the screen twice.
+ *
+ * On a phone that cannot be asked what it holds the two lower groups are empty
+ * and every app row reads `unknown` — see {@link InstalledKnowledge} for why a
+ * confident answer there would be a lie.
  */
 export function offlineVoiceModels(
   languages: readonly Language[],
   deviceLocale: string,
   supported: readonly string[] | null | undefined,
   installed: readonly string[] | null | undefined,
+  knowledge: InstalledKnowledge,
 ): OfflineVoiceModels {
   const installedTags = installed ?? [];
+  const knowable = knowledge === 'reported';
   const app: OfflineVoiceModel[] = languages.map((language) => {
     const tag = speechLocale(language, deviceLocale);
-    return { tag, language, installed: onDeviceLocaleInstalled(tag, installedTags) };
+    const state: OfflineVoiceModelState = !knowable
+      ? 'unknown'
+      : onDeviceLocaleInstalled(tag, installedTags)
+        ? 'installed'
+        : 'missing';
+    return { tag, language, state };
   });
-  const claimed = new Set(app.map((model) => normaliseTag(model.tag)));
+
+  const empty = { app, alsoInstalled: [], downloadable: [] };
+  if (!knowable) return empty;
 
   const alsoInstalled: OfflineVoiceModel[] = [];
   const downloadable: OfflineVoiceModel[] = [];
   // The phone may name a tag in `installedLocales` that never appears in
   // `locales`, so both lists are walked; `seen` keeps a tag to one row.
-  const seen = new Set(claimed);
+  const seen = new Set(app.map((model) => normaliseTag(model.tag)));
   for (const raw of [...installedTags, ...(supported ?? [])]) {
     const tag = raw.trim();
     const key = normaliseTag(tag);
     if (!key || seen.has(key)) continue;
     seen.add(key);
+    // The same matcher the mic uses, asked backwards: does this one tag satisfy
+    // any app row? A bare `en` satisfies `en-IN`, so it is that row's model and
+    // not a second one. `en-US` satisfies nothing above and stays.
+    if (app.some((model) => onDeviceLocaleInstalled(model.tag, [tag]))) continue;
     const isInstalled = installedTags.some((entry) => normaliseTag(entry) === key);
     (isInstalled ? alsoInstalled : downloadable).push({
       tag,
       language: null,
-      installed: isInstalled,
+      state: isInstalled ? 'installed' : 'missing',
     });
   }
 

--- a/apps/mobile/src/lib/speechModels.ts
+++ b/apps/mobile/src/lib/speechModels.ts
@@ -33,18 +33,27 @@ export interface SpeechLocales {
 }
 
 export interface SpeechModelsApi {
-  /** Whether a recogniser is usable at all on this phone right now. */
-  available: () => boolean;
   /** Whether this phone can recognise speech without a connection. */
   supportsOnDevice: () => boolean;
   /**
+   * Whether {@link listLocales}'s `installedLocales` is a fact or an echo.
+   *
+   * Android reports the models actually on the device, separate from the ones it
+   * merely supports. iOS assigns one to the other — its module literally returns
+   * the supported list under both names — so on iPhone the answer means nothing
+   * and must not be drawn as if it did.
+   */
+  reportsInstalled: () => boolean;
+  /**
    * Whether a model can be fetched from inside the app.
    *
-   * Android only, and only from Android 13: `androidTriggerOfflineModelDownload`
-   * is not implemented on iOS at all (calling it there throws), and it rejects
-   * with `not_supported` below API 33. iOS installs its dictation languages
-   * through the system's own settings and offers no API to ask for one, so the
-   * screen falls back to telling somebody where to tap.
+   * Android 13 and up. `androidTriggerOfflineModelDownload` is not implemented
+   * in the iOS module at all — calling it there throws — and on Android below
+   * API 33 the native side rejects it with `not_supported` before doing
+   * anything. Both are checked here rather than left to fail at the tap, so no
+   * button is ever offered that cannot work. iOS installs its dictation
+   * languages through the system's own settings and offers no API to ask for
+   * one, so the screen falls back to telling somebody where to tap.
    */
   canDownload: () => boolean;
   /** Ask the phone for its locale lists. Rejects on a service that is busy. */
@@ -55,7 +64,6 @@ export interface SpeechModelsApi {
 
 /** The shape this file uses from the native module — no more than it needs. */
 interface SpeechModule {
-  isRecognitionAvailable: () => boolean;
   supportsOnDeviceRecognition: () => boolean;
   getDefaultRecognitionService?: () => { packageName: string };
   getSupportedLocales: (options: {
@@ -83,13 +91,6 @@ function load(): SpeechModelsApi | null {
   }
 
   return {
-    available: () => {
-      try {
-        return module.isRecognitionAvailable();
-      } catch {
-        return false;
-      }
-    },
     supportsOnDevice: () => {
       try {
         return module.supportsOnDeviceRecognition();
@@ -97,11 +98,28 @@ function load(): SpeechModelsApi | null {
         return false;
       }
     },
-    canDownload: () => Platform.OS === 'android',
+    reportsInstalled: () => Platform.OS === 'android',
+    // API 33 is where the native side stops rejecting outright. `Platform.Version`
+    // is the API level on Android (a string on iOS, which the platform check has
+    // already excluded).
+    canDownload: () => Platform.OS === 'android' && Number(Platform.Version) >= 33,
     listLocales: async () => {
-      // Asking Google's own recogniser by name is what makes `installedLocales`
-      // meaningful: the library returns an empty installed list for any other
-      // service package. iOS has no service concept, so it is queried bare.
+      // The service package is named so this asks the *same* recogniser the mic
+      // asks, and so cannot answer differently from it.
+      //
+      // It is worth being plain that this is a trade, not a free win. Naming a
+      // package makes the native side bind to that service instead of the
+      // on-device recogniser, and the library's own note is that installedLocales
+      // "will likely be an empty array if the service package is not
+      // com.google.android.as" — which the default service usually is not. So on
+      // many phones this under-reports: models that are present read as absent.
+      //
+      // That is the direction to fail in. An under-report offers a download for
+      // something already there, which costs a tap and resolves immediately. The
+      // other direction — querying the on-device recogniser bare, getting a
+      // fuller list, and ticking a model the mic (which asks by package) will not
+      // find — is the silence bug this whole screen exists to cure. Until the mic
+      // and this share one probe, they stay wrong the same way.
       let androidRecognitionServicePackage: string | undefined;
       try {
         const packageName = module.getDefaultRecognitionService?.().packageName;
@@ -109,6 +127,8 @@ function load(): SpeechModelsApi | null {
       } catch {
         // No service to name — query without one rather than fail the read.
       }
+      // iOS has no service concept and answers with an empty package name, so it
+      // falls through to the bare query on its own.
       const answer = await module.getSupportedLocales(
         androidRecognitionServicePackage ? { androidRecognitionServicePackage } : {},
       );

--- a/apps/mobile/src/lib/speechModels.ts
+++ b/apps/mobile/src/lib/speechModels.ts
@@ -1,0 +1,133 @@
+/**
+ * A non-throwing gate to the speech recogniser's *model* surface.
+ *
+ * `expo-speech-recognition` calls `requireNativeModule` at the top of its file,
+ * so importing it in a binary built before the native module existed throws at
+ * load — and expo-router loads every route file to build its route tree, so a
+ * plain import in the offline-voice route would kill the app at launch rather
+ * than break one screen. The module is therefore reached through a guarded
+ * `require`, exactly as `VoiceMicPanel` reaches the microphone and `nativeMaps`
+ * reaches Google Maps. When it is absent this is `null` and the screen says so.
+ *
+ * Only the model-management calls live here. The microphone itself stays in
+ * `VoiceCapture`, which owns the one recogniser session (see `speechMic.ts`);
+ * nothing on this path starts or stops a capture.
+ */
+
+import { Platform } from 'react-native';
+
+/**
+ * What the phone says when asked to fetch a model.
+ *
+ * These are the library's own words, and they are worth keeping apart because
+ * they mean three different things to the person waiting: the model is here,
+ * the system has taken over with a dialog of its own, or it has been queued for
+ * later (typically until the phone is on Wi-Fi).
+ */
+export type OfflineModelDownload = 'download_success' | 'opened_dialog' | 'download_scheduled';
+
+/** The locales the recogniser knows about, and the ones it already holds. */
+export interface SpeechLocales {
+  readonly locales: string[];
+  readonly installedLocales: string[];
+}
+
+export interface SpeechModelsApi {
+  /** Whether a recogniser is usable at all on this phone right now. */
+  available: () => boolean;
+  /** Whether this phone can recognise speech without a connection. */
+  supportsOnDevice: () => boolean;
+  /**
+   * Whether a model can be fetched from inside the app.
+   *
+   * Android only, and only from Android 13: `androidTriggerOfflineModelDownload`
+   * is not implemented on iOS at all (calling it there throws), and it rejects
+   * with `not_supported` below API 33. iOS installs its dictation languages
+   * through the system's own settings and offers no API to ask for one, so the
+   * screen falls back to telling somebody where to tap.
+   */
+  canDownload: () => boolean;
+  /** Ask the phone for its locale lists. Rejects on a service that is busy. */
+  listLocales: () => Promise<SpeechLocales>;
+  /** Ask the phone to fetch the model for `tag`. See {@link OfflineModelDownload}. */
+  download: (tag: string) => Promise<OfflineModelDownload>;
+}
+
+/** The shape this file uses from the native module — no more than it needs. */
+interface SpeechModule {
+  isRecognitionAvailable: () => boolean;
+  supportsOnDeviceRecognition: () => boolean;
+  getDefaultRecognitionService?: () => { packageName: string };
+  getSupportedLocales: (options: {
+    androidRecognitionServicePackage?: string;
+  }) => Promise<SpeechLocales>;
+  androidTriggerOfflineModelDownload: (options: {
+    locale: string;
+  }) => Promise<{ status: OfflineModelDownload; message: string }>;
+}
+
+function load(): SpeechModelsApi | null {
+  if (Platform.OS !== 'ios' && Platform.OS !== 'android') return null;
+  let module: SpeechModule;
+  try {
+    // Deliberately require, not import: an import is hoisted to module load,
+    // which is the throw this whole file exists to contain.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const loaded = require('expo-speech-recognition') as {
+      ExpoSpeechRecognitionModule: SpeechModule;
+    };
+    module = loaded.ExpoSpeechRecognitionModule;
+    if (typeof module?.getSupportedLocales !== 'function') return null;
+  } catch {
+    return null;
+  }
+
+  return {
+    available: () => {
+      try {
+        return module.isRecognitionAvailable();
+      } catch {
+        return false;
+      }
+    },
+    supportsOnDevice: () => {
+      try {
+        return module.supportsOnDeviceRecognition();
+      } catch {
+        return false;
+      }
+    },
+    canDownload: () => Platform.OS === 'android',
+    listLocales: async () => {
+      // Asking Google's own recogniser by name is what makes `installedLocales`
+      // meaningful: the library returns an empty installed list for any other
+      // service package. iOS has no service concept, so it is queried bare.
+      let androidRecognitionServicePackage: string | undefined;
+      try {
+        const packageName = module.getDefaultRecognitionService?.().packageName;
+        if (packageName) androidRecognitionServicePackage = packageName;
+      } catch {
+        // No service to name — query without one rather than fail the read.
+      }
+      const answer = await module.getSupportedLocales(
+        androidRecognitionServicePackage ? { androidRecognitionServicePackage } : {},
+      );
+      return {
+        locales: answer.locales ?? [],
+        installedLocales: answer.installedLocales ?? [],
+      };
+    },
+    download: async (tag: string) => {
+      const { status } = await module.androidTriggerOfflineModelDownload({ locale: tag });
+      return status;
+    },
+  };
+}
+
+/**
+ * The phone's speech models, or null on a build that cannot reach them.
+ *
+ * Resolved once at module load — the native module either imports or it does
+ * not, and that answer cannot change while the app is running.
+ */
+export const speechModels: SpeechModelsApi | null = load();

--- a/apps/mobile/test/dictation.test.ts
+++ b/apps/mobile/test/dictation.test.ts
@@ -12,6 +12,7 @@ import {
   dictationError,
   englishSpeechLocale,
   mergeTranscript,
+  offlineVoiceModels,
   onDeviceLocaleInstalled,
   speechLocale,
 } from '@/lib/dictation';
@@ -159,5 +160,56 @@ describe('onDeviceLocaleInstalled', () => {
     expect(onDeviceLocaleInstalled('en-IN', [])).toBe(false);
     expect(onDeviceLocaleInstalled('en-IN', null)).toBe(false);
     expect(onDeviceLocaleInstalled('', ['en'])).toBe(false);
+  });
+});
+
+describe('offlineVoiceModels', () => {
+  const languages = [Language.En, Language.Ta, Language.Hi, Language.Ar];
+
+  it('lists every app language whether or not its model is there', () => {
+    // The rows somebody came to this screen to fix are the missing ones, so
+    // they cannot be filtered out for being missing.
+    const models = offlineVoiceModels(languages, 'en-IN', [], []);
+    expect(models.app.map((model) => model.tag)).toEqual(['en-IN', 'ta-IN', 'hi-IN', 'ar-IN']);
+    expect(models.app.every((model) => !model.installed)).toBe(true);
+  });
+
+  it('reads an app row’s installed state the way the mic does', () => {
+    // A bare `en` really is the generic model and covers en-IN; en-US really is
+    // a different model and does not. The screen must give the same answer the
+    // recogniser will, or it promises a model that then returns silence.
+    const generic = offlineVoiceModels(languages, 'en-IN', [], ['en']);
+    expect(generic.app[0]?.installed).toBe(true);
+    const wrongRegion = offlineVoiceModels(languages, 'en-IN', [], ['en-US']);
+    expect(wrongRegion.app[0]?.installed).toBe(false);
+  });
+
+  it('splits everything else by whether the phone already holds it', () => {
+    const models = offlineVoiceModels(
+      languages,
+      'en-IN',
+      ['fr-FR', 'de-DE', 'bn-IN'],
+      ['de-DE', 'en-US'],
+    );
+    // en-US is installed but no app row claims it, so it belongs with the extras
+    // rather than quietly satisfying the en-IN row above.
+    expect(models.alsoInstalled.map((model) => model.tag)).toEqual(['de-DE', 'en-US']);
+    expect(models.downloadable.map((model) => model.tag)).toEqual(['bn-IN', 'fr-FR']);
+  });
+
+  it('never lists the same model twice', () => {
+    // The phone repeats tags across its two lists, and an app tag must not
+    // reappear below as something still to download.
+    const models = offlineVoiceModels(languages, 'en-IN', ['en-IN', 'ta-IN', 'FR_fr'], ['fr-FR']);
+    expect(models.alsoInstalled.map((model) => model.tag)).toEqual(['fr-FR']);
+    expect(models.downloadable).toEqual([]);
+  });
+
+  it('survives a phone that answers with nothing at all', () => {
+    // Android 12 and below name no locales; the app rows must still draw.
+    const models = offlineVoiceModels(languages, 'en-IN', null, null);
+    expect(models.app).toHaveLength(4);
+    expect(models.alsoInstalled).toEqual([]);
+    expect(models.downloadable).toEqual([]);
   });
 });

--- a/apps/mobile/test/dictation.test.ts
+++ b/apps/mobile/test/dictation.test.ts
@@ -169,19 +169,19 @@ describe('offlineVoiceModels', () => {
   it('lists every app language whether or not its model is there', () => {
     // The rows somebody came to this screen to fix are the missing ones, so
     // they cannot be filtered out for being missing.
-    const models = offlineVoiceModels(languages, 'en-IN', [], []);
+    const models = offlineVoiceModels(languages, 'en-IN', [], [], 'reported');
     expect(models.app.map((model) => model.tag)).toEqual(['en-IN', 'ta-IN', 'hi-IN', 'ar-IN']);
-    expect(models.app.every((model) => !model.installed)).toBe(true);
+    expect(models.app.every((model) => model.state === 'missing')).toBe(true);
   });
 
   it('reads an app row’s installed state the way the mic does', () => {
     // A bare `en` really is the generic model and covers en-IN; en-US really is
     // a different model and does not. The screen must give the same answer the
     // recogniser will, or it promises a model that then returns silence.
-    const generic = offlineVoiceModels(languages, 'en-IN', [], ['en']);
-    expect(generic.app[0]?.installed).toBe(true);
-    const wrongRegion = offlineVoiceModels(languages, 'en-IN', [], ['en-US']);
-    expect(wrongRegion.app[0]?.installed).toBe(false);
+    const generic = offlineVoiceModels(languages, 'en-IN', [], ['en'], 'reported');
+    expect(generic.app[0]?.state).toBe('installed');
+    const wrongRegion = offlineVoiceModels(languages, 'en-IN', [], ['en-US'], 'reported');
+    expect(wrongRegion.app[0]?.state).toBe('missing');
   });
 
   it('splits everything else by whether the phone already holds it', () => {
@@ -190,6 +190,7 @@ describe('offlineVoiceModels', () => {
       'en-IN',
       ['fr-FR', 'de-DE', 'bn-IN'],
       ['de-DE', 'en-US'],
+      'reported',
     );
     // en-US is installed but no app row claims it, so it belongs with the extras
     // rather than quietly satisfying the en-IN row above.
@@ -200,14 +201,50 @@ describe('offlineVoiceModels', () => {
   it('never lists the same model twice', () => {
     // The phone repeats tags across its two lists, and an app tag must not
     // reappear below as something still to download.
-    const models = offlineVoiceModels(languages, 'en-IN', ['en-IN', 'ta-IN', 'FR_fr'], ['fr-FR']);
+    const models = offlineVoiceModels(
+      languages,
+      'en-IN',
+      ['en-IN', 'ta-IN', 'FR_fr'],
+      ['fr-FR'],
+      'reported',
+    );
     expect(models.alsoInstalled.map((model) => model.tag)).toEqual(['fr-FR']);
+    expect(models.downloadable).toEqual([]);
+  });
+
+  it('does not list a bare tag that an app row already covers', () => {
+    // Android's usual way of saying it holds generic English is the bare `en`,
+    // which is not the `en-IN` the app row names but is the very same model.
+    // Listing both would put one model on the screen twice — once ticked at the
+    // top and once again under "also on this phone".
+    const models = offlineVoiceModels(languages, 'en-IN', ['en', 'fr-FR'], ['en'], 'reported');
+    expect(models.app[0]?.state).toBe('installed');
+    expect(models.alsoInstalled).toEqual([]);
+    expect(models.downloadable.map((model) => model.tag)).toEqual(['fr-FR']);
+  });
+
+  it('claims nothing about a phone that cannot be asked what it holds', () => {
+    // iOS returns its supported list under `installedLocales` too, so believing
+    // it would tick every locale the phone can recognise at all — the silence
+    // bug arriving through the UI. Nothing below the app rows is trustworthy
+    // either, since the split between "here" and "on offer" comes from the same
+    // answer.
+    const models = offlineVoiceModels(
+      languages,
+      'en-IN',
+      ['en-IN', 'fr-FR'],
+      ['en-IN', 'fr-FR'],
+      'unknowable',
+    );
+    expect(models.app.map((model) => model.tag)).toEqual(['en-IN', 'ta-IN', 'hi-IN', 'ar-IN']);
+    expect(models.app.every((model) => model.state === 'unknown')).toBe(true);
+    expect(models.alsoInstalled).toEqual([]);
     expect(models.downloadable).toEqual([]);
   });
 
   it('survives a phone that answers with nothing at all', () => {
     // Android 12 and below name no locales; the app rows must still draw.
-    const models = offlineVoiceModels(languages, 'en-IN', null, null);
+    const models = offlineVoiceModels(languages, 'en-IN', null, null, 'reported');
     expect(models.app).toHaveLength(4);
     expect(models.alsoInstalled).toEqual([]);
     expect(models.downloadable).toEqual([]);

--- a/apps/mobile/test/routeAccess.test.ts
+++ b/apps/mobile/test/routeAccess.test.ts
@@ -41,6 +41,8 @@ describe('isPublicRoute', () => {
     expect(isPublicRoute(['group', 'abc', 'plan'], false)).toBe(false);
     expect(isPublicRoute(['personal', 'transactions'], false)).toBe(false);
     expect(isPublicRoute(['personal', 'source', 'salary'], false)).toBe(false);
+    expect(isPublicRoute(['voice'], false)).toBe(false);
+    expect(isPublicRoute(['settings', 'offline-voice'], false)).toBe(false);
     expect(isPublicRoute(['capture'], false)).toBe(false);
   });
 
@@ -76,5 +78,7 @@ describe('isRouteAllowed', () => {
     expect(isRouteAllowed(['group', 'abc', 'plan'], true, false, flags)).toBe(true);
     expect(isRouteAllowed(['personal', 'transactions'], true, false, flags)).toBe(true);
     expect(isRouteAllowed(['personal', 'source', 'salary'], true, false, flags)).toBe(true);
+    expect(isRouteAllowed(['voice'], true, false, flags)).toBe(true);
+    expect(isRouteAllowed(['settings', 'offline-voice'], true, false, flags)).toBe(true);
   });
 });


### PR DESCRIPTION
## What this is

Voice quick-add asks for on-device recognition only when a model for the language is actually installed — asking for one that is not there returns silence (the trap `dictation.ts` documents at length). Everything else falls back to the network recogniser, and on some OEM Android ROMs that service is dead: the mic hears you and answers nothing, with no way out inside the app. The cure has always been to download the on-device model, but that lived in Android's own settings, several screens deep.

This brings it into the app.

- **Settings › Preferences › "Offline voice"** — a new row, opening a pushed screen built like the rest of them (same header shape, same padding, `useScreenClearance()`).
- **A list of models, plural.** The four app languages lead, each resolved through `speechLocale()` to the exact tag the mic will ask for; then anything else already on the phone; then everything else the recogniser says it knows about, each downloadable. Every row says whether the model is on the phone.
- **A progress bar per model,** with a refresh in the header for downloads that finish outside the app.

## What the platform actually supports

This is the part worth reading, because it is narrower than "download a model" sounds.

| Platform | What the API allows |
| --- | --- |
| **Android 14+** | `androidTriggerOfflineModelDownload(locale)` fetches the model and resolves with `download_success` or `download_scheduled`. **No progress reaches JS.** The native `ModelDownloadListener.onProgress(Int)` is implemented in expo-speech-recognition as `// Todo: let user know the progress` — the percentage is received and dropped. There is no event, no emitter, nothing to subscribe to. |
| **Android 13** | Cannot download in the background at all. The call posts the system's own download dialog and resolves immediately with `opened_dialog`. |
| **Android 12 and below** | Rejects with `not_supported`, and `getSupportedLocales` returns empty lists, so nothing can be listed either. |
| **iOS** | `androidTriggerOfflineModelDownload` is not implemented in the iOS module at all — calling it throws. There is no iOS equivalent: dictation languages are installed by the system. Its `getSupportedLocales` also returns `installedLocales === supportedLocales` (the Swift literally assigns one to the other), so "installed" is not a fact iOS can be asked for. |

So the bar is **indeterminate**, and the copy under it says the phone is downloading and that Android does not report how far along it is. No fake percentage is animated. The Android 13 row says the phone has taken over with its own screen and to come back and refresh; the Android 12 case surfaces `not_supported` as an honest sentence pointing at Android settings; iPhone gets a note naming Settings › General › Keyboard › Dictation Languages and **no download button**, since one would lie about what it does. (No iOS deep link either — the `App-Prefs:` URL that would land on that screen is private API, and `Linking.openSettings()` opens the app's own page, which is the wrong place.)

## Decisions worth flagging

- **The screen uses the same installed-matcher as the mic** (`onDeviceLocaleInstalled`), not plain membership. A phone listing a bare `en` really does cover `en-IN`; a phone listing only `en-US` really does not. Anything else and the screen would show a tick next to a model the recogniser then fails to find — the original silence bug, arriving through the UI.
- **Three groups, not one list.** An installed model is a fact about the phone; a merely supported one is an offer. Merging them would invite downloading something already present.
- **`FlashList`,** per the house rule — the "other languages" group runs to dozens of locales on Android.
- **Native module behind a guarded require** in the new `lib/speechModels.ts`, the same shape `nativeMaps.ts` and `VoiceMicPanel.tsx` use. expo-router loads every route file to build its route tree, so a plain import here would cost the whole app at launch on a binary built before the module existed, and nothing in React would catch it.
- The existing one-shot "Set up offline voice" button inside the voice screen is untouched; this is the reachable-in-advance version of the same act.

## i18n

New `offlineVoice` string section in all four languages (en, ta, hi, ar). Layout is flex/`Row`-based with `directionalIcon` on the back chevron, so it mirrors under RTL.

## Testing

`offlineVoiceModels` is pure and covered by five new cases in `dictation.test.ts` (app rows always present, the region-matching trap, the installed/available split, no double-listing, and a phone that answers with nothing). Full mobile suite green: 68 files, 870 tests. `pnpm format` and `pnpm lint` run clean (the only warnings are pre-existing ones in `phone.tsx`).

**Not device-tested.** No native build was run — nothing here is native code, but the platform behaviours above are read from the library's Kotlin and Swift sources, not observed on hardware.
