### PR TITLE
fix(mobile): let the plan screen scroll clear of the bottom bar

### DIFF
--- a/apps/mobile/src/app/(tabs)/me.tsx
+++ b/apps/mobile/src/app/(tabs)/me.tsx
@@ -54,7 +54,7 @@ import {
   Row,
   Screen,
   Text,
-  useScreenClearance,
+  useTabBarClearance,
   useTheme,
   type BarDatum,
 } from '@waves/ui';
@@ -87,7 +87,7 @@ const HERO_CONTROL_BG = 'rgba(255, 255, 255, 0.16)';
 
 export default function MeScreen() {
   const theme = useTheme();
-  const clearance = useScreenClearance();
+  const clearance = useTabBarClearance();
   const { t, locale } = useStrings();
   const dc = useDefaultCurrency();
   const sourceLabel = useSourceLabel();

--- a/apps/mobile/src/app/clone-group.tsx
+++ b/apps/mobile/src/app/clone-group.tsx
@@ -11,6 +11,7 @@ import {
   Screen,
   Text,
   tintForKey,
+  useTabBarClearance,
   useTheme,
 } from '@waves/ui';
 
@@ -34,6 +35,7 @@ import { fill, plural, useStrings } from '@/i18n';
  */
 export default function CloneGroupScreen() {
   const theme = useTheme();
+  const clearance = useTabBarClearance();
   const { t, locale } = useStrings();
   const { profile } = useAuth();
   const groups = useGroups();
@@ -63,7 +65,7 @@ export default function CloneGroupScreen() {
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: theme.spacing.xl,
+          paddingBottom: clearance,
           gap: theme.spacing.xs,
         }}
         showsVerticalScrollIndicator={false}

--- a/apps/mobile/src/app/country.tsx
+++ b/apps/mobile/src/app/country.tsx
@@ -37,7 +37,7 @@ import {
   Row,
   Screen,
   Text,
-  useScreenClearance,
+  useTabBarClearance,
   useTheme,
 } from '@waves/ui';
 
@@ -48,7 +48,7 @@ import { takeCountryRequest } from '@/lib/countryPickerBridge';
 export default function CountryScreen(): React.JSX.Element {
   const theme = useTheme();
   const { t } = useStrings();
-  const clearance = useScreenClearance();
+  const clearance = useTabBarClearance();
 
   // Taken once on mount — this captures the request and clears the bridge in
   // one step, so the route owns it outright and no re-render or later open can

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -20,7 +20,7 @@ import {
   SegmentedTabs,
   Text,
   useTheme,
-  useScreenClearance,
+  useTabBarClearance,
 } from '@waves/ui';
 
 import {
@@ -429,7 +429,14 @@ const ExpenseFeedRow = memo(function ExpenseFeedRow({
 
 export default function GroupScreen() {
   const theme = useTheme();
-  const clearance = useScreenClearance(112);
+  // The root bar is over this screen, so the room starts from the bar's own
+  // clearance rather than the bare system inset. The extra 36 has no cause
+  // anywhere in this file — there is no floating action and no pinned footer
+  // asking for it — it is simply what the hardcoded 112 this replaces comes to
+  // once the bar (60) and its breath (16) are taken out, kept so the ledger
+  // renders exactly as it did. Derived rather than hardcoded so it follows
+  // `BAR_HEIGHT` instead of quietly sliding under a taller bar one day.
+  const clearance = useTabBarClearance() + 36;
   const pull = usePullRefresh();
   const { t, locale } = useStrings();
   // `?welcome=trip` is set once, by the create screen, when a trip is made

--- a/apps/mobile/src/app/group/[id]/plan.tsx
+++ b/apps/mobile/src/app/group/[id]/plan.tsx
@@ -45,7 +45,7 @@ import {
   Screen,
   Text,
   type Theme,
-  useScreenClearance,
+  useTabBarClearance,
   useTheme,
 } from '@waves/ui';
 
@@ -91,7 +91,7 @@ function dayLabel(day: string, locale: string): string {
 
 export default function PlanScreen() {
   const theme = useTheme();
-  const clearance = useScreenClearance();
+  const clearance = useTabBarClearance();
   const { t, locale } = useStrings();
   const { id } = useLocalSearchParams<{ id: string }>();
   const groupId = id ?? '';

--- a/apps/mobile/src/app/groups.tsx
+++ b/apps/mobile/src/app/groups.tsx
@@ -14,7 +14,7 @@ import {
   Row,
   Screen,
   Text,
-  useScreenClearance,
+  useTabBarClearance,
   useTheme,
 } from '@waves/ui';
 
@@ -50,7 +50,7 @@ const absBig = (n: bigint): bigint => (n < 0n ? -n : n);
  */
 export default function AllGroupsScreen() {
   const theme = useTheme();
-  const clearance = useScreenClearance();
+  const clearance = useTabBarClearance();
   const { t, locale } = useStrings();
   const { profile } = useAuth();
   const summary = useHomeSummary(profile?.id ?? null);

--- a/apps/mobile/src/app/settings/packs.tsx
+++ b/apps/mobile/src/app/settings/packs.tsx
@@ -30,7 +30,7 @@ import {
   Screen,
   Sheet,
   Text,
-  useScreenClearance,
+  useTabBarClearance,
   useTheme,
 } from '@waves/ui';
 
@@ -39,7 +39,7 @@ import { plural, useStrings } from '@/i18n';
 
 export default function PacksScreen() {
   const theme = useTheme();
-  const clearance = useScreenClearance();
+  const clearance = useTabBarClearance();
   const { t, locale } = useStrings();
   const packs = usePacks();
   const installed = useInstalledPacks();

--- a/apps/mobile/src/app/settings/packs/[slug].tsx
+++ b/apps/mobile/src/app/settings/packs/[slug].tsx
@@ -27,7 +27,7 @@ import {
   Row,
   Screen,
   Text,
-  useScreenClearance,
+  useTabBarClearance,
   useTheme,
 } from '@waves/ui';
 
@@ -36,7 +36,7 @@ import { plural, useStrings } from '@/i18n';
 
 export default function PackScreen() {
   const theme = useTheme();
-  const clearance = useScreenClearance();
+  const clearance = useTabBarClearance();
   const { t, locale } = useStrings();
   const { slug } = useLocalSearchParams<{ slug: string }>();
 

--- a/packages/ui/src/components/PillTabBar.tsx
+++ b/packages/ui/src/components/PillTabBar.tsx
@@ -42,7 +42,9 @@ const INDICATOR_HEIGHT = 30;
  *
  * This is what nearly every scrolling screen wants, not just the four tabs: the
  * bar is rendered once at the root over the whole navigation stack (`AppTabBar`),
- * so a pushed group, settings or personal screen carries it too.
+ * so a pushed group, settings or personal screen carries it too. The exceptions
+ * are the routes named in `TAB_BAR_HIDDEN_ROUTES` (`apps/mobile/src/lib/tabBar.ts`)
+ * and anything reached without a session, which want `useScreenClearance`.
  */
 export function useTabBarClearance(): number {
   const insets = useSafeAreaInsets();
@@ -51,18 +53,26 @@ export function useTabBarClearance(): number {
 
 /**
  * How much room a scrolling screen that is NOT under the app's own bottom bar
- * has to leave at its foot — only the routes the bar hides itself on, which is
- * the full-screen camera, the rise-from-bottom modals (add an expense, settle
- * up, invite, itemize) and the signed-out screens.
+ * has to leave at its foot.
+ *
+ * One place decides which screens those are: `TAB_BAR_HIDDEN_ROUTES` in
+ * `apps/mobile/src/lib/tabBar.ts`, the set of route names the bar hides itself
+ * on — plus anything reached without a session, which the same module handles.
+ * Go and read that set; do not trust a list written here. It is edited every
+ * time a screen is added, so a copy in this comment would be stale within a
+ * release, and a stale copy is worse than none: it reads as authority. If the
+ * route is not in the set, the bar is over the screen and it wants
+ * `useTabBarClearance` instead. (For the shape of it: the full-screen camera and
+ * the add-an-expense sheet are in the set today; a pushed group, settings or
+ * personal screen is not.)
  *
  * Being *pushed* is not the test, and reading it that way is what left the plan
  * screen's last day under the bar: the bar lives at the root and stays on top of
- * pushed screens too, so those want `useTabBarClearance` instead. The one thing
- * this reserves is the system navigation bar (gesture pill or the three
- * buttons), which sits *over* the content because the app draws edge-to-edge —
- * a fixed `paddingBottom` cannot know its height, so the last row ends up under
- * the system UI. Pass a larger `base` on a screen with a floating action or a
- * pinned footer.
+ * pushed screens too. The one thing this reserves is the system navigation bar
+ * (gesture pill or the three buttons), which sits *over* the content because the
+ * app draws edge-to-edge — a fixed `paddingBottom` cannot know its height, so
+ * the last row ends up under the system UI. Pass a larger `base` on a screen
+ * with a floating action or a pinned footer.
  */
 export function useScreenClearance(base: number = spacing.xxxl): number {
   const insets = useSafeAreaInsets();

--- a/packages/ui/src/components/PillTabBar.tsx
+++ b/packages/ui/src/components/PillTabBar.tsx
@@ -32,13 +32,17 @@ const INDICATOR_WIDTH = 56;
 const INDICATOR_HEIGHT = 30;
 
 /**
- * How much room a scrolling tab screen has to leave at its foot.
+ * How much room a screen under the bar has to leave at its foot.
  *
  * The bar is anchored flush to the bottom edge and is opaque, so a list has to
  * end above it rather than scroll behind it. Derived from the bar height plus
  * the system inset — both move with the phone, which is the half a hardcoded
  * number gets wrong — with a small breath so the last row is not jammed to the
  * bar's top edge.
+ *
+ * This is what nearly every scrolling screen wants, not just the four tabs: the
+ * bar is rendered once at the root over the whole navigation stack (`AppTabBar`),
+ * so a pushed group, settings or personal screen carries it too.
  */
 export function useTabBarClearance(): number {
   const insets = useSafeAreaInsets();
@@ -46,15 +50,19 @@ export function useTabBarClearance(): number {
 }
 
 /**
- * How much room a scrolling screen that is NOT under the tab bar has to leave at
- * its foot — a pushed detail screen, a settings page, a modal.
+ * How much room a scrolling screen that is NOT under the app's own bottom bar
+ * has to leave at its foot — only the routes the bar hides itself on, which is
+ * the full-screen camera, the rise-from-bottom modals (add an expense, settle
+ * up, invite, itemize) and the signed-out screens.
  *
- * The app draws edge-to-edge, so the system navigation bar (gesture pill or the
- * three buttons) sits *over* the bottom of the content. A fixed `paddingBottom`
- * that ignores it leaves the last row hidden behind the bar — you scroll to the
- * end and the end is under the system UI. This is the system inset plus a
- * caller-chosen breath, so the last row always clears it on every phone. Pass a
- * larger `base` on a screen with a floating action or a pinned footer.
+ * Being *pushed* is not the test, and reading it that way is what left the plan
+ * screen's last day under the bar: the bar lives at the root and stays on top of
+ * pushed screens too, so those want `useTabBarClearance` instead. The one thing
+ * this reserves is the system navigation bar (gesture pill or the three
+ * buttons), which sits *over* the content because the app draws edge-to-edge —
+ * a fixed `paddingBottom` cannot know its height, so the last row ends up under
+ * the system UI. Pass a larger `base` on a screen with a floating action or a
+ * pinned footer.
  */
 export function useScreenClearance(base: number = spacing.xxxl): number {
   const insets = useSafeAreaInsets();


### PR DESCRIPTION
The trip plan screen could not be scrolled to its end — the last day sat behind the bottom navigation bar.

## What was wrong

`group/[id]/plan.tsx` reserved its bottom room with `useScreenClearance()`, which returns the system inset plus a 32dp breath. That clears the gesture pill or the three buttons. It does not clear the app's *own* bottom bar, which is opaque, anchored flush to the bottom edge, and a further 60dp tall on top of that inset. About 28dp of content plus the breath was permanently underneath it.

The hook's own comment invited the mistake. It described itself as the clearance for a screen "NOT under the tab bar — a pushed detail screen, a settings page, a modal", and the plan screen is a pushed detail screen. But since the bar moved to the root (`AppTabBar` renders once over the whole navigation stack, so it does not vanish when you leave the tabs), being pushed says nothing about whether the bar is there. The real test is `TAB_BAR_HIDDEN_ROUTES` in `lib/tabBar.ts`: the bar hides itself on the camera, the rise-from-bottom modals, a handful of pushed full-screen flows, and the signed-out screens, and shows everywhere else.

This has now been worked out three times independently — once in a comment left on `settings/import.tsx`, once on the country picker, and now here — so both hooks' doc comments have been rewritten. The first attempt at that rewrite swapped one wrong rule for a hand-copied list of the hidden routes, which was already missing six of them; review caught it, and the comments now name `TAB_BAR_HIDDEN_ROUTES` and tell you to go and read it, so they cannot drift the way the thing they replaced did.

## What is fixed

The clearance sits on the `ScrollView`'s `contentContainerStyle` (none of these screens has a pinned footer), so most of this is one hook swapped for the other, no restructuring.

| Screen | Bar shows? | Was | Now |
| --- | --- | --- | --- |
| `group/[id]/plan.tsx` | yes | `useScreenClearance()` | `useTabBarClearance()` |
| `country.tsx` | yes | `useScreenClearance()` | `useTabBarClearance()` |
| `(tabs)/me.tsx` | yes (a tab) | `useScreenClearance()` | `useTabBarClearance()` |
| `groups.tsx` | yes | `useScreenClearance()` | `useTabBarClearance()` |
| `settings/packs.tsx` | yes | `useScreenClearance()` | `useTabBarClearance()` |
| `settings/packs/[slug].tsx` | yes | `useScreenClearance()` | `useTabBarClearance()` |
| `clone-group.tsx` | yes | `paddingBottom: spacing.xl` | `useTabBarClearance()` |
| `group/[id]/index.tsx` | yes | `useScreenClearance(112)` | `useTabBarClearance() + 36` |

The country picker is the one the user hit alongside the plan screen; it is only ever opened from three signed-in screens, so there is no signed-out path where the bar is absent and the new room would be a dead gap. The Me tab is a tab screen, so the bar is unambiguously over it. The two pack screens were the only pages under `settings/` not already using the bar-aware clearance — all 23 of their siblings do.

The last two came out of review:

- `clone-group.tsx` was worse than the rest — a plain `paddingBottom: spacing.xl` reserving neither the bar nor the system inset, on a route the bar shows on. On a phone with three-button navigation the last group in the clone picker sat about 88dp under the bar.
- `group/[id]/index.tsx` was going to be left alone, because its hardcoded `112` does already exceed the bar's 60 plus its 16dp breath. But it exceeds it by hand: the number does not follow `BAR_HEIGHT`, so raising the bar would slide the ledger back underneath while every bar-aware screen moved out of the way. `useTabBarClearance() + 36` is the same 112 to the pixel today and tracks the constant tomorrow. Nothing in that file explains the 36 — no floating action, no pinned footer — and the comment says so rather than inventing a reason.

## Not fixed here — the same bug, left for a follow-up

Sixteen screens reserve `useScreenClearance()` on a route where the bar shows. They are the identical one-line change, kept out of this PR to keep it reviewable. All sixteen were re-checked after the review — each resolves to a route absent from `TAB_BAR_HIDDEN_ROUTES`, and each uses the value as the bottom padding of a full-height scroller — so there are no false entries in this list:

- `group/[id]/`: `insights.tsx`, `export.tsx`, `map.tsx`, `members.tsx`, `month.tsx`, `pending.tsx`, `recap.tsx`, `simplify.tsx`, `member/[memberId].tsx`, `expense/[expenseId].tsx`
- `personal/`: `budgets.tsx`, `entry.tsx`, `loans.tsx`, `recurring.tsx`, `transactions.tsx`, `source/[id].tsx`

Deliberately left alone, because they are correct as they stand:

- `group/[id]/settle.tsx`, `invite.tsx`, `itemize.tsx` — all three are on the bar's hidden list, so `useScreenClearance` is the right hook.
- `dev/local-privacy.tsx` — reserves nothing at all, but it is a `__DEV__`-only screen.

## Verification

`pnpm format`, `pnpm lint` (0 errors; the 3 `import/first` warnings in `phone.tsx` are pre-existing and untouched) and `tsc --noEmit` for the mobile app and `@waves/ui` are clean, and the mobile suite passes from `apps/mobile` — 868 tests, all green with no timeouts on the latest run.

Not visually verified: this was not run on a device or emulator, so the fix rests on the arithmetic (the bar is `height: 60 + insets.bottom`, the screen now reserves `insets.bottom + 60 + 16`) rather than on having seen it.
