### PR TITLE
feat(scan): make the scan-to-join screen a real scanner

### DIFF
--- a/apps/mobile/src/app/join.tsx
+++ b/apps/mobile/src/app/join.tsx
@@ -36,7 +36,10 @@ import { useGuestGuard } from '@/lib/guestGuard';
 export default function JoinScreen() {
   const theme = useTheme();
   const { t, locale } = useStrings();
-  const { token } = useLocalSearchParams<{ token?: string }>();
+  // `from` says how the link was opened. The scanner sends `scan`, because a
+  // link that turns out to be dead has a different next step there: point the
+  // camera at another code, rather than being shown the door to the app.
+  const { token, from } = useLocalSearchParams<{ token?: string; from?: string }>();
   const { session, continueAsGuest } = useAuth();
   const guard = useGuestGuard();
   const queryClient = useQueryClient();
@@ -137,7 +140,20 @@ export default function JoinScreen() {
         <EmptyState
           title={t.misc.linkExpired}
           body={shown ?? t.misc.linkExpiredBody}
-          action={<Button label={t.misc.goToWaves} onPress={() => router.replace('/')} />}
+          action={
+            from === 'scan' ? (
+              <View style={{ alignItems: 'center', gap: theme.spacing.sm }}>
+                <Button label={t.misc.scanAnother} onPress={() => router.replace('/scan')} />
+                <Button
+                  label={t.misc.goToWaves}
+                  variant="ghost"
+                  onPress={() => router.replace('/')}
+                />
+              </View>
+            ) : (
+              <Button label={t.misc.goToWaves} onPress={() => router.replace('/')} />
+            )
+          }
         />
       </Screen>
     );

--- a/apps/mobile/src/app/scan.tsx
+++ b/apps/mobile/src/app/scan.tsx
@@ -1,12 +1,25 @@
-import { lazy, Suspense } from 'react';
+import { lazy, Suspense, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
+import * as Clipboard from 'expo-clipboard';
 import { router } from 'expo-router';
-import { ActivityIndicator, View } from 'react-native';
+import { ActivityIndicator, TextInput, View } from 'react-native';
 
-import { EmptyState, IconButton, iconSize, Row, Screen, Text, useTheme } from '@waves/ui';
+import {
+  Button,
+  Callout,
+  EmptyState,
+  IconButton,
+  iconSize,
+  palette,
+  Row,
+  Screen,
+  Sheet,
+  Text,
+  useTheme,
+} from '@waves/ui';
 
 import { useStrings } from '@/i18n';
-import { cameraAvailable } from '@/lib/qrScan';
+import { cameraAvailable, tokenFromScan } from '@/lib/qrScan';
 
 // Only pulled in when the native camera is present — a dynamic import so an
 // older binary never even evaluates `expo-camera`.
@@ -17,50 +30,150 @@ const ScannerCamera = lazy(() => import('@/components/ScannerCamera'));
  *
  * The scanned code carries the same invite token an invite link does, so a good
  * read just hands off to `/join?token=…` — the one screen that already previews
- * the group and runs the ghost-claim. When the running binary predates
- * `expo-camera` (a JS-only reload of an old dev-client), the screen says so
- * instead of reaching for a camera that is not in the build yet.
+ * the group and runs the ghost-claim. `from=scan` travels with it so that
+ * screen knows a dead link should offer another scan rather than only a way
+ * back to the app.
+ *
+ * The camera is not the only way in, and this route rather than the camera leaf
+ * owns the other one. A QR-only screen strands the commonest case there is: the
+ * link arrived in a chat on this same phone, so there is no second screen to
+ * point a camera at. The paste sheet lives here because it has to keep working
+ * on every state where the camera does not — refused permission, a camera that
+ * will not start, a binary built before `expo-camera` existed.
  */
 export default function ScanScreen() {
   const theme = useTheme();
   const { t } = useStrings();
   const available = cameraAvailable();
+  const [pasting, setPasting] = useState(false);
+  const [pasted, setPasted] = useState('');
+  const [pasteError, setPasteError] = useState<string | null>(null);
 
-  const onToken = (token: string): void => {
-    router.replace(`/join?token=${encodeURIComponent(token)}`);
+  const open = (token: string): void => {
+    router.replace(`/join?token=${encodeURIComponent(token)}&from=scan`);
+  };
+
+  /**
+   * Offer the clipboard, but only when it is holding one of our links.
+   *
+   * Reading the clipboard to fill a field is a small liberty, and it is only
+   * worth taking when the answer is the thing the person came here to do.
+   * Anything else — a password, half an email — is dropped without ever being
+   * shown, so the sheet cannot surface clipboard contents that have nothing to
+   * do with Waves.
+   */
+  const openPaste = (): void => {
+    setPasteError(null);
+    setPasting(true);
+    void Clipboard.getStringAsync().then((clip) => {
+      if (clip && tokenFromScan(clip)) setPasted(clip.trim());
+    });
+  };
+
+  const submitPaste = (): void => {
+    const token = tokenFromScan(pasted);
+    if (!token) {
+      setPasteError(t.misc.scanPasteInvalid);
+      return;
+    }
+    setPasting(false);
+    open(token);
   };
 
   return (
-    <Screen edges={['top', 'bottom']}>
-      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
-        <IconButton label={t.common.close} onPress={() => router.back()}>
-          <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
-        </IconButton>
-        <View style={{ flex: 1, alignItems: 'center' }}>
-          <Text variant="heading">{t.misc.scanToJoin}</Text>
-        </View>
-        <View style={{ width: 44 }} />
-      </Row>
-
+    <>
       {available ? (
-        <Suspense
-          fallback={
-            <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-              <ActivityIndicator color={theme.color.brand} />
-            </View>
-          }
-        >
-          <ScannerCamera onToken={onToken} />
-        </Suspense>
+        <View style={{ flex: 1, backgroundColor: palette.night900 }}>
+          <Suspense
+            fallback={
+              <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+                <ActivityIndicator color={palette.white} />
+              </View>
+            }
+          >
+            <ScannerCamera onToken={open} onClose={() => router.back()} onPasteLink={openPaste} />
+          </Suspense>
+        </View>
       ) : (
-        <View style={{ flex: 1, justifyContent: 'center' }}>
-          <EmptyState
-            icon={<Ionicons name="qr-code-outline" size={iconSize.xxl} color={theme.color.brand} />}
-            title={t.misc.scanToJoin}
-            body={t.misc.scanRebuild}
+        // No camera in this build. Nothing here is a camera screen, so it wears
+        // the app's ordinary chrome rather than pretending to be a viewfinder —
+        // and it still carries the paste route, which works perfectly well
+        // without one.
+        <Screen edges={['top', 'bottom']}>
+          <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+            <IconButton label={t.common.close} onPress={() => router.back()}>
+              <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
+            </IconButton>
+            <View style={{ flex: 1, alignItems: 'center' }}>
+              <Text variant="heading">{t.misc.scanToJoin}</Text>
+            </View>
+            <View style={{ width: 44 }} />
+          </Row>
+
+          <View style={{ flex: 1, justifyContent: 'center', paddingHorizontal: theme.spacing.xl }}>
+            <EmptyState
+              icon={
+                <Ionicons name="qr-code-outline" size={iconSize.xxl} color={theme.color.brand} />
+              }
+              title={t.misc.scanToJoin}
+              body={t.misc.scanRebuild}
+              action={<Button label={t.misc.scanPasteLink} onPress={openPaste} />}
+            />
+          </View>
+        </Screen>
+      )}
+
+      <Sheet visible={pasting} onClose={() => setPasting(false)} closeLabel={t.common.close}>
+        <View style={{ gap: theme.spacing.md }}>
+          <Text variant="heading">{t.misc.scanPasteTitle}</Text>
+          <Text variant="caption" tone="muted">
+            {t.misc.scanPasteBody}
+          </Text>
+
+          <Row
+            style={{
+              backgroundColor: theme.color.surfaceMuted,
+              borderRadius: theme.radius.md,
+              paddingHorizontal: theme.spacing.md,
+              paddingVertical: theme.spacing.sm,
+            }}
+          >
+            <Ionicons name="link" size={iconSize.md} color={theme.color.textMuted} />
+            <TextInput
+              value={pasted}
+              onChangeText={(next) => {
+                setPasted(next);
+                setPasteError(null);
+              }}
+              placeholder={t.misc.scanPastePlaceholder}
+              placeholderTextColor={theme.color.textFaint}
+              accessibilityLabel={t.misc.scanPasteTitle}
+              autoCapitalize="none"
+              autoCorrect={false}
+              autoFocus
+              keyboardType="url"
+              onSubmitEditing={submitPaste}
+              returnKeyType="go"
+              style={{
+                flex: 1,
+                ...theme.typography.body,
+                color: theme.color.text,
+                paddingVertical: theme.spacing.xs,
+              }}
+            />
+          </Row>
+
+          {pasteError ? <Callout tone="negative">{pasteError}</Callout> : null}
+
+          <Button
+            label={t.misc.scanPasteAction}
+            size="lg"
+            fullWidth
+            disabled={pasted.trim().length === 0}
+            onPress={submitPaste}
           />
         </View>
-      )}
-    </Screen>
+      </Sheet>
+    </>
   );
 }

--- a/apps/mobile/src/app/scan.tsx
+++ b/apps/mobile/src/app/scan.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useState } from 'react';
+import { lazy, Suspense, useRef, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import * as Clipboard from 'expo-clipboard';
 import { router } from 'expo-router';
@@ -49,7 +49,15 @@ export default function ScanScreen() {
   const [pasted, setPasted] = useState('');
   const [pasteError, setPasteError] = useState<string | null>(null);
 
+  // Both ways in — the camera and the sheet — end in the same navigation, and
+  // either can fire twice: a double tap on "Open invite", or the camera reading
+  // a code in the moment before the screen goes. The leaf holds the same guard
+  // for its own reads; this one covers both roads at the point they meet.
+  const navigated = useRef(false);
+
   const open = (token: string): void => {
+    if (navigated.current) return;
+    navigated.current = true;
     router.replace(`/join?token=${encodeURIComponent(token)}&from=scan`);
   };
 
@@ -63,11 +71,24 @@ export default function ScanScreen() {
    * do with Waves.
    */
   const openPaste = (): void => {
+    // A fresh sheet every time. Reopening onto the rejected text from last time,
+    // with the error that explained it already gone, reads as the field having
+    // broken rather than as a link that did not work.
+    setPasted('');
     setPasteError(null);
     setPasting(true);
-    void Clipboard.getStringAsync().then((clip) => {
-      if (clip && tokenFromScan(clip)) setPasted(clip.trim());
-    });
+    void Clipboard.getStringAsync()
+      .then((clip) => {
+        if (!clip || !tokenFromScan(clip)) return;
+        // Only into a field nobody has touched yet: the read is asynchronous and
+        // somebody typing fast can be ahead of it, and their own text wins.
+        setPasted((current) => (current === '' ? clip.trim() : current));
+      })
+      .catch(() => {
+        // Some Android builds refuse a clipboard read outright. Offering to fill
+        // the field is a courtesy, so failing at it is not worth a word — the
+        // field is there to be typed into either way.
+      });
   };
 
   const submitPaste = (): void => {
@@ -91,7 +112,12 @@ export default function ScanScreen() {
               </View>
             }
           >
-            <ScannerCamera onToken={open} onClose={() => router.back()} onPasteLink={openPaste} />
+            <ScannerCamera
+              onToken={open}
+              onClose={() => router.back()}
+              onPasteLink={openPaste}
+              paused={pasting}
+            />
           </Suspense>
         </View>
       ) : (

--- a/apps/mobile/src/components/ScannerCamera.tsx
+++ b/apps/mobile/src/components/ScannerCamera.tsx
@@ -4,111 +4,475 @@
  *
  * It is only ever loaded (via a dynamic import) once `cameraAvailable()` is
  * true, so importing `expo-camera` here cannot crash an older binary: the
- * module is never evaluated on a build that lacks the native side. It owns the
- * permission dance because that is an `expo-camera` hook; the surrounding
- * chrome (close, title) belongs to the route.
+ * module is never evaluated on a build that lacks the native side. Everything
+ * that belongs to the camera lives here — the permission dance, the torch, the
+ * viewfinder — while the route above owns navigation and the paste-a-link way
+ * in, which has to work on the states where there is no camera at all.
+ *
+ * The screen is the camera, edge to edge, with the surround dimmed and a hole
+ * cut where the code goes. That shape is the one every mature scanner has
+ * converged on (WhatsApp, LINE, Telegram, BeReal, Splitwise): the dim says
+ * where to aim without a word, and the corner brackets mark the target without
+ * boxing in the frame the way a full border does. The one instruction sits
+ * above the hole so it never covers what the person is aiming at, and the
+ * feedback sits below it, in space that is always reserved so nothing jumps
+ * when a message arrives.
+ *
+ * The geometry is deliberately symmetric — three stacked bands, the middle one
+ * a row of dim / hole / dim — so it mirrors correctly in Arabic for free.
+ * Nothing here is positioned from a hardcoded edge.
  */
 
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
 import { CameraView, useCameraPermissions } from 'expo-camera';
-import { ActivityIndicator, Linking, StyleSheet, View } from 'react-native';
+import {
+  AccessibilityInfo,
+  ActivityIndicator,
+  Linking,
+  Pressable,
+  StyleSheet,
+  useWindowDimensions,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { Button, Callout, Text, useTheme } from '@waves/ui';
+import { Button, Callout, iconSize, palette, Row, Text, useTheme } from '@waves/ui';
 
 import { useStrings } from '@/i18n';
 import { tokenFromScan } from '@/lib/qrScan';
 
-export default function ScannerCamera({ onToken }: { onToken: (token: string) => void }) {
+/** The wash over everything that is not the viewfinder. Dark enough to say
+ *  "aim here", light enough that the rest of the shot is still visible — a
+ *  blackout would hide the thing being pointed at. */
+const DIM = 'rgba(10, 10, 26, 0.62)';
+/** The chip a floating control sits on, so a white glyph survives a white wall
+ *  behind it. */
+const GLASS = 'rgba(10, 10, 26, 0.55)';
+/** How long a good read is celebrated before the screen changes. Long enough to
+ *  be seen as "it worked", short enough not to feel like a wait. */
+const FOUND_MS = 420;
+/** How long a "that is not a Waves code" stays up after the bad code leaves the
+ *  frame. The timer restarts on every frame the code is still in view. */
+const INVALID_MS = 4000;
+/** The corner brackets: arm length and stroke. */
+const CORNER = 34;
+const STROKE = 4;
+
+/** What the camera has to say about the last thing it read. */
+type Reading = 'idle' | 'found' | 'invalid';
+
+/**
+ * One of the four bracket arms around the viewfinder. Drawn as a corner rather
+ * than a closed border because a closed border reads as a window the code has
+ * to fit exactly, and it does not — the reader is happy with a code anywhere in
+ * the hole. All four corners are drawn, so mirroring the layout in Arabic swaps
+ * which is which and changes nothing about how it looks.
+ */
+function Corner({
+  vertical,
+  horizontal,
+  color,
+}: {
+  vertical: 'top' | 'bottom';
+  horizontal: 'left' | 'right';
+  color: string;
+}) {
   const theme = useTheme();
+  const top = vertical === 'top';
+  const left = horizontal === 'left';
+  return (
+    <View
+      style={{
+        position: 'absolute',
+        top: top ? 0 : undefined,
+        bottom: top ? undefined : 0,
+        left: left ? 0 : undefined,
+        right: left ? undefined : 0,
+        width: CORNER,
+        height: CORNER,
+        borderColor: color,
+        borderTopWidth: top ? STROKE : 0,
+        borderBottomWidth: top ? 0 : STROKE,
+        borderLeftWidth: left ? STROKE : 0,
+        borderRightWidth: left ? 0 : STROKE,
+        borderTopLeftRadius: top && left ? theme.radius.xl : 0,
+        borderTopRightRadius: top && !left ? theme.radius.xl : 0,
+        borderBottomLeftRadius: !top && left ? theme.radius.xl : 0,
+        borderBottomRightRadius: !top && !left ? theme.radius.xl : 0,
+      }}
+    />
+  );
+}
+
+/** A round control that floats on the camera: dark chip by default, inverted to
+ *  white while it is on, so its state is a fill and a label rather than a
+ *  colour alone. */
+function GlassButton({
+  label,
+  onPress,
+  active,
+  children,
+}: {
+  label: string;
+  onPress: () => void;
+  /** Omitted for a control that is not a toggle. */
+  active?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityState={active === undefined ? undefined : { selected: active }}
+      onPress={onPress}
+      hitSlop={8}
+      style={({ pressed }) => ({
+        width: 44,
+        height: 44,
+        borderRadius: 22,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: active ? palette.white : GLASS,
+        opacity: pressed ? 0.7 : 1,
+      })}
+    >
+      {children}
+    </Pressable>
+  );
+}
+
+/**
+ * The states where there is a screen but no picture: permission not asked for
+ * yet, permission refused, a camera that would not start. They wear the same
+ * dark ground as the camera — the person opened a scanner, and dropping them
+ * onto a light page would read as having been thrown somewhere else — and each
+ * one carries the way out that actually applies to it.
+ */
+function DarkState({
+  title,
+  body,
+  action,
+  onClose,
+  onPasteLink,
+  closeLabel,
+  pasteLabel,
+}: {
+  title: string;
+  body: string;
+  action?: ReactNode;
+  onClose: () => void;
+  onPasteLink: () => void;
+  closeLabel: string;
+  pasteLabel: string;
+}) {
+  const theme = useTheme();
+  const insets = useSafeAreaInsets();
+  return (
+    <View style={{ flex: 1, backgroundColor: palette.night900 }}>
+      <Row
+        style={{ paddingTop: insets.top + theme.spacing.sm, paddingHorizontal: theme.spacing.xl }}
+      >
+        <GlassButton label={closeLabel} onPress={onClose}>
+          <Ionicons name="close" size={iconSize.lg} color={palette.white} />
+        </GlassButton>
+      </Row>
+
+      <View
+        style={{
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: theme.spacing.md,
+          paddingHorizontal: theme.spacing.xxl,
+          paddingBottom: insets.bottom + theme.spacing.xxxl,
+        }}
+      >
+        <View
+          style={{
+            width: 64,
+            height: 64,
+            borderRadius: theme.radius.xl,
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: GLASS,
+            marginBottom: theme.spacing.sm,
+          }}
+        >
+          <Ionicons name="camera-outline" size={iconSize.huge} color={palette.white} />
+        </View>
+        <Text variant="heading" align="center" style={{ color: palette.white }}>
+          {title}
+        </Text>
+        <Text variant="body" align="center" style={{ color: palette.ink300 }}>
+          {body}
+        </Text>
+        <View style={{ height: theme.spacing.md }} />
+        {action}
+        <Button label={pasteLabel} variant="onBrandOutline" onPress={onPasteLink} />
+      </View>
+    </View>
+  );
+}
+
+export default function ScannerCamera({
+  onToken,
+  onClose,
+  onPasteLink,
+}: {
+  onToken: (token: string) => void;
+  onClose: () => void;
+  /** Opens the route's paste-a-link sheet. Offered on every state, including
+   *  the ones with no working camera — a person whose camera is refused is
+   *  otherwise stranded on a screen that can do nothing for them. */
+  onPasteLink: () => void;
+}) {
+  const theme = useTheme();
+  const insets = useSafeAreaInsets();
   const { t } = useStrings();
+  const { width } = useWindowDimensions();
   const [permission, requestPermission] = useCameraPermissions();
+
   // A read fires many frames a second; once we have a good token we hand it up
   // once and stop, and a bad read only flags itself without locking the camera.
   const handled = useRef(false);
-  const [invalid, setInvalid] = useState(false);
+  const [reading, setReading] = useState<Reading>('idle');
+  const [torch, setTorch] = useState(false);
+  const [mountFailed, setMountFailed] = useState(false);
+
+  // Both the celebration and the "not a Waves code" notice are timed, and both
+  // are still pending if the person backs out mid-read. One ref holds whichever
+  // is outstanding so unmounting cancels it rather than calling `onToken` — a
+  // navigation — from a screen that is already gone.
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Whether the refusal has already been spoken for the code currently in
+  // frame. Tracked in a ref rather than off `reading`, because a bad code sits
+  // in view for many frames a second and a screen reader must say so once.
+  const announced = useRef(false);
+  useEffect(
+    () => () => {
+      if (timer.current) clearTimeout(timer.current);
+    },
+    [],
+  );
+
+  const onScan = (data: string): void => {
+    if (handled.current) return;
+    const token = tokenFromScan(data);
+    if (!token) {
+      if (timer.current) clearTimeout(timer.current);
+      timer.current = setTimeout(() => {
+        announced.current = false;
+        setReading('idle');
+      }, INVALID_MS);
+      if (!announced.current) {
+        announced.current = true;
+        AccessibilityInfo.announceForAccessibility(t.misc.scanInvalid);
+      }
+      setReading('invalid');
+      return;
+    }
+    handled.current = true;
+    setReading('found');
+    AccessibilityInfo.announceForAccessibility(t.misc.scanFound);
+    // Hand off a beat later, so the frame turning and the "code found" line are
+    // seen. A scanner that navigates the instant it reads leaves the person
+    // wondering whether their own tap did it.
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => onToken(token), FOUND_MS);
+  };
 
   if (!permission) {
-    return (
-      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-        <ActivityIndicator color={theme.color.brand} />
-      </View>
-    );
-  }
-
-  if (!permission.granted) {
-    const canAsk = permission.canAskAgain;
     return (
       <View
         style={{
           flex: 1,
           alignItems: 'center',
           justifyContent: 'center',
-          gap: theme.spacing.lg,
-          padding: theme.spacing.xl,
+          backgroundColor: palette.night900,
         }}
       >
-        <Text variant="body" tone="muted" align="center">
-          {canAsk ? t.misc.scanAllowBody : t.misc.scanDenied}
-        </Text>
-        <Button
-          label={t.misc.scanAllow}
-          size="lg"
-          onPress={() => void (canAsk ? requestPermission() : Linking.openSettings())}
-        />
+        <ActivityIndicator color={palette.white} />
       </View>
     );
   }
 
+  if (!permission.granted) {
+    // Two different refusals. "Not asked yet" can still be asked; a permanent
+    // no can only be undone in the system settings, and a button that says
+    // "Allow camera" and then does nothing is the worst of both.
+    const canAsk = permission.canAskAgain;
+    return (
+      <DarkState
+        title={canAsk ? t.misc.scanAllowTitle : t.misc.scanDeniedTitle}
+        body={canAsk ? t.misc.scanAllowBody : t.misc.scanDenied}
+        action={
+          <Button
+            label={canAsk ? t.misc.scanAllow : t.pickers.openSettings}
+            variant="onBrand"
+            size="lg"
+            onPress={() => void (canAsk ? requestPermission() : Linking.openSettings())}
+          />
+        }
+        onClose={onClose}
+        onPasteLink={onPasteLink}
+        closeLabel={t.common.close}
+        pasteLabel={t.misc.scanPasteLink}
+      />
+    );
+  }
+
+  if (mountFailed) {
+    // The camera is in the build and allowed, and still would not start: a
+    // device without one, or one another app is holding.
+    return (
+      <DarkState
+        title={t.misc.scanCameraFailedTitle}
+        body={t.misc.scanCameraFailed}
+        onClose={onClose}
+        onPasteLink={onPasteLink}
+        closeLabel={t.common.close}
+        pasteLabel={t.misc.scanPasteLink}
+      />
+    );
+  }
+
+  // The hole, sized off the screen so it stays a comfortable square on a small
+  // phone and does not grow into a wall on a tablet.
+  const hole = Math.max(200, Math.min(width - 96, 300));
+  const brackets = reading === 'found' ? theme.color.brand : palette.white;
+
   return (
-    <View style={{ flex: 1 }}>
+    <View style={{ flex: 1, backgroundColor: palette.night900 }}>
       <CameraView
-        style={{ flex: 1 }}
+        style={StyleSheet.absoluteFill}
         facing="back"
+        enableTorch={torch}
         barcodeScannerSettings={{ barcodeTypes: ['qr'] }}
-        onBarcodeScanned={({ data }) => {
-          if (handled.current) return;
-          const token = tokenFromScan(data);
-          if (!token) {
-            setInvalid(true);
-            return;
-          }
-          handled.current = true;
-          onToken(token);
-        }}
+        onBarcodeScanned={({ data }) => onScan(data)}
+        onMountError={() => setMountFailed(true)}
+        // A camera has nothing for a screen reader to read, so it is named
+        // instead: what this region is, and that it works by itself.
+        accessible
+        accessibilityLabel={t.misc.scanViewfinder}
       />
 
-      {/* The aiming frame and the one line that says what to point at, floated
-          over the feed. */}
-      <View
-        pointerEvents="none"
-        style={[StyleSheet.absoluteFill, { alignItems: 'center', justifyContent: 'center' }]}
-      >
+      {/* Three bands: dim, then the row that carries the hole, then dim. The
+          bottom band is the taller one, which lifts the viewfinder above the
+          middle of the screen — where a phone held out at a code naturally
+          points, and clear of the controls underneath. `box-none` so the dim
+          never eats a tap meant for a control sitting on it. */}
+      <View style={StyleSheet.absoluteFill} pointerEvents="box-none">
         <View
+          pointerEvents="box-none"
           style={{
-            width: 232,
-            height: 232,
-            borderRadius: theme.radius.xl,
-            borderWidth: 3,
-            borderColor: '#FFFFFF',
+            flex: 1,
+            backgroundColor: DIM,
+            paddingTop: insets.top + theme.spacing.sm,
+            paddingHorizontal: theme.spacing.xl,
+            justifyContent: 'space-between',
           }}
-        />
-      </View>
+        >
+          <Row>
+            <GlassButton label={t.common.close} onPress={onClose}>
+              <Ionicons name="close" size={iconSize.lg} color={palette.white} />
+            </GlassButton>
+            <View style={{ flex: 1, alignItems: 'center' }}>
+              <Text variant="heading" style={{ color: palette.white }}>
+                {t.misc.scanToJoin}
+              </Text>
+            </View>
+            {/* Restaurants at night are most of what gets scanned, so the light
+                is a peer of the close button rather than something to go
+                looking for. */}
+            <GlassButton
+              label={torch ? t.misc.scanTorchOff : t.misc.scanTorchOn}
+              active={torch}
+              onPress={() => setTorch((on) => !on)}
+            >
+              <Ionicons
+                name={torch ? 'flashlight' : 'flashlight-outline'}
+                size={iconSize.lg}
+                color={torch ? palette.ink900 : palette.white}
+              />
+            </GlassButton>
+          </Row>
 
-      <View
-        pointerEvents="box-none"
-        style={{
-          position: 'absolute',
-          left: theme.spacing.xl,
-          right: theme.spacing.xl,
-          bottom: theme.spacing.xxxl,
-          gap: theme.spacing.md,
-          alignItems: 'center',
-        }}
-      >
-        {invalid ? <Callout tone="negative">{t.misc.scanInvalid}</Callout> : null}
-        <Text variant="body" style={{ color: '#FFFFFF' }} align="center">
-          {t.misc.scanHint}
-        </Text>
+          {/* The one instruction, above the hole so it is never covering the
+              thing being aimed at. */}
+          <Text
+            variant="body"
+            align="center"
+            style={{ color: palette.white, paddingBottom: theme.spacing.xl }}
+          >
+            {t.misc.scanHint}
+          </Text>
+        </View>
+
+        <View style={{ flexDirection: 'row', height: hole }} pointerEvents="none">
+          <View style={{ flex: 1, backgroundColor: DIM }} />
+          <View style={{ width: hole, height: hole }}>
+            <Corner vertical="top" horizontal="left" color={brackets} />
+            <Corner vertical="top" horizontal="right" color={brackets} />
+            <Corner vertical="bottom" horizontal="left" color={brackets} />
+            <Corner vertical="bottom" horizontal="right" color={brackets} />
+          </View>
+          <View style={{ flex: 1, backgroundColor: DIM }} />
+        </View>
+
+        <View
+          pointerEvents="box-none"
+          style={{
+            flex: 1.35,
+            backgroundColor: DIM,
+            paddingHorizontal: theme.spacing.xl,
+            paddingBottom: insets.bottom + theme.spacing.xl,
+            justifyContent: 'space-between',
+          }}
+        >
+          {/* Reserved height whether or not there is anything to say, so the
+              paste button underneath does not move when a message arrives. */}
+          <View
+            accessibilityLiveRegion="polite"
+            style={{
+              minHeight: 84,
+              paddingTop: theme.spacing.xl,
+              alignItems: 'center',
+              justifyContent: 'flex-start',
+            }}
+          >
+            {reading === 'found' ? (
+              <Row
+                style={{
+                  backgroundColor: theme.color.brand,
+                  borderRadius: theme.radius.pill,
+                  paddingVertical: theme.spacing.sm,
+                  paddingHorizontal: theme.spacing.lg,
+                  gap: theme.spacing.sm,
+                }}
+              >
+                <Ionicons name="checkmark-circle" size={iconSize.lg} color={palette.white} />
+                <Text variant="subheading" style={{ color: palette.white }}>
+                  {t.misc.scanFound}
+                </Text>
+              </Row>
+            ) : reading === 'invalid' ? (
+              <Callout tone="negative">{t.misc.scanInvalid}</Callout>
+            ) : null}
+          </View>
+
+          {/* The way in for somebody who cannot scan — most often because the
+              link arrived in a chat on this very phone, and there is no second
+              screen to point the camera at. */}
+          <View style={{ alignItems: 'center' }}>
+            <Button
+              label={t.misc.scanPasteLink}
+              variant="onBrandOutline"
+              icon={<Ionicons name="link" size={iconSize.base} color={palette.white} />}
+              onPress={onPasteLink}
+            />
+          </View>
+        </View>
       </View>
     </View>
   );

--- a/apps/mobile/src/components/ScannerCamera.tsx
+++ b/apps/mobile/src/components/ScannerCamera.tsx
@@ -219,6 +219,7 @@ export default function ScannerCamera({
   onToken,
   onClose,
   onPasteLink,
+  paused = false,
 }: {
   onToken: (token: string) => void;
   onClose: () => void;
@@ -226,6 +227,16 @@ export default function ScannerCamera({
    *  the ones with no working camera — a person whose camera is refused is
    *  otherwise stranded on a screen that can do nothing for them. */
   onPasteLink: () => void;
+  /**
+   * True while something is covering the camera — today, the paste sheet.
+   *
+   * The sheet is a `Modal`, so the viewfinder underneath stays mounted and goes
+   * on reading every frame. Without this a phone lying on a table facing a code
+   * reads it while somebody is typing into the sheet, and the screen navigates
+   * away mid-sentence, throwing away what they had typed to join whichever
+   * group happened to be in shot.
+   */
+  paused?: boolean;
 }) {
   const theme = useTheme();
   const insets = useSafeAreaInsets();
@@ -257,7 +268,7 @@ export default function ScannerCamera({
   );
 
   const onScan = (data: string): void => {
-    if (handled.current) return;
+    if (paused || handled.current) return;
     const token = tokenFromScan(data);
     if (!token) {
       if (timer.current) clearTimeout(timer.current);

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1888,6 +1888,21 @@ export interface UiStrings {
     scanDenied: string;
     scanInvalid: string;
     scanRebuild: string;
+    scanAllowTitle: string;
+    scanDeniedTitle: string;
+    scanCameraFailedTitle: string;
+    scanCameraFailed: string;
+    scanFound: string;
+    scanViewfinder: string;
+    scanTorchOn: string;
+    scanTorchOff: string;
+    scanPasteLink: string;
+    scanPasteTitle: string;
+    scanPasteBody: string;
+    scanPastePlaceholder: string;
+    scanPasteAction: string;
+    scanPasteInvalid: string;
+    scanAnother: string;
     personName: string;
     createGroup: string;
     linkExpired: string;
@@ -4121,6 +4136,23 @@ const en: UiStrings = {
     scanDenied: 'Camera access is off. Turn it on in Settings to scan.',
     scanInvalid: 'That is not a Waves invite code.',
     scanRebuild: 'Update the app to scan invite codes.',
+    scanAllowTitle: 'Turn on the camera',
+    scanDeniedTitle: 'The camera is switched off',
+    scanCameraFailedTitle: 'The camera would not start',
+    scanCameraFailed:
+      'Another app may be using it. Close this and try again, or paste the invite link instead.',
+    scanFound: 'Invite code found',
+    scanViewfinder: 'Camera viewfinder. Point it at an invite QR code — it reads by itself.',
+    scanTorchOn: 'Turn the light on',
+    scanTorchOff: 'Turn the light off',
+    scanPasteLink: 'Paste a link instead',
+    scanPasteTitle: 'Paste an invite link',
+    scanPasteBody: 'If the link came through a chat on this phone, paste it here.',
+    scanPastePlaceholder: 'Paste the invite link',
+    scanPasteAction: 'Open invite',
+    scanPasteInvalid:
+      'That is not a Waves invite link. Paste the whole link, including the code at the end.',
+    scanAnother: 'Scan another code',
     personName: "Person's name",
     createGroup: 'Create group',
     linkExpired: 'This link has expired',
@@ -6445,6 +6477,24 @@ const ta: UiStrings = {
     scanDenied: 'கேமரா அணுகல் அணைக்கப்பட்டுள்ளது. ஸ்கேன் செய்ய அமைப்புகளில் இயக்கவும்.',
     scanInvalid: 'இது Waves அழைப்புக் குறியீடு அல்ல.',
     scanRebuild: 'அழைப்புக் குறியீடுகளை ஸ்கேன் செய்ய ஆப்பைப் புதுப்பிக்கவும்.',
+    scanAllowTitle: 'கேமராவை இயக்கவும்',
+    scanDeniedTitle: 'கேமரா அணைக்கப்பட்டுள்ளது',
+    scanCameraFailedTitle: 'கேமரா தொடங்கவில்லை',
+    scanCameraFailed:
+      'வேறு ஒரு ஆப் அதைப் பயன்படுத்தலாம். இதை மூடி மீண்டும் முயற்சிக்கவும், அல்லது அழைப்பு இணைப்பை ஒட்டவும்.',
+    scanFound: 'அழைப்புக் குறியீடு கிடைத்தது',
+    scanViewfinder:
+      'கேமரா காட்சி. அழைப்பு QR குறியீட்டை நோக்கிக் காட்டவும் — அது தானாகவே படிக்கும்.',
+    scanTorchOn: 'விளக்கை இயக்கு',
+    scanTorchOff: 'விளக்கை அணை',
+    scanPasteLink: 'இணைப்பை ஒட்டவும்',
+    scanPasteTitle: 'அழைப்பு இணைப்பை ஒட்டவும்',
+    scanPasteBody: 'இந்த ஃபோனில் ஒரு அரட்டையில் இணைப்பு வந்திருந்தால், அதை இங்கே ஒட்டவும்.',
+    scanPastePlaceholder: 'அழைப்பு இணைப்பை ஒட்டவும்',
+    scanPasteAction: 'அழைப்பைத் திற',
+    scanPasteInvalid:
+      'இது Waves அழைப்பு இணைப்பு அல்ல. இறுதியில் உள்ள குறியீடு உட்பட முழு இணைப்பையும் ஒட்டவும்.',
+    scanAnother: 'வேறு ஒரு குறியீட்டை ஸ்கேன் செய்',
     personName: 'நபரின் பெயர்',
     createGroup: 'குழுவை உருவாக்கு',
     linkExpired: 'இந்த இணைப்பு காலாவதியாகிவிட்டது',
@@ -8758,6 +8808,22 @@ const hi: UiStrings = {
     scanDenied: 'कैमरा एक्सेस बंद है। स्कैन करने के लिए सेटिंग्स में चालू करें।',
     scanInvalid: 'यह Waves इनवाइट कोड नहीं है।',
     scanRebuild: 'इनवाइट कोड स्कैन करने के लिए ऐप अपडेट करें।',
+    scanAllowTitle: 'कैमरा चालू करें',
+    scanDeniedTitle: 'कैमरा बंद है',
+    scanCameraFailedTitle: 'कैमरा शुरू नहीं हो सका',
+    scanCameraFailed:
+      'हो सकता है कोई दूसरा ऐप उसे इस्तेमाल कर रहा हो। इसे बंद करके फिर कोशिश करें, या इनवाइट लिंक पेस्ट करें।',
+    scanFound: 'इनवाइट कोड मिल गया',
+    scanViewfinder: 'कैमरा व्यूफ़ाइंडर। इनवाइट QR कोड की ओर करें — यह अपने आप पढ़ लेता है।',
+    scanTorchOn: 'लाइट चालू करें',
+    scanTorchOff: 'लाइट बंद करें',
+    scanPasteLink: 'लिंक पेस्ट करें',
+    scanPasteTitle: 'इनवाइट लिंक पेस्ट करें',
+    scanPasteBody: 'अगर लिंक इसी फ़ोन की किसी चैट में आया है, तो उसे यहाँ पेस्ट करें।',
+    scanPastePlaceholder: 'इनवाइट लिंक पेस्ट करें',
+    scanPasteAction: 'इनवाइट खोलें',
+    scanPasteInvalid: 'यह Waves इनवाइट लिंक नहीं है। आख़िर के कोड सहित पूरा लिंक पेस्ट करें।',
+    scanAnother: 'दूसरा कोड स्कैन करें',
     personName: 'व्यक्ति का नाम',
     createGroup: 'समूह बनाएँ',
     linkExpired: 'यह लिंक खत्म हो चुका है',
@@ -11146,6 +11212,21 @@ const ar: UiStrings = {
     scanDenied: 'الوصول إلى الكاميرا متوقف. فعّله من الإعدادات للمسح.',
     scanInvalid: 'هذا ليس رمز دعوة Waves.',
     scanRebuild: 'حدّث التطبيق لمسح رموز الدعوة.',
+    scanAllowTitle: 'شغّل الكاميرا',
+    scanDeniedTitle: 'الكاميرا متوقفة',
+    scanCameraFailedTitle: 'تعذّر تشغيل الكاميرا',
+    scanCameraFailed: 'قد يستخدمها تطبيق آخر. أغلق هذه الشاشة وحاول مرة أخرى، أو ألصق رابط الدعوة.',
+    scanFound: 'تم العثور على رمز الدعوة',
+    scanViewfinder: 'عدسة الكاميرا. وجّهها إلى رمز QR الخاص بالدعوة — يُقرأ تلقائيًا.',
+    scanTorchOn: 'شغّل الضوء',
+    scanTorchOff: 'أطفئ الضوء',
+    scanPasteLink: 'ألصق رابطًا بدلاً من ذلك',
+    scanPasteTitle: 'ألصق رابط الدعوة',
+    scanPasteBody: 'إذا وصلك الرابط في محادثة على هذا الهاتف، فألصقه هنا.',
+    scanPastePlaceholder: 'ألصق رابط الدعوة',
+    scanPasteAction: 'افتح الدعوة',
+    scanPasteInvalid: 'هذا ليس رابط دعوة Waves. ألصق الرابط كاملاً بما فيه الرمز في آخره.',
+    scanAnother: 'امسح رمزًا آخر',
     personName: 'اسم الشخص',
     createGroup: 'إنشاء مجموعة',
     linkExpired: 'انتهت صلاحية هذا الرابط',

--- a/apps/mobile/src/lib/qrScan.ts
+++ b/apps/mobile/src/lib/qrScan.ts
@@ -26,19 +26,27 @@ const INVITE_SCHEMES = new Set(['waves']);
 
 /**
  * The three shapes a Waves join link has ever had, in the order a token is
- * looked for when more than one could apply.
+ * looked for.
  *
  *  - `#<token>` — what `groupJoinLink` writes today, and the only shape the
  *    invite screen paints as a QR. The token lives in the fragment on purpose:
  *    a fragment is never sent to a server, so it stays out of access logs,
  *    proxies and `Referer` headers on the way to the web join page.
- *  - `?token=<token>` — the older query form. Still handled because a link
- *    pasted out of an old chat thread is exactly the case this screen is for.
  *  - `/join/<token>` — the older path form, which the web app still serves
  *    (`apps/web/src/app/join/[token]`).
+ *  - `?token=<token>` — the older query form. Still handled because a link
+ *    pasted out of an old chat thread is exactly the case this screen is for.
  *
- * Query before path before fragment, so `…/join?token=abc#token=evil` reads the
- * token the server would have honoured rather than the one appended after it.
+ * Fragment first, because that is the shape the app emits and the only shape
+ * the web actually honours: `apps/web/src/app/join/page.tsx` reads
+ * `window.location.hash` and never looks at the query at all. Reading the query
+ * first would make one link mean two different groups — `…/join?token=A#B`
+ * would join B in a browser and A on the phone — which is precisely the gap
+ * somebody splicing a `?token=` into a link they forwarded would be reaching
+ * for.
+ *
+ * And when two shapes are both present and disagree, no token is returned at
+ * all. See `tokenFromScan`.
  */
 
 /** The part of an https invite path that follows `/join`: `''` for the join
@@ -129,5 +137,19 @@ export function tokenFromScan(data: string): string | null {
   // Read the query off the raw search string rather than `searchParams`, whose
   // support is patchy in the React Native URL polyfill.
   const queried = parsed.search.match(/[?&]token=([^&]+)/)?.[1];
-  return cleanToken(queried ?? (remainder || null) ?? (fragment || null));
+
+  // Fragment, then path, then query — and a shape that cleans away to nothing
+  // (`?token=%20%20`) counts as absent rather than as an empty answer, so a
+  // chat client that rewrites a link cannot blank out a token that is really
+  // there in the fragment.
+  const candidates = [cleanToken(fragment), cleanToken(remainder), cleanToken(queried)].filter(
+    (token): token is string => token !== null,
+  );
+  if (candidates.length === 0) return null;
+  // Two shapes naming two different tokens is not a link this app has ever
+  // written, and picking a winner is what makes it dangerous: whichever one
+  // loses is the one the person can see and believes they are accepting. Refuse
+  // instead. It costs a genuine link nothing — a genuine link carries one.
+  if (candidates.some((token) => token !== candidates[0])) return null;
+  return candidates[0];
 }

--- a/apps/mobile/src/lib/qrScan.ts
+++ b/apps/mobile/src/lib/qrScan.ts
@@ -21,27 +21,97 @@ export function cameraAvailable(): boolean {
   return requireOptionalNativeModule('ExpoCamera') != null;
 }
 
+/** The app's own deep-link schemes, the non-https half of the allowlist. */
+const INVITE_SCHEMES = new Set(['waves']);
+
 /**
- * The invite token out of whatever the camera read.
+ * The three shapes a Waves join link has ever had, in the order a token is
+ * looked for when more than one could apply.
  *
- * A Waves invite QR encodes the join URL (`${INVITE_HOST}/join?token=…`, or the
- * `waves://join?token=…` deep link). We only trust a value that carries a
- * `token` query on a join URL; a random QR from a poster is not an invite, and
- * returns null so the screen can say so rather than routing nowhere.
+ *  - `#<token>` — what `groupJoinLink` writes today, and the only shape the
+ *    invite screen paints as a QR. The token lives in the fragment on purpose:
+ *    a fragment is never sent to a server, so it stays out of access logs,
+ *    proxies and `Referer` headers on the way to the web join page.
+ *  - `?token=<token>` — the older query form. Still handled because a link
+ *    pasted out of an old chat thread is exactly the case this screen is for.
+ *  - `/join/<token>` — the older path form, which the web app still serves
+ *    (`apps/web/src/app/join/[token]`).
+ *
+ * Query before path before fragment, so `…/join?token=abc#token=evil` reads the
+ * token the server would have honoured rather than the one appended after it.
+ */
+
+/** The part of an https invite path that follows `/join`: `''` for the join
+ *  root itself, the trailing segment for the path form, null for anything that
+ *  is not a join URL at all. The match on `/join` is exact so
+ *  `https://…/x/join` is not mistaken for one. */
+function afterJoin(path: string): string | null {
+  if (path === '/join') return '';
+  if (path.startsWith('/join/')) return path.slice('/join/'.length);
+  return null;
+}
+
+/**
+ * Whether this URL is one of ours, and what its path carries past `/join`.
  *
  * `INVITE_HOST` comes from `@/lib/webUrl` — the same constant `groupJoinLink`
  * builds outgoing links from, so this allowlist can never point somewhere
  * different than the app's own invites do.
  */
-const INVITE_SCHEMES = new Set(['waves']);
+function joinRemainder(parsed: URL): string | null {
+  const scheme = parsed.protocol.replace(/:$/, '').toLowerCase();
+  const host = parsed.hostname.toLowerCase();
+  const path = parsed.pathname.replace(/\/+$/, '') || '/';
 
+  if (scheme === 'https') {
+    if (host !== INVITE_HOST) return null;
+    return afterJoin(path);
+  }
+  if (!INVITE_SCHEMES.has(scheme)) return null;
+  // `waves://join/…` parses with `join` as the host and the token alone in the
+  // path; `waves:///join/…` parses with an empty host and `join` as the first
+  // path segment. Do not accept an arbitrary host just because its path is
+  // `/join` — `waves://evil.example/join` is not our link.
+  if (host === 'join') return path === '/' ? '' : path.slice(1);
+  if (host === '') return afterJoin(path);
+  return null;
+}
+
+/** A candidate token as the person can actually use it: decoded when that is
+ *  possible, trimmed, and null rather than empty. Malformed percent-encoding
+ *  keeps the raw value — the server is the judge of whether a token exists, and
+ *  a decode that throws is not proof that it does not. */
+function cleanToken(raw: string | null | undefined): string | null {
+  const trimmed = raw?.trim();
+  if (!trimmed) return null;
+  try {
+    const decoded = decodeURIComponent(trimmed).trim();
+    return decoded.length > 0 ? decoded : null;
+  } catch {
+    return trimmed;
+  }
+}
+
+/**
+ * The invite token out of whatever the camera read — or out of a link somebody
+ * pasted, which is the same problem.
+ *
+ * Only a join URL on the app's own host (or one of its deep-link schemes) is
+ * trusted; a random QR from a poster is not an invite, and returns null so the
+ * screen can say so rather than routing nowhere.
+ */
 export function tokenFromScan(data: string): string | null {
   const text = data.trim();
   if (!text) return null;
 
-  // A token must not carry a fragment; drop anything after '#' before reading
-  // the query so `token=abc#frag` cannot smuggle the fragment into the token.
-  const withoutFragment = text.split('#')[0];
+  // The fragment is read off the raw string rather than from `URL.hash`,
+  // because the fragment is where today's links keep the token and the
+  // polyfilled `URL` in React Native is only trusted here for the origin and
+  // the path. Splitting first also means a fragment can never be read as part
+  // of the query below.
+  const hashAt = text.indexOf('#');
+  const fragment = hashAt === -1 ? '' : text.slice(hashAt + 1);
+  const withoutFragment = hashAt === -1 ? text : text.slice(0, hashAt);
 
   let parsed: URL;
   try {
@@ -50,33 +120,14 @@ export function tokenFromScan(data: string): string | null {
     return null;
   }
 
-  // Only our own invite surfaces: the https link on the invite host, or the
-  // app's own deep-link schemes. The path must be exactly /join, not merely
-  // contain it, so `https://evil.example/x/join` is rejected.
-  const scheme = parsed.protocol.replace(/:$/, '').toLowerCase();
-  const path = parsed.pathname.replace(/\/+$/, '') || '/';
-  if (scheme === 'https') {
-    if (parsed.hostname.toLowerCase() !== INVITE_HOST || path !== '/join') return null;
-  } else if (INVITE_SCHEMES.has(scheme)) {
-    // `waves://join?token=…` parses with `join` as the host and an empty path;
-    // `waves:///join?token=…` parses with an empty host and `/join` as the path.
-    // Do not accept arbitrary hosts just because their path is `/join`.
-    const host = parsed.hostname.toLowerCase();
-    if (!((host === 'join' && path === '/') || (host === '' && path === '/join'))) return null;
-  } else {
-    return null;
-  }
+  const remainder = joinRemainder(parsed);
+  if (remainder === null) return null;
+  // A token is one path segment. `/join/a/b` is some other page of ours, not an
+  // invite carrying a token with a slash in it.
+  if (remainder.includes('/')) return null;
 
-  // Read the token off the raw query rather than `searchParams`, whose support
-  // is patchy in the React Native URL polyfill. The fragment is already gone, so
-  // the capture cannot run past the query.
-  const match = parsed.search.match(/[?&]token=([^&]+)/);
-  const rawToken = match?.[1]?.trim();
-  if (!rawToken) return null;
-  try {
-    const token = decodeURIComponent(rawToken).trim();
-    return token.length > 0 ? token : null;
-  } catch {
-    return rawToken;
-  }
+  // Read the query off the raw search string rather than `searchParams`, whose
+  // support is patchy in the React Native URL polyfill.
+  const queried = parsed.search.match(/[?&]token=([^&]+)/)?.[1];
+  return cleanToken(queried ?? (remainder || null) ?? (fragment || null));
 }

--- a/apps/mobile/test/qrScan.test.ts
+++ b/apps/mobile/test/qrScan.test.ts
@@ -92,10 +92,45 @@ describe('tokenFromScan', () => {
     }
   });
 
-  it('prefers the token a server would have honoured over one appended after it', () => {
-    expect(tokenFromScan('https://app.wavs.co.in/join?token=abc#token=evil')).toBe('abc');
-    expect(tokenFromScan('https://app.wavs.co.in/join?other=1&token=abc#frag')).toBe('abc');
-    expect(tokenFromScan('https://app.wavs.co.in/join/path-token#frag')).toBe('path-token');
+  it('refuses a link whose shapes name different tokens instead of picking a winner', () => {
+    // This test used to assert the opposite, and the reason it did has since
+    // inverted — so if you are here to "fix" it back, read this first.
+    //
+    // When `?token=` was the shape the app wrote, a `#…` bolted on afterwards
+    // was the suspicious half, and preferring the query was preferring the real
+    // token. The app now writes `…/join#<token>` and nothing else, and
+    // `apps/web/src/app/join/page.tsx` reads `window.location.hash` and never
+    // looks at the query at all. So the query is now the half that can only
+    // have been added by somebody, and query-first would have meant one link
+    // joining two different groups depending on whether it was opened in a
+    // browser or on the phone.
+    //
+    // Preferring the fragment fixes the disagreement with the web. Refusing
+    // outright fixes something the ordering alone cannot: whichever shape loses
+    // is the one the person can see in the link they were sent, so any winner
+    // is a token they did not choose. A genuine link carries exactly one shape,
+    // so there is nothing real to lose by refusing.
+    expect(tokenFromScan('https://app.wavs.co.in/join?token=EVIL#GENUINE')).toBeNull();
+    expect(tokenFromScan('https://app.wavs.co.in/join?token=abc#token=evil')).toBeNull();
+    expect(tokenFromScan('https://app.wavs.co.in/join?other=1&token=abc#frag')).toBeNull();
+    expect(tokenFromScan('https://app.wavs.co.in/join/path-token#frag')).toBeNull();
+    expect(tokenFromScan('https://app.wavs.co.in/join/path-token?token=query-token')).toBeNull();
+  });
+
+  it('accepts two shapes that agree, because nothing is in dispute', () => {
+    expect(tokenFromScan('https://app.wavs.co.in/join/same?token=same')).toBe('same');
+    expect(tokenFromScan('https://app.wavs.co.in/join?token=same#same')).toBe('same');
+    // Percent-encoding is a spelling, not a different token: both sides are
+    // compared after decoding.
+    expect(tokenFromScan('https://app.wavs.co.in/join?token=a%20b#a b')).toBe('a b');
+  });
+
+  it('treats a shape that cleans away to nothing as absent, not as an empty answer', () => {
+    // A chat client that rewrites a forwarded link into `?token=` with nothing
+    // in it must not blank out the token that is really there in the fragment.
+    expect(tokenFromScan('https://app.wavs.co.in/join?token=%20%20#realtoken')).toBe('realtoken');
+    expect(tokenFromScan('https://app.wavs.co.in/join?token=#realtoken')).toBe('realtoken');
+    expect(tokenFromScan('https://app.wavs.co.in/join?token=abc#')).toBe('abc');
   });
 
   it('keeps malformed percent-encoding as the trimmed raw non-empty token', () => {

--- a/apps/mobile/test/qrScan.test.ts
+++ b/apps/mobile/test/qrScan.test.ts
@@ -45,6 +45,37 @@ describe('tokenFromScan', () => {
     expect(tokenFromScan('waves:///join?token=triple-slash')).toBe('triple-slash');
   });
 
+  it('reads the fragment form the invite QR actually paints', () => {
+    // `groupJoinLink` writes `…/join#<token>`: the token stays in the fragment
+    // so it never reaches a server, a proxy or a Referer header. This is the
+    // shape every QR in the app encodes, so it is the one that matters most.
+    expect(tokenFromScan('https://app.wavs.co.in/join#frag-token')).toBe('frag-token');
+    expect(tokenFromScan(' https://APP.WAVS.CO.IN/join/#a%20b ')).toBe('a b');
+    expect(tokenFromScan('waves://join#deep-frag')).toBe('deep-frag');
+    expect(tokenFromScan('waves:///join#triple-frag')).toBe('triple-frag');
+  });
+
+  it('reads the older path form the web app still serves', () => {
+    expect(tokenFromScan('https://app.wavs.co.in/join/path-token')).toBe('path-token');
+    expect(tokenFromScan('https://app.wavs.co.in/join/path-token/')).toBe('path-token');
+    expect(tokenFromScan('waves://join/deep-path')).toBe('deep-path');
+    expect(tokenFromScan('waves:///join/triple-path')).toBe('triple-path');
+  });
+
+  it('rejects join URLs that carry no token in any of the three places', () => {
+    for (const data of [
+      'https://app.wavs.co.in/join',
+      'https://app.wavs.co.in/join/',
+      'https://app.wavs.co.in/join#',
+      'https://app.wavs.co.in/join#%20',
+      // A token is one path segment; a deeper path is some other page of ours.
+      'https://app.wavs.co.in/join/a/b',
+      'waves://join',
+    ]) {
+      expect(tokenFromScan(data)).toBeNull();
+    }
+  });
+
   it('rejects unrelated hosts, paths, schemes and blank token values', () => {
     for (const data of [
       '',
@@ -61,9 +92,10 @@ describe('tokenFromScan', () => {
     }
   });
 
-  it('does not let fragments leak into the invite token', () => {
+  it('prefers the token a server would have honoured over one appended after it', () => {
     expect(tokenFromScan('https://app.wavs.co.in/join?token=abc#token=evil')).toBe('abc');
     expect(tokenFromScan('https://app.wavs.co.in/join?other=1&token=abc#frag')).toBe('abc');
+    expect(tokenFromScan('https://app.wavs.co.in/join/path-token#frag')).toBe('path-token');
   });
 
   it('keeps malformed percent-encoding as the trimmed raw non-empty token', () => {


### PR DESCRIPTION
The scan-to-join screen — the camera you point at somebody else's group QR — was a small preview in a page. App chrome at the top, a thin white square floated over the feed, one line at the bottom, and nothing but a spinner or a grey sentence when anything went wrong. This makes it the screen the job actually calls for.

## What changed, and where it came from

I looked at how apps that have solved this do it: [WhatsApp](https://mobbin.com/screens/a6a15547-94da-4b3a-88f1-4103747854d3), [LINE](https://mobbin.com/screens/a969a8cc-f627-42b8-8688-70cdcbf4917b), [Telegram](https://mobbin.com/screens/0444d454-4fcc-49cc-b07d-296a6af86b77), [BeReal](https://mobbin.com/screens/d3bf4c32-c7b1-495e-a18e-7415ce22df8f), [Splitwise](https://mobbin.com/screens/b6ea2eea-7373-4701-8830-eee63202a696), [Uber](https://mobbin.com/screens/c9df75d3-ad98-407a-b196-516df6283491), [TikTok](https://mobbin.com/screens/5362435a-4095-4c63-8917-870af1201d76), [Grab](https://mobbin.com/screens/02899d7d-a7e8-4e2d-b719-ef914a26cf81), [Lex](https://mobbin.com/screens/d3cc7183-6e09-4d85-8edd-2702b2a07541), [Satispay](https://mobbin.com/screens/14e9fa98-6915-4aa1-a147-021a8760b9ce). They agree on almost everything: the camera is the screen, the surround is dimmed, the target is marked with corner brackets rather than a closed border, the controls float on the dim as round chips, the torch is a peer of the close button, and there is always a second road in for somebody who cannot scan — "Enter ID instead" (Uber), "Enter the code manually" (Satispay), "Import image" (N26).

The new screen, top to bottom:

- The camera fills it, edge to edge.
- Three bands of dim over the feed: a top band, a row of dim / hole / dim, a taller bottom band. The taller bottom band is what lifts the viewfinder above the middle of the screen, where a phone held out at a code naturally points.
- Floating over the top band: a close chip, the title, and a torch chip. The torch inverts to a white fill while it is on and its label changes with it, so the state is never carried by colour alone.
- One instruction, sitting above the hole so it never covers what is being aimed at.
- Four corner brackets on the hole, white while looking, brand-coloured the moment a Waves code is read.
- Below the hole, a status area with reserved height — so the button under it does not jump when a message arrives — carrying either the "invite code found" pill or the "that is not a Waves code" callout.
- At the foot, "Paste a link instead".

## The scanner has never worked, not once

Not "the redesign uncovered a bug". The scan-to-join feature has been incapable of reading a Waves invite QR since the day it shipped, and it is in production now.

`519e629` (#351, 2026-08-22) is the commit that added the scanner. That same commit's invite screen, at line 62, already wrote the link as `` `${INVITE_BASE}#${invite.token}` `` — the token in the fragment. The parser that shipped alongside it stripped everything after `#` and then required a `?token=` query. There was never a version of this app in which the two agreed. Every person who opened the camera, pointed it at a group's invite code and waited was told **"That is not a Waves invite code."**

`groupJoinLink` (`webUrl.ts:48`) still writes `…/join#<token>`, and the fragment is deliberate: it never reaches a server, a proxy or a `Referer` header. That part is right. The scanner was reading somewhere else.

Parsing now handles all three shapes the link has ever had — the fragment, the `/join/<token>` path the web app still serves at `apps/web/src/app/join/[token]`, and the older `?token=` query — for `https` on the invite host and for the `waves://` deep-link scheme in both its `waves://join…` and `waves:///join…` spellings. The host allowlist, the exact `/join` path match, and the decode-or-keep-raw behaviour are unchanged.

### Precedence: fragment, then path, then query — and a refusal when they disagree

The first version of this fix read the query first, and justified it in a comment as taking "the token the server would have honoured". That was wrong, and it was the one claim in the change that could not be checked from the file it was written in. `apps/web/src/app/join/page.tsx` reads `window.location.hash` and never looks at the query at all. Query-first meant the app preferred the shape the web ignores, so one link named two different groups depending on where it was opened:

```
https://app.wavs.co.in/join?token=A#B     →  browser joins B
                                          →  phone   joins A
```

Fragment-first closes that. But ordering alone cannot close the rest of it: whichever shape loses an ordering is the one the person can see in the link they were sent, so any winner at all is a token they did not choose. So when two shapes are present and name **different** tokens, no token is returned. A genuine link carries exactly one shape, so refusing costs nothing real, and a `?token=` spliced into a forwarded link stops being a way to make the phone disagree with the browser — or with the person reading it.

A shape that cleans away to nothing now counts as absent rather than as an empty answer: `…/join?token=%20%20#realtoken` used to return null, the blank query short-circuiting the fallback and blanking out a token that was really there. A chat client that rewrites a forwarded link should not be able to make a live invite unscannable.

The test whose reasoning has inverted is updated rather than deleted, and carries the whole story in its name and body — when `?token=` was canonical, preferring the query *was* preferring the real token; that is no longer the world we are in, and the next person to read it would otherwise "fix" it back.
## Every failure state, and what it now shows

| State | Before | Now |
| --- | --- | --- |
| Permission not asked yet | Grey sentence and a button | Dark primer: camera glyph, "Turn on the camera", why, **Allow camera**, plus paste |
| Permission refused for good | Same button, which does nothing useful | "The camera is switched off" with **Open settings**, plus paste |
| Camera will not start / no camera on the device | Nothing — a black rectangle | `onMountError` → "The camera would not start", the reason, plus paste |
| No `expo-camera` in the binary | Empty state, dead end | Same empty state, now with **Paste a link instead** |
| A QR that is not a Waves invite | A callout that appeared once and never went away | Callout that clears itself once the code leaves the frame, so the next try starts clean |
| A Waves link that has expired or was reset | Bounced to the join screen's dead end ("Go to Waves") | Scan sends `from=scan`, so that screen offers **Scan another code** with "Go to Waves" demoted to a ghost |
| Cannot scan at all | No way through | "Paste a link instead" on every state, camera or no camera |

The paste sheet offers the clipboard, but only when the clipboard is holding one of our links — anything else is dropped without ever being displayed, so the sheet cannot surface a password or half an email.

## Four more the review caught on the screen itself

**The camera went on reading frames behind the paste sheet.** The sheet is a `Modal`, so the viewfinder underneath stays mounted and keeps scanning. A phone lying on a table facing a code would read it while somebody was typing into the sheet — navigating away mid-sentence, throwing away what they had typed, to join whatever happened to be in shot. The leaf takes a `paused` prop and ignores reads while it is set.

**Both roads into the join screen could fire twice.** The camera already guarded its own reads with a ref; the paste button was `disabled` only on empty text, so a double tap navigated twice. The guard now sits where the two roads meet, rather than on one of them.

**The clipboard read had no rejection handler.** Some Android builds refuse one outright, and `void promise.then(…)` with no `.catch` turns that into an unhandled rejection. Offering to fill the field is a courtesy, so failing at it is silent now. A late-resolving read also no longer overwrites text somebody has already typed ahead of it.

**The paste field kept its contents between openings.** Reopening onto rejected text, with the error that explained it already gone, reads as the field having broken rather than as a link that did not work.

## Feedback, accessibility, RTL

A good read is visible before the navigation: brackets turn brand, a pill says the code was found, and the hand-off waits 420ms so it is actually seen. Both the good read and the refusal are announced with `announceForAccessibility` (the refusal once per code, not once per frame), the status region is a polite live region, and the camera itself is named for a screen reader rather than being an unlabelled rectangle. The torch exposes `accessibilityState.selected`.

For Arabic: the geometry is symmetric bands and a symmetric hole with all four corners drawn, so there is nothing to mirror. The header is a `Row`, which React Native reverses on its own — close and torch swap sides, the title stays centred. No `left`/`right` is used to place anything that is not symmetric, and every string on the screen is in en / ta / hi / ar (fifteen new keys).

## Dependencies

None added. The torch is `enableTorch` on the `CameraView` already here; the sheet is `@waves/ui`'s `Sheet`; the clipboard read is `expo-clipboard`, already a dependency. This stays an over-the-air change.

I deliberately left out the "scan a QR out of a photo in your gallery" path several of the reference apps have. `CameraView.scanFromURLAsync` and `expo-image-picker` are both already here so it is cheap to add later, but the paste-a-link route covers the case that actually happens — the link arriving in a chat on the same phone.

## Checks

`pnpm format`, `expo lint` (clean; the three remaining warnings are pre-existing in `phone.tsx`), `tsc --noEmit`, and the full mobile suite from `apps/mobile` — 873 tests across 69 files, all passing, `watchSendFailure` included.

Not visually verified and not device-tested: this needs a build to see, and I could not run one.

