### PR TITLE
feat(group): drawn group marks, a real identity row, and exit actions that differ

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -42,6 +42,7 @@ import { useGuestGuard } from '@/lib/guestGuard';
 import { usePromptSlot } from '@/lib/promptQueue';
 import { useDashboardTips } from '@/lib/tips';
 import { TourTarget, useTour } from '@/lib/tour';
+import { GroupMark } from '@/components/GroupMark';
 import { SyncStatusIcon } from '@/components/SyncBanner';
 import { ImportProgressBanner } from '@/components/ImportProgressBanner';
 import { SkeletonList } from '@/components/Skeletons';
@@ -1670,7 +1671,7 @@ function GroupRow({
             justifyContent: 'center',
           }}
         >
-          <Text style={{ fontSize: 20 }}>{coverEmoji ?? '👥'}</Text>
+          <GroupMark emoji={coverEmoji} size={22} />
         </View>
         <View style={{ flex: 1, gap: 2 }}>
           <Row style={{ alignItems: 'center', gap: theme.spacing.xs }}>

--- a/apps/mobile/src/app/capture.tsx
+++ b/apps/mobile/src/app/capture.tsx
@@ -32,6 +32,7 @@ import {
   useTheme,
 } from '@waves/ui';
 
+import { GroupMark } from '@/components/GroupMark';
 import { CategoryPicker } from '@/components/Category';
 import { TagEditorSheet } from '@/components/TagEditorSheet';
 import { PaymentMethodPicker } from '@/components/PaymentMethodPicker';
@@ -882,7 +883,7 @@ function GroupPicker({
   const renderGroup = (group: GroupRow): React.JSX.Element => (
     <ChoiceRow
       key={group.id}
-      leading={<Text variant="subheading">{group.cover_emoji ?? '👥'}</Text>}
+      leading={<GroupMark emoji={group.cover_emoji} size={22} />}
       label={groupLabel(group, membersFor(group.id), profileId)}
       selected={selectedId === group.id}
       onPress={() => onPick(group.id)}

--- a/apps/mobile/src/app/group/[id]/settings.tsx
+++ b/apps/mobile/src/app/group/[id]/settings.tsx
@@ -36,10 +36,10 @@ import { pickGroupPhoto } from '@/lib/image';
 import { requestContacts } from '@/lib/contactPickerBridge';
 import { isPhoneCountryError } from '@/lib/phone';
 import { CountryRow } from '@/components/CountryPicker';
-import { CoverEmojiPicker } from '@/components/CoverEmojiPicker';
+import { GroupCoverSheet } from '@/components/CoverEmojiPicker';
 import { InfoDisclosure } from '@/components/InfoDisclosure';
 import { TripDates } from '@/components/TripDates';
-import { photoGateParam, photoGateStatus, photoTapAction } from '@/lib/groupPhotoGate';
+import { photoGateParam, photoGateStatus } from '@/lib/groupPhotoGate';
 import { canUploadGroupPhoto, removeGroupPhoto, uploadGroupPhoto } from '@/data/api';
 import {
   useAddGhostMember,
@@ -62,11 +62,65 @@ const iconFor =
   // eslint-disable-next-line react/display-name
   (color: string): ReactNode => <Ionicons name={name} size={iconSize.base} color={color} />;
 
+/**
+ * The round mark on one of the three exit rows, and the whole of how they are
+ * told apart at a glance.
+ *
+ * One shape, three weights, in the order the consequence grows: `quiet` is the
+ * brand chip every ordinary row in the app wears, because archiving is an
+ * ordinary, reversible thing; `soft` is the same chip in the negative colour,
+ * for the act that ends your own membership; `loud` fills with that colour and
+ * cuts the glyph out of it in the card's own surface, for the one act that
+ * cannot be taken back. Red is spent sparingly on purpose — if it were on all
+ * three it would distinguish none of them.
+ */
+function ExitChip({
+  icon,
+  tone,
+}: {
+  icon: keyof typeof Ionicons.glyphMap;
+  tone: 'quiet' | 'soft' | 'loud';
+}) {
+  const theme = useTheme();
+  return (
+    <View
+      style={{
+        width: 40,
+        height: 40,
+        borderRadius: theme.radius.pill,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor:
+          tone === 'quiet'
+            ? theme.color.brandSoft
+            : tone === 'soft'
+              ? theme.color.negativeSoft
+              : theme.color.negative,
+      }}
+    >
+      <Ionicons
+        name={icon}
+        size={iconSize.lg}
+        // On the filled chip the glyph is cut from the card behind it — white
+        // on the light red, near-black on the dark one — which clears the 3:1
+        // a graphic needs in both schemes where white alone would not.
+        color={
+          tone === 'quiet'
+            ? theme.color.brand
+            : tone === 'soft'
+              ? theme.color.negative
+              : theme.color.surface
+        }
+      />
+    </View>
+  );
+}
+
 export default function GroupSettingsScreen() {
   const theme = useTheme();
   // This screen renders under the persistent bottom nav, so it must pad for the
-  // bar, not just the system inset — with the plain inset the last row (Leave
-  // group, below Archive) sat behind the bar and could not be reached.
+  // bar, not just the system inset — with the plain inset the last of the exit
+  // rows sat behind the bar and could not be reached.
   const clearance = useTabBarClearance();
   const { t, locale } = useStrings();
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -172,6 +226,27 @@ export default function GroupSettingsScreen() {
   }
   const [status, setStatus] = useState<string | null>(null);
   const [uploading, setUploading] = useState(false);
+  // Whether the name is being edited (the rule under it lights up) and whether
+  // the cover sheet is open. Both are about the identity row at the top.
+  const [naming, setNaming] = useState(false);
+  const [coverOpen, setCoverOpen] = useState(false);
+
+  /**
+   * Save the name, if it has actually changed.
+   *
+   * There used to be a Save button beside the field, which asked for a tap to
+   * confirm a change the person had already made and then sat disabled for the
+   * rest of the screen's life. Committing on blur and on "done" is the same
+   * act with one fewer control. The guard compares against what the group
+   * already carries rather than against emptiness, because clearing the field
+   * is a real choice: the group goes back to being named after the people in
+   * it, and that is a change worth sending.
+   */
+  const commitName = (): void => {
+    const next = name.trim();
+    if (next === (group.data?.name ?? '')) return;
+    updateGroup.mutate({ name: next || null }, { onSuccess: () => setStatus(t.account.saved) });
+  };
 
   // A group photo is a paid feature; the cover emoji is free. The group may
   // carry a photo if anyone in it is paid (or it holds a pass) — a server-side
@@ -197,15 +272,6 @@ export default function GroupSettingsScreen() {
     } finally {
       setUploading(false);
     }
-  };
-
-  // Tapping the photo: pick when allowed, otherwise point at the upgrade screen.
-  // Removing an existing photo is never gated — a group that loses its paying
-  // member can always fall back to an icon.
-  const onPhotoPress = (): void => {
-    const action = photoTapAction(photoStatus);
-    if (action === 'pick') void changePhoto();
-    else if (action === 'showLockedHint') router.push('/settings/upgrade');
   };
 
   const dropPhoto = async (): Promise<void> => {
@@ -381,14 +447,25 @@ export default function GroupSettingsScreen() {
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
-        <Card style={{ gap: theme.spacing.lg }}>
+        {/* The group's identity, as one thing rather than three controls.
+            A group *is* its mark and its name — that is the pair every list
+            in the app shows — so they sit on one line: the mark on the left,
+            tappable, opening every way of changing it; the name written
+            straight into the row beside it, over a rule that lights up while
+            it is being edited. The three loose buttons that used to sit under
+            this card (Save name, Choose an icon, Remove photo) are gone: the
+            first asked for a tap to confirm a change already made, and the
+            other two are ways of changing the mark, which is what the mark
+            itself is for. This is the same row the new-group screen opens
+            with, so naming a group and renaming one look like one control. */}
+        <Card>
           <Row style={{ gap: theme.spacing.lg }}>
             <GroupPhoto
               photoPath={group.data.photo_path}
               emoji={group.data.cover_emoji}
-              size={72}
+              size={64}
               busy={uploading}
-              onPress={onPhotoPress}
+              onPress={() => setCoverOpen(true)}
             />
             <View style={{ flex: 1, gap: theme.spacing.xs }}>
               <Text variant="caption" tone="muted">
@@ -397,6 +474,16 @@ export default function GroupSettingsScreen() {
               <TextInput
                 value={name}
                 onChangeText={setName}
+                onFocus={() => setNaming(true)}
+                // The name commits itself: on the keyboard's "done" and again
+                // when the field loses focus, so leaving the screen never
+                // silently drops what was typed.
+                onBlur={() => {
+                  setNaming(false);
+                  commitName();
+                }}
+                onSubmitEditing={commitName}
+                returnKeyType="done"
                 accessibilityLabel={t.group.groupName}
                 placeholder={groupLabel(null, members.data ?? [], profile?.id)}
                 placeholderTextColor={theme.color.textFaint}
@@ -405,43 +492,27 @@ export default function GroupSettingsScreen() {
                   fontWeight: '700',
                   color: theme.color.text,
                   paddingVertical: theme.spacing.sm,
+                  borderBottomWidth: 1.5,
+                  borderBottomColor: naming ? theme.color.brand : theme.color.border,
                 }}
               />
             </View>
           </Row>
-
-          {/* The cover is set two ways from here: the photo by tapping the
-              picture above, and the icon by the picker — which now opens a wide,
-              scrollable set instead of a fixed nine crammed into the card. */}
-          <Row style={{ flexWrap: 'wrap', gap: theme.spacing.sm }}>
-            <Button
-              label={t.group.saveName}
-              size="sm"
-              variant="secondary"
-              // Clearing the field is a real choice: the group goes back to
-              // being named after the people in it.
-              disabled={name.trim() === (group.data.name ?? '')}
-              onPress={() =>
-                updateGroup.mutate(
-                  { name: name.trim() || null },
-                  { onSuccess: () => setStatus(t.account.saved) },
-                )
-              }
-            />
-            <CoverEmojiPicker
-              value={group.data.cover_emoji}
-              onChange={(emoji) => updateGroup.mutate({ cover_emoji: emoji })}
-            />
-            {group.data.photo_path ? (
-              <Button
-                label={t.group.removePhoto}
-                size="sm"
-                variant="ghost"
-                onPress={() => void dropPhoto()}
-              />
-            ) : null}
-          </Row>
         </Card>
+
+        {/* Opened by the mark above and nothing else, so there is one door to
+            the cover rather than a button per way through it. */}
+        <GroupCoverSheet
+          visible={coverOpen}
+          onClose={() => setCoverOpen(false)}
+          value={group.data.cover_emoji}
+          onChange={(emoji) => updateGroup.mutate({ cover_emoji: emoji })}
+          hasPhoto={Boolean(group.data.photo_path)}
+          photoStatus={photoStatus}
+          onPickPhoto={() => void changePhoto()}
+          onRemovePhoto={() => void dropPhoto()}
+          onUpgrade={() => router.push('/settings/upgrade')}
+        />
 
         {/* The kind of group. Only changes the label, cover default and trip
             affordances — nothing already recorded moves. */}
@@ -662,31 +733,67 @@ export default function GroupSettingsScreen() {
           </Text>
         ) : null}
 
-        <View style={{ gap: theme.spacing.md }}>
-          <Button label={t.group.archiveGroup} variant="ghostDanger" fullWidth onPress={archive} />
-          <Button label={t.group.leaveGroup} variant="ghostDanger" fullWidth onPress={leave} />
-          {/* Deleting drops the group for everyone, so it is an admin-only power
-              and sits below leave/archive as the most final of the three. */}
-          {isAdmin ? (
-            <Button
-              label={t.group.deleteGroup}
-              variant="ghostDanger"
-              fullWidth
-              disabled={deleteGroup.isPending}
-              onPress={confirmDelete}
+        {/* The three ways out.
+            They used to be three identical red pill buttons stacked in a
+            column, which said the wrong thing twice over: that the three acts
+            weigh the same, and that all three are dangerous. They are not.
+            Archiving is reversible and touches nobody but your own list;
+            leaving affects only you and leaves the group standing; deleting
+            takes the whole thing away from everyone, at once, with no undo.
+            So each is a row with its own mark and one line saying whose it is,
+            and the weight climbs across them: a brand mark and plain ink for
+            archive, a red mark and a red title for leave, and — alone on its
+            own card, ringed in red — the delete. Delete standing apart is the
+            same grammar the account screen's danger zone uses; a section that
+            ends things announces itself by being set off, not by a heading. */}
+        <View style={{ gap: theme.spacing.xl }}>
+          <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+            <ListRow
+              title={t.group.archiveGroup}
+              subtitle={t.group.archiveHint}
+              leading={<ExitChip icon="archive-outline" tone="quiet" />}
+              onPress={archive}
             />
-          ) : null}
-          {/* An admin looking at an unsettled group should know what the button
-              costs before they tap it, not only in the alert afterwards. */}
-          {isAdmin && !ledger.groupSettled ? (
-            <Text variant="micro" tone="muted" align="center">
-              {t.group.deleteUnsettledHint}
-            </Text>
-          ) : null}
-          {!settled ? (
-            <Text variant="micro" tone="muted" align="center">
-              {t.group.leaveWhenZero}
-            </Text>
+            <View style={{ height: 1, backgroundColor: theme.color.border }} />
+            <ListRow
+              title={t.group.leaveGroup}
+              subtitle={t.group.leaveHint}
+              destructive
+              // Not `exit-outline`: that glyph is an arrow through a door, and
+              // an arrow drawn to the right still points right in a mirrored
+              // layout. Taking yourself off the list is direction-free.
+              leading={<ExitChip icon="person-remove-outline" tone="soft" />}
+              onPress={leave}
+            />
+          </Card>
+
+          {/* Deleting drops the group for everyone, so it is an admin-only
+              power (the RPC refuses it regardless) and stands alone. */}
+          {isAdmin ? (
+            <View style={{ gap: theme.spacing.sm }}>
+              <Card
+                padded={false}
+                style={{
+                  paddingHorizontal: theme.spacing.lg,
+                  borderWidth: 1,
+                  borderColor: theme.color.negative,
+                  opacity: deleteGroup.isPending ? 0.45 : 1,
+                }}
+              >
+                <ListRow
+                  title={t.group.deleteGroup}
+                  subtitle={t.group.deleteHint}
+                  destructive
+                  leading={<ExitChip icon="trash-outline" tone="loud" />}
+                  onPress={deleteGroup.isPending ? undefined : confirmDelete}
+                />
+              </Card>
+              {/* An admin looking at an unsettled group should know what the
+                  row costs before they tap it, not only in the alert after. */}
+              {!ledger.groupSettled ? (
+                <Callout tone="negative">{t.group.deleteUnsettledHint}</Callout>
+              ) : null}
+            </View>
           ) : null}
         </View>
       </ScrollView>

--- a/apps/mobile/src/app/group/[id]/settings.tsx
+++ b/apps/mobile/src/app/group/[id]/settings.tsx
@@ -220,9 +220,14 @@ export default function GroupSettingsScreen() {
   // loaded group changes) — synced in render, the app's idiom for following a
   // value until the user edits it, rather than a setState-in-effect.
   const [seededId, setSeededId] = useState<string | null>(null);
+  // The name last handed to the server, so a rename is not sent twice while the
+  // group query is still catching up (see `commitName`). Cleared alongside the
+  // field whenever a different group is loaded into this screen.
+  const [sentName, setSentName] = useState<string | null>(null);
   if (group.data && seededId !== group.data.id) {
     setSeededId(group.data.id);
     setName(group.data.name ?? '');
+    setSentName(null);
   }
   const [status, setStatus] = useState<string | null>(null);
   const [uploading, setUploading] = useState(false);
@@ -237,14 +242,20 @@ export default function GroupSettingsScreen() {
    * There used to be a Save button beside the field, which asked for a tap to
    * confirm a change the person had already made and then sat disabled for the
    * rest of the screen's life. Committing on blur and on "done" is the same
-   * act with one fewer control. The guard compares against what the group
+   * act with one fewer control. The first guard compares against what the group
    * already carries rather than against emptiness, because clearing the field
    * is a real choice: the group goes back to being named after the people in
    * it, and that is a change worth sending.
+   *
+   * The second guard is about the two triggers overlapping. Pressing "done"
+   * both submits and blurs, so this runs twice in a row, and the second run
+   * still sees the old name on `group.data` because the mutation has not come
+   * back yet — without `sentName` the same rename would be queued twice.
    */
   const commitName = (): void => {
     const next = name.trim();
-    if (next === (group.data?.name ?? '')) return;
+    if (next === (group.data?.name ?? '') || next === sentName) return;
+    setSentName(next);
     updateGroup.mutate({ name: next || null }, { onSuccess: () => setStatus(t.account.saved) });
   };
 
@@ -506,7 +517,14 @@ export default function GroupSettingsScreen() {
           visible={coverOpen}
           onClose={() => setCoverOpen(false)}
           value={group.data.cover_emoji}
-          onChange={(emoji) => updateGroup.mutate({ cover_emoji: emoji })}
+          // Says "Saved" like every other setting on this screen. The mark is
+          // drawn, so a changed cover has no words of its own to confirm it.
+          onChange={(emoji) =>
+            updateGroup.mutate(
+              { cover_emoji: emoji },
+              { onSuccess: () => setStatus(t.account.saved) },
+            )
+          }
           hasPhoto={Boolean(group.data.photo_path)}
           photoStatus={photoStatus}
           onPickPhoto={() => void changePhoto()}

--- a/apps/mobile/src/app/groups.tsx
+++ b/apps/mobile/src/app/groups.tsx
@@ -22,6 +22,7 @@ import { useGroups, useHomeSummary } from '@/data/hooks';
 import { groupLabel } from '@/data/types';
 import { plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
+import { GroupMark } from '@/components/GroupMark';
 import { SkeletonList } from '@/components/Skeletons';
 
 /**
@@ -297,7 +298,7 @@ export default function AllGroupsScreen() {
                       justifyContent: 'center',
                     }}
                   >
-                    <Text style={{ fontSize: 20 }}>{group.cover_emoji ?? '👥'}</Text>
+                    <GroupMark emoji={group.cover_emoji} size={22} />
                   </View>
                   <View style={{ flex: 1 }}>
                     <Text variant="body" numberOfLines={2}>

--- a/apps/mobile/src/app/join.tsx
+++ b/apps/mobile/src/app/join.tsx
@@ -18,6 +18,7 @@ import {
   useTheme,
 } from '@waves/ui';
 
+import { GroupMark } from '@/components/GroupMark';
 import { fill, plural, useStrings } from '@/i18n';
 import { friendlyError } from '@/lib/errors';
 
@@ -189,6 +190,11 @@ export default function JoinScreen() {
     );
   }
 
+  // Read out of the narrowed preview before the render: inside the `mark`
+  // callback below TypeScript can no longer see that `preview.group` survived
+  // the guard above.
+  const group = preview.group;
+
   return (
     <Screen edges={['top', 'bottom']}>
       <ScrollView
@@ -201,7 +207,11 @@ export default function JoinScreen() {
         }}
       >
         <Card style={{ alignItems: 'center', gap: theme.spacing.md }}>
-          <Avatar name={preview.group.name} emoji={preview.group.cover_emoji ?? '👥'} size={78} />
+          <Avatar
+            name={group.name}
+            mark={(color) => <GroupMark emoji={group.cover_emoji} size={40} color={color} />}
+            size={78}
+          />
           <Text variant="title" align="center">
             {preview.group.name}
           </Text>

--- a/apps/mobile/src/components/CoverEmojiPicker.tsx
+++ b/apps/mobile/src/components/CoverEmojiPicker.tsx
@@ -1,38 +1,166 @@
 /**
- * Picking the little icon a group wears.
+ * Picking the little mark a group wears.
  *
- * The old control was nine emoji crammed under the name field with no way to
- * reach a tenth — fine until the group is a badminton league or a wedding, and
- * then it is a wall. This is the same idea with room to breathe: a curated set,
- * grouped so the eye can find the row it wants, shown in a bottom sheet with the
- * current pick previewed large at the top.
+ * This control has been through three shapes. It started as nine emoji crammed
+ * under the name field with no way to reach a tenth; it became a bottom sheet
+ * holding a curated emoji set, grouped so the eye could find the row it wanted;
+ * and it is now a grid of *drawn* marks (see `GroupMark`), because an emoji
+ * rendered as text never belonged beside the app's own iconography — see that
+ * file for why.
  *
- * Deliberately not the whole emoji keyboard. A shared-expense group wants a
- * cover somebody recognises at a glance in a list, not 🫠 — so the set is the
- * trips, homes, meals, journeys and pastimes a group is actually named after.
- * Whatever is picked is stored as a single character, same as before.
+ * What is stored has not changed at any point: the pick is written to
+ * `groups.cover_emoji` as a single emoji, which is what the web client, the
+ * export and every older build already know how to read. A mark is a way of
+ * drawing that value, not a replacement for it.
  *
- * Two ways to open it. Left to itself it renders its own trigger (a compact
- * swatch or a button) and owns the open state. Passed `open`/`onOpenChange` it
- * is controlled and renders no trigger — so a caller can open it from somewhere
- * else entirely, like tapping the group's avatar.
+ * Two ways to open the grid. Left to itself `CoverEmojiPicker` renders its own
+ * trigger and owns the open state — that is the new-group screen, where the
+ * only thing to choose is the mark. `GroupCoverSheet` is the fuller version for
+ * an existing group, where the cover can also be a photo: one sheet with two
+ * panes, so tapping the group's mark reaches every way of changing it without
+ * stacking a second modal on top of the first.
  */
 
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Pressable, ScrollView, View } from 'react-native';
 
-import { Button, Row, Sheet, Text, iconSize, useTheme } from '@waves/ui';
+import { Button, ListRow, Row, Sheet, Text, directionalIcon, iconSize, useTheme } from '@waves/ui';
 
 import { useStrings } from '@/i18n';
 
-const EMOJI_GROUPS: readonly (readonly string[])[] = [
-  ['🏖️', '🏝️', '⛰️', '🏔️', '🏕️', '🏜️', '🗺️', '✈️', '🚗', '🚕', '🚌', '🚆', '⛵', '🛵'],
-  ['🏠', '🏡', '🏢', '🏨', '🏬', '🛏️', '🛋️', '🔑', '🧹', '💡', '🧾', '💰'],
-  ['🍽️', '🍕', '🍔', '🍜', '🍣', '🍻', '☕', '🍩', '🎂', '🥡', '🛒'],
-  ['🎉', '🎁', '🎈', '💜', '❤️', '🎵', '🎬', '🎮', '⚽', '🏀', '🏏', '🏸', '🧗', '🏊'],
-  ['🎓', '💼', '📚', '👥', '🐶', '🐱', '🌱', '🌸', '⭐', '🌈'],
-];
+import { EMOJI_FOR_MARK, GROUP_MARK_IDS, GroupMark, markForEmoji } from './GroupMark';
+import type { PhotoGateStatus } from '@/lib/groupPhotoGate';
+
+/** The tile a mark is drawn in, and the label under it. */
+const TILE_WIDTH = 72;
+
+/**
+ * The grid itself, with no surface of its own, so both the plain picker and the
+ * two-pane cover sheet can put it wherever they need it.
+ *
+ * Selection is stated three ways: the ring and fill that mark the tile, a tick
+ * in its corner, and `accessibilityState.selected` on a radio — the last is the
+ * one a screen reader actually reads, and colour alone would tell it nothing.
+ */
+function MarkGrid({ value, onPick }: { value: string | null; onPick: (emoji: string) => void }) {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const current = markForEmoji(value);
+
+  return (
+    <Row style={{ flexWrap: 'wrap', gap: theme.spacing.sm, justifyContent: 'center' }}>
+      {GROUP_MARK_IDS.map((id) => {
+        const selected = current === id;
+        return (
+          <Pressable
+            key={id}
+            accessibilityRole="radio"
+            accessibilityState={{ selected }}
+            accessibilityLabel={t.groupMarks[id]}
+            onPress={() => onPick(EMOJI_FOR_MARK[id])}
+            style={({ pressed }) => ({
+              width: TILE_WIDTH,
+              paddingVertical: theme.spacing.sm,
+              borderRadius: theme.radius.lg,
+              alignItems: 'center',
+              gap: 2,
+              borderWidth: selected ? 2 : 1,
+              borderColor: selected ? theme.color.brand : theme.color.border,
+              backgroundColor: selected ? theme.color.brandSoft : theme.color.surfaceMuted,
+              opacity: pressed ? 0.7 : 1,
+            })}
+          >
+            <GroupMark emoji={EMOJI_FOR_MARK[id]} size={28} />
+            <Text variant="micro" tone={selected ? 'brand' : 'muted'} numberOfLines={1}>
+              {t.groupMarks[id]}
+            </Text>
+            {selected ? (
+              // `right` is mirrored for an RTL layout by React Native itself,
+              // so the tick follows the corner the reading eye ends on.
+              <View style={{ position: 'absolute', top: 2, right: 2 }}>
+                <Ionicons name="checkmark-circle" size={iconSize.sm} color={theme.color.brand} />
+              </View>
+            ) : null}
+          </Pressable>
+        );
+      })}
+    </Row>
+  );
+}
+
+/** The current pick, shown large enough to judge before the grid below it. */
+function CoverPreview({ value }: { value: string | null }) {
+  const theme = useTheme();
+  return (
+    <View style={{ alignItems: 'center', paddingVertical: theme.spacing.lg }}>
+      <View
+        style={{
+          width: 84,
+          height: 84,
+          borderRadius: 28,
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: theme.color.brandSoft,
+        }}
+      >
+        <GroupMark emoji={value} size={48} />
+      </View>
+    </View>
+  );
+}
+
+/** The sheet's own title bar, with an optional way back to the pane before it. */
+function SheetHeader({
+  title,
+  onBack,
+  onClose,
+}: {
+  title: string;
+  onBack?: () => void;
+  onClose: () => void;
+}) {
+  const theme = useTheme();
+  const { t } = useStrings();
+  return (
+    <Row
+      style={{
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        paddingHorizontal: theme.spacing.xl,
+        gap: theme.spacing.sm,
+      }}
+    >
+      <Row style={{ alignItems: 'center', gap: theme.spacing.sm, flex: 1 }}>
+        {onBack ? (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t.common.back}
+            onPress={onBack}
+            hitSlop={8}
+            style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1 })}
+          >
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.textMuted}
+            />
+          </Pressable>
+        ) : null}
+        <Text variant="heading">{title}</Text>
+      </Row>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={t.common.close}
+        onPress={onClose}
+        hitSlop={8}
+        style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1 })}
+      >
+        <Ionicons name="close" size={iconSize.lg} color={theme.color.textMuted} />
+      </Pressable>
+    </Row>
+  );
+}
 
 export function CoverEmojiPicker({
   value,
@@ -43,7 +171,7 @@ export function CoverEmojiPicker({
 }: {
   value: string | null;
   onChange: (emoji: string) => void;
-  /** A small emoji-swatch pill instead of a full button, for tight layouts. */
+  /** A small mark-swatch pill instead of a full button, for tight layouts. */
   compact?: boolean;
   /** Controlled open state. When set, no trigger is rendered. */
   open?: boolean;
@@ -79,7 +207,7 @@ export function CoverEmojiPicker({
             opacity: pressed ? 0.7 : 1,
           })}
         >
-          <Text style={{ fontSize: 16 }}>{value ?? '🙂'}</Text>
+          <GroupMark emoji={value} size={18} />
           <Text variant="caption" tone="muted">
             {t.group.chooseIcon}
           </Text>
@@ -100,89 +228,173 @@ export function CoverEmojiPicker({
         closeLabel={t.common.close}
         style={{ maxHeight: '82%' }}
       >
-        <Row
-          style={{
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            paddingHorizontal: theme.spacing.xl,
-          }}
-        >
-          <Text variant="heading">{t.group.chooseIcon}</Text>
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel={t.common.close}
-            onPress={() => setOpen(false)}
-            hitSlop={8}
-            style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1 })}
-          >
-            <Ionicons name="close" size={iconSize.lg} color={theme.color.textMuted} />
-          </Pressable>
-        </Row>
-
-        {/* The current pick, previewed large on a tinted circle. */}
-        <View style={{ alignItems: 'center', paddingVertical: theme.spacing.lg }}>
-          <View
-            style={{
-              width: 84,
-              height: 84,
-              borderRadius: 28,
-              alignItems: 'center',
-              justifyContent: 'center',
-              backgroundColor: theme.color.buttonPrimary,
-            }}
-          >
-            <Text style={{ fontSize: 44 }}>{value ?? '👥'}</Text>
-          </View>
-        </View>
-
+        <SheetHeader title={t.group.chooseIcon} onClose={() => setOpen(false)} />
+        <CoverPreview value={value} />
         <ScrollView
           contentContainerStyle={{
             paddingHorizontal: theme.spacing.xl,
             paddingBottom: theme.spacing.xl,
-            gap: theme.spacing.lg,
           }}
           showsVerticalScrollIndicator={false}
         >
-          {EMOJI_GROUPS.map((emojis, index) => (
-            <View key={index} style={{ gap: theme.spacing.sm }}>
-              {index > 0 ? (
-                <View style={{ height: 1, backgroundColor: theme.color.border }} />
-              ) : null}
-              <Row style={{ flexWrap: 'wrap', gap: theme.spacing.sm }}>
-                {emojis.map((emoji) => {
-                  const selected = value === emoji;
-                  return (
-                    <Pressable
-                      key={emoji}
-                      accessibilityRole="radio"
-                      accessibilityState={{ selected }}
-                      accessibilityLabel={emoji}
-                      onPress={() => {
-                        onChange(emoji);
-                        setOpen(false);
-                      }}
-                      style={{
-                        width: 52,
-                        height: 52,
-                        borderRadius: theme.radius.lg,
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        borderWidth: selected ? 2 : 1,
-                        borderColor: selected ? theme.color.brand : theme.color.border,
-                        backgroundColor: selected
-                          ? theme.color.brandSoft
-                          : theme.color.surfaceMuted,
-                      }}
-                    >
-                      <Text style={{ fontSize: 26 }}>{emoji}</Text>
-                    </Pressable>
-                  );
-                })}
-              </Row>
-            </View>
-          ))}
+          <MarkGrid
+            value={value}
+            onPick={(emoji) => {
+              onChange(emoji);
+              setOpen(false);
+            }}
+          />
         </ScrollView>
       </Sheet>
     </>
+  );
+}
+
+/**
+ * Every way of changing an existing group's cover, behind one tap on the mark
+ * itself.
+ *
+ * Two panes rather than two sheets: a `Modal` opened from inside another
+ * `Modal` is a fight with the platform on Android, and swapping the content of
+ * the one that is already up says the same thing more simply — the list of
+ * ways in, and the grid you reach through it.
+ *
+ * The photo half stays gated exactly as it was (a photo is a Plus feature, an
+ * icon is free): when the gate is locked the row says so and leads to the
+ * upgrade screen instead of the camera roll, and while the answer is still in
+ * flight the row is disabled rather than acting on a guess.
+ */
+export function GroupCoverSheet({
+  visible,
+  onClose,
+  value,
+  onChange,
+  hasPhoto,
+  photoStatus,
+  onPickPhoto,
+  onRemovePhoto,
+  onUpgrade,
+}: {
+  visible: boolean;
+  onClose: () => void;
+  value: string | null;
+  onChange: (emoji: string) => void;
+  hasPhoto: boolean;
+  photoStatus: PhotoGateStatus;
+  onPickPhoto: () => void;
+  onRemovePhoto: () => void;
+  onUpgrade: () => void;
+}) {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const [showGrid, setShowGrid] = useState(false);
+
+  const close = (): void => {
+    onClose();
+    // Reset to the list of ways in, so the sheet always opens where it did
+    // last time rather than wherever it happened to be left.
+    setShowGrid(false);
+  };
+
+  const chip = (icon: ReactNode, tone: 'brand' | 'danger'): ReactNode => (
+    <View
+      style={{
+        width: 40,
+        height: 40,
+        borderRadius: theme.radius.pill,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: tone === 'danger' ? theme.color.negativeSoft : theme.color.brandSoft,
+      }}
+    >
+      {icon}
+    </View>
+  );
+
+  return (
+    <Sheet
+      visible={visible}
+      onClose={close}
+      padded={false}
+      closeLabel={t.common.close}
+      style={{ maxHeight: '82%' }}
+    >
+      <SheetHeader
+        title={showGrid ? t.group.chooseIcon : t.group.changeCover}
+        onBack={showGrid ? () => setShowGrid(false) : undefined}
+        onClose={close}
+      />
+      <CoverPreview value={value} />
+
+      {showGrid ? (
+        <ScrollView
+          contentContainerStyle={{
+            paddingHorizontal: theme.spacing.xl,
+            paddingBottom: theme.spacing.xl,
+          }}
+          showsVerticalScrollIndicator={false}
+        >
+          <MarkGrid
+            value={value}
+            onPick={(emoji) => {
+              onChange(emoji);
+              close();
+            }}
+          />
+        </ScrollView>
+      ) : (
+        <View style={{ paddingHorizontal: theme.spacing.xl, paddingBottom: theme.spacing.xl }}>
+          <ListRow
+            title={t.group.chooseIcon}
+            subtitle={t.group.chooseIconHint}
+            leading={chip(<GroupMark emoji={value} size={22} />, 'brand')}
+            onPress={() => setShowGrid(true)}
+            trailing={
+              <Ionicons
+                name={directionalIcon('chevron-forward')}
+                size={iconSize.md}
+                color={theme.color.textFaint}
+              />
+            }
+          />
+          <ListRow
+            title={hasPhoto ? t.misc.changeGroupPhoto : t.misc.addGroupPhoto}
+            subtitle={photoStatus === 'locked' ? t.group.photoIsPaid : t.group.usePhotoHint}
+            leading={chip(
+              <Ionicons
+                name={photoStatus === 'locked' ? 'lock-closed-outline' : 'camera-outline'}
+                size={iconSize.lg}
+                color={theme.color.brand}
+              />,
+              'brand',
+            )}
+            onPress={
+              photoStatus === 'loading'
+                ? undefined
+                : () => {
+                    close();
+                    if (photoStatus === 'locked') onUpgrade();
+                    else onPickPhoto();
+                  }
+            }
+          />
+          {hasPhoto ? (
+            <ListRow
+              title={t.group.removePhoto}
+              subtitle={t.group.removePhotoHint}
+              destructive
+              leading={chip(
+                <Ionicons name="trash-outline" size={iconSize.lg} color={theme.color.negative} />,
+                'danger',
+              )}
+              onPress={() => {
+                close();
+                onRemovePhoto();
+              }}
+            />
+          ) : null}
+        </View>
+      )}
+    </Sheet>
   );
 }

--- a/apps/mobile/src/components/GroupCard.tsx
+++ b/apps/mobile/src/components/GroupCard.tsx
@@ -14,6 +14,8 @@ import { Pressable, View } from 'react-native';
 import type { CurrencyCode } from '@waves/core';
 import { Avatar, Badge, MoneyText, Row, Text, tintForKey, useTheme } from '@waves/ui';
 
+import { GroupMark } from './GroupMark';
+
 export function GroupCard({
   id,
   title,
@@ -64,7 +66,12 @@ export function GroupCard({
         {/* A bigger circular avatar carries the group's colour and initial. The
             LINE-services look: solid round icon, bold name, muted line beneath,
             airy rows with no hairline between them. */}
-        <Avatar name={title} emoji={coverEmoji ?? undefined} size={52} tint={tintForKey(id)} />
+        <Avatar
+          name={title}
+          mark={(color) => <GroupMark emoji={coverEmoji} size={26} color={color} />}
+          size={52}
+          tint={tintForKey(id)}
+        />
 
         <View style={{ flex: 1, minWidth: 0 }}>
           <Row style={{ gap: theme.spacing.xs, alignItems: 'center' }}>

--- a/apps/mobile/src/components/GroupMark.tsx
+++ b/apps/mobile/src/components/GroupMark.tsx
@@ -31,8 +31,6 @@ import Svg, { Circle, Ellipse, Path, Rect } from 'react-native-svg';
 
 import { Text, useTheme } from '@waves/ui';
 
-import { useStrings } from '@/i18n';
-
 /** The marks, in the order the picker lays them out. */
 export const GROUP_MARK_IDS = [
   'beach',
@@ -503,14 +501,4 @@ export function GroupMark({ emoji, size = 24, color }: GroupMarkProps) {
       <Drawing color={ink} />
     </Svg>
   );
-}
-
-/**
- * The mark's name, for a screen reader and for the picker's labels. Kept here
- * rather than in the picker because every surface that draws a mark owes the
- * same word to somebody who cannot see it.
- */
-export function useGroupMarkName(): (id: GroupMarkId) => string {
-  const { t } = useStrings();
-  return (id) => t.groupMarks[id];
 }

--- a/apps/mobile/src/components/GroupMark.tsx
+++ b/apps/mobile/src/components/GroupMark.tsx
@@ -1,0 +1,516 @@
+/**
+ * The little picture a group wears, drawn rather than typed.
+ *
+ * A group's cover used to be an emoji rendered as text, and that is exactly why
+ * it looked wrong next to everything else on the screen: an emoji is a glyph
+ * from the operating system's font, so it changes shape between Android
+ * versions, sits on the text baseline instead of on the icon grid, carries its
+ * own colours that answer to nobody's palette, and reads as a character dropped
+ * in a box rather than as a mark somebody designed. Beside a screen full of
+ * Ionicons it is the one thing that does not belong to the app.
+ *
+ * So the covers are drawn here instead: one family of vector marks on a 24×24
+ * grid, one stroke weight, round caps and joins throughout, and a single colour
+ * that comes from the theme — strokes at full strength, fills of the same
+ * colour at `ACCENT_OPACITY`. Two weights of one colour rather than a second
+ * hue, so a mark stays legible on white, on the dark surface, and on the
+ * saturated cards without anybody having to pick a contrasting accent per
+ * ground.
+ *
+ * **The stored data does not change.** `groups.cover_emoji` still holds an
+ * emoji, and the picker still writes one; a mark is only a way of *drawing*
+ * that value. `MARK_FOR_EMOJI` maps the emoji a group may already carry onto
+ * the mark that means the same thing (🏝️ and ⛱️ both draw the beach), and an
+ * emoji with no mark — an older pick, or one from the wider set the picker used
+ * to offer — falls back to rendering the character itself. Nobody's group
+ * changes identity because this file exists.
+ */
+
+import type { ReactElement } from 'react';
+import Svg, { Circle, Ellipse, Path, Rect } from 'react-native-svg';
+
+import { Text, useTheme } from '@waves/ui';
+
+import { useStrings } from '@/i18n';
+
+/** The marks, in the order the picker lays them out. */
+export const GROUP_MARK_IDS = [
+  'beach',
+  'mountain',
+  'tent',
+  'plane',
+  'car',
+  'boat',
+  'home',
+  'building',
+  'bed',
+  'key',
+  'receipt',
+  'coins',
+  'plate',
+  'pizza',
+  'bowl',
+  'coffee',
+  'cake',
+  'drinks',
+  'party',
+  'gift',
+  'heart',
+  'ball',
+  'star',
+  'people',
+] as const;
+
+export type GroupMarkId = (typeof GROUP_MARK_IDS)[number];
+
+/**
+ * The emoji each mark is stored as. This is the value written to
+ * `cover_emoji`, so a group picked in this app is still readable by the web
+ * client, the export, and any older build — all of which render the character.
+ */
+export const EMOJI_FOR_MARK: Readonly<Record<GroupMarkId, string>> = {
+  beach: '🏖️',
+  mountain: '⛰️',
+  tent: '🏕️',
+  plane: '✈️',
+  car: '🚗',
+  boat: '⛵',
+  home: '🏠',
+  building: '🏢',
+  bed: '🛏️',
+  key: '🔑',
+  receipt: '🧾',
+  coins: '💰',
+  plate: '🍽️',
+  pizza: '🍕',
+  bowl: '🍜',
+  coffee: '☕',
+  cake: '🎂',
+  drinks: '🍻',
+  party: '🎉',
+  gift: '🎁',
+  heart: '💜',
+  ball: '⚽',
+  star: '⭐',
+  people: '👥',
+};
+
+/**
+ * Every emoji that draws as a mark, including the ones the picker no longer
+ * offers. A group whose cover was set before the marks existed keeps the
+ * picture it has always had wherever the two mean the same thing — 🏡 is a
+ * home, 🏨 is a building, 🏀 is a ball. Anything not listed here is drawn as
+ * the emoji itself, which is what it already was.
+ *
+ * The keys are matched with the variation selector stripped, so 🏖 and 🏖️ (the
+ * same character with and without U+FE0F) both find their mark.
+ */
+export const MARK_FOR_EMOJI: Readonly<Record<string, GroupMarkId>> = {
+  '🏖': 'beach',
+  '🏝': 'beach',
+  '⛱': 'beach',
+  '⛰': 'mountain',
+  '🏔': 'mountain',
+  '🏕': 'tent',
+  '✈': 'plane',
+  '🚗': 'car',
+  '🚕': 'car',
+  '🚌': 'car',
+  '🛵': 'car',
+  '⛵': 'boat',
+  '🏠': 'home',
+  '🏡': 'home',
+  '🏢': 'building',
+  '🏬': 'building',
+  '🏨': 'building',
+  '🛏': 'bed',
+  '🛋': 'bed',
+  '🔑': 'key',
+  '🧾': 'receipt',
+  '💰': 'coins',
+  '🍽': 'plate',
+  '🍕': 'pizza',
+  '🍜': 'bowl',
+  '🥡': 'bowl',
+  '☕': 'coffee',
+  '🎂': 'cake',
+  '🍩': 'cake',
+  '🍻': 'drinks',
+  '🎉': 'party',
+  '🎈': 'party',
+  '🎁': 'gift',
+  '💜': 'heart',
+  '❤': 'heart',
+  '⚽': 'ball',
+  '🏀': 'ball',
+  '🏏': 'ball',
+  '🏸': 'ball',
+  '⭐': 'star',
+  '👥': 'people',
+};
+
+/** U+FE0F, the variation selector that makes a character render in colour. */
+const VARIATION_SELECTOR = /️/g;
+
+/**
+ * The mark a stored cover draws as, or `null` when the value is one this set
+ * has no drawing for — which is the signal to render the character instead.
+ */
+export function markForEmoji(emoji: string | null | undefined): GroupMarkId | null {
+  if (!emoji) return null;
+  return MARK_FOR_EMOJI[emoji.replace(VARIATION_SELECTOR, '')] ?? null;
+}
+
+/**
+ * Fills sit at a fraction of the stroke colour rather than in a second hue, so
+ * one `color` prop is all a caller ever has to get right.
+ */
+const ACCENT_OPACITY = 0.28;
+/** One stroke weight across the whole set, on the 24-unit grid. */
+const STROKE = 1.8;
+
+interface PartProps {
+  color: string;
+}
+
+/**
+ * The drawings themselves. Each is described in a sentence because a reader
+ * cannot see path data — and because the point of the set is that the marks
+ * agree with each other, which is a thing worth being able to check in words.
+ */
+const MARKS: Readonly<Record<GroupMarkId, (props: PartProps) => ReactElement>> = {
+  // A sun over two lines of surf.
+  beach: ({ color }) => (
+    <>
+      <Circle cx={12} cy={7} r={3.4} fill={color} fillOpacity={ACCENT_OPACITY} />
+      <Circle cx={12} cy={7} r={3.4} stroke={color} strokeWidth={STROKE} fill="none" />
+      <Path d="M2.5 15c1.6-1.6 3.2-1.6 4.8 0s3.2 1.6 4.8 0 3.2-1.6 4.8 0 3.2 1.6 4.8 0" />
+      <Path d="M2.5 19.5c1.6-1.6 3.2-1.6 4.8 0s3.2 1.6 4.8 0 3.2-1.6 4.8 0 3.2 1.6 4.8 0" />
+    </>
+  ),
+  // Two peaks, the taller one with a filled snow cap.
+  mountain: ({ color }) => (
+    <>
+      <Path d="M11 19.5 16.2 10.8 21.5 19.5Z" />
+      <Path d="M2.5 19.5 8.8 7.5 15.1 19.5Z" />
+      <Path d="M8.8 7.5 6.5 11.9h4.6Z" fill={color} fillOpacity={ACCENT_OPACITY} stroke="none" />
+    </>
+  ),
+  // A ridge tent: outline, centre pole, and a filled doorway.
+  tent: ({ color }) => (
+    <>
+      <Path d="M12 4.5 21 19.5H3Z" />
+      <Path d="M12 4.5V19.5" />
+      <Path d="M12 11 15.4 19.5H8.6Z" fill={color} fillOpacity={ACCENT_OPACITY} stroke="none" />
+    </>
+  ),
+  // A paper plane, its near wing filled.
+  plane: ({ color }) => (
+    <>
+      <Path d="M21 3 3 10.6l7.4 3L13.4 21Z" />
+      <Path d="M10.4 13.6 21 3" />
+      <Path d="M10.4 13.6 13.4 21 21 3Z" fill={color} fillOpacity={ACCENT_OPACITY} stroke="none" />
+    </>
+  ),
+  // A small car: cabin, body, two filled wheels.
+  car: ({ color }) => (
+    <>
+      <Path d="M6.2 12 8 7.5h8l1.8 4.5" />
+      <Rect x={3} y={12} width={18} height={5} rx={2} />
+      <Circle cx={7.5} cy={18} r={1.9} fill={color} fillOpacity={ACCENT_OPACITY} />
+      <Circle cx={7.5} cy={18} r={1.9} />
+      <Circle cx={16.5} cy={18} r={1.9} fill={color} fillOpacity={ACCENT_OPACITY} />
+      <Circle cx={16.5} cy={18} r={1.9} />
+    </>
+  ),
+  // A sailboat: filled sail on a mast, hull below.
+  boat: ({ color }) => (
+    <>
+      <Path d="M12 3.5V14" />
+      <Path d="M12 5 19 13.5h-7Z" fill={color} fillOpacity={ACCENT_OPACITY} />
+      <Path d="M3.5 16h17L18 20.5H6Z" />
+    </>
+  ),
+  // A house: roof, walls, and a filled door.
+  home: ({ color }) => (
+    <>
+      <Path d="M3 10.8 12 3.8l9 7" />
+      <Path d="M5.4 9.4V20.2h13.2V9.4" />
+      <Rect
+        x={10}
+        y={14.4}
+        width={4}
+        height={5.8}
+        rx={1}
+        fill={color}
+        fillOpacity={ACCENT_OPACITY}
+        stroke="none"
+      />
+    </>
+  ),
+  // A block of flats with six filled windows.
+  building: ({ color }) => (
+    <>
+      <Rect x={4} y={3.5} width={16} height={17} rx={2} />
+      {[7, 11, 15].map((y) => (
+        <Rect
+          key={y}
+          x={7.2}
+          y={y}
+          width={3.4}
+          height={2.6}
+          rx={0.7}
+          fill={color}
+          fillOpacity={ACCENT_OPACITY}
+          stroke="none"
+        />
+      ))}
+      {[7, 11, 15].map((y) => (
+        <Rect
+          key={y}
+          x={13.4}
+          y={y}
+          width={3.4}
+          height={2.6}
+          rx={0.7}
+          fill={color}
+          fillOpacity={ACCENT_OPACITY}
+          stroke="none"
+        />
+      ))}
+    </>
+  ),
+  // A bed seen from the side: headboard, mattress, filled pillow, two legs.
+  bed: ({ color }) => (
+    <>
+      <Path d="M3 17.5V7.5" />
+      <Rect x={3} y={11.5} width={18} height={6} rx={1.6} />
+      <Rect
+        x={5.2}
+        y={13.2}
+        width={5}
+        height={2.8}
+        rx={1.1}
+        fill={color}
+        fillOpacity={ACCENT_OPACITY}
+        stroke="none"
+      />
+      <Path d="M4.4 17.5v3" />
+      <Path d="M19.6 17.5v3" />
+    </>
+  ),
+  // A key lying on its side, bit to the right.
+  key: ({ color }) => (
+    <>
+      <Circle cx={7} cy={12} r={4} fill={color} fillOpacity={ACCENT_OPACITY} />
+      <Circle cx={7} cy={12} r={4} />
+      <Circle cx={7} cy={12} r={1.2} fill={color} stroke="none" />
+      <Path d="M11 12h10" />
+      <Path d="M17 12v3.6" />
+      <Path d="M20 12v2.6" />
+    </>
+  ),
+  // A till receipt with a torn foot and two filled lines of print.
+  receipt: ({ color }) => (
+    <>
+      <Path d="M6 3.5h12v17l-2.5-1.6L13 20.5l-2.5-1.6L8 20.5l-2-1.3Z" />
+      <Path d="M9 8h6" stroke={color} strokeOpacity={0.55} />
+      <Path d="M9 12h6" stroke={color} strokeOpacity={0.55} />
+    </>
+  ),
+  // Three coins in a stack, the top one filled.
+  coins: ({ color }) => (
+    <>
+      <Ellipse cx={12} cy={17} rx={7} ry={2.8} />
+      <Ellipse cx={12} cy={12} rx={7} ry={2.8} />
+      <Ellipse cx={12} cy={7} rx={7} ry={2.8} fill={color} fillOpacity={ACCENT_OPACITY} />
+      <Ellipse cx={12} cy={7} rx={7} ry={2.8} />
+    </>
+  ),
+  // A plate with a fork beside it.
+  plate: ({ color }) => (
+    <>
+      <Circle cx={14} cy={12} r={6.4} />
+      <Circle cx={14} cy={12} r={3.2} fill={color} fillOpacity={ACCENT_OPACITY} stroke="none" />
+      <Path d="M3 4v4.6h3.2V4" />
+      <Path d="M4.6 8.6V20" />
+    </>
+  ),
+  // A wedge of pizza with three toppings.
+  pizza: ({ color }) => (
+    <>
+      <Path d="M12 3.5 20.5 19.5h-17Z" />
+      <Path d="M4.6 17.2h14.8" stroke={color} strokeOpacity={0.55} />
+      <Circle cx={10} cy={11.5} r={1.3} fill={color} fillOpacity={ACCENT_OPACITY} stroke="none" />
+      <Circle cx={14.4} cy={13} r={1.3} fill={color} fillOpacity={ACCENT_OPACITY} stroke="none" />
+      <Circle cx={11.6} cy={15.8} r={1.3} fill={color} fillOpacity={ACCENT_OPACITY} stroke="none" />
+    </>
+  ),
+  // A noodle bowl with two curls of steam.
+  bowl: ({ color }) => (
+    <>
+      <Path d="M3 11.5h18a9 9 0 0 1-18 0Z" fill={color} fillOpacity={ACCENT_OPACITY} />
+      <Path d="M9 4.5v3.5" />
+      <Path d="M13 4.5v3.5" />
+    </>
+  ),
+  // A cup with a handle and two wisps of steam.
+  coffee: ({ color }) => (
+    <>
+      <Path d="M4.5 8h12.5l-1.4 10H5.9Z" fill={color} fillOpacity={ACCENT_OPACITY} />
+      <Path d="M17 10h1.6a2.6 2.6 0 0 1 0 5.2h-1.1" />
+      <Path d="M9 2.5v2.6" />
+      <Path d="M13 2.5v2.6" />
+    </>
+  ),
+  // A cake with one lit candle.
+  cake: ({ color }) => (
+    <>
+      <Rect x={3.5} y={12} width={17} height={8.2} rx={2} />
+      <Path d="M3.5 15.6h17" stroke={color} strokeOpacity={0.55} />
+      <Path d="M12 8V12" />
+      <Circle cx={12} cy={5.8} r={1.7} fill={color} fillOpacity={ACCENT_OPACITY} />
+      <Circle cx={12} cy={5.8} r={1.7} />
+    </>
+  ),
+  // Two glasses raised together.
+  drinks: ({ color }) => (
+    <>
+      <Path d="M4.5 4.5h6.4L7.7 11Z" fill={color} fillOpacity={ACCENT_OPACITY} />
+      <Path d="M7.7 11v7" />
+      <Path d="M5.2 18h5" />
+      <Path d="M13.1 4.5h6.4L16.3 11Z" fill={color} fillOpacity={ACCENT_OPACITY} />
+      <Path d="M16.3 11v7" />
+      <Path d="M13.8 18h5" />
+    </>
+  ),
+  // A party popper firing confetti.
+  party: ({ color }) => (
+    <>
+      <Path d="M3 21 9.6 8.4 15.6 14.4Z" fill={color} fillOpacity={ACCENT_OPACITY} />
+      <Circle cx={17.6} cy={5.4} r={1.4} fill={color} stroke="none" />
+      <Circle cx={20.4} cy={9.6} r={1.1} fill={color} stroke="none" />
+      <Circle cx={13.4} cy={3.6} r={1.1} fill={color} stroke="none" />
+    </>
+  ),
+  // A wrapped box: lid, ribbon down the front, a bow of two loops.
+  gift: ({ color }) => (
+    <>
+      <Rect x={3.8} y={9.6} width={16.4} height={10.9} rx={1.6} />
+      <Rect
+        x={2.6}
+        y={5.8}
+        width={18.8}
+        height={4}
+        rx={1.3}
+        fill={color}
+        fillOpacity={ACCENT_OPACITY}
+      />
+      <Path d="M12 5.8v14.7" />
+      <Circle cx={9.6} cy={3.7} r={2.1} />
+      <Circle cx={14.4} cy={3.7} r={2.1} />
+    </>
+  ),
+  // A filled heart.
+  heart: ({ color }) => (
+    <Path
+      d="M12 20.6C5 15.6 2.6 12 2.6 8.8a5.2 5.2 0 0 1 9.4-2.9 5.2 5.2 0 0 1 9.4 2.9c0 3.2-2.4 6.8-9.4 11.8Z"
+      fill={color}
+      fillOpacity={ACCENT_OPACITY}
+    />
+  ),
+  // A football: a filled centre panel with seams running to the rim.
+  ball: ({ color }) => (
+    <>
+      <Circle cx={12} cy={12} r={8.6} />
+      <Path
+        d="M12 7.4 16.2 10.5 14.6 15.4H9.4L7.8 10.5Z"
+        fill={color}
+        fillOpacity={ACCENT_OPACITY}
+      />
+      <Path d="M12 7.4V3.4" />
+      <Path d="M16.2 10.5 20 9.2" />
+      <Path d="M7.8 10.5 4 9.2" />
+      <Path d="M14.6 15.4 17 18.7" />
+      <Path d="M9.4 15.4 7 18.7" />
+    </>
+  ),
+  // A five-pointed star, filled.
+  star: ({ color }) => (
+    <Path
+      d="M12 2.8 14.9 9.1 21.7 9.9 16.7 14.6 18 21.3 12 18 6 21.3 7.3 14.6 2.3 9.9 9.1 9.1Z"
+      fill={color}
+      fillOpacity={ACCENT_OPACITY}
+    />
+  ),
+  // Two people, one a step behind the other.
+  people: ({ color }) => (
+    <>
+      <Circle cx={16} cy={8.4} r={2.8} />
+      <Path d="M15.6 14.2a5.4 5.4 0 0 1 5 5.4" />
+      <Circle cx={9.4} cy={8} r={3.4} fill={color} fillOpacity={ACCENT_OPACITY} />
+      <Circle cx={9.4} cy={8} r={3.4} />
+      <Path d="M3.4 19.6a6 6 0 0 1 12 0" />
+    </>
+  ),
+};
+
+export interface GroupMarkProps {
+  /** The stored cover — an emoji, or null for a group that never picked one. */
+  emoji?: string | null;
+  /** Box size in points. The drawing scales; the stroke weight scales with it. */
+  size?: number;
+  /**
+   * The mark's one colour. Strokes take it at full strength, fills at
+   * `ACCENT_OPACITY`. Defaults to the brand accent.
+   */
+  color?: string;
+}
+
+/**
+ * A group's cover, drawn when we have a mark for it and rendered as the stored
+ * character when we do not.
+ *
+ * The fallback is deliberately the plain emoji rather than a generic
+ * "unknown" mark: a group that picked 🍔 years ago should keep showing a
+ * burger, not lose its identity to a placeholder because this set is finite.
+ */
+export function GroupMark({ emoji, size = 24, color }: GroupMarkProps) {
+  const theme = useTheme();
+  const ink = color ?? theme.color.brand;
+  // A group that never picked a cover draws the two-people mark, which is the
+  // 👥 it has always shown — only drawn rather than typed.
+  const id = emoji ? markForEmoji(emoji) : 'people';
+
+  if (!id) {
+    // No mark for this cover: the character itself, sized to fill the same box
+    // an icon would, so a mixed list still lines up.
+    return <Text style={{ fontSize: size * 0.82 }}>{emoji}</Text>;
+  }
+
+  const Drawing = MARKS[id];
+  return (
+    <Svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={ink}
+      strokeWidth={STROKE}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <Drawing color={ink} />
+    </Svg>
+  );
+}
+
+/**
+ * The mark's name, for a screen reader and for the picker's labels. Kept here
+ * rather than in the picker because every surface that draws a mark owes the
+ * same word to somebody who cannot see it.
+ */
+export function useGroupMarkName(): (id: GroupMarkId) => string {
+  const { t } = useStrings();
+  return (id) => t.groupMarks[id];
+}

--- a/apps/mobile/src/components/GroupPhoto.tsx
+++ b/apps/mobile/src/components/GroupPhoto.tsx
@@ -15,10 +15,11 @@ import { Image } from 'expo-image';
 import { ActivityIndicator, Pressable, View } from 'react-native';
 import Ionicons from '@expo/vector-icons/Ionicons';
 
-import { Text, useTheme } from '@waves/ui';
+import { useTheme } from '@waves/ui';
 
 import { useStrings } from '@/i18n';
 
+import { GroupMark } from './GroupMark';
 import { groupPhotoUrl } from '@/data/api';
 import { useSignedUrl } from '@/lib/useSignedUrl';
 
@@ -67,7 +68,11 @@ export function GroupPhoto({
           transition={150}
         />
       ) : (
-        <Text style={{ fontSize: size * 0.45 }}>{emoji ?? '👥'}</Text>
+        // The drawn mark, not the raw character: see `GroupMark` for why an
+        // emoji rendered as text never sat right beside the app's own icons.
+        // A cover with no mark still falls back to the character there, so a
+        // group keeps whatever picture it has always had.
+        <GroupMark emoji={emoji} size={size * 0.55} />
       )}
 
       {onPress && !busy ? (

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1314,6 +1314,37 @@ export interface UiStrings {
     duplicates: PluralForms;
   };
   /** Group photos are a paid feature; the cover emoji stays free for everyone. */
+  /**
+   * The word for each drawn group mark (see `components/GroupMark.tsx`). A mark
+   * is a picture, and a picture announces nothing: this is what a screen reader
+   * says in its place, and what the cover picker labels each tile with.
+   */
+  groupMarks: {
+    beach: string;
+    mountain: string;
+    tent: string;
+    plane: string;
+    car: string;
+    boat: string;
+    home: string;
+    building: string;
+    bed: string;
+    key: string;
+    receipt: string;
+    coins: string;
+    plate: string;
+    pizza: string;
+    bowl: string;
+    coffee: string;
+    cake: string;
+    drinks: string;
+    party: string;
+    gift: string;
+    heart: string;
+    ball: string;
+    star: string;
+    people: string;
+  };
   groupPhoto: {
     paidHint: string;
   };
@@ -1569,10 +1600,16 @@ export interface UiStrings {
     photoUpdated: string;
     nameOptional: string;
     groupName: string;
-    saveName: string;
-    /** Opens the group cover-emoji picker. */
+    /** The cover sheet, reached by tapping the group's mark: pick one of the
+     *  drawn marks, put a photo from the phone in its place (a Plus feature),
+     *  or drop a photo already set. */
+    changeCover: string;
     chooseIcon: string;
+    chooseIconHint: string;
+    usePhotoHint: string;
+    photoIsPaid: string;
     removePhoto: string;
+    removePhotoHint: string;
     simplifyDebts: string;
     simplifyDebtsBody: string;
     simplifyDebtsHint: string;
@@ -1586,7 +1623,11 @@ export interface UiStrings {
     importSplitwiseHint: string;
     archiveGroup: string;
     leaveGroup: string;
-    leaveWhenZero: string;
+    /** One line under each of the three exit actions, naming the scope of what
+     *  it does: your own list, only you, or everybody in the group. */
+    archiveHint: string;
+    leaveHint: string;
+    deleteHint: string;
     settleFirst: string;
     settleFirstBody: string;
     leaveQuestion: string;
@@ -3621,6 +3662,32 @@ const en: UiStrings = {
     hint: 'Seeing the same guest in more than one group? Merge the duplicates into one person.',
     duplicates: { one: '{n} possible duplicate', other: '{n} possible duplicates' },
   },
+  groupMarks: {
+    beach: 'Beach',
+    mountain: 'Mountains',
+    tent: 'Camping',
+    plane: 'Flight',
+    car: 'Road trip',
+    boat: 'Boat',
+    home: 'Home',
+    building: 'Apartment',
+    bed: 'Stay',
+    key: 'Rent',
+    receipt: 'Bills',
+    coins: 'Savings',
+    plate: 'Meals',
+    pizza: 'Pizza',
+    bowl: 'Takeaway',
+    coffee: 'Coffee',
+    cake: 'Birthday',
+    drinks: 'Drinks',
+    party: 'Party',
+    gift: 'Gift',
+    heart: 'Couple',
+    ball: 'Sport',
+    star: 'Favourite',
+    people: 'Friends',
+  },
   groupPhoto: {
     paidHint: 'Group photos are a Plus feature. Pick an icon, or upgrade to add a photo.',
   },
@@ -3860,9 +3927,13 @@ const en: UiStrings = {
     photoUpdated: 'Photo updated',
     nameOptional: 'Name (optional)',
     groupName: 'Group name',
-    saveName: 'Save name',
+    changeCover: 'Group cover',
     chooseIcon: 'Choose an icon',
+    chooseIconHint: 'One of the drawn marks',
+    usePhotoHint: 'A picture from this phone',
+    photoIsPaid: 'Photos come with Plus',
     removePhoto: 'Remove photo',
+    removePhotoHint: 'Go back to the icon',
     simplifyDebts: 'Fewer repayments',
     simplifyDebtsBody:
       'Suggest the fewest payments that settle the group. The real who-owes-whom ledger is never rewritten.',
@@ -3877,7 +3948,9 @@ const en: UiStrings = {
     importSplitwiseHint: 'Bring an old group’s history across',
     archiveGroup: 'Archive group',
     leaveGroup: 'Leave group',
-    leaveWhenZero: 'You can leave once your balance here is zero.',
+    archiveHint: 'Off your list; nothing is deleted',
+    leaveHint: 'You step out, the group carries on',
+    deleteHint: 'Gone for everyone, with no undo',
     settleFirst: 'Settle up first',
     settleFirstBody:
       'You still have a balance in this group. Leaving now would strand it — settle up, then leave.',
@@ -5913,6 +5986,32 @@ const ta: UiStrings = {
     hint: 'ஒரே விருந்தினர் ஒன்றுக்கு மேற்பட்ட குழுக்களில் தெரிகிறாரா? நகல்களை ஒரே நபராக இணைக்கவும்.',
     duplicates: { one: '{n} சாத்தியமான நகல்', other: '{n} சாத்தியமான நகல்கள்' },
   },
+  groupMarks: {
+    beach: 'கடற்கரை',
+    mountain: 'மலைகள்',
+    tent: 'முகாம்',
+    plane: 'விமானப் பயணம்',
+    car: 'சாலைப் பயணம்',
+    boat: 'படகு',
+    home: 'வீடு',
+    building: 'குடியிருப்பு',
+    bed: 'தங்குமிடம்',
+    key: 'வாடகை',
+    receipt: 'பில்கள்',
+    coins: 'சேமிப்பு',
+    plate: 'உணவு',
+    pizza: 'பீட்சா',
+    bowl: 'பார்சல் உணவு',
+    coffee: 'காபி',
+    cake: 'பிறந்தநாள்',
+    drinks: 'பானங்கள்',
+    party: 'கொண்டாட்டம்',
+    gift: 'பரிசு',
+    heart: 'ஜோடி',
+    ball: 'விளையாட்டு',
+    star: 'பிடித்தது',
+    people: 'நண்பர்கள்',
+  },
   groupPhoto: {
     paidHint:
       'குழு புகைப்படங்கள் Plus அம்சம். ஒரு ஐகானைத் தேர்ந்தெடுக்கவும், அல்லது புகைப்படம் சேர்க்க மேம்படுத்தவும்.',
@@ -6164,9 +6263,13 @@ const ta: UiStrings = {
     photoUpdated: 'புகைப்படம் புதுப்பிக்கப்பட்டது',
     nameOptional: 'பெயர் (விருப்பம்)',
     groupName: 'குழுவின் பெயர்',
-    saveName: 'பெயரைச் சேமி',
+    changeCover: 'குழுவின் அட்டை',
     chooseIcon: 'ஐகானைத் தேர்ந்தெடு',
+    chooseIconHint: 'வரையப்பட்ட அடையாளங்களில் ஒன்று',
+    usePhotoHint: 'இந்த ஃபோனிலிருந்து ஒரு படம்',
+    photoIsPaid: 'புகைப்படங்கள் Plus-உடன் வரும்',
     removePhoto: 'புகைப்படத்தை நீக்கு',
+    removePhotoHint: 'மீண்டும் ஐகானுக்குச் செல்',
     simplifyDebts: 'குறைந்த திருப்பிச் செலுத்தல்கள்',
     simplifyDebtsBody:
       'குழுவைத் தீர்க்கும் மிகக் குறைந்த பணப்பரிமாற்றங்களைப் பரிந்துரைக்கும். யார் யாருக்குத் தர வேண்டும் என்ற உண்மையான கணக்கு மாற்றப்படுவதே இல்லை.',
@@ -6182,7 +6285,9 @@ const ta: UiStrings = {
     importSplitwiseHint: 'பழைய குழுவின் வரலாற்றைக் கொண்டுவா',
     archiveGroup: 'குழுவைக் காப்பகப்படுத்து',
     leaveGroup: 'குழுவிலிருந்து விலகு',
-    leaveWhenZero: 'இங்கே உங்கள் இருப்பு பூஜ்ஜியமானதும் விலகலாம்.',
+    archiveHint: 'உங்கள் பட்டியலில் இராது; எதுவும் அழியாது',
+    leaveHint: 'நீங்கள் மட்டும் விலகுவீர்கள், குழு தொடரும்',
+    deleteHint: 'அனைவருக்கும் அழியும், மீட்க முடியாது',
     settleFirst: 'முதலில் தீர்த்துக்கொள்ளுங்கள்',
     settleFirstBody:
       'இந்தக் குழுவில் உங்களுக்கு இன்னும் இருப்பு உள்ளது. இப்போது விலகினால் அது தொங்கிவிடும் — தீர்த்துவிட்டு விலகுங்கள்.',
@@ -8243,6 +8348,32 @@ const hi: UiStrings = {
     hint: 'एक ही मेहमान कई समूहों में दिख रहा है? डुप्लिकेट को एक व्यक्ति में मर्ज करें.',
     duplicates: { one: '{n} संभावित डुप्लिकेट', other: '{n} संभावित डुप्लिकेट' },
   },
+  groupMarks: {
+    beach: 'समुद्र तट',
+    mountain: 'पहाड़',
+    tent: 'कैंपिंग',
+    plane: 'हवाई यात्रा',
+    car: 'रोड ट्रिप',
+    boat: 'नाव',
+    home: 'घर',
+    building: 'अपार्टमेंट',
+    bed: 'ठहरना',
+    key: 'किराया',
+    receipt: 'बिल',
+    coins: 'बचत',
+    plate: 'खाना',
+    pizza: 'पिज़्ज़ा',
+    bowl: 'पार्सल खाना',
+    coffee: 'कॉफ़ी',
+    cake: 'जन्मदिन',
+    drinks: 'ड्रिंक्स',
+    party: 'पार्टी',
+    gift: 'तोहफ़ा',
+    heart: 'जोड़ी',
+    ball: 'खेल',
+    star: 'पसंदीदा',
+    people: 'दोस्त',
+  },
   groupPhoto: {
     paidHint: 'ग्रुप फ़ोटो एक Plus सुविधा है। कोई आइकन चुनें, या फ़ोटो जोड़ने के लिए अपग्रेड करें।',
   },
@@ -8483,9 +8614,13 @@ const hi: UiStrings = {
     photoUpdated: 'फ़ोटो बदल गई',
     nameOptional: 'नाम (वैकल्पिक)',
     groupName: 'समूह का नाम',
-    saveName: 'नाम सेव करें',
+    changeCover: 'समूह का कवर',
     chooseIcon: 'आइकन चुनें',
+    chooseIconHint: 'बने-बनाए चिह्नों में से एक',
+    usePhotoHint: 'इसी फ़ोन से एक तस्वीर',
+    photoIsPaid: 'फ़ोटो Plus के साथ आती हैं',
     removePhoto: 'फ़ोटो हटाएँ',
+    removePhotoHint: 'वापस आइकन पर जाएँ',
     simplifyDebts: 'कम भुगतान',
     simplifyDebtsBody:
       'समूह को निपटाने के सबसे कम भुगतान सुझाता है। किस पर किसका बाकी है, वह असली हिसाब कभी नहीं बदला जाता।',
@@ -8500,7 +8635,9 @@ const hi: UiStrings = {
     importSplitwiseHint: 'पुराने समूह का इतिहास ले आएँ',
     archiveGroup: 'समूह संग्रहित करें',
     leaveGroup: 'समूह छोड़ें',
-    leaveWhenZero: 'यहाँ आपका हिसाब शून्य होते ही आप छोड़ सकते हैं।',
+    archiveHint: 'आपकी सूची से हट जाएगा; कुछ मिटेगा नहीं',
+    leaveHint: 'सिर्फ़ आप निकलते हैं, समूह चलता रहेगा',
+    deleteHint: 'सबके लिए मिट जाएगा, वापस नहीं आएगा',
     settleFirst: 'पहले हिसाब चुकाएँ',
     settleFirstBody:
       'इस समूह में अभी आपका हिसाब बाकी है। अभी छोड़ने पर वह अधर में रह जाएगा — पहले चुकाएँ, फिर छोड़ें।',
@@ -10560,6 +10697,32 @@ const ar: UiStrings = {
       other: '{n} مكرَّر محتمل',
     },
   },
+  groupMarks: {
+    beach: 'الشاطئ',
+    mountain: 'الجبال',
+    tent: 'تخييم',
+    plane: 'رحلة جوية',
+    car: 'رحلة برية',
+    boat: 'قارب',
+    home: 'المنزل',
+    building: 'شقة',
+    bed: 'إقامة',
+    key: 'إيجار',
+    receipt: 'فواتير',
+    coins: 'ادخار',
+    plate: 'وجبات',
+    pizza: 'بيتزا',
+    bowl: 'طعام سفري',
+    coffee: 'قهوة',
+    cake: 'عيد ميلاد',
+    drinks: 'مشروبات',
+    party: 'حفلة',
+    gift: 'هدية',
+    heart: 'ثنائي',
+    ball: 'رياضة',
+    star: 'مفضّل',
+    people: 'أصدقاء',
+  },
   groupPhoto: {
     paidHint: 'صور المجموعة ميزة Plus. اختر أيقونة، أو قم بالترقية لإضافة صورة.',
   },
@@ -10839,9 +11002,13 @@ const ar: UiStrings = {
     photoUpdated: 'تم تحديث الصورة',
     nameOptional: 'الاسم (اختياري)',
     groupName: 'اسم المجموعة',
-    saveName: 'حفظ الاسم',
+    changeCover: 'غلاف المجموعة',
     chooseIcon: 'اختر أيقونة',
+    chooseIconHint: 'أحد الرموز المرسومة',
+    usePhotoHint: 'صورة من هذا الهاتف',
+    photoIsPaid: 'الصور تأتي مع Plus',
     removePhoto: 'إزالة الصورة',
+    removePhotoHint: 'العودة إلى الأيقونة',
     simplifyDebts: 'مدفوعات أقل',
     simplifyDebtsBody:
       'يقترح أقل عدد من الدفعات لتسوية المجموعة. أما دفتر من يدين لمن فلا يُعاد كتابته أبدًا.',
@@ -10856,7 +11023,9 @@ const ar: UiStrings = {
     importSplitwiseHint: 'أحضر سجل مجموعة قديمة',
     archiveGroup: 'أرشفة المجموعة',
     leaveGroup: 'مغادرة المجموعة',
-    leaveWhenZero: 'يمكنك المغادرة حين يصبح رصيدك هنا صفرًا.',
+    archiveHint: 'تختفي من قائمتك ولا يُحذف شيء',
+    leaveHint: 'أنت وحدك تخرج، والمجموعة تستمر',
+    deleteHint: 'تُحذف للجميع بلا رجعة',
     settleFirst: 'سوِّ حسابك أولًا',
     settleFirstBody:
       'ما زال لك رصيد في هذه المجموعة. المغادرة الآن تتركه معلّقًا — سوِّ الحساب ثم غادر.',

--- a/e2e/change-logo.yaml
+++ b/e2e/change-logo.yaml
@@ -1,8 +1,8 @@
 # Changing a group's icon (its "logo") applies live from Group settings
-# (F-CFG-02). Opens the seeded group, opens its cover-emoji picker, picks a new
-# icon, and confirms the sheet dismisses with the change accepted. The photo path
-# is a separate paid-gated flow (group-photo-paid-gate.yaml); this covers the
-# free icon path every account has.
+# (F-CFG-02). Opens the seeded group, opens the cover sheet from the group's own
+# mark, picks a new mark, and confirms the write landed. The photo path is a
+# separate paid-gated flow (group-photo-paid-gate.yaml); this covers the free
+# icon path every account has.
 appId: app.waves.mobile
 ---
 - runFlow: login.yaml
@@ -11,17 +11,20 @@ appId: app.waves.mobile
 - tapOn: 'Goa trip'
 - tapOn: 'Group settings'
 
-# The cover-emoji picker trigger is always present on the settings form.
-- assertVisible: 'Choose an icon'
+# The cover is now reached through the group's own mark rather than through a
+# button beside it. The mark's accessibility label is the photo action, because
+# tapping it is how a photo is added too — the seeded group has none.
+- tapOn: 'Add a group photo'
+- assertVisible: 'Group cover'
 - tapOn: 'Choose an icon'
 
-# The bottom sheet is up (its close control is the labelled way out); pick a new
-# icon. Selecting fires the update and dismisses the sheet in one tap.
-- assertVisible: 'Close'
-- tapOn: '🏕️'
+# The marks grid. Each tile carries its name, so a pick is made by word rather
+# than by emoji — the covers are drawn now, not typed. Selecting fires the
+# update and dismisses the sheet in one tap.
+- tapOn: 'Camping'
+- assertNotVisible: 'Group cover'
 
-# Back on the settings form: the sheet is gone and the settings header now
-# renders the chosen icon — proof the update applied, not just that the picker
-# dismissed (which would also happen if the write failed).
-- assertNotVisible: 'Close'
-- assertVisible: '🏕️'
+# Proof the write applied rather than only that the sheet closed: the settings
+# screen says "Saved" for a cover change the same way it does for every other
+# setting on it. The mark itself is a drawing, so there is no glyph to assert.
+- assertVisible: 'Saved'

--- a/e2e/group-photo-paid-gate.yaml
+++ b/e2e/group-photo-paid-gate.yaml
@@ -25,12 +25,14 @@ appId: app.waves.mobile
     text: 'Plus feature'
     optional: true
 
-# The icon path still works: pick an emoji, name the group, create it.
+# The icon path still works: pick a mark, name the group, create it. The tiles
+# carry the mark's name now — the covers are drawn rather than typed, so there
+# is no emoji to tap.
 - tapOn:
     id: 'CoverEmojiPicker'
     optional: true
 - tapOn:
-    text: '🏠'
+    text: 'Home'
     optional: true
 - inputText: 'Flat 4B'
 - tapOn:

--- a/e2e/leave-group.yaml
+++ b/e2e/leave-group.yaml
@@ -25,7 +25,7 @@ appId: app.waves.mobile
 - tapOn: 'Settings'
 - assertVisible: 'Members'
 
-# The Leave button sits below Archive at the very bottom, under the tab bar —
+# The Leave row sits under Archive at the very bottom, under the tab bar —
 # scroll it into reach (the clearance this flow also guards) and confirm.
 - scrollUntilVisible:
     element: 'Leave group'

--- a/e2e/rename-archive-group.yaml
+++ b/e2e/rename-archive-group.yaml
@@ -6,14 +6,17 @@ appId: app.waves.mobile
 
 - tapOn: 'Goa trip'
 - tapOn: 'Settings'
-- assertVisible: 'Save name'
+- assertVisible: 'Name (optional)'
 
-# Rename: the name field holds "Goa trip".
+# Rename: the name field holds "Goa trip". There is no Save button any more —
+# the field commits itself on the keyboard's "done" and again on blur, so the
+# Enter key is the whole of the save.
 - tapOn: 'Goa trip'
 - eraseText: 30
 - inputText: 'Goa 2026'
+- pressKey: Enter
 - hideKeyboard
-- tapOn: 'Save name'
+- assertVisible: 'Saved'
 
 # Prove the rename persisted before archiving: back on the group screen the new
 # name shows (it is re-read from the mirror, not the input we typed into). Without
@@ -22,7 +25,7 @@ appId: app.waves.mobile
 - tapOn: 'Back'
 - assertVisible: 'Goa 2026'
 
-# Archive it from settings — the button sits below, past the roster.
+# Archive it from settings — the row sits below, past the roster.
 - tapOn: 'Settings'
 - scrollUntilVisible:
     element: 'Archive group'

--- a/packages/ui/src/components/Avatar.tsx
+++ b/packages/ui/src/components/Avatar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import { Image, Pressable, View } from 'react-native';
 
 import { useTheme } from '../theme';
@@ -22,6 +22,7 @@ export function initialsOf(name: string): string {
 export function Avatar({
   name,
   emoji,
+  mark,
   size = 44,
   tint,
   /** Ghost members (ADR-006) read as provisional until somebody claims them. */
@@ -32,6 +33,14 @@ export function Avatar({
 }: {
   name: string;
   emoji?: string;
+  /**
+   * A drawn glyph to stand where the emoji or the initials would — a group's
+   * cover mark, say. Handed the tint's ink so it matches the circle it sits in
+   * without the caller resolving the palette, the same bargain `Callout` makes
+   * with its `icon`. Passed as a node because this package carries no icon or
+   * vector library of its own.
+   */
+  mark?: (color: string) => ReactNode;
   size?: number;
   tint?: TintName;
   ghost?: boolean;
@@ -89,6 +98,8 @@ export function Avatar({
           resizeMode="cover"
           onError={() => setBroken(photoUrl)}
         />
+      ) : mark ? (
+        mark(resolved.ink)
       ) : (
         <Text variant={size >= 44 ? 'subheading' : 'caption'} style={{ color: resolved.ink }}>
           {emoji ?? initialsOf(name)}


### PR DESCRIPTION
Three changes to how a group presents itself, all asked for in one sitting and all landing on `apps/mobile/src/app/group/[id]/settings.tsx`, so they ride together.

This was written on top of `feat/admin-delete-unsettled-group` (#703), which rewrites the delete half of the same section. #703 was squash-merged while the work was in flight and its branch deleted, so this is rebased onto `main` and targets it instead. It keeps #703's delete rule and its `deleteUnsettledHint` copy intact and only re-dresses them.

## 1. The three ways out, redesigned

Archive, leave and delete were three identical `ghostDanger` pill buttons stacked in a column with two grey hint lines trailing after them. That says the three acts weigh the same and that all three are dangerous, and neither is true.

They are now rows, and the weight climbs with the consequence:

| | mark | chip | title | placement |
|---|---|---|---|---|
| Archive group — *"Off your list; nothing is deleted"* | `archive-outline` | brand-soft | ordinary ink | first row |
| Leave group — *"You step out, the group carries on"* | `person-remove-outline` | negative-soft | red | second row, hairline above |
| Delete group — *"Gone for everyone, with no undo"* | `trash-outline` | filled red, glyph knocked out in the card's surface | red | alone on its own card, ringed in red, a section gap below the other two |

Delete standing apart on its own card is the same grammar the account screen's danger zone already uses — a section that ends things announces itself by being set off, not by a heading. Red is deliberately spent on only two of the three: on all three it would distinguish none of them.

All three marks are direction-free. `exit-outline` was rejected on purpose — it is an arrow through a door, and an arrow drawn rightwards still points rightwards in a mirrored layout.

The admin's unsettled-group warning (#703's `deleteUnsettledHint`) moved from a floating grey sentence into a `Callout` under the delete card, so it belongs to the row it is about.

## 2. "You can leave once your balance here is zero" — removed

Deleted from the `UiStrings` type and from all four locales (en, ta, hi, ar); no orphan keys remain.

**The rule is untouched, and this is a question for you.** Leaving still refuses while you carry a balance — `leave()` checks `settled` and shows the "Settle up first" alert, and nothing server-side moved. Only the standing hint line is gone. It was not clear from the request whether you wanted the *sentence* gone or the *rule* relaxed so somebody can walk out of a group still owing money, so I did the reversible half. **Do you also want leaving-while-unsettled allowed?** That is a separate change with a real consequence — a debt left stranded with nobody attached to it — and I did not want to make it silently.

## 3. The name and icon block, and the icon itself

**The block.** A name field with a Save button that asked for a tap to confirm a change already made, next to a "Choose an icon" button, next to a sometimes-present "Remove photo" button. All three buttons are gone. What is left is the row the new-group screen already opens with, so naming a group and renaming one now look like one control:

> `[ 64pt cover, tappable ]  Name (optional)` <br> `                        Goa December` <br> `                        ─────────────` ← rule, brand-coloured while focused

The name commits itself on blur and on the keyboard's "done", and only when the trimmed value actually differs from what the group carries (clearing it is still a real choice — the group goes back to being named after its people). Tapping the cover opens **one** sheet with every way of changing it, in two panes rather than two stacked modals: a list of ways in (choose an icon / add-or-change a photo / remove photo when there is one), and behind the first of those, the grid. The photo half is gated behind Plus exactly as before — locked shows a padlock and the "Photos come with Plus" line and leads to upgrade, and while the gate answer is in flight the row does not respond rather than guessing.

**The icon.** A group was pictured by an emoji rendered as text, which is why it looked off: it changes shape between OS versions, sits on the text baseline rather than the icon grid, and carries colours that answer to nobody's palette. `apps/mobile/src/components/GroupMark.tsx` replaces it with **24 drawn marks** on one 24×24 grid — stroke 1.8, round caps and joins throughout, one colour from the theme with strokes at full strength and fills of that same colour at 28%, so a mark reads on white, on the dark surface and on the saturated cards with no second hue to get right.

The set, in the order the grid lays it out:

- **Travel** — beach (sun over two lines of surf), mountains (two peaks, filled snow cap), camping (ridge tent, centre pole, filled doorway), flight (paper plane, near wing filled), road trip (cabin, body, two filled wheels), boat (filled sail on a mast over a hull)
- **Home** — home (roof, walls, filled door), apartment (block with six filled windows), stay (headboard, mattress, filled pillow, two legs), rent (a key on its side, bit to the right), bills (till receipt with a torn foot and two lines of print), savings (three stacked coins, the top one filled)
- **Food** — meals (plate with a fork beside it), pizza (wedge with three toppings), takeaway (noodle bowl with two curls of steam), coffee (cup, handle, two wisps), birthday (cake with one lit candle), drinks (two glasses raised together)
- **Life** — party (popper firing confetti), gift (lid, ribbon, a bow of two loops), couple (filled heart), sport (football, filled centre panel with seams to the rim), favourite (five-pointed star), friends (two people, one a step behind)

**No data is migrated or destroyed.** `groups.cover_emoji` still holds an emoji and the picker still writes one — the web client, the export and every older build keep reading it. `MARK_FOR_EMOJI` maps covers already set onto the mark that means the same thing (🏝️ and ⛱️ both draw the beach; 🏡 is a home, 🏨 an apartment, 🏀 a ball), matched with the U+FE0F variation selector stripped so both spellings find their mark. Anything with no drawing renders as the character it always was.

Stored covers that fall back to raw emoji: 🗺️ 🚆 🏜️ 🧹 💡 🛒 🍔 🍣 🎬 🧗 🏊 🌈 — all from the old picker's wider set. A group that picked one keeps showing it.

The marks are wired into every mobile surface that shows a group's cover: `GroupPhoto` (which covers group settings, archived groups, the group header, clone-group, contacts, captures), the cover picker's grid and preview, the dashboard group row, the all-groups list, the capture destination picker, and the join screen. `Avatar` gained an optional `mark?: (color: string) => ReactNode` that is handed the tint's ink — the same bargain `Callout` makes with its `icon` — so `packages/ui` still carries no vector library. The web client keeps rendering the emoji.

The picker grid states selection three ways: a 2px brand ring with a brand-soft fill, a tick in the corner, and `accessibilityRole="radio"` with `accessibilityState={{ selected }}` — the last being the one a screen reader actually reads.

## i18n

Every new string is in all four locales, including a name for each of the 24 marks (`groupMarks.*`), which is what a screen reader says in place of the picture and what labels each tile in the grid. Removed: `group.leaveWhenZero` and `group.saveName`, from the type and all four locales.

## Device flows

Four Maestro flows reached for controls this removes and were updated with it: `rename-archive-group.yaml` now renames with the keyboard's "done" instead of a Save button, `change-logo.yaml` opens the cover through the group's own mark and picks "Camping" by name, and `group-photo-paid-gate.yaml` picks "Home" rather than 🏠. `leave-group.yaml` only needed a comment corrected. None of these run in CI — they are device flows, and they have not been run here.

Changing the cover now sets the screen's "Saved" line the way every other setting on it does. It had no confirmation of its own before, which was survivable while the cover was a character you could watch change and is not now that it is a drawing — and it gives the icon flow something true to assert on.

## Checks

`pnpm format`, `pnpm lint` (0 errors; the 3 remaining warnings are pre-existing in `phone.tsx`), `typecheck` clean for `@waves/mobile` and `@waves/ui`, and the mobile suite green: 68 files, 865 tests, no flakes. No native build was run — I cannot see the screen, so the layout above is described rather than verified visually, and the drawn marks in particular have never been rendered on a device.
