### PR TITLE
fix(expense): give the amount its line back and make "how to split" one control

### DIFF
--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -259,6 +259,17 @@ function textEntries(
   );
 }
 
+/**
+ * The travel shortcuts a trip group is offered, in the order they are shown.
+ *
+ * `none` is not one of them: it is the state of the row before any has been
+ * applied, which a strip that always has exactly one chip lit has no other way
+ * to say. Nothing is stored under it and it is never an option to tap.
+ */
+const PRESET_KINDS = ['nights', 'car', 'ride', 'treat'] as const;
+type PresetKind = (typeof PRESET_KINDS)[number];
+type PresetChoice = PresetKind | 'none';
+
 // A route param is not a trusted integer string; a throw here is a white screen.
 function safeBigInt(value: string | undefined): bigint {
   if (!value) return 0n;
@@ -426,10 +437,12 @@ export default function AddExpenseScreen() {
   // live from the amount via `treatHost`. Any manual edit clears the preset.
   const [presetParams, setPresetParams] = useState<SplitParams | null>(null);
   const [treatHost, setTreatHost] = useState<MemberId | null>(null);
-  const [presetLabel, setPresetLabel] = useState<string | null>(null);
-  const [presetEditor, setPresetEditor] = useState<'nights' | 'car' | 'ride' | 'treat' | null>(
-    null,
-  );
+  // Which shortcut is currently applied, if any. It used to be held as the
+  // shortcut's translated label and compared string-to-string to decide which
+  // button looked pressed, which made the lit control depend on the locale
+  // rather than on what was chosen.
+  const [appliedPreset, setAppliedPreset] = useState<PresetKind | null>(null);
+  const [presetEditor, setPresetEditor] = useState<PresetKind | null>(null);
   const [nightCounts, setNightCounts] = useState<Record<MemberId, string>>({});
   const [riderPick, setRiderPick] = useState<MemberId[]>([]);
   const [fuelAmounts, setFuelAmounts] = useState<Record<MemberId, bigint>>({});
@@ -438,7 +451,7 @@ export default function AddExpenseScreen() {
   const clearPreset = (): void => {
     setPresetParams(null);
     setTreatHost(null);
-    setPresetLabel(null);
+    setAppliedPreset(null);
   };
   // Guessed from the description until somebody picks one themselves, at which
   // point the guess must stop moving it — see `categoryChosen`.
@@ -1356,7 +1369,7 @@ export default function AddExpenseScreen() {
   // message rather than a crash, and nothing is applied.
   const roster = members.data ?? [];
 
-  const openPreset = (kind: 'nights' | 'car' | 'ride' | 'treat'): void => {
+  const openPreset = (kind: PresetKind): void => {
     setError(null);
     setRiderPick(participants.length > 0 ? participants : roster.map((member) => member.id));
     setNightCounts({});
@@ -1387,7 +1400,7 @@ export default function AddExpenseScreen() {
       setSplitKind(SplitKind.Shares);
       setParticipants(chosen);
       setWeights(Object.fromEntries(chosen.map((id) => [id, String(units[id])])));
-      setPresetLabel(t.expense.presets.nights);
+      setAppliedPreset('nights');
       setPresetEditor(null);
     } catch (caught) {
       setError(friendlyError(caught, t.couldNotSave, 'preset.nights'));
@@ -1400,7 +1413,7 @@ export default function AddExpenseScreen() {
       clearPreset();
       setSplitKind(SplitKind.Equal);
       setParticipants(result.participants);
-      setPresetLabel(t.expense.presets.ride);
+      setAppliedPreset('ride');
       setPresetEditor(null);
     } catch (caught) {
       setError(friendlyError(caught, t.couldNotSave, 'preset.ride'));
@@ -1423,7 +1436,7 @@ export default function AddExpenseScreen() {
       setSplitKind(SplitKind.Equal);
       setParticipants(result.participants);
       setPresetParams(result.params);
-      setPresetLabel(t.expense.presets.car);
+      setAppliedPreset('car');
       setPresetEditor(null);
     } catch (caught) {
       setError(friendlyError(caught, t.couldNotSave, 'preset.car'));
@@ -1444,7 +1457,7 @@ export default function AddExpenseScreen() {
       // A treat is one person picking up the whole bill, by definition.
       applyPayers([host], new Map([[host, amount]]), EMPTY_LOCKS, amount);
       setTreatHost(host);
-      setPresetLabel(t.expense.presets.treat);
+      setAppliedPreset('treat');
       setPresetEditor(null);
     } catch (caught) {
       setError(friendlyError(caught, t.couldNotSave, 'preset.treat'));
@@ -1707,44 +1720,92 @@ export default function AddExpenseScreen() {
             </Pressable>
           ) : null}
 
-          {/* Just the heading. The summary card that used to stand here folded
-            the three controls away behind a sentence — one more thing to read,
-            and one more tap between somebody and the split they came to change.
-            The controls below say the same thing and can be acted on. */}
-          <Text variant="caption" tone="muted">
-            {t.expense.howToSplit}
-          </Text>
+          {/* "How is this split" as one block instead of three.
 
+            The heading, the row of modes and the itemise button used to be three
+            siblings of the scroll view with a 16pt gutter between each, so a
+            question with one answer looked like three separate decisions — and
+            the last of them was a full-width button, the widest control on the
+            screen, for the rarest of the four ways to split. Here the heading
+            owns the block, carries the one action that is not a mode (itemising
+            leaves for another screen) at the end of its own line, and the
+            choices sit directly under it — the shape the payer card's heading
+            below already has, so the two read as the same kind of question. */}
           <View style={{ gap: theme.spacing.sm }}>
+            <Row style={{ justifyContent: 'space-between' }}>
+              <Text variant="caption" tone="muted" numberOfLines={1} style={{ flexShrink: 1 }}>
+                {t.expense.howToSplit}
+              </Text>
+              {/* Splitting the bill line by line is another answer to "how is
+                  this split", so it belongs to this heading rather than to the
+                  top bar, where it competed with the title. A link like the
+                  payer card's, not a button: it goes somewhere, and the controls
+                  that change something on this screen are all chips. New
+                  expenses only — an existing one is edited in place, not
+                  re-itemised. */}
+              {!editing ? (
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={t.expense.splitByItem}
+                  onPress={() => router.replace(`/group/${groupId}/itemize`)}
+                  hitSlop={8}
+                  style={{ flexShrink: 0 }}
+                >
+                  <Text
+                    variant="micro"
+                    tone="brand"
+                    numberOfLines={1}
+                    style={{ fontWeight: '700' }}
+                  >
+                    {t.expense.splitByItem}
+                  </Text>
+                </Pressable>
+              ) : null}
+            </Row>
+
+            {/* The trip shortcuts, on one scrolling lane like every other strip
+              of choices here. Wrapped across two rows — which four buttons did
+              on a narrow phone in any of the four languages — they made the
+              block taller than the question it answers and left a ragged second
+              line under the first. Brand green rather than the modes' black:
+              these seed a split and then hand it over, so the row below is
+              still the thing that says how the bill is actually divided. */}
             {isTrip && !editing ? (
               <View style={{ gap: theme.spacing.xs }}>
                 <Text variant="micro" tone="muted">
                   {t.expense.presets.title}
                 </Text>
-                <Row style={{ flexWrap: 'wrap', gap: theme.spacing.sm }}>
-                  {(
-                    [
-                      ['nights', t.expense.presets.nights],
-                      ['car', t.expense.presets.car],
-                      ['ride', t.expense.presets.ride],
-                      ['treat', t.expense.presets.treat],
-                    ] as const
-                  ).map(([kind, label]) => (
-                    <Button
-                      key={kind}
-                      label={label}
-                      size="sm"
-                      variant={presetLabel === label ? 'primary' : 'secondary'}
-                      onPress={() => openPreset(kind)}
-                    />
-                  ))}
-                </Row>
+                <ChipRow<PresetChoice>
+                  value={appliedPreset ?? 'none'}
+                  onChange={(kind) => {
+                    // 'none' is never offered, so this only ever opens a sheet.
+                    if (kind !== 'none') openPreset(kind);
+                  }}
+                  variant="brand"
+                  options={PRESET_KINDS.map((kind) => ({
+                    value: kind,
+                    label:
+                      kind === 'nights'
+                        ? t.expense.presets.nights
+                        : kind === 'car'
+                          ? t.expense.presets.car
+                          : kind === 'ride'
+                            ? t.expense.presets.ride
+                            : t.expense.presets.treat,
+                  }))}
+                />
               </View>
             ) : null}
 
-            {/* Word plus glyph, not three identical word-pills: the icon is what
+            {/* Word plus glyph, not four identical word-pills: the icon is what
               carries over to the expense screen, where the same split comes back
-              as a marked row rather than a bare word. */}
+              as a marked row rather than a bare word. Four labelled modes do not
+              fit one line on a narrow phone in any of the four languages, so the
+              lane scrolls rather than wraps: a fourth chip alone on a second row
+              is what reads as a broken control, where a chip cut off at the edge
+              reads as more to the side. Each chip states its own selected state
+              to the screen reader; the fill is not the only thing saying which
+              one is on. */}
             <ChipRow<SplitKind>
               value={splitKind}
               onChange={(next) => {
@@ -1769,22 +1830,6 @@ export default function AddExpenseScreen() {
               )}
             />
           </View>
-
-          {/* Splitting the bill line by line is another answer to "how is this
-            split", so it sits with the split rather than as a word in the top
-            bar, where it competed with the title and would have had to lose
-            either its icon or its words to fit the hero. Outside the fold, so it
-            is still found without opening the split first. New expenses only: an
-            existing one is edited in place, not re-itemised. */}
-          {!editing ? (
-            <Button
-              label={t.expense.splitByItem}
-              variant="secondary"
-              size="sm"
-              onPress={() => router.replace(`/group/${groupId}/itemize`)}
-              icon={<Ionicons name="list-outline" size={iconSize.md} color={theme.color.brand} />}
-            />
-          ) : null}
 
           {/* Who paid — on an edit as much as on a new expense, and now as many
             people as actually put money in.

--- a/apps/mobile/src/components/expense/ExpenseHero.tsx
+++ b/apps/mobile/src/components/expense/ExpenseHero.tsx
@@ -50,7 +50,12 @@ export function ExpenseHero({
   amount: bigint;
   onAmountChange: (value: bigint) => void;
   onPressCurrency: () => void;
-  /** A trailing action; a 44pt spacer keeps the row balanced when omitted. */
+  /**
+   * A trailing action. Omitted, nothing stands in for it: the row used to keep a
+   * 44pt spacer there for balance, but the amount field now grows into whatever
+   * the row has spare, and an empty box holding 44 points away from it is 44
+   * points the number does not get.
+   */
   right?: ReactNode;
   /** A modal (capture) dismisses with an X; a pushed page goes back. */
   leading?: 'close' | 'back';
@@ -103,8 +108,15 @@ export function ExpenseHero({
           <Text variant="micro" tone="onBrand" numberOfLines={1} style={{ opacity: 0.85 }}>
             {title}
           </Text>
-          {/* Amount and currency on one line: the number leads, the code it is
-              counted in sits at the end of it as the pill that opens the picker. */}
+          {/* Amount and currency on one line, and the line belongs to the
+              amount: the field takes the whole run between the category badge
+              and the pill, which sits hard against the trailing edge. The two
+              used to be sized by their content, so a freshly opened form put a
+              well barely wider than the "0" in it next to a currency pill
+              floating in the middle of the header, with the rest of the line
+              empty — the smallest thing on the row was the one the screen is
+              for. Nothing here wraps: the pill refuses to shrink and the field
+              gives ground (and drops a point or two of type) instead. */}
           <Row style={{ alignItems: 'center', gap: theme.spacing.sm }}>
             <AmountField
               currency={currency}
@@ -124,6 +136,10 @@ export function ExpenseHero({
                 flexDirection: 'row',
                 alignItems: 'center',
                 gap: theme.spacing.xs,
+                // Whatever the amount does, the pill keeps its own width: a
+                // three-letter code squeezed to "IN…" beside a long total would
+                // be the one part of this row that must never be ambiguous.
+                flexShrink: 0,
                 // A real tap target, not a label: the pill is the only way to
                 // change the currency, and `hitSlop` alone left it under 44pt.
                 minHeight: 36,
@@ -150,7 +166,7 @@ export function ExpenseHero({
           </Row>
         </View>
 
-        {right ?? <View style={{ width: 44 }} />}
+        {right}
       </Row>
     </Gradient>
   );

--- a/apps/mobile/src/components/expense/splitIcon.ts
+++ b/apps/mobile/src/components/expense/splitIcon.ts
@@ -10,6 +10,16 @@
  * Keyed by the ledger's `split_type` (TDR §8), which is a superset of the three
  * kinds this form offers — an itemized or adjusted split is written by other
  * screens but still has to be shown here.
+ *
+ * Every glyph here is a *diagram of a division* drawn in the same thin outline
+ * weight — a grid, bars, a pie, a keypad, sliders, a list. That rule is the
+ * point of the set. The first version mixed a pair of human silhouettes
+ * (`people-outline` for an even split) and a banknote (`cash-outline` for typed
+ * amounts) in among two thin chart drawings, and side by side in one chip strip
+ * the four did not read as four settings of one control: two were dense filled
+ * shapes and two were sparse line drawings, so the row looked assembled from
+ * whatever was to hand. Anything added here must be another line diagram of how
+ * the total divides, not a picture of a person, a wallet or a coin.
  */
 
 import type Ionicons from '@expo/vector-icons/Ionicons';
@@ -17,11 +27,11 @@ import type Ionicons from '@expo/vector-icons/Ionicons';
 type IconName = keyof typeof Ionicons.glyphMap;
 
 const SPLIT_ICONS: Record<string, IconName> = {
-  // Everyone the same: a row of people, not a maths symbol.
-  equal: 'people-outline',
-  // Typed amounts, one per person — money, straight.
-  exact: 'cash-outline',
-  // Slices of a whole.
+  // Cells of one size: every share the same.
+  equal: 'grid-outline',
+  // A keypad, because an exact split is the one you type in figure by figure.
+  exact: 'calculator-outline',
+  // Slices of a hundred.
   percent: 'pie-chart-outline',
   // Weights: bars of different heights.
   shares: 'stats-chart-outline',
@@ -31,8 +41,8 @@ const SPLIT_ICONS: Record<string, IconName> = {
   itemized: 'list-outline',
 };
 
-/** The glyph for a split type, falling back to the even-split people for a
- *  value this build does not know (a newer server writing an older client). */
+/** The glyph for a split type, falling back to the even-split grid for a value
+ *  this build does not know (a newer server writing an older client). */
 export function splitIcon(splitType: string): IconName {
-  return SPLIT_ICONS[splitType] ?? 'people-outline';
+  return SPLIT_ICONS[splitType] ?? 'grid-outline';
 }

--- a/packages/ui/src/components/AmountField.tsx
+++ b/packages/ui/src/components/AmountField.tsx
@@ -164,9 +164,14 @@ export function AmountField({
         alignItems: 'center',
         justifyContent: compact ? 'flex-end' : hero ? 'flex-start' : 'center',
         gap: theme.spacing.xs,
-        // The hero shares its line with the currency pill, so a long amount has
-        // to give ground rather than push the pill off the header; the standalone
-        // sizes have the row to themselves and must not be squeezed by a sibling.
+        // The hero takes every point its line does not owe to something else and
+        // gives them back when the amount is long: it grows into the gap between
+        // the category badge and the currency pill, and shrinks rather than
+        // pushing that pill off the end of the header. It is the field the screen
+        // exists to fill, so it should be the widest thing on its row even when
+        // it holds a single digit. The standalone sizes have the row to
+        // themselves and must be neither stretched nor squeezed by a sibling.
+        flexGrow: hero ? 1 : 0,
         flexShrink: hero ? 1 : 0,
         minWidth: 0,
         ...(framed
@@ -211,7 +216,14 @@ export function AmountField({
           fontWeight: '700',
           color: digitInk,
           fontVariant: ['tabular-nums'],
+          // Physical, not logical, on purpose: React Native flips `textAlign`
+          // itself in an RTL layout, so 'left' is already "the side the digits
+          // start on" in Arabic.
           textAlign: compact ? 'right' : 'left',
+          // The input fills whatever the well grew to, so the whole well raises
+          // the keyboard. Sized to its text it would leave most of a wide hero
+          // field as dead space that looks like a tap target and is not one.
+          flexGrow: hero ? 1 : 0,
           flexShrink: hero ? 1 : 0,
         }}
       />


### PR DESCRIPTION
Two things at the top of the add-expense form, both cases of a control being smaller or more scattered than the thing it stands for.

## The amount row

The amount field and the currency pill were each sized by their content. A form opened fresh showed a well barely wider than the `0` inside it, a currency pill floating in the middle of the header, and the rest of the line empty — the field the whole screen exists to fill was the smallest thing on its row.

Left to right, the hero row is now: back chevron, category badge, then a flexible column whose first line is the title and whose second is the amount field taking every point the row does not owe to something else, with the currency pill hard against the trailing edge. The pill no longer shrinks, so a long total can never squeeze `INR` into `IN…` or push it off the row; the amount gives ground instead, and drops a point or two of type the way it already did. The input inside the well grows with the well, so tapping anywhere in it raises the keyboard rather than only the few points the digits occupy. The 44pt spacer that used to stand in for an absent trailing action is gone: no caller passes one, and it was 44 points the number did not get.

Money handling is untouched — minor units, `sanitiseMinorInput`, native numerals, the currency sheet and the long-amount shrink all behave exactly as before. This is layout only. In Arabic the whole row mirrors on React Native's own `flexDirection: 'row'` reversal, so the badge sits on the right and the pill on the left, and the digits keep starting at the field's leading edge because RN also flips `textAlign`.

## The "how to split" section

It was a heading, a strip of modes and a full-width `Split by item` button — three siblings of the scroll view with a 16pt gutter between each, so one question looked like three decisions and the widest control on the screen belonged to the rarest of the four ways to split.

It is now one block. The heading owns it and carries itemising, the only action there that leaves for another screen, as a link at the end of its own line — the shape the payer heading directly below already has. Under it: the trip shortcuts, if this is a trip group, then the four modes.

The shortcuts were a wrapping row of buttons that fell onto two lines on a narrow phone; they are a chip lane that scrolls instead, in brand green so they do not read as part of the mode row underneath. Which shortcut is applied is now held as the shortcut itself rather than as its translated label compared string-to-string, so the lit chip no longer depends on the locale.

The four modes stay a horizontally scrolling `ChipRow`, deliberately: four labelled modes with glyphs do not fit one 360dp line in English, let alone Tamil, Hindi or Arabic, and a fourth chip alone on a wrapped second row is what reads as a broken control, where one cut off at the edge reads as more to the side. `SegmentedTabs` was considered and rejected — it gives every tab `flex: 1` with an uppercased, letterspaced label and no line clamp, so four localised words would wrap to two lines each and reproduce the exact complaint, and its underline styling is for a page with several faces rather than for a field's mode. Each chip already exposes `accessibilityState={{ selected }}`, so the fill is not the only thing saying which mode is on.

## The glyphs

`equal` was a pair of human silhouettes and `exact` a banknote, sitting beside two thin chart drawings — dense shapes next to sparse ones, which is most of why the row looked assembled from whatever was to hand. All six are now line diagrams of a division in one outline weight: a grid for equal, bars for shares, a pie for percent, a keypad for exact, sliders for adjusted, a list for itemized. The rule is written into `splitIcon.ts` so the next glyph added keeps to it. The expense screen reads the same table, so a saved bill still comes back marked with the glyph that was tapped.

No new strings — everything here reuses keys that already exist in all four languages.

## Checks

- `pnpm --filter @waves/mobile run typecheck`, `run lint` — clean (three pre-existing `import/first` warnings in `phone.tsx`).
- `pnpm --filter @waves/ui run typecheck` — clean.
- `prettier --check` — clean.
- Mobile suite from `apps/mobile`: 69 files, 868 tests, all passing.

Not run on a device — the layout claims above are read off the flex rules, not off a screenshot.
