### PR TITLE
feat(trip): pick both trip dates on one calendar

### DIFF
--- a/apps/mobile/src/components/ActivityDateFilter.tsx
+++ b/apps/mobile/src/components/ActivityDateFilter.tsx
@@ -25,6 +25,7 @@ import { Button, Row, Text, useTheme } from '@waves/ui';
 import { SheetOverlay } from '@/components/expense/SheetOverlay';
 import { RangeCalendar } from '@/components/RangeCalendar';
 import { useStrings } from '@/i18n';
+import { gregorianFormatter } from '@/lib/calendarGrid';
 
 /** A committed filter range — both ends are calendar-day anchors (local noon). */
 export interface DateRange {
@@ -88,10 +89,13 @@ export function ActivityDateFilter({
     },
   ];
 
+  // Pinned to the Gregorian calendar for the same reason the grid below it is:
+  // `ar-SA` resolves to Umm al-Qura by default, and a read-out naming a Hijri
+  // month over a calendar drawn in Gregorian ones contradicts the thing it is
+  // meant to echo. The language, and its digits, are still the reader's.
+  const readable = gregorianFormatter(locale, { weekday: 'short', day: 'numeric', month: 'short' });
   const showDate = (value: Date | null): string =>
-    value
-      ? value.toLocaleDateString(locale, { weekday: 'short', day: 'numeric', month: 'short' })
-      : t.pickers.notSet;
+    value ? (readable?.format(value) ?? value.toDateString()) : t.pickers.notSet;
 
   // A preset is a one-tap answer: commit it and close, no Apply needed.
   const applyPreset = (p: { start: Date; end: Date }): void => {

--- a/apps/mobile/src/components/RangeCalendar.tsx
+++ b/apps/mobile/src/components/RangeCalendar.tsx
@@ -1,82 +1,57 @@
 /**
  * An inline month calendar with range selection — the modern date-range control
- * (Monzo, Spotify, StubHub): one calendar on screen, tap the start day then the
- * end day, the span between them tinted. It replaces the old from/to pair that
- * opened a native picker modal per end (open, pick, dismiss, open, pick, dismiss
- * — four taps before Apply). Here a custom range is two taps on a calendar that
- * never leaves the sheet.
+ * (Monzo, Spotify, StubHub, and every travel app: Airbnb, Booking.com, Vrbo,
+ * Agoda): one calendar on screen, tap the start day then the end day, the span
+ * between them tinted. It replaces the old from/to pair that opened a native
+ * picker modal per end (open, pick, dismiss, open, pick, dismiss — four taps
+ * before Apply). Here a range is two taps on a calendar that never leaves the
+ * screen.
  *
- * Pure React Native, no calendar dependency: the feed is small and the control
- * is simple, so a hand-built month grid avoids adding a native-ish library for
- * one screen. Days outside the feed's own span (`earliest`/`latest`) are
- * disabled, and month paging stops at the months that hold those bounds — you
- * cannot wander into empty time. Every day is anchored at local noon so the grid
- * is DST-proof and agrees with the `DateRange` the sheet commits.
+ * Pure React Native, no calendar dependency: the grid is simple enough to build
+ * by hand, and a native calendar library would turn every screen that picks
+ * dates into a store release instead of an over-the-air update. This file is
+ * only the drawing of it — the day arithmetic, the reader's first weekday and
+ * the Gregorian pinning of the labels all live in `@/lib/calendarGrid`, where
+ * they can be tested without a renderer. Every day is anchored at local noon, so
+ * the grid is DST-proof and agrees with the day anchors its callers commit.
+ *
+ * Bounds are optional. The activity feed clamps to the span it actually holds
+ * (`earliest`/`latest`), because a day before the first event or after the last
+ * is empty time; a trip has no such bounds — it may have happened last year or
+ * be booked for next — so leaving them off pages freely in both directions.
  */
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Pressable, View } from 'react-native';
 
 import { directionalIcon, iconSize, Row, Text, useTheme } from '@waves/ui';
 
-/** A calendar day at local noon — the anchor the whole control works in. */
-function dayAt(year: number, month: number, date: number): Date {
-  return new Date(year, month, date, 12, 0, 0, 0);
-}
-
-function startOfDay(d: Date): Date {
-  return dayAt(d.getFullYear(), d.getMonth(), d.getDate());
-}
-
-function firstOfMonth(d: Date): Date {
-  return dayAt(d.getFullYear(), d.getMonth(), 1);
-}
-
-function addMonths(d: Date, delta: number): Date {
-  return dayAt(d.getFullYear(), d.getMonth() + delta, 1);
-}
-
-/** Whole days between two day-anchors (b − a), sign preserved. */
-function dayDiff(a: Date, b: Date): number {
-  return Math.round((b.getTime() - a.getTime()) / 86_400_000);
-}
-
-function sameDay(a: Date, b: Date): boolean {
-  return (
-    a.getFullYear() === b.getFullYear() &&
-    a.getMonth() === b.getMonth() &&
-    a.getDate() === b.getDate()
-  );
-}
-
-/** The seven weekday initials in the reader's language, Sunday first. */
-function weekdayLabels(locale: string): string[] {
-  const fmt = new Intl.DateTimeFormat(locale, { weekday: 'narrow' });
-  // 2023-01-01 was a Sunday — walk a known week to get localized initials.
-  return Array.from({ length: 7 }, (_, i) => fmt.format(dayAt(2023, 0, 1 + i)));
-}
-
-function monthLabel(d: Date, locale: string): string {
-  try {
-    return new Intl.DateTimeFormat(locale, { month: 'long', year: 'numeric' }).format(d);
-  } catch {
-    return `${d.getFullYear()}-${d.getMonth() + 1}`;
-  }
-}
+import {
+  addMonths,
+  dayAt,
+  firstOfMonth,
+  firstWeekday,
+  gregorianFormatter,
+  monthGrid,
+  sameDay,
+  startOfDay,
+} from '@/lib/calendarGrid';
 
 const CELL = 40;
 
 export function RangeCalendar({
-  earliest,
-  latest,
+  earliest = null,
+  latest = null,
   locale,
   start,
   end,
   onSelect,
 }: {
-  earliest: Date;
-  latest: Date;
+  /** The earliest selectable day, or null for no lower bound. */
+  earliest?: Date | null;
+  /** The latest selectable day, or null for no upper bound. */
+  latest?: Date | null;
   locale: string;
   start: Date | null;
   end: Date | null;
@@ -84,17 +59,48 @@ export function RangeCalendar({
   onSelect: (start: Date | null, end: Date | null) => void;
 }): React.JSX.Element {
   const theme = useTheme();
-  const lo = startOfDay(earliest);
-  const hi = startOfDay(latest);
+  const lo = earliest ? startOfDay(earliest) : null;
+  const hi = latest ? startOfDay(latest) : null;
 
-  // Which month the grid shows — opens on the current start, else the latest
-  // event's month (the newest activity, where the reader most likely looks).
-  const [view, setView] = useState<Date>(() => firstOfMonth(start ?? latest));
+  // Which month the grid shows — opens on the current start, else on the upper
+  // bound's month (the newest activity, where a feed's reader most likely
+  // looks), else on today's, which is where an unbounded picker belongs.
+  const [view, setView] = useState<Date>(() => firstOfMonth(start ?? latest ?? new Date()));
 
-  const canPrev = firstOfMonth(view).getTime() > firstOfMonth(lo).getTime();
-  const canNext = firstOfMonth(view).getTime() < firstOfMonth(hi).getTime();
+  const canPrev = lo === null || firstOfMonth(view).getTime() > firstOfMonth(lo).getTime();
+  const canNext = hi === null || firstOfMonth(view).getTime() < firstOfMonth(hi).getTime();
 
-  const inBounds = (d: Date): boolean => d.getTime() >= lo.getTime() && d.getTime() <= hi.getTime();
+  const inBounds = (d: Date): boolean =>
+    (lo === null || d.getTime() >= lo.getTime()) && (hi === null || d.getTime() <= hi.getTime());
+
+  // The three formatters the grid needs, built once per language rather than
+  // once per cell — a 42-cell grid re-formatting on every render is the kind of
+  // cost that only shows up on the cheap phone somebody actually owns.
+  const format = useMemo(() => {
+    const month = gregorianFormatter(locale, { month: 'long', year: 'numeric' });
+    const weekday = gregorianFormatter(locale, { weekday: 'narrow' });
+    const full = gregorianFormatter(locale, { weekday: 'long', day: 'numeric', month: 'long' });
+    let number: Intl.NumberFormat | null = null;
+    try {
+      number = new Intl.NumberFormat(locale);
+    } catch {
+      // Western digits are the fallback, and they are legible everywhere.
+    }
+    return {
+      month: (d: Date): string => month?.format(d) ?? `${d.getFullYear()}-${d.getMonth() + 1}`,
+      weekday: (d: Date): string => weekday?.format(d) ?? '',
+      full: (d: Date): string => full?.format(d) ?? d.toDateString(),
+      day: (n: number): string => number?.format(n) ?? String(n),
+    };
+  }, [locale]);
+
+  // Where the week begins for this reader, and the seven initials in that
+  // order. 2023-01-01 was a Sunday, so walking from it plus the offset gives
+  // each column's day without any date arithmetic worth checking twice.
+  const weekStart = useMemo(() => firstWeekday(locale), [locale]);
+  const weekdays = Array.from({ length: 7 }, (_, i) =>
+    format.weekday(dayAt(2023, 0, 1 + ((weekStart + i) % 7))),
+  );
 
   // The selection span, ordered, for the tint band.
   const spanLo = start && end ? (start <= end ? start : end) : start;
@@ -105,35 +111,25 @@ export function RangeCalendar({
     d.getTime() >= spanLo.getTime() &&
     d.getTime() <= spanHi.getTime();
 
+  const today = startOfDay(new Date());
+
   const pick = (d: Date): void => {
     // Fresh start when nothing is pending or the range is already whole; else
-    // close the range on the second tap. The sheet orders the two ends, so an
+    // close the range on the second tap. Callers order the two ends, so an
     // end-before-start tap is fine.
     if (start === null || end !== null) onSelect(d, null);
     else onSelect(start, d);
   };
 
-  // Build the grid: lead blanks for the first-of-month's weekday, then the days.
-  const first = firstOfMonth(view);
-  const lead = first.getDay(); // 0 = Sunday
-  const daysInMonth = dayDiff(first, addMonths(view, 1));
-  const cells: (Date | null)[] = [
-    ...Array.from({ length: lead }, () => null),
-    ...Array.from({ length: daysInMonth }, (_, i) =>
-      dayAt(view.getFullYear(), view.getMonth(), i + 1),
-    ),
-  ];
-  while (cells.length % 7 !== 0) cells.push(null);
-  const weeks: (Date | null)[][] = [];
-  for (let i = 0; i < cells.length; i += 7) weeks.push(cells.slice(i, i + 7));
+  const weeks = monthGrid(view, weekStart);
 
   return (
     <View style={{ gap: theme.spacing.sm }}>
-      {/* Month header with ‹ › paging, clamped to the feed's months. */}
+      {/* Month header with ‹ › paging, clamped to the caller's months. */}
       <Row style={{ alignItems: 'center', justifyContent: 'space-between' }}>
         <Pressable
           accessibilityRole="button"
-          accessibilityLabel={monthLabel(addMonths(view, -1), locale)}
+          accessibilityLabel={format.month(addMonths(view, -1))}
           disabled={!canPrev}
           onPress={() => setView((v) => addMonths(v, -1))}
           hitSlop={10}
@@ -146,11 +142,11 @@ export function RangeCalendar({
           />
         </Pressable>
         <Text variant="subheading" style={{ fontWeight: '700' }}>
-          {monthLabel(view, locale)}
+          {format.month(view)}
         </Text>
         <Pressable
           accessibilityRole="button"
-          accessibilityLabel={monthLabel(addMonths(view, 1), locale)}
+          accessibilityLabel={format.month(addMonths(view, 1))}
           disabled={!canNext}
           onPress={() => setView((v) => addMonths(v, 1))}
           hitSlop={10}
@@ -164,9 +160,11 @@ export function RangeCalendar({
         </Pressable>
       </Row>
 
-      {/* Weekday initials. */}
+      {/* Weekday initials. The row is a plain `row`, which React Native reverses
+          under RTL, so the first weekday lands on the side the reader starts
+          from and the columns below line up with it either way. */}
       <Row>
-        {weekdayLabels(locale).map((w, i) => (
+        {weekdays.map((w, i) => (
           <View key={i} style={{ width: CELL, alignItems: 'center' }}>
             <Text variant="micro" tone="faint" style={{ fontWeight: '600' }}>
               {w}
@@ -182,18 +180,25 @@ export function RangeCalendar({
             {week.map((d, di) => {
               if (!d) return <View key={di} style={{ width: CELL, height: CELL }} />;
               const disabled = !inBounds(d);
-              const isEnd = (spanLo && sameDay(d, spanLo)) || (spanHi && sameDay(d, spanHi));
+              const isFrom = spanLo !== null && sameDay(d, spanLo);
+              const isTo = spanHi !== null && sameDay(d, spanHi);
+              const isEnd = isFrom || isTo;
               const banded = inSpan(d) && !isEnd;
+              // The band runs under the two end circles as well, as a half each,
+              // so a chosen range reads as one continuous bar rather than a
+              // circle, a gap, a bar, a gap and another circle. `start`/`end`
+              // rather than `left`/`right`: they are the direction-relative
+              // insets, so the half that points at the rest of the range keeps
+              // pointing at it when the whole grid mirrors for Arabic. A range
+              // of one day gets no band at all — there is nothing to span.
+              const bandFrom = isFrom && !isTo;
+              const bandTo = isTo && !isFrom;
               return (
                 <Pressable
                   key={di}
                   accessibilityRole="button"
-                  accessibilityLabel={d.toLocaleDateString(locale, {
-                    weekday: 'long',
-                    day: 'numeric',
-                    month: 'long',
-                  })}
-                  accessibilityState={{ disabled, selected: Boolean(isEnd) }}
+                  accessibilityLabel={format.full(d)}
+                  accessibilityState={{ disabled, selected: isEnd }}
                   disabled={disabled}
                   onPress={() => pick(d)}
                   style={{
@@ -205,6 +210,19 @@ export function RangeCalendar({
                     borderRadius: banded ? 0 : theme.radius.md,
                   }}
                 >
+                  {bandFrom || bandTo ? (
+                    <View
+                      pointerEvents="none"
+                      style={{
+                        position: 'absolute',
+                        top: 0,
+                        bottom: 0,
+                        start: bandFrom ? '50%' : 0,
+                        end: bandTo ? '50%' : 0,
+                        backgroundColor: theme.color.brandSoft,
+                      }}
+                    />
+                  ) : null}
                   <View
                     style={{
                       width: CELL - 6,
@@ -213,6 +231,11 @@ export function RangeCalendar({
                       alignItems: 'center',
                       justifyContent: 'center',
                       backgroundColor: isEnd ? theme.color.brand : 'transparent',
+                      // Today keeps a quiet ring when it is not itself an end of
+                      // the range, so a calendar that can page anywhere still
+                      // says where now is.
+                      borderWidth: !isEnd && sameDay(d, today) ? 1 : 0,
+                      borderColor: theme.color.brand,
                     }}
                   >
                     <Text
@@ -226,7 +249,7 @@ export function RangeCalendar({
                         fontWeight: isEnd ? '700' : '500',
                       }}
                     >
-                      {d.getDate()}
+                      {format.day(d.getDate())}
                     </Text>
                   </View>
                 </Pressable>

--- a/apps/mobile/src/components/TripDates.tsx
+++ b/apps/mobile/src/components/TripDates.tsx
@@ -1,21 +1,36 @@
 /**
- * When the trip is — its start and end, as one framed range.
+ * When the trip is — its start and end, chosen on one calendar.
  *
  * The span is worth recording on its own: it labels the group with its dates
  * and marks how long the shared ledger was meant to cover. The daily-reminder
  * controls that used to live here were removed, so this card now only asks the
  * two dates; the underlying `remind_*` fields stay on the type for whatever
  * else reads them, but nothing here sets them.
+ *
+ * It used to ask for them one at a time: a Starts field that opened the native
+ * date picker, a scroll, a confirm, then the same again for Ends — four or more
+ * interactions to express a single idea ("we are away from the 4th to the
+ * 11th"), and never once a view of both ends together. Every travel app settled
+ * on the other shape years ago — Airbnb, Booking.com, Vrbo, Agoda, Wanderlog
+ * all show one calendar, take the start on the first tap and the end on the
+ * second, and tint the days in between — so that is what this is now. The two
+ * fields survive as a read-out rather than as two doors: they show the start the
+ * moment it is picked, which is the whole point of picking on one surface.
+ *
+ * Nothing is written until both ends are known. A half-chosen range is a local
+ * draft, so walking away mid-selection leaves the stored dates exactly as they
+ * were, and a completed range is one save rather than two.
  */
 
-import { useState } from 'react';
-import DateTimePicker, { type DateTimePickerEvent } from '@react-native-community/datetimepicker';
+import { useMemo, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { Platform, Pressable, View } from 'react-native';
+import { Pressable, View } from 'react-native';
 
-import { Button, Card, iconSize, Row, Text, useTheme } from '@waves/ui';
+import { Card, directionalIcon, iconSize, Row, Text, useTheme } from '@waves/ui';
 
-import { useStrings } from '@/i18n';
+import { RangeCalendar } from '@/components/RangeCalendar';
+import { plural, useStrings } from '@/i18n';
+import { gregorianFormatter } from '@/lib/calendarGrid';
 
 /**
  * Only the fields this card reads and writes — not a whole `GroupRow`. A saved
@@ -32,11 +47,6 @@ export interface TripDatesValue {
   remind_evening_at: string;
 }
 
-enum Field {
-  Start = 'start',
-  End = 'end',
-}
-
 export interface TripDatesPatch {
   start_date?: string | null;
   end_date?: string | null;
@@ -51,42 +61,50 @@ export interface TripDatesPatch {
  * midnight UTC lands on the previous day for anybody west of Greenwich, which
  * is how a trip silently starts a day early.
  */
-function dateFrom(iso: string | null): Date {
-  if (!iso) return new Date();
+function dateFrom(iso: string | null): Date | null {
+  if (!iso) return null;
   const [year, month, day] = iso.split('-').map(Number);
-  return new Date(year ?? 2026, (month ?? 1) - 1, day ?? 1, 12);
+  if (!year || !month || !day) return null;
+  return new Date(year, month - 1, day, 12);
 }
 
+/**
+ * Back to the `YYYY-MM-DD` the `date` columns hold, read off the local calendar
+ * fields. Never `toISOString`, which would convert to UTC first and hand back
+ * the day before for anybody east of Greenwich after lunch.
+ */
 function isoDate(value: Date): string {
   const month = String(value.getMonth() + 1).padStart(2, '0');
   const day = String(value.getDate()).padStart(2, '0');
   return `${value.getFullYear()}-${month}-${day}`;
 }
 
-function showDate(iso: string | null, locale: string, notSet: string): string {
-  if (!iso) return notSet;
-  return dateFrom(iso).toLocaleDateString(locale, {
-    weekday: 'short',
-    day: 'numeric',
-    month: 'short',
-  });
+/** Whole days between two local-noon day anchors, inclusive of both ends. */
+function daysBetween(from: Date, to: Date): number {
+  return Math.round((to.getTime() - from.getTime()) / 86_400_000) + 1;
 }
 
 /**
- * One end of the range — its own bordered field, a small label over the date
- * with a calendar glyph. `set` lights the field in the brand tint so a chosen
- * end reads as filled and an untouched one reads as waiting, and the two boxes
- * sit side by side like the from/to of a date-range picker.
+ * One end of the range as it reads back — its own half of a single framed
+ * strip, a small label over the date. `active` marks the end the next tap on
+ * the calendar will set, so while the end is being chosen the start stays on
+ * screen, plainly filled in, and it is obvious which half is listening.
  */
 function RangeEnd({
   label,
   value,
   set,
+  active,
+  align,
   onPress,
 }: {
   label: string;
   value: string;
   set: boolean;
+  active: boolean;
+  /** Which way the half reads — `end` puts the "Ends" half against the far
+   *  edge. Both are direction-relative, so the pair mirrors under RTL. */
+  align: 'start' | 'end';
   onPress: () => void;
 }) {
   const theme = useTheme();
@@ -94,32 +112,31 @@ function RangeEnd({
     <Pressable
       accessibilityRole="button"
       accessibilityLabel={`${label}: ${value}`}
+      accessibilityState={{ selected: active }}
       onPress={onPress}
       style={({ pressed }) => ({
         flex: 1,
-        gap: 4,
-        paddingVertical: theme.spacing.md,
-        paddingHorizontal: theme.spacing.md,
-        borderRadius: theme.radius.lg,
-        borderWidth: 1,
-        borderColor: set ? theme.color.brand : theme.color.border,
-        backgroundColor: set ? theme.color.brandSoft : theme.color.surface,
+        gap: 2,
+        alignItems: align === 'end' ? 'flex-end' : 'flex-start',
+        paddingVertical: theme.spacing.sm,
+        paddingHorizontal: theme.spacing.sm,
+        borderRadius: theme.radius.md,
+        backgroundColor: active ? theme.color.brandSoft : 'transparent',
         opacity: pressed ? 0.7 : 1,
       })}
     >
       <Text variant="caption" tone="muted">
         {label}
       </Text>
-      <Row style={{ alignItems: 'center', gap: theme.spacing.xs }}>
-        <Ionicons
-          name="calendar-outline"
-          size={iconSize.sm}
-          color={set ? theme.color.brand : theme.color.textMuted}
-        />
-        <Text variant="subheading" style={{ fontWeight: '700' }}>
-          {value}
-        </Text>
-      </Row>
+      <Text
+        variant="subheading"
+        style={{
+          fontWeight: '700',
+          color: set ? theme.color.text : theme.color.textMuted,
+        }}
+      >
+        {value}
+      </Text>
     </Pressable>
   );
 }
@@ -134,37 +151,63 @@ export function TripDates({
   locale: string;
   onChange: (patch: TripDatesPatch) => void;
   /**
-   * Drop the outer card and the title/info header, leaving just the two date
-   * fields, the clear link and the picker — for when this editor is unfolded
-   * inside a row of a bigger card that already carries the "Dates" label.
+   * Drop the outer card and the title/info header, and keep the calendar
+   * unfolded — for when this editor is opened inside a row of a bigger card
+   * that already carries the "Dates" label and has already asked for it.
    */
   embedded?: boolean;
 }) {
   const theme = useTheme();
   const { t } = useStrings();
-  const [editing, setEditing] = useState<Field | null>(null);
   // The why-does-this-exist paragraph is long, and once you have read it once
   // you do not need it every time you open settings. Folded behind the info
   // icon by default; the dates themselves stay in view.
   const [showInfo, setShowInfo] = useState(false);
+  // Whether the calendar is on screen. Embedded, the host row has already made
+  // that decision by unfolding this editor at all.
+  const [open, setOpen] = useState(embedded);
+  /**
+   * The start of a range being chosen, held here rather than saved.
+   *
+   * Non-null means exactly one thing: the next tap on the calendar closes the
+   * range. That covers both ways of getting there — a fresh first tap, and
+   * tapping the "Ends" half of the strip to move only the end of a range that
+   * is already stored — so the calendar needs no mode of its own.
+   */
+  const [pendingStart, setPendingStart] = useState<Date | null>(null);
 
-  const apply = (field: Field, event: DateTimePickerEvent, picked?: Date): void => {
-    // Android's picker is a modal that reports its own dismissal; iOS's is
-    // inline and reports every scroll.
-    if (Platform.OS === 'android') setEditing(null);
-    if (event.type === 'dismissed' || !picked) return;
+  const savedStart = dateFrom(group.start_date);
+  const savedEnd = dateFrom(group.end_date);
+  // Mid-selection the strip and the grid show the draft: the pending start on
+  // its own, with the end blank and waiting.
+  const shownStart = pendingStart ?? savedStart;
+  const shownEnd = pendingStart ? null : savedEnd;
 
-    if (field === Field.Start) {
-      const start = isoDate(picked);
-      // An end date before the start is not a trip. Dragging the start past
-      // the end moves the end rather than refusing the tap.
-      const end = group.end_date && group.end_date < start ? start : group.end_date;
-      onChange({ start_date: start, end_date: end ?? start, time_zone: group.time_zone });
-      return;
-    }
-    const end = isoDate(picked);
-    const start = group.start_date && group.start_date > end ? end : group.start_date;
-    onChange({ end_date: end, start_date: start ?? end });
+  // The same Gregorian pinning the grid uses, so the read-out cannot name a
+  // Hijri month over a Gregorian calendar. Built once per language.
+  const readable = useMemo(() => {
+    const fmt = gregorianFormatter(locale, { weekday: 'short', day: 'numeric', month: 'short' });
+    return (value: Date | null): string =>
+      value ? (fmt?.format(value) ?? value.toDateString()) : t.pickers.notSet;
+  }, [locale, t]);
+
+  const commit = (a: Date, b: Date): void => {
+    // Whichever way round they were tapped, the earlier day is the start. That
+    // is why an end before a start is not something this control has to refuse:
+    // it cannot be expressed.
+    const [from, to] = a <= b ? [a, b] : [b, a];
+    onChange({
+      start_date: isoDate(from),
+      end_date: isoDate(to),
+      // Re-sent with every range so a group that never recorded a zone picks up
+      // this phone's — the reminders and the day-of-trip maths need one.
+      time_zone: group.time_zone,
+    });
+    setPendingStart(null);
+    // The range is saved and the strip above now reads it back, so there is
+    // nothing left to confirm; folding the calendar away is the confirmation.
+    // Embedded, folding is the host row's business, not ours.
+    if (!embedded) setOpen(false);
   };
 
   const body = (
@@ -178,7 +221,7 @@ export function TripDates({
               accessibilityState={{ expanded: showInfo }}
               accessibilityLabel={t.misc.aboutTripDates}
               hitSlop={8}
-              onPress={() => setShowInfo((open) => !open)}
+              onPress={() => setShowInfo((shown) => !shown)}
               style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
             >
               <Ionicons
@@ -196,67 +239,103 @@ export function TripDates({
         </View>
       )}
 
-      {/* Start and end as two side-by-side fields — each its own bordered box
-          that lights up once picked, the way a from/to date-range picker reads,
-          rather than two labels sharing one strip. */}
-      <Row style={{ alignItems: 'stretch', gap: theme.spacing.sm }}>
+      {/* The range as one framed strip rather than two doors: start, arrow, end.
+          Closed, tapping anywhere on it opens the calendar. Open, each half says
+          which end the next tap sets — so the end can be moved on its own
+          without re-picking the start. */}
+      <Row
+        style={{
+          alignItems: 'center',
+          gap: theme.spacing.xs,
+          padding: theme.spacing.xs,
+          borderRadius: theme.radius.lg,
+          borderWidth: 1,
+          borderColor: open ? theme.color.brand : theme.color.border,
+          backgroundColor: theme.color.surface,
+        }}
+      >
         <RangeEnd
           label={t.pickers.starts}
-          value={showDate(group.start_date, locale, t.pickers.notSet)}
-          set={Boolean(group.start_date)}
-          onPress={() => setEditing(Field.Start)}
+          value={readable(shownStart)}
+          set={shownStart !== null}
+          active={open && pendingStart === null}
+          align="start"
+          onPress={() => {
+            setPendingStart(null);
+            setOpen(true);
+          }}
+        />
+        {/* The arrow means "onward", so it is content, not layout: React Native
+            mirrors the row for Arabic but would leave this glyph pointing the
+            way it was drawn. `directionalIcon` is what flips it. */}
+        <Ionicons
+          name={directionalIcon('arrow-forward')}
+          size={iconSize.sm}
+          color={theme.color.textFaint}
         />
         <RangeEnd
           label={t.pickers.ends}
-          value={showDate(group.end_date, locale, t.pickers.notSet)}
-          set={Boolean(group.end_date)}
-          onPress={() => setEditing(Field.End)}
+          // Mid-selection this half is the instruction, not a blank: it says
+          // what the next tap will do while the start sits filled in beside it.
+          value={pendingStart ? t.pickers.pickEnd : readable(shownEnd)}
+          set={shownEnd !== null}
+          active={open && pendingStart !== null}
+          align="end"
+          onPress={() => {
+            // Only meaningful once there is a start to keep — otherwise this is
+            // the same request as tapping the other half.
+            setPendingStart(savedStart);
+            setOpen(true);
+          }}
         />
       </Row>
 
-      {/* A quiet way out, not a competing action: a small muted link tucked
-          under the range rather than a full-width button. */}
-      {group.start_date && group.end_date ? (
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel={t.pickers.clearDates}
-          onPress={() => onChange({ start_date: null, end_date: null })}
-          hitSlop={8}
-          style={({ pressed }) => ({ alignSelf: 'center', opacity: pressed ? 0.6 : 1 })}
-        >
-          <Row style={{ alignItems: 'center', gap: theme.spacing.xs }}>
-            <Ionicons
-              name="close-circle-outline"
-              size={iconSize.sm}
-              color={theme.color.textMuted}
-            />
-            <Text variant="caption" tone="muted">
-              {t.pickers.clearDates}
-            </Text>
-          </Row>
-        </Pressable>
-      ) : null}
-
-      {editing ? (
-        <DateTimePicker
-          value={editing === Field.Start ? dateFrom(group.start_date) : dateFrom(group.end_date)}
-          mode="date"
-          // The end of a trip cannot be before its beginning, so the picker
-          // does not offer it.
-          minimumDate={
-            editing === Field.End && group.start_date ? dateFrom(group.start_date) : undefined
-          }
-          onChange={(event, picked) => apply(editing, event, picked)}
+      {open ? (
+        <RangeCalendar
+          locale={locale}
+          start={shownStart}
+          end={shownEnd}
+          onSelect={(from, to) => {
+            // A null `to` is the first of the two taps: hold it and wait.
+            if (!from) return;
+            if (!to) {
+              setPendingStart(from);
+              return;
+            }
+            commit(from, to);
+          }}
         />
       ) : null}
 
-      {Platform.OS === 'ios' && editing ? (
-        <Button
-          label={t.common.done}
-          size="sm"
-          variant="secondary"
-          onPress={() => setEditing(null)}
-        />
+      {/* How long the trip is, and a quiet way out — a small muted link rather
+          than a button competing with the calendar above it. */}
+      {savedStart && savedEnd && !pendingStart ? (
+        <Row style={{ alignItems: 'center', justifyContent: 'center', gap: theme.spacing.md }}>
+          <Text variant="caption" tone="muted">
+            {plural(locale, daysBetween(savedStart, savedEnd), t.pickers.dayCount)}
+          </Text>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t.pickers.clearDates}
+            onPress={() => {
+              setPendingStart(null);
+              onChange({ start_date: null, end_date: null });
+            }}
+            hitSlop={8}
+            style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+          >
+            <Row style={{ alignItems: 'center', gap: theme.spacing.xs }}>
+              <Ionicons
+                name="close-circle-outline"
+                size={iconSize.sm}
+                color={theme.color.textMuted}
+              />
+              <Text variant="caption" tone="muted">
+                {t.pickers.clearDates}
+              </Text>
+            </Row>
+          </Pressable>
+        </Row>
       ) : null}
     </>
   );

--- a/apps/mobile/src/components/TripDates.tsx
+++ b/apps/mobile/src/components/TripDates.tsx
@@ -31,6 +31,7 @@ import { Card, directionalIcon, iconSize, Row, Text, useTheme } from '@waves/ui'
 import { RangeCalendar } from '@/components/RangeCalendar';
 import { plural, useStrings } from '@/i18n';
 import { gregorianFormatter } from '@/lib/calendarGrid';
+import { inclusiveTripDays, tripDateFromIso, tripDateRangePatch } from '@/lib/tripDateRange';
 
 /**
  * Only the fields this card reads and writes — not a whole `GroupRow`. A saved
@@ -54,34 +55,6 @@ export interface TripDatesPatch {
   remind_daily?: boolean;
   remind_morning_at?: string;
   remind_evening_at?: string;
-}
-
-/**
- * Parsed as local noon rather than midnight. A date-only string turned into
- * midnight UTC lands on the previous day for anybody west of Greenwich, which
- * is how a trip silently starts a day early.
- */
-function dateFrom(iso: string | null): Date | null {
-  if (!iso) return null;
-  const [year, month, day] = iso.split('-').map(Number);
-  if (!year || !month || !day) return null;
-  return new Date(year, month - 1, day, 12);
-}
-
-/**
- * Back to the `YYYY-MM-DD` the `date` columns hold, read off the local calendar
- * fields. Never `toISOString`, which would convert to UTC first and hand back
- * the day before for anybody east of Greenwich after lunch.
- */
-function isoDate(value: Date): string {
-  const month = String(value.getMonth() + 1).padStart(2, '0');
-  const day = String(value.getDate()).padStart(2, '0');
-  return `${value.getFullYear()}-${month}-${day}`;
-}
-
-/** Whole days between two local-noon day anchors, inclusive of both ends. */
-function daysBetween(from: Date, to: Date): number {
-  return Math.round((to.getTime() - from.getTime()) / 86_400_000) + 1;
 }
 
 /**
@@ -176,8 +149,8 @@ export function TripDates({
    */
   const [pendingStart, setPendingStart] = useState<Date | null>(null);
 
-  const savedStart = dateFrom(group.start_date);
-  const savedEnd = dateFrom(group.end_date);
+  const savedStart = tripDateFromIso(group.start_date);
+  const savedEnd = tripDateFromIso(group.end_date);
   // Mid-selection the strip and the grid show the draft: the pending start on
   // its own, with the end blank and waiting.
   const shownStart = pendingStart ?? savedStart;
@@ -195,14 +168,7 @@ export function TripDates({
     // Whichever way round they were tapped, the earlier day is the start. That
     // is why an end before a start is not something this control has to refuse:
     // it cannot be expressed.
-    const [from, to] = a <= b ? [a, b] : [b, a];
-    onChange({
-      start_date: isoDate(from),
-      end_date: isoDate(to),
-      // Re-sent with every range so a group that never recorded a zone picks up
-      // this phone's — the reminders and the day-of-trip maths need one.
-      time_zone: group.time_zone,
-    });
+    onChange(tripDateRangePatch(a, b, group.time_zone));
     setPendingStart(null);
     // The range is saved and the strip above now reads it back, so there is
     // nothing left to confirm; folding the calendar away is the confirmation.
@@ -312,7 +278,7 @@ export function TripDates({
       {savedStart && savedEnd && !pendingStart ? (
         <Row style={{ alignItems: 'center', justifyContent: 'center', gap: theme.spacing.md }}>
           <Text variant="caption" tone="muted">
-            {plural(locale, daysBetween(savedStart, savedEnd), t.pickers.dayCount)}
+            {plural(locale, inclusiveTripDays(savedStart, savedEnd), t.pickers.dayCount)}
           </Text>
           <Pressable
             accessibilityRole="button"

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -2230,6 +2230,14 @@ export interface UiStrings {
     countryNote: string;
     starts: string;
     ends: string;
+    /**
+     * Shown in place of the end date while the end is still being chosen, so
+     * the half that is waiting says what the next tap does rather than sitting
+     * blank beside the start that has just been picked.
+     */
+    pickEnd: string;
+    /** How long a chosen range is, counting both of its end days. */
+    dayCount: PluralForms;
     dailyReminders: string;
     breakfast: string;
     endOfDay: string;
@@ -4484,6 +4492,8 @@ const en: UiStrings = {
       'This decides how you can pay each other, and what currency a new expense starts in. Nothing already recorded changes.',
     starts: 'Starts',
     ends: 'Ends',
+    pickEnd: 'Pick the end',
+    dayCount: { one: '{n} day', other: '{n} days' },
     dailyReminders: 'Daily reminders',
     breakfast: 'Breakfast',
     endOfDay: 'End of day',
@@ -6834,6 +6844,8 @@ const ta: UiStrings = {
       'இது நீங்கள் ஒருவருக்கொருவர் எப்படிப் பணம் தரலாம் என்பதையும், புதிய செலவு எந்த நாணயத்தில் தொடங்கும் என்பதையும் தீர்மானிக்கிறது. ஏற்கெனவே பதிவானவை மாறாது.',
     starts: 'தொடக்கம்',
     ends: 'முடிவு',
+    pickEnd: 'முடிவைத் தேர்ந்தெடுக்கவும்',
+    dayCount: { one: '{n} நாள்', other: '{n} நாட்கள்' },
     dailyReminders: 'தினசரி நினைவூட்டல்கள்',
     breakfast: 'காலை உணவு',
     endOfDay: 'நாள் முடிவு',
@@ -9125,6 +9137,8 @@ const hi: UiStrings = {
       'इससे तय होता है कि आप एक-दूसरे को कैसे पैसे दे सकते हैं, और नया खर्च किस मुद्रा में शुरू होगा। जो पहले से दर्ज है वह नहीं बदलता।',
     starts: 'शुरू',
     ends: 'समाप्त',
+    pickEnd: 'आख़िरी तारीख़ चुनें',
+    dayCount: { one: '{n} दिन', other: '{n} दिन' },
     dailyReminders: 'रोज़ाना याद दिलाना',
     breakfast: 'नाश्ता',
     endOfDay: 'दिन का अंत',
@@ -11636,6 +11650,15 @@ const ar: UiStrings = {
       'يحدّد هذا كيف يمكنكم الدفع لبعضكم، وبأي عملة يبدأ المصروف الجديد. ولا يتغيّر شيء مما سُجّل من قبل.',
     starts: 'يبدأ',
     ends: 'ينتهي',
+    pickEnd: 'اختر تاريخ النهاية',
+    dayCount: {
+      zero: 'بلا أيام',
+      one: 'يوم واحد',
+      two: 'يومان',
+      few: '{n} أيام',
+      many: '{n} يومًا',
+      other: '{n} يوم',
+    },
     dailyReminders: 'تذكيرات يومية',
     breakfast: 'الإفطار',
     endOfDay: 'نهاية اليوم',

--- a/apps/mobile/src/lib/calendarGrid.ts
+++ b/apps/mobile/src/lib/calendarGrid.ts
@@ -1,0 +1,240 @@
+/**
+ * The arithmetic and the localisation behind a month grid, with no React and no
+ * React Native in sight.
+ *
+ * {@link RangeCalendar} draws the grid; everything that could be silently wrong
+ * about it lives here instead, where a test can hold it. Two things in
+ * particular are worth pinning down rather than eyeballing on a device: which
+ * weekday a week opens on (Saturday in Cairo, Sunday in Chennai and Riyadh,
+ * Monday in Dubai and Berlin — get it wrong and every row is off by a column),
+ * and which calendar system the labels name.
+ *
+ * Every day here is anchored at local noon. A calendar day is not an instant:
+ * anchoring at midnight puts a day within an hour of the boundary that daylight
+ * saving moves, and noon is the one hour of the day no time zone shift has ever
+ * crossed.
+ */
+
+/** A calendar day at local noon — the anchor the whole grid works in. */
+export function dayAt(year: number, month: number, date: number): Date {
+  return new Date(year, month, date, 12, 0, 0, 0);
+}
+
+/** The day-anchor for whatever day an instant falls on, locally. */
+export function startOfDay(d: Date): Date {
+  return dayAt(d.getFullYear(), d.getMonth(), d.getDate());
+}
+
+export function firstOfMonth(d: Date): Date {
+  return dayAt(d.getFullYear(), d.getMonth(), 1);
+}
+
+export function addMonths(d: Date, delta: number): Date {
+  return dayAt(d.getFullYear(), d.getMonth() + delta, 1);
+}
+
+/** Whole days between two day-anchors (b − a), sign preserved. */
+export function dayDiff(a: Date, b: Date): number {
+  return Math.round((b.getTime() - a.getTime()) / 86_400_000);
+}
+
+export function sameDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+/**
+ * A date formatter in the reader's language, pinned to the Gregorian calendar.
+ *
+ * The grid is built out of JavaScript `Date`, which knows only Gregorian months
+ * and Gregorian day numbers. Left alone, `Intl` labels that grid with whatever
+ * calendar the locale prefers — `ar-SA` resolves to the Umm al-Qura Hijri
+ * calendar — and a Hijri month name written over a Gregorian grid names
+ * something the grid is not. Pinning the label to the calendar the grid is
+ * actually drawn in keeps the two telling the same story; the language, and
+ * with it the numbering system, still belongs to the reader.
+ *
+ * A phone whose engine refuses the option, or the locale, gets the next best
+ * formatter rather than an exception — these are captions, not computations.
+ */
+export function gregorianFormatter(
+  locale: string,
+  options: Intl.DateTimeFormatOptions,
+): Intl.DateTimeFormat | null {
+  try {
+    return new Intl.DateTimeFormat(locale, { ...options, calendar: 'gregory' });
+  } catch {
+    try {
+      return new Intl.DateTimeFormat(locale, options);
+    } catch {
+      return null;
+    }
+  }
+}
+
+/**
+ * Where a week does not open on Monday.
+ *
+ * A calendar that starts its week on the wrong day is not a cosmetic slip: the
+ * columns are a reader's mental model of a week, and somebody in Cairo counting
+ * from Monday has to translate every row. Monday is the default because it is
+ * both ISO-8601 and the commonest answer worldwide, so only the places that
+ * disagree are written out and the table stays short enough to read.
+ *
+ * These follow CLDR, and CLDR moves: Saudi Arabia's week now opens on Sunday
+ * and the UAE's on Monday, both of them changes of the last few years, and both
+ * of them countries a stale table would still have opening on Saturday. That
+ * churn is exactly why {@link firstWeekday} asks the engine before it consults
+ * this list — the table is the answer for phones whose engine has none.
+ */
+const WEEK_STARTS_SATURDAY = new Set([
+  'AF',
+  'BH',
+  'DJ',
+  'DZ',
+  'EG',
+  'IQ',
+  'IR',
+  'JO',
+  'KW',
+  'LY',
+  'OM',
+  'QA',
+  'SD',
+  'SY',
+]);
+
+const WEEK_STARTS_SUNDAY = new Set([
+  'AG',
+  'AS',
+  'BD',
+  'BR',
+  'BS',
+  'BT',
+  'BW',
+  'BZ',
+  'CA',
+  'CO',
+  'DO',
+  'ET',
+  'GT',
+  'GU',
+  'HK',
+  'HN',
+  'ID',
+  'IL',
+  'IN',
+  'JM',
+  'JP',
+  'KE',
+  'KH',
+  'KR',
+  'LA',
+  'MH',
+  'MM',
+  'MO',
+  'MT',
+  'MX',
+  'MZ',
+  'NI',
+  'NP',
+  'PA',
+  'PE',
+  'PH',
+  'PK',
+  'PR',
+  'PT',
+  'PY',
+  'SA',
+  'SG',
+  'SV',
+  'TH',
+  'TT',
+  'TW',
+  'US',
+  'VE',
+  'YE',
+  'ZA',
+  'ZW',
+]);
+
+/** The Maldives, and nowhere else, opens its week on Friday. */
+const WEEK_STARTS_FRIDAY = new Set(['MV']);
+
+/** What `Intl.Locale.getWeekInfo` returns where an engine implements it. */
+interface WeekInfoCarrier {
+  getWeekInfo?: () => { firstDay?: number };
+  weekInfo?: { firstDay?: number };
+}
+
+/**
+ * Which weekday this reader's week starts on, as `Date.getDay` counts them
+ * (0 = Sunday).
+ *
+ * The engine is asked first: where `Intl.Locale` carries week info it holds the
+ * whole of CLDR and beats any table written here. It numbers days 1 = Monday
+ * through 7 = Sunday, so Sunday's 7 has to come back round to 0. Only when the
+ * engine has no answer — and the Hermes builds this app ships on generally do
+ * not — does the region table decide, falling back to the language when the tag
+ * carries no region at all.
+ */
+export function firstWeekday(locale: string): number {
+  try {
+    const info = new Intl.Locale(locale) as unknown as WeekInfoCarrier;
+    const first = info.getWeekInfo?.().firstDay ?? info.weekInfo?.firstDay;
+    if (typeof first === 'number' && first >= 1 && first <= 7) return first % 7;
+  } catch {
+    // An engine without `Intl.Locale`, or a tag it will not parse. The table
+    // below is the answer, not a crash.
+  }
+
+  // The region sits in a fixed place in a BCP-47 tag: straight after the
+  // language, or after the four-letter script when there is one. Hunting for
+  // "the first two-letter part" instead would read the `ca` of
+  // `ar-u-ca-islamic` as Canada.
+  const parts = locale.split(/[-_]/);
+  const afterScript = parts[1] && /^[A-Za-z]{4}$/.test(parts[1]) ? parts[2] : parts[1];
+  const region =
+    afterScript && /^[A-Za-z]{2}$/.test(afterScript) ? afterScript.toUpperCase() : null;
+  if (region) {
+    if (WEEK_STARTS_FRIDAY.has(region)) return 5;
+    if (WEEK_STARTS_SATURDAY.has(region)) return 6;
+    if (WEEK_STARTS_SUNDAY.has(region)) return 0;
+    return 1;
+  }
+
+  // A bare language tag, with no region to look up. Arabic without one is
+  // likeliest to be read in Egypt, where the week opens on Saturday; the other
+  // three languages Waves speaks are read where it opens on Sunday.
+  const language = parts[0]?.toLowerCase();
+  if (language === 'ar') return 6;
+  if (language === 'en' || language === 'hi' || language === 'ta') return 0;
+  return 1;
+}
+
+/**
+ * The month laid out in weeks, each week seven slots long, with `null` for the
+ * lead and trail slots that belong to the neighbouring months.
+ *
+ * The lead is counted from the reader's own first weekday rather than from
+ * Sunday, which is the whole reason this is a function and not a loop inlined
+ * in the view.
+ */
+export function monthGrid(view: Date, weekStart: number): (Date | null)[][] {
+  const first = firstOfMonth(view);
+  const lead = (first.getDay() - weekStart + 7) % 7;
+  const daysInMonth = dayDiff(first, addMonths(view, 1));
+  const cells: (Date | null)[] = [
+    ...Array.from({ length: lead }, () => null),
+    ...Array.from({ length: daysInMonth }, (_, i) =>
+      dayAt(view.getFullYear(), view.getMonth(), i + 1),
+    ),
+  ];
+  while (cells.length % 7 !== 0) cells.push(null);
+  const weeks: (Date | null)[][] = [];
+  for (let i = 0; i < cells.length; i += 7) weeks.push(cells.slice(i, i + 7));
+  return weeks;
+}

--- a/apps/mobile/src/lib/tripDateRange.ts
+++ b/apps/mobile/src/lib/tripDateRange.ts
@@ -1,0 +1,48 @@
+/**
+ * Trip date range arithmetic, kept outside the component so the things a trip
+ * depends on are testable without rendering React Native.
+ *
+ * These values land in `date` columns, not timestamp columns. Every conversion
+ * therefore reads and writes the local calendar fields directly: a traveller in
+ * Dubai picking 4 October must store `2026-10-04`, not whatever UTC thinks that
+ * local evening is.
+ */
+
+export interface TripDateRangePatch {
+  readonly start_date: string;
+  readonly end_date: string;
+  readonly time_zone: string;
+}
+
+/** Parsed as local noon rather than midnight, avoiding UTC/date-boundary drift. */
+export function tripDateFromIso(iso: string | null): Date | null {
+  if (!iso) return null;
+  const [year, month, day] = iso.split('-').map(Number);
+  if (!year || !month || !day) return null;
+  return new Date(year, month - 1, day, 12);
+}
+
+/** Serialize a local calendar day to the `YYYY-MM-DD` stored in date columns. */
+export function tripDateToIso(value: Date): string {
+  const month = String(value.getMonth() + 1).padStart(2, '0');
+  const day = String(value.getDate()).padStart(2, '0');
+  return `${value.getFullYear()}-${month}-${day}`;
+}
+
+/** Whole trip days, inclusive of both endpoints. */
+export function inclusiveTripDays(from: Date, to: Date): number {
+  return Math.round((to.getTime() - from.getTime()) / 86_400_000) + 1;
+}
+
+/**
+ * Build the saved patch from the two tapped dates. The order of taps does not
+ * matter: the earlier day is always the stored start.
+ */
+export function tripDateRangePatch(a: Date, b: Date, timeZone: string): TripDateRangePatch {
+  const [from, to] = a <= b ? [a, b] : [b, a];
+  return {
+    start_date: tripDateToIso(from),
+    end_date: tripDateToIso(to),
+    time_zone: timeZone,
+  };
+}

--- a/apps/mobile/test/calendarGrid.test.ts
+++ b/apps/mobile/test/calendarGrid.test.ts
@@ -1,0 +1,179 @@
+/**
+ * The month grid's arithmetic and localisation.
+ *
+ * These are the parts of the range calendar nobody can check by looking at a
+ * screenshot: whether an Arabic reader's week opens on Saturday, whether the
+ * lead blanks put the first of the month under the right column once it does,
+ * and whether a date-only string survives a round trip in a time zone west of
+ * Greenwich. Each of those has a wrong answer that looks perfectly plausible.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  addMonths,
+  dayAt,
+  dayDiff,
+  firstOfMonth,
+  firstWeekday,
+  gregorianFormatter,
+  monthGrid,
+  sameDay,
+  startOfDay,
+} from '@/lib/calendarGrid';
+
+describe('firstWeekday', () => {
+  it('opens the week on Saturday where the Arab world still does', () => {
+    for (const locale of ['ar-EG', 'ar-QA', 'ar-JO', 'ar-IQ']) {
+      expect(firstWeekday(locale)).toBe(6);
+    }
+  });
+
+  it('follows the Gulf states that have since moved their week', () => {
+    // Both of these were Saturday within living memory and are cited as
+    // Saturday all over the internet. Saudi Arabia's week now opens on Sunday
+    // and the UAE's on Monday, and the language is no guide to either — an
+    // Arabic reader in Dubai and one in Cairo want different grids.
+    expect(firstWeekday('ar-SA')).toBe(0);
+    expect(firstWeekday('ar-AE')).toBe(1);
+    expect(firstWeekday('en-AE')).toBe(1);
+  });
+
+  it('opens the week on Sunday in India and the United States', () => {
+    for (const locale of ['en-IN', 'hi-IN', 'ta-IN', 'en-US']) {
+      expect(firstWeekday(locale)).toBe(0);
+    }
+  });
+
+  it('opens the week on Monday where ISO-8601 does', () => {
+    for (const locale of ['en-GB', 'de-DE', 'fr-FR']) {
+      expect(firstWeekday(locale)).toBe(1);
+    }
+  });
+
+  it('reads a bare language tag by where that language is read', () => {
+    expect(firstWeekday('ar')).toBe(6);
+    expect(firstWeekday('hi')).toBe(0);
+    expect(firstWeekday('ta')).toBe(0);
+  });
+
+  it('answers from its own table when the engine carries no week info', () => {
+    // This is the path real phones take. Node has the whole of CLDR behind
+    // `Intl.Locale`, and the Hermes builds this app ships on have no
+    // `Intl.Locale` at all — so without taking it away here, every assertion
+    // above proves only that Node knows its own data.
+    const engine = Intl as unknown as { Locale: unknown };
+    const real = engine.Locale;
+    engine.Locale = undefined;
+    try {
+      expect(firstWeekday('ar-EG')).toBe(6);
+      expect(firstWeekday('ar-SA')).toBe(0);
+      expect(firstWeekday('ar-AE')).toBe(1);
+      expect(firstWeekday('en-IN')).toBe(0);
+      expect(firstWeekday('en-GB')).toBe(1);
+      expect(firstWeekday('dv-MV')).toBe(5);
+      expect(firstWeekday('ar-u-ca-islamic')).toBe(6);
+      expect(firstWeekday('en-Latn-GB')).toBe(1);
+      expect(firstWeekday('ar')).toBe(6);
+    } finally {
+      engine.Locale = real;
+    }
+  });
+
+  it('does not mistake a Unicode extension for a region', () => {
+    // `ca` here names the Islamic calendar, not Canada — and Canada would be a
+    // Sunday answer where the Arabic default is Saturday, so the confusion
+    // would be visible on screen.
+    expect(firstWeekday('ar-u-ca-islamic')).toBe(6);
+  });
+
+  it('reads the region past a script subtag', () => {
+    expect(firstWeekday('ar-Arab-EG')).toBe(6);
+    expect(firstWeekday('en-Latn-GB')).toBe(1);
+  });
+});
+
+describe('monthGrid', () => {
+  it('pads the lead so the first of the month lands under its own weekday', () => {
+    // October 2026 opens on a Thursday.
+    const october = dayAt(2026, 9, 1);
+    expect(october.getDay()).toBe(4);
+
+    const sundayFirst = monthGrid(october, 0);
+    expect(sundayFirst[0]?.slice(0, 4).every((cell) => cell === null)).toBe(true);
+    expect(sundayFirst[0]?.[4]?.getDate()).toBe(1);
+
+    // Starting the week on Saturday moves the first of the month one column on,
+    // because Saturday and Sunday now precede it instead of just Sunday.
+    const saturdayFirst = monthGrid(october, 6);
+    expect(saturdayFirst[0]?.[5]?.getDate()).toBe(1);
+
+    // Starting on Monday moves it back the other way.
+    const mondayFirst = monthGrid(october, 1);
+    expect(mondayFirst[0]?.[3]?.getDate()).toBe(1);
+  });
+
+  it('holds every day of the month and nothing from its neighbours', () => {
+    const february = dayAt(2028, 1, 1); // A leap February.
+    const days = monthGrid(february, 1)
+      .flat()
+      .filter((cell): cell is Date => cell !== null);
+    expect(days).toHaveLength(29);
+    expect(days[0]?.getDate()).toBe(1);
+    expect(days[28]?.getDate()).toBe(29);
+    expect(days.every((day) => day.getMonth() === 1)).toBe(true);
+  });
+
+  it('lays out whole weeks, however the month falls', () => {
+    for (let month = 0; month < 12; month += 1) {
+      for (const weekStart of [0, 1, 6]) {
+        const weeks = monthGrid(dayAt(2026, month, 1), weekStart);
+        expect(weeks.every((week) => week.length === 7)).toBe(true);
+      }
+    }
+  });
+});
+
+describe('day anchors', () => {
+  it('anchors at noon, so no time-zone shift can move the day', () => {
+    const day = dayAt(2026, 9, 4);
+    expect(day.getHours()).toBe(12);
+    expect(day.getFullYear()).toBe(2026);
+    expect(day.getMonth()).toBe(9);
+    expect(day.getDate()).toBe(4);
+  });
+
+  it('keeps the local day when an instant is late in the evening', () => {
+    // 23:30 is the hour a UTC round trip would push into tomorrow for anybody
+    // east of Greenwich; the anchor stays on the day the person is living in.
+    const anchor = startOfDay(new Date(2026, 9, 4, 23, 30));
+    expect(anchor.getDate()).toBe(4);
+    expect(sameDay(anchor, dayAt(2026, 9, 4))).toBe(true);
+  });
+
+  it('counts whole days across a month boundary and a leap day', () => {
+    expect(dayDiff(dayAt(2026, 9, 4), dayAt(2026, 9, 11))).toBe(7);
+    expect(dayDiff(dayAt(2028, 1, 28), dayAt(2028, 2, 1))).toBe(2);
+    expect(dayDiff(dayAt(2026, 9, 11), dayAt(2026, 9, 4))).toBe(-7);
+  });
+
+  it('walks months without spilling into the next one', () => {
+    expect(sameDay(addMonths(dayAt(2026, 0, 31), 1), dayAt(2026, 1, 1))).toBe(true);
+    expect(sameDay(addMonths(dayAt(2026, 0, 15), -1), dayAt(2025, 11, 1))).toBe(true);
+    expect(sameDay(firstOfMonth(dayAt(2026, 9, 27)), dayAt(2026, 9, 1))).toBe(true);
+  });
+});
+
+describe('gregorianFormatter', () => {
+  it('names the Gregorian month even where the locale prefers another calendar', () => {
+    // `ar-SA` resolves to the Umm al-Qura Hijri calendar by default, which
+    // would label a Gregorian grid with a month it is not showing.
+    const formatter = gregorianFormatter('ar-SA', { month: 'long', year: 'numeric' });
+    expect(formatter?.resolvedOptions().calendar).toBe('gregory');
+  });
+
+  it('formats in the language the reader chose', () => {
+    const formatter = gregorianFormatter('en-GB', { month: 'long', year: 'numeric' });
+    expect(formatter?.format(dayAt(2026, 9, 4))).toContain('October');
+  });
+});

--- a/apps/mobile/test/tripDateRange.test.ts
+++ b/apps/mobile/test/tripDateRange.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  inclusiveTripDays,
+  tripDateFromIso,
+  tripDateRangePatch,
+  tripDateToIso,
+} from '../src/lib/tripDateRange';
+
+describe('trip date range helpers', () => {
+  it('stores the earlier tapped day first, so traveller return-before-departure taps still save a valid range', () => {
+    const patch = tripDateRangePatch(
+      new Date(2026, 9, 11, 12),
+      new Date(2026, 9, 4, 12),
+      'Asia/Dubai',
+    );
+
+    expect(patch).toEqual({
+      start_date: '2026-10-04',
+      end_date: '2026-10-11',
+      time_zone: 'Asia/Dubai',
+    });
+  });
+
+  it('allows a one-day trip for a rider or user who taps the same day twice', () => {
+    const day = new Date(2026, 9, 4, 12);
+
+    expect(tripDateRangePatch(day, day, 'Asia/Kolkata')).toEqual({
+      start_date: '2026-10-04',
+      end_date: '2026-10-04',
+      time_zone: 'Asia/Kolkata',
+    });
+    expect(inclusiveTripDays(day, day)).toBe(1);
+  });
+
+  it('counts both endpoints for financer budget pacing across the trip', () => {
+    expect(inclusiveTripDays(new Date(2026, 9, 4, 12), new Date(2026, 9, 11, 12))).toBe(8);
+  });
+
+  it('serializes the local calendar day instead of leaking through UTC', () => {
+    const lateEvening = new Date(2026, 9, 4, 23, 30);
+    expect(tripDateToIso(lateEvening)).toBe('2026-10-04');
+  });
+
+  it('ignores incomplete or malformed stored dates', () => {
+    expect(tripDateFromIso(null)).toBeNull();
+    expect(tripDateFromIso('2026-10')).toBeNull();
+    expect(tripDateFromIso('not-a-date')).toBeNull();
+  });
+});


### PR DESCRIPTION
Setting a group's trip dates asked for them one at a time. Tap **Starts**, the native date picker opens, scroll to the day, confirm; tap **Ends**, the picker opens again, scroll, confirm. Six interactions to express one idea — "we are away from the 4th to the 11th" — and at no point were both ends of the range on screen together, so choosing the end meant remembering the start.

The two fields are now one range calendar.

## The new flow, tap by tap

Starting from the group settings screen with no dates set:

1. **Tap the date strip.** It reads `Starts — Not set → Ends — Not set`. The strip's border lights in the brand tint, the "Starts" half lights, and a month grid unfolds beneath it, opened on the current month with today ringed.
2. **Tap a day — say 4 October.** That day fills with a brand circle. The strip's "Starts" half immediately reads `Sat, 4 Oct`; the highlight moves to the "Ends" half, which now reads **"Pick the end"** rather than sitting blank. Nothing has been saved yet.
3. **Tap another day — say 11 October.** Both days get brand circles, the days between fill with the soft brand tint, and the range is saved in one write. The calendar folds away and the strip reads `Sat, 4 Oct → Sun, 11 Oct`, with `8 days` and a `Clear dates` link beneath it.

**Three taps, no confirm** — closing the calendar is the confirmation. Old flow: six.

Two more things the strip buys:

- **Moving only the end.** Tapping the "Ends" half of a range that is already saved reopens the calendar with the start kept and the end waiting, so shifting the return date does not mean re-picking the departure.
- **A one-day trip.** Tap the same day twice.

The order of the two taps does not matter: the earlier day becomes the start. That is what makes an end before a start *unexpressible* rather than merely refused. Both dates remain optional; a group with no trip dates is untouched by any of this.

## Nothing is written until both ends are known

Previously, picking only a start wrote `start = end = that day` — a one-day trip nobody asked for, created by walking away halfway. A half-chosen range is now local state, so leaving mid-selection changes nothing stored, and a completed range is one mutation instead of two.

Everything that reads these two columns — the dashboard's active-trip card, the capture screen's day-of-trip tagging, the trip plan forecast, the recap, the new-group nudge — checks for both dates together and is unaffected. The stored format is unchanged.

## No new dependency

The calendar is the `RangeCalendar` the activity feed's date filter already used, so nothing is installed and **this ships over the air**. It grew what a trip needs: bounds are now optional, since a trip may have happened last year or be booked for next, where a feed can only be filtered inside the span it holds. The range band also runs under the two end circles now, as a half each, so a selection reads as one continuous bar instead of a circle, a gap and a bar.

## RTL and i18n

The grid's rows are plain `row` flex, which React Native reverses under RTL, so the whole calendar mirrors and the range fills leftward for Arabic. Two things that do not mirror themselves are handled explicitly: the `→` between the two halves of the strip goes through `directionalIcon`, and the half-band under each end circle is positioned with the direction-relative `start`/`end` insets so the half pointing at the rest of the range keeps pointing at it.

Two i18n fixes came out of this, both previously wrong and both now tested:

- **The week starts on the reader's own weekday**, not always on Sunday. `Intl.Locale`'s week info answers where an engine carries it; a CLDR region table answers on Hermes, which does not. Writing that table turned up how stale the common knowledge is: **Saudi Arabia's week now opens on Sunday and the UAE's on Monday**, though both are cited as Saturday nearly everywhere — Egypt, Iraq, Jordan and the rest are still Saturday. The table path is tested with `Intl.Locale` taken away, since that is the path real phones take.
- **The month name is pinned to the Gregorian calendar.** `ar-SA` otherwise resolves to Umm al-Qura, and the grid was labelling Gregorian columns with Hijri month names. The language and its numbering system are still the reader's, so day numbers render in Arabic-Indic digits where the locale asks for them.

`pickEnd` and `dayCount` are added in all four languages, with the full zero/one/two/few/many/other set for Arabic.

## Timezones

The columns are `date`, not `timestamptz`, and nothing here goes near UTC. Days are anchored at local noon — the one hour of the day no time zone shift has crossed — and `YYYY-MM-DD` is assembled from `getFullYear`/`getMonth`/`getDate` rather than `toISOString`. A day picked as the 4th is stored as the 4th and read back as the 4th on either side of Greenwich. There is a test for the 23:30 case that a UTC round trip would push into tomorrow.

## What this was drawn from

Mobbin, the range-picker pattern as it actually ships:

- [Vrbo](https://mobbin.com/screens/239980ba-6019-439f-9d73-3d2133aa0d97) — the `Thu, 22 May → Fri, 30 May` header with the active end underlined. This is the "I should be able to see the start I selected" half, and the strip here is that.
- [Booking.com](https://mobbin.com/screens/42dd45a2-1924-4e6e-b0ac-36c76bca8721) and [Airbnb](https://mobbin.com/screens/11dd34c9-777f-4370-ba40-75759998ca19) — filled circles on the two ends over a tinted band, and a length read out beneath (`2 nights`), which became the `8 days` line.
- [Agoda](https://mobbin.com/screens/e087034b-9e3e-4cdb-95af-0ff7043a9bf7) and [IHG](https://mobbin.com/screens/f81d5604-798c-459d-a7d4-25f05c57b6b8) — the departure/return pair kept on screen as a read-out below the grid rather than as two doors into it.
- [Wanderlog's "Plan a new trip"](https://mobbin.com/flows/3f41dc9e-344c-412d-ad8b-6869c6077e48) — the closest match to this exact screen: optional `Start date` / `End date` fields on a create-a-trip form that open **one** calendar between them, and read back as `Dec 1 | Dec 4` once chosen.

## Not verified on a device

No native build was run and nothing here was seen on a screen. Types, lint, format and the full mobile suite (885 tests, including 17 new ones for the grid arithmetic and the week-start table) pass.

## Files

Only the date section is touched — `settings.tsx` and `new-group.tsx` are unchanged, since the `TripDates` props are the same as before.

- `apps/mobile/src/components/TripDates.tsx` — the strip and the new interaction
- `apps/mobile/src/components/RangeCalendar.tsx` — optional bounds, continuous band, today's ring
- `apps/mobile/src/lib/calendarGrid.ts` — new; the arithmetic, the week-start table and the Gregorian pinning
- `apps/mobile/test/calendarGrid.test.ts` — new
- `apps/mobile/src/i18n/index.ts` — `pickEnd`, `dayCount` in en/ta/hi/ar
- `apps/mobile/src/components/ActivityDateFilter.tsx` — second commit: its From/To read-out formatted with the locale calendar while the grid it echoes is now explicitly Gregorian, so on a Saudi phone the sheet named a Hijri month over Gregorian columns. Same pinned formatter now.
