### PR TITLE
The contacts picker remembers who you have already added

### DIFF
--- a/apps/mobile/src/app/friends/contacts.tsx
+++ b/apps/mobile/src/app/friends/contacts.tsx
@@ -13,11 +13,18 @@
  * nobody anything. The whole lot goes into one group: picking six people for a
  * trip and then answering "which group?" six times is the same answer six
  * times.
+ *
+ * What the screen adds to the bare picker is memory. It knows who you have
+ * already written down — every ghost in every group you are in — so a contact
+ * you added last summer says where they already are instead of looking new, and
+ * the group step will not write them into the same group a second time. That
+ * knowledge is assembled on this device from the local mirror; the address book
+ * still goes nowhere.
  */
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { router } from 'expo-router';
 import { ActivityIndicator, ScrollView, View } from 'react-native';
 
@@ -42,10 +49,13 @@ import {
 
 import { fill, plural, useStrings } from '@/i18n';
 import { friendlyError } from '@/lib/errors';
+import { sameAddress } from '@/lib/contactMatch';
 
 import { ContactPicker, type PickedContact } from '@/components/ContactPicker';
-import { addGhostMember, fetchGroups } from '@/data/api';
-import { groupLabel } from '@/data/types';
+import { addGhostMember } from '@/data/api';
+import { useGroups } from '@/data/hooks';
+import { useKnownContacts } from '@/data/knownContacts';
+import { groupLabel, type MemberRow } from '@/data/types';
 
 export default function ContactsScreen(): React.JSX.Element {
   const theme = useTheme();
@@ -54,12 +64,42 @@ export default function ContactsScreen(): React.JSX.Element {
 
   const [picked, setPicked] = useState<readonly PickedContact[]>([]);
   const [added, setAdded] = useState<number | null>(null);
+  const [skipped, setSkipped] = useState(0);
   const [error, setError] = useState<string | null>(null);
 
-  const groups = useQuery({ queryKey: ['groups'], queryFn: fetchGroups });
+  // Read off the mirror rather than the wire (ADR-005). The group list was a
+  // network query, which meant the last step of this screen — "which group?" —
+  // was the one part of it that needed signal, on the screen most likely to be
+  // used on a trip.
+  const groups = useGroups();
+  const { index: known, membersByGroup } = useKnownContacts();
+
+  /**
+   * How many of the people picked are already in each group.
+   *
+   * Computed for every group at once so the "which group?" step can say it on
+   * each row before anything is written, rather than making somebody pick a
+   * group to find out. Matching is by address (`sameAddress`), not by name: two
+   * flatmates called Ravi are two members, and a name test would silently
+   * refuse to add the second one.
+   */
+  const alreadyIn = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const group of groups.data) {
+      const members = membersByGroup.get(group.id) ?? [];
+      counts.set(group.id, picked.filter((contact) => isMember(members, contact)).length);
+    }
+    return counts;
+  }, [groups.data, membersByGroup, picked]);
 
   /**
    * Everybody picked, into the one group, one call each.
+   *
+   * Anyone already in that group is skipped rather than written again: the
+   * server would happily make a second ghost with the same number, and the
+   * group would end up owing money to two copies of one person — a mess the
+   * merge screen exists to clean up, and one worth not making in the first
+   * place.
    *
    * A failure part-way leaves the earlier ones added, and says whose name did
    * not make it. Adding five people is five separate acts, not a transaction:
@@ -74,8 +114,10 @@ export default function ContactsScreen(): React.JSX.Element {
       groupId: string;
       contacts: readonly PickedContact[];
     }) => {
+      const members = membersByGroup.get(groupId) ?? [];
+      const fresh = contacts.filter((contact) => !isMember(members, contact));
       const failed: string[] = [];
-      for (const contact of contacts) {
+      for (const contact of fresh) {
         try {
           await addGhostMember(groupId, contact.name, {
             email: contact.email,
@@ -92,12 +134,17 @@ export default function ContactsScreen(): React.JSX.Element {
       // A partial failure is a normal outcome, not an exception: the names that
       // did not make it ride back in the result, so nothing raw is thrown and
       // onError is left for a genuine transport failure of the whole call.
-      return { added: contacts.length - failed.length, failed };
+      return {
+        added: fresh.length - failed.length,
+        skipped: contacts.length - fresh.length,
+        failed,
+      };
     },
-    onSuccess: async ({ added, failed }, { groupId }) => {
+    onSuccess: async ({ added, skipped, failed }, { groupId }) => {
       // Only announce a count when at least one landed; on a total failure the
       // error below carries the whole story.
       setAdded(added > 0 ? added : null);
+      setSkipped(skipped);
       setPicked([]);
       setError(failed.length > 0 ? fill(t.misc.couldNotAdd, { names: failed.join(', ') }) : null);
       await queryClient.invalidateQueries({ queryKey: ['members', groupId] });
@@ -142,7 +189,8 @@ export default function ContactsScreen(): React.JSX.Element {
         {picked.length > 0 ? (
           <ChooseGroup
             contacts={picked}
-            groups={groups.data ?? []}
+            groups={groups.data}
+            alreadyIn={alreadyIn}
             busy={add.isPending}
             error={error}
             onCancel={() => {
@@ -153,7 +201,10 @@ export default function ContactsScreen(): React.JSX.Element {
           />
         ) : (
           <>
-            {added !== null ? (
+            {/* Also shown when nothing was added but somebody was skipped:
+                ticking five people and being told nothing at all is the outcome
+                that reads as a failure when it was in fact a no-op. */}
+            {added !== null || skipped > 0 ? (
               <Card style={{ backgroundColor: theme.color.buttonPrimary }}>
                 <Row style={{ gap: theme.spacing.sm }}>
                   <Ionicons
@@ -162,14 +213,33 @@ export default function ContactsScreen(): React.JSX.Element {
                     color={theme.color.onBrand}
                   />
                   <Text variant="caption" tone="onBrand" style={{ flex: 1 }}>
-                    {fill(t.misc.contactsAdded, {
-                      count: plural(locale, added, t.misc.peopleCount),
-                    })}
+                    {added !== null
+                      ? fill(t.misc.contactsAdded, {
+                          count: plural(locale, added, t.misc.peopleCount),
+                        })
+                      : ''}
+                    {/* Somebody who ticked five and sees "3 people added" is owed
+                        the other two, or the count reads as a bug. */}
+                    {skipped > 0
+                      ? `${added !== null ? ' ' : ''}${plural(locale, skipped, t.misc.alreadyThereSkipped)}`
+                      : ''}
                   </Text>
                 </Row>
               </Card>
             ) : null}
-            <ContactPicker onConfirm={setPicked} confirmVerb={t.misc.continueWith} />
+            <ContactPicker
+              onConfirm={setPicked}
+              confirmVerb={t.misc.continueWith}
+              known={known}
+              // The person who is not in the address book at all. Waves already
+              // has a screen that takes a typed name and makes the one-to-one
+              // group behind it, so this points at that rather than growing a
+              // second way to invent a person.
+              escape={{
+                label: t.misc.someoneNotInContacts,
+                onPress: () => router.push('/friends/add-person' as never),
+              }}
+            />
           </>
         )}
       </View>
@@ -186,6 +256,7 @@ export default function ContactsScreen(): React.JSX.Element {
 function ChooseGroup({
   contacts,
   groups,
+  alreadyIn,
   busy,
   error,
   onCancel,
@@ -193,6 +264,8 @@ function ChooseGroup({
 }: {
   contacts: readonly PickedContact[];
   groups: readonly { id: string; name: string | null; cover_emoji: string | null }[];
+  /** How many of `contacts` each group already holds, keyed by group id. */
+  alreadyIn: ReadonlyMap<string, number>;
   busy: boolean;
   error: string | null;
   onCancel: () => void;
@@ -243,29 +316,45 @@ function ChooseGroup({
         </Card>
       ) : (
         <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
-          {groups.map((group, index) => (
-            <View key={group.id}>
-              <ListRow
-                title={groupLabel(group)}
-                leading={
-                  <Avatar
-                    name={groupLabel(group)}
-                    emoji={group.cover_emoji ?? undefined}
-                    size={40}
-                  />
-                }
-                onPress={busy ? undefined : () => onChoose(group.id)}
-                trailing={
-                  <Ionicons
-                    name={directionalIcon('chevron-forward')}
-                    size={iconSize.md}
-                    color={theme.color.textFaint}
-                  />
-                }
-              />
-              {index < groups.length - 1 ? <Divider /> : null}
-            </View>
-          ))}
+          {groups.map((group, index) => {
+            const here = alreadyIn.get(group.id) ?? 0;
+            // Every person picked is already in here, so there is nothing this
+            // row could do. Said, not hidden: a group that vanishes from the
+            // list reads as data lost rather than as a question answered.
+            const full = here >= contacts.length;
+            return (
+              <View key={group.id} style={full ? { opacity: 0.5 } : undefined}>
+                <ListRow
+                  title={groupLabel(group)}
+                  subtitle={
+                    full
+                      ? t.misc.everyoneAlreadyIn
+                      : here > 0
+                        ? plural(locale, here, t.misc.alreadyInCount)
+                        : undefined
+                  }
+                  leading={
+                    <Avatar
+                      name={groupLabel(group)}
+                      emoji={group.cover_emoji ?? undefined}
+                      size={40}
+                    />
+                  }
+                  onPress={busy || full ? undefined : () => onChoose(group.id)}
+                  trailing={
+                    full ? undefined : (
+                      <Ionicons
+                        name={directionalIcon('chevron-forward')}
+                        size={iconSize.md}
+                        color={theme.color.textFaint}
+                      />
+                    )
+                  }
+                />
+                {index < groups.length - 1 ? <Divider /> : null}
+              </View>
+            );
+          })}
         </Card>
       )}
 
@@ -278,5 +367,21 @@ function ChooseGroup({
 
       <Button label={t.misc.pickDifferentPeople} variant="ghost" onPress={onCancel} />
     </ScrollView>
+  );
+}
+
+/**
+ * Whether this contact is already one of the group's members.
+ *
+ * Matched on the address the invite was written to, never on the name: two
+ * people called Ravi in one flat are two members, and a name test would refuse
+ * to add the second of them while giving no reason anybody could act on.
+ */
+function isMember(members: readonly MemberRow[], contact: PickedContact): boolean {
+  return members.some((member) =>
+    sameAddress(
+      { email: member.invite_email ?? null, phone: member.invite_phone ?? null },
+      contact,
+    ),
   );
 }

--- a/apps/mobile/src/components/ContactPicker.tsx
+++ b/apps/mobile/src/components/ContactPicker.tsx
@@ -17,6 +17,21 @@
  * letter sections that stick to the top as you scroll, and an index rail down
  * the side to throw yourself at a letter. A thousand contacts is not a list you
  * scroll — it is a list you aim at.
+ *
+ * Three things sit on top of that shape, and each is answered locally:
+ *
+ *  - The people you have already written down float to a section at the head of
+ *    the list and say which group they are in, so the friends you split with
+ *    every week are two rows from the top instead of four hundred (the same
+ *    move Monzo, Splitwise, Snapchat and LINE all make with their "recent"
+ *    section). It comes out of your own groups, not out of a server that was
+ *    told your address book.
+ *  - A pinned way out for the person who is not in the address book at all,
+ *    which is where every picker eventually fails somebody. Splitwise puts "add
+ *    a new contact" at the top of the same list; so does this.
+ *  - iOS 18 lets somebody grant access to *some* contacts. That is not the same
+ *    as a short address book, and showing eleven names with no explanation is a
+ *    quiet lie about what the phone contains, so it is said out loud.
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -36,6 +51,7 @@ import {
 import {
   Avatar,
   Button,
+  Callout,
   directionalIcon,
   EmptyState,
   iconSize,
@@ -44,7 +60,13 @@ import {
   useTheme,
 } from '@waves/ui';
 
-import { plural, useStrings } from '@/i18n';
+import { fill, plural, useStrings } from '@/i18n';
+import {
+  lookupKnown,
+  matchesContactQuery,
+  type KnownIndex,
+  type KnownPerson,
+} from '@/lib/contactMatch';
 import { normaliseContactPhone } from '@/lib/phone';
 import { SkeletonList } from '@/components/Skeletons';
 
@@ -73,6 +95,18 @@ interface ContactPickerProps {
    * for a list that only ever wanted one answer.
    */
   single?: boolean;
+  /**
+   * Who Waves already has, built on the device from your own groups. Contacts
+   * that match are named with the group they are in and float to a section at
+   * the head of the list. Omitted, the picker behaves as it always did.
+   */
+  known?: KnownIndex;
+  /**
+   * The way out for somebody who is not in the address book — a row pinned to
+   * the head of the list. The caller owns the destination because it differs by
+   * screen: adding a friend is a different act from adding to an open group.
+   */
+  escape?: { readonly label: string; readonly onPress: () => void };
 }
 
 /**
@@ -105,16 +139,39 @@ const FIELDS = [
   ContactField.PHONES,
 ] as const;
 
-/** A letter heading, or somebody. One flat array so the list can recycle both. */
-type Entry = { readonly letter: string } | PickedContact;
-
-const isHeading = (entry: Entry): entry is { readonly letter: string } => 'letter' in entry;
+/**
+ * One row of the flat list: the way out, a heading, or somebody.
+ *
+ * A discriminated union rather than the old "is there a `letter` key" test,
+ * because there are three shapes now and a heading is no longer always a
+ * letter — the section of people you already split with is headed by a phrase.
+ * `known` is resolved here, once per rebuild, rather than in `renderItem`:
+ * matching a contact against every ghost you have is cheap but not free, and
+ * `renderItem` runs again on every keystroke and every tick.
+ */
+type Entry =
+  | { readonly kind: 'escape' }
+  | { readonly kind: 'heading'; readonly id: string; readonly label: string }
+  | {
+      readonly kind: 'person';
+      readonly id: string;
+      readonly contact: PickedContact;
+      readonly known: KnownPerson | null;
+    };
 
 const ROW_HEIGHT = 64;
 const HEADING_HEIGHT = 38;
 const RAIL_WIDTH = 24;
 const RAIL_LETTER_HEIGHT = 15;
 const STRIP_HEIGHT = 62;
+
+/**
+ * How many already-known people ride at the top before the alphabet takes over.
+ *
+ * A shortcut that is longer than a screen has stopped being a shortcut. Anybody
+ * past the cap is still in their letter section, where they always were.
+ */
+const RECENT_LIMIT = 8;
 
 export function ContactPicker({
   onConfirm,
@@ -123,12 +180,19 @@ export function ContactPicker({
   confirmVerb,
   busy = false,
   single = false,
+  known,
+  escape,
 }: ContactPickerProps): React.JSX.Element {
   const theme = useTheme();
   const { t, locale } = useStrings();
   const [access, setAccess] = useState<Access>(Access.Asking);
+  // iOS 18 and up can grant access to a chosen handful rather than the book.
+  // Kept apart from `access` because the list works either way — it is a
+  // caption on what you are looking at, not a state the list has to handle.
+  const [limited, setLimited] = useState(false);
   const [contacts, setContacts] = useState<PickedContact[]>([]);
   const [query, setQuery] = useState('');
+  const hasEscape = Boolean(escape);
   // Seeded from whoever is already chosen, so opening the picker shows them
   // ticked and in the strip rather than an empty selection.
   const [picked, setPicked] = useState<ReadonlyMap<string, PickedContact>>(
@@ -140,8 +204,15 @@ export function ContactPicker({
     let granted: boolean;
     try {
       const current = await getPermissionsAsync();
-      granted =
-        current.granted || (current.canAskAgain && (await requestPermissionsAsync()).granted);
+      const answered = current.granted
+        ? current
+        : current.canAskAgain
+          ? await requestPermissionsAsync()
+          : current;
+      granted = answered.granted;
+      // Absent on Android and on older iOS, where the grant is all-or-nothing —
+      // so the default is "not limited" rather than a guess.
+      if (!cancelled.current) setLimited(answered.accessPrivileges === 'limited');
     } catch {
       // Permission itself could not be asked: no contacts module on this
       // platform (web) or an OS that refused the question.
@@ -203,42 +274,92 @@ export function ContactPicker({
     return () => subscription.remove();
   }, [access, load]);
 
-  const matches = useMemo(() => {
-    const needle = query.trim().toLowerCase();
-    if (!needle) return contacts;
-    return contacts.filter(
-      (contact) =>
-        contact.name.toLowerCase().includes(needle) ||
-        contact.email?.includes(needle) ||
-        contact.phone?.includes(needle),
-    );
-  }, [contacts, query]);
+  /**
+   * Every contact, each paired with the person Waves already has under that
+   * address — resolved once per load rather than once per keystroke.
+   *
+   * The lookup walks every ghost you have for every contact in the book, which
+   * is nothing on its own and a great deal a thousand times over. Keying it on
+   * the contacts and the index alone keeps it out of the typing path entirely;
+   * only the filter below runs as you type.
+   */
+  const people = useMemo(
+    () =>
+      contacts.map((contact) => ({
+        contact,
+        known: known ? lookupKnown(known, contact) : null,
+      })),
+    [contacts, known],
+  );
+
+  // The search itself lives in `lib/contactMatch` so the rules that decide a
+  // match — accent folding, and a number compared by its digits — can be tested
+  // without a screen. The old test was a raw `toLowerCase().includes`, which
+  // missed `José` for `jose` and missed a number the moment either side had a
+  // space in it.
+  const matches = useMemo(
+    () => (query.trim() ? people.filter((row) => matchesContactQuery(row.contact, query)) : people),
+    [people, query],
+  );
 
   /**
    * The flat list, the indices that stick, and where each letter starts.
    *
-   * All three come out of one pass because they have to agree: a rail that
-   * jumps to a stale index scrolls to the wrong person, and that is the kind of
-   * wrong that only shows up on somebody else's address book.
+   * All four come out of one pass because they have to agree: a rail that jumps
+   * to a stale index scrolls to the wrong person, and that is the kind of wrong
+   * that only shows up on somebody else's address book.
+   *
+   * The already-known section is skipped while a search is running. A search
+   * returning three rows, one of them printed twice, reads as a bug rather than
+   * as a shortcut; the shortcut is for the list you did not narrow.
    */
   const sections = useMemo(() => {
     const entries: Entry[] = [];
     const sticky: number[] = [];
     const starts = new Map<string, number>();
-    let current: string | null = null;
 
-    for (const contact of matches) {
-      const letter = bucketOf(contact.name);
+    if (hasEscape) entries.push({ kind: 'escape' });
+
+    if (!query.trim()) {
+      const recent = matches
+        .filter((row): row is { contact: PickedContact; known: KnownPerson } => row.known !== null)
+        .slice(0, RECENT_LIMIT);
+      if (recent.length > 0) {
+        sticky.push(entries.length);
+        entries.push({ kind: 'heading', id: 'recent', label: t.pickers.splitWithBefore });
+        for (const row of recent) {
+          entries.push({
+            kind: 'person',
+            // Prefixed, because these same people appear again under their own
+            // letter and a list cannot have one key twice.
+            id: `recent-${keyOf(row.contact)}`,
+            contact: row.contact,
+            known: row.known,
+          });
+        }
+      }
+    }
+
+    let current: string | null = null;
+    for (const row of matches) {
+      const letter = bucketOf(row.contact.name);
       if (letter !== current) {
         current = letter;
         starts.set(letter, entries.length);
         sticky.push(entries.length);
-        entries.push({ letter });
+        entries.push({ kind: 'heading', id: `letter-${letter}`, label: letter });
       }
-      entries.push(contact);
+      entries.push({
+        kind: 'person',
+        id: keyOf(row.contact),
+        contact: row.contact,
+        known: row.known,
+      });
     }
     return { entries, sticky, starts, letters: [...starts.keys()] };
-  }, [matches]);
+    // `hasEscape` rather than `escape` itself: callers build that object inline,
+    // so a new identity every render would rebuild the whole list every render.
+  }, [matches, query, hasEscape, t.pickers.splitWithBefore]);
 
   const listRef = useRef<FlashListRef<Entry>>(null);
   // Tapping the search row (the magnifier or its padding, not just the input's
@@ -362,6 +483,18 @@ export function ContactPicker({
         ) : null}
       </Pressable>
 
+      {/* Said out loud rather than left to look like a short address book: on
+          iOS 18 a "limited" grant means the phone is showing Waves a handful the
+          person chose, and the way to widen it is the same settings screen the
+          refusal state points at. */}
+      {limited ? (
+        <Callout tone="info">
+          <Text variant="micro" tone="muted">
+            {t.pickers.contactsLimited}
+          </Text>
+        </Callout>
+      ) : null}
+
       {!single && chosen.length > 0 ? <PickedStrip chosen={chosen} onRemove={toggle} /> : null}
 
       {matches.length === 0 ? (
@@ -375,6 +508,13 @@ export function ContactPicker({
           }
           title={t.pickers.nobodyHere}
           body={query ? t.pickers.noContactMatches : t.pickers.noneHasEmailOrNumber}
+          // An empty list is exactly when somebody needs the way out, and the
+          // pinned row lives inside the list they cannot see.
+          action={
+            escape ? (
+              <Button label={escape.label} variant="secondary" onPress={escape.onPress} />
+            ) : undefined
+          }
         />
       ) : (
         <View style={{ flex: 1, flexDirection: 'row' }}>
@@ -399,27 +539,34 @@ export function ContactPicker({
               // Headings and people are different shapes; telling the list so
               // lets it recycle each against its own kind instead of throwing
               // away a row every time a letter goes by.
-              getItemType={(entry) => (isHeading(entry) ? 'heading' : 'person')}
-              keyExtractor={(entry) => (isHeading(entry) ? `letter-${entry.letter}` : keyOf(entry))}
+              getItemType={(entry) => entry.kind}
+              keyExtractor={(entry) => (entry.kind === 'escape' ? 'escape' : entry.id)}
               keyboardShouldPersistTaps="handled"
               renderItem={({ item }) => {
-                if (isHeading(item)) return <Heading letter={item.letter} />;
-                const key = keyOf(item);
+                if (item.kind === 'escape') {
+                  return escape ? (
+                    <EscapeRow label={escape.label} onPress={escape.onPress} />
+                  ) : null;
+                }
+                if (item.kind === 'heading') return <Heading label={item.label} />;
+                const { contact } = item;
+                const key = keyOf(contact);
                 const already = Boolean(
-                  (item.email && existing?.has(item.email)) ||
-                  (item.phone && existing?.has(item.phone)),
+                  (contact.email && existing?.has(contact.email)) ||
+                  (contact.phone && existing?.has(contact.phone)),
                 );
                 return (
                   <ContactRow
-                    contact={item}
+                    contact={contact}
                     already={already}
+                    known={item.known}
                     single={single}
                     // Single-pick confirms on the tap, so `busy` has no button to
                     // disable — it has to lock the rows themselves, or a second
                     // tap fires a second confirm while the first is still writing.
                     disabled={single && busy}
                     selected={single ? false : picked.has(key)}
-                    onPress={() => (single ? onConfirm([item]) : toggle(key, item))}
+                    onPress={() => (single ? onConfirm([contact]) : toggle(key, contact))}
                   />
                 );
               }}
@@ -464,12 +611,17 @@ export function ContactPicker({
 }
 
 /**
- * The letter heading. A filled square rather than the app's usual pill, because
+ * A section heading. A filled square rather than the app's usual pill, because
  * a pill in this design system means "you can tap this" and a heading is not
  * something you tap — you tap the rail on the right.
+ *
+ * A single letter keeps the square; the named section at the head of the list
+ * is a phrase, and a phrase in a 26pt box would either wrap or be cut, so it is
+ * set as plain muted text instead of squeezed into a shape built for one glyph.
  */
-function Heading({ letter }: { letter: string }): React.JSX.Element {
+function Heading({ label }: { label: string }): React.JSX.Element {
   const theme = useTheme();
+  const single = [...label].length === 1;
   return (
     <View
       style={{
@@ -480,27 +632,85 @@ function Heading({ letter }: { letter: string }): React.JSX.Element {
         backgroundColor: theme.color.surface,
       }}
     >
-      <View
-        style={{
-          width: 26,
-          height: 26,
-          borderRadius: theme.radius.sm,
-          alignItems: 'center',
-          justifyContent: 'center',
-          backgroundColor: theme.color.brand,
-        }}
-      >
-        <Text variant="caption" tone="onBrand">
-          {letter}
+      {single ? (
+        <View
+          style={{
+            width: 26,
+            height: 26,
+            borderRadius: theme.radius.sm,
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: theme.color.brand,
+          }}
+        >
+          <Text variant="caption" tone="onBrand">
+            {label}
+          </Text>
+        </View>
+      ) : (
+        <Text variant="micro" tone="muted" numberOfLines={1}>
+          {label}
         </Text>
-      </View>
+      )}
     </View>
+  );
+}
+
+/**
+ * The way out, at the head of the list.
+ *
+ * Every address-book picker eventually fails somebody — the flatmate saved
+ * under a nickname, the person you met yesterday, the friend whose number is in
+ * a chat and not in the contacts app. Splitwise pins "add a new contact" to the
+ * top of exactly this list rather than making you back out and hunt for another
+ * entry point, and this is the same row: a name typed by hand is a first-class
+ * way to add a person here, not the fallback for when the good one failed.
+ */
+function EscapeRow({ label, onPress }: { label: string; onPress: () => void }): React.JSX.Element {
+  const theme = useTheme();
+  const inset = theme.spacing.lg + 40 + theme.spacing.md;
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      style={({ pressed }) => ({
+        backgroundColor: pressed ? theme.color.surfaceMuted : theme.color.surface,
+      })}
+    >
+      <Row
+        style={{ height: ROW_HEIGHT, paddingHorizontal: theme.spacing.lg, gap: theme.spacing.md }}
+      >
+        <View
+          style={{
+            width: 40,
+            height: 40,
+            borderRadius: 20,
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: theme.color.brandSoft,
+          }}
+        >
+          <Ionicons name="person-add-outline" size={iconSize.md} color={theme.color.brand} />
+        </View>
+        <Text variant="body" tone="brand" style={{ flex: 1 }} numberOfLines={1}>
+          {label}
+        </Text>
+        <Ionicons
+          name={directionalIcon('chevron-forward')}
+          size={iconSize.md}
+          color={theme.color.textFaint}
+        />
+      </Row>
+      <View style={{ height: 1, marginLeft: inset, backgroundColor: theme.color.border }} />
+    </Pressable>
   );
 }
 
 function ContactRow({
   contact,
   already,
+  known = null,
   selected,
   single = false,
   disabled = false,
@@ -508,6 +718,9 @@ function ContactRow({
 }: {
   contact: PickedContact;
   already: boolean;
+  /** The person Waves already has under this address, if any. Never locks the
+   *  row: somebody in last year's trip is exactly who you want in this one. */
+  known?: KnownPerson | null;
   selected: boolean;
   single?: boolean;
   /** Locked for a reason other than membership (a single-pick write in flight). */
@@ -515,11 +728,23 @@ function ContactRow({
   onPress: () => void;
 }): React.JSX.Element {
   const theme = useTheme();
-  const { t } = useStrings();
+  const { t, locale } = useStrings();
   const inset = theme.spacing.lg + 40 + theme.spacing.md;
   // `already` is one reason a row is inert (and the only one that renames the
   // subtitle); `disabled` is the other. Both dim and deafen the row the same way.
   const locked = already || disabled;
+
+  // The one line under the name, in the order that answers the most pressing
+  // question first: can I even pick this person, then do I already know them,
+  // then who is this. `already` beats `known` because "in this group" is the
+  // more specific truth when both are true.
+  const subtitle = already
+    ? t.pickers.alreadyInGroup
+    : known
+      ? known.groupIds.length === 1
+        ? fill(t.pickers.knownInGroup, { group: known.groupNames[0] ?? '' })
+        : plural(locale, known.groupIds.length, t.pickers.knownInGroups)
+      : (contact.email ?? contact.phone ?? '');
 
   return (
     <Pressable
@@ -529,8 +754,15 @@ function ContactRow({
       // acts on the tap; multi keeps the checkbox it fills and unfills.
       accessibilityRole={single ? 'button' : 'checkbox'}
       accessibilityState={single ? { disabled: locked } : { checked: selected, disabled: locked }}
+      // The subtitle rides in the label rather than being left to the tint on
+      // it: "already in Goa" is the whole reason a row looks different, and a
+      // screen reader that only says the name loses the difference entirely.
       accessibilityLabel={
-        already ? t.pickers.alreadyAddedName.replace('{name}', contact.name) : contact.name
+        already
+          ? t.pickers.alreadyAddedName.replace('{name}', contact.name)
+          : known
+            ? `${contact.name}, ${subtitle}`
+            : contact.name
       }
       style={({ pressed }) => ({
         opacity: locked ? 0.45 : 1,
@@ -549,8 +781,8 @@ function ContactRow({
           <Text variant="body" numberOfLines={1}>
             {contact.name}
           </Text>
-          <Text variant="micro" tone="muted" numberOfLines={1}>
-            {already ? t.pickers.alreadyInGroup : (contact.email ?? contact.phone ?? '')}
+          <Text variant="micro" tone={!already && known ? 'brand' : 'muted'} numberOfLines={1}>
+            {subtitle}
           </Text>
         </View>
         {single ? (

--- a/apps/mobile/src/data/knownContacts.ts
+++ b/apps/mobile/src/data/knownContacts.ts
@@ -1,0 +1,82 @@
+/**
+ * Who Waves already has, read off the mirror.
+ *
+ * The picker used to offer every contact identically, so adding six people to a
+ * trip and then adding a seventh next week meant re-reading the same list with
+ * no memory of the six. This is that memory, and it is built entirely out of
+ * rows the device already holds: the ghost members in your own groups, each of
+ * which carries the one email or number you gave when you invited them.
+ *
+ * It is deliberately *not* a contact-book upload wearing a different hat. The
+ * index is assembled on the phone from the local mirror (ADR-005), matched on
+ * the phone by `lib/contactMatch`, and never sent anywhere; the address book is
+ * read to find the match and is not stored. Nothing here can say which of your
+ * contacts use Waves — only which of them you have already written down
+ * yourself, which is a question your own device can answer without telling a
+ * server about anybody (ADR-006).
+ *
+ * Members who joined with a real account carry no address here, because a
+ * profile deliberately does not expose an email or a number another member
+ * could read. They are matched by name instead, which is why that rule exists
+ * at all and why it is confined to rows that have nothing better.
+ */
+
+import { useMemo } from 'react';
+
+import { materialiseGroups, materialiseMembers } from '@waves/core';
+
+import { useSync } from '@/sync';
+import { useAuth } from '@/lib/auth';
+import { buildKnownIndex, type KnownGroupInput, type KnownIndex } from '@/lib/contactMatch';
+import { displayName, groupLabel, type GroupRow, type MemberRow } from '@/data/types';
+
+/** Everything the contacts screen needs to know about who it already has. */
+export interface KnownContacts {
+  /** Matched against an address-book entry to name where somebody already is. */
+  readonly index: KnownIndex;
+  /** The live membership of each of your groups, for the "which group?" step. */
+  readonly membersByGroup: ReadonlyMap<string, readonly MemberRow[]>;
+}
+
+/**
+ * A mirror read rather than a query, so the picker knows who it already has
+ * with no signal — the same rule the rest of the app reads by (ADR-005), and
+ * the case that matters most here is a trip abroad with the data off.
+ *
+ * The index and the per-group membership come out of one pass because the
+ * second is what builds the first, and materialising every group's members
+ * twice to answer two halves of the same question would be work for nothing.
+ */
+export function useKnownContacts(): KnownContacts {
+  const { mirror, queue } = useSync();
+  const { profile } = useAuth();
+  const profileId = profile?.id ?? null;
+
+  return useMemo(() => {
+    const groups = materialiseGroups(mirror, queue) as unknown as GroupRow[];
+    const membersByGroup = new Map<string, readonly MemberRow[]>();
+    const inputs: KnownGroupInput[] = [];
+
+    for (const group of groups) {
+      const members = materialiseMembers(mirror, queue, {
+        groupId: group.id,
+      }) as unknown as MemberRow[];
+      membersByGroup.set(group.id, members);
+      inputs.push({
+        id: group.id,
+        label: groupLabel(group, members, profileId),
+        members: members
+          // You are not somebody you can add to a group, so leaving yourself out
+          // keeps your own contact card from claiming to be already added.
+          .filter((member) => !(member.profile_id && member.profile_id === profileId))
+          .map((member) => ({
+            name: displayName(member, profileId),
+            email: member.invite_email ?? null,
+            phone: member.invite_phone ?? null,
+          })),
+      });
+    }
+
+    return { index: buildKnownIndex(inputs), membersByGroup };
+  }, [mirror, queue, profileId]);
+}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1916,6 +1916,14 @@ export interface UiStrings {
     addThemAllToWhichGroup: string;
     startAGroup: string;
     pickDifferentPeople: string;
+    /** The way out of the contact picker for somebody not in the address book. */
+    someoneNotInContacts: string;
+    /** On a group row in "which group?": how many of the people picked are in it. */
+    alreadyInCount: PluralForms;
+    /** That row when every single person picked is already a member. */
+    everyoneAlreadyIn: string;
+    /** Appended to the added-count when some were skipped for already being there. */
+    alreadyThereSkipped: PluralForms;
     someone: string;
     /** Badges on a cross-group activity row: its group is archived, or no
      *  longer on this device (left or deleted). */
@@ -2238,6 +2246,14 @@ export interface UiStrings {
     personCount: PluralForms;
     alreadyAddedName: string;
     alreadyInGroup: string;
+    /** Heading over the contacts you have already written into a group. */
+    splitWithBefore: string;
+    /** A contact who is already in exactly one of your groups: "Already in {group}". */
+    knownInGroup: string;
+    /** A contact who is in several of them. */
+    knownInGroups: PluralForms;
+    /** iOS 18's partial contacts grant — said out loud so a short list is not a lie. */
+    contactsLimited: string;
     removeName: string;
     remindZoneNote: string;
     useMyTimezone: string;
@@ -4148,6 +4164,13 @@ const en: UiStrings = {
     addThemAllToWhichGroup: 'Add them all to which group?',
     startAGroup: 'Start a group',
     pickDifferentPeople: 'Pick different people',
+    someoneNotInContacts: 'Someone not in your contacts',
+    alreadyInCount: { one: '{n} of them is already here', other: '{n} of them are already here' },
+    everyoneAlreadyIn: 'Everyone you picked is already here',
+    alreadyThereSkipped: {
+      one: '{n} was already in that group.',
+      other: '{n} were already in that group.',
+    },
     someone: 'Someone',
     archivedGroup: 'Archived',
     unavailableGroup: 'Unavailable',
@@ -4469,7 +4492,7 @@ const en: UiStrings = {
     contactCount: { one: '{n} contact', other: '{n} contacts' },
     clearSearch: 'Clear search',
     nobodyHere: 'Nobody here',
-    noContactMatches: 'No contact matches that.',
+    noContactMatches: 'No contact matches that. Try a name, a phone number or an email.',
     noneHasEmailOrNumber: 'None of your contacts has an email or number.',
     onlyPickedAreSent:
       'Only the people you pick are sent to Waves. Your contacts stay on this phone.',
@@ -4492,6 +4515,10 @@ const en: UiStrings = {
     personCount: { one: '{n} person', other: '{n} people' },
     alreadyAddedName: '{name}, already added',
     alreadyInGroup: 'Already in this group',
+    splitWithBefore: 'People you split with',
+    knownInGroup: 'Already in {group}',
+    knownInGroups: { one: 'In {n} of your groups', other: 'In {n} of your groups' },
+    contactsLimited: 'You gave Waves only some of your contacts. Open settings to let it see more.',
     removeName: 'Remove {name}',
     remindZoneNote: 'Asked in {zone} — where the trip is, not where each person is.',
     useMyTimezone: 'Use my timezone ({zone})',
@@ -6473,6 +6500,16 @@ const ta: UiStrings = {
     addThemAllToWhichGroup: 'அனைவரையும் எந்தக் குழுவில் சேர்ப்பது?',
     startAGroup: 'ஒரு குழுவைத் தொடங்கு',
     pickDifferentPeople: 'வேறு ஆட்களைத் தேர்ந்தெடு',
+    someoneNotInContacts: 'உங்கள் தொடர்புகளில் இல்லாத ஒருவர்',
+    alreadyInCount: {
+      one: 'அவர்களில் {n} பேர் ஏற்கனவே இங்கே உள்ளார்',
+      other: 'அவர்களில் {n} பேர் ஏற்கனவே இங்கே உள்ளனர்',
+    },
+    everyoneAlreadyIn: 'நீங்கள் தேர்ந்தெடுத்த அனைவரும் ஏற்கனவே இங்கே உள்ளனர்',
+    alreadyThereSkipped: {
+      one: '{n} பேர் ஏற்கனவே அந்தக் குழுவில் இருந்தார்.',
+      other: '{n} பேர் ஏற்கனவே அந்தக் குழுவில் இருந்தனர்.',
+    },
     someone: 'யாரோ',
     archivedGroup: 'காப்பகம்',
     unavailableGroup: 'கிடைக்கவில்லை',
@@ -6819,7 +6856,8 @@ const ta: UiStrings = {
     contactCount: { one: '{n} தொடர்பு', other: '{n} தொடர்புகள்' },
     clearSearch: 'தேடலை அழி',
     nobodyHere: 'இங்கே யாரும் இல்லை',
-    noContactMatches: 'அதற்குப் பொருந்தும் தொடர்பு இல்லை.',
+    noContactMatches:
+      'அதற்குப் பொருந்தும் தொடர்பு இல்லை. பெயர், தொலைபேசி எண் அல்லது மின்னஞ்சலை முயலுங்கள்.',
     noneHasEmailOrNumber: 'உங்கள் தொடர்புகளில் யாருக்கும் மின்னஞ்சலோ எண்ணோ இல்லை.',
     onlyPickedAreSent:
       'நீங்கள் தேர்ந்தெடுத்த நபர்கள் மட்டுமே Waves-க்கு அனுப்பப்படுவார்கள். உங்கள் தொடர்புகள் இந்த ஃபோனிலேயே இருக்கும்.',
@@ -6842,6 +6880,14 @@ const ta: UiStrings = {
     personCount: { one: '{n} நபர்', other: '{n} நபர்கள்' },
     alreadyAddedName: '{name}, ஏற்கனவே சேர்க்கப்பட்டது',
     alreadyInGroup: 'ஏற்கனவே இந்தக் குழுவில் உள்ளார்',
+    splitWithBefore: 'நீங்கள் செலவுகளைப் பகிர்பவர்கள்',
+    knownInGroup: 'ஏற்கனவே {group} இல் உள்ளார்',
+    knownInGroups: {
+      one: 'உங்கள் {n} குழுவில் உள்ளார்',
+      other: 'உங்கள் {n} குழுக்களில் உள்ளார்',
+    },
+    contactsLimited:
+      'உங்கள் தொடர்புகளில் சிலவற்றை மட்டுமே Waves-க்குக் கொடுத்துள்ளீர்கள். மேலும் பார்க்க அமைப்புகளைத் திறக்கவும்.',
     removeName: '{name} ஐ நீக்கு',
     remindZoneNote:
       '{zone} இல் கேட்கப்படுகிறது — பயணம் இருக்கும் இடம், ஒவ்வொருவரும் இருக்கும் இடம் அல்ல.',
@@ -8785,6 +8831,16 @@ const hi: UiStrings = {
     addThemAllToWhichGroup: 'इन सबको किस समूह में जोड़ें?',
     startAGroup: 'समूह शुरू करें',
     pickDifferentPeople: 'दूसरे लोग चुनें',
+    someoneNotInContacts: 'कोई जो आपके संपर्कों में नहीं है',
+    alreadyInCount: {
+      one: 'उनमें से {n} पहले से यहाँ है',
+      other: 'उनमें से {n} पहले से यहाँ हैं',
+    },
+    everyoneAlreadyIn: 'आपने जिन्हें चुना, वे सब पहले से यहाँ हैं',
+    alreadyThereSkipped: {
+      one: '{n} पहले से उस समूह में था।',
+      other: '{n} पहले से उस समूह में थे।',
+    },
     someone: 'कोई',
     archivedGroup: 'संग्रहीत',
     unavailableGroup: 'अनुपलब्ध',
@@ -9110,7 +9166,7 @@ const hi: UiStrings = {
     contactCount: { one: '{n} संपर्क', other: '{n} संपर्क' },
     clearSearch: 'खोज मिटाएँ',
     nobodyHere: 'यहाँ कोई नहीं',
-    noContactMatches: 'उससे कोई संपर्क नहीं मिला।',
+    noContactMatches: 'उससे कोई संपर्क नहीं मिला। नाम, फ़ोन नंबर या ईमेल आज़माएँ।',
     noneHasEmailOrNumber: 'आपके किसी संपर्क के पास ईमेल या नंबर नहीं है।',
     onlyPickedAreSent:
       'सिर्फ़ वही लोग Waves को भेजे जाते हैं जिन्हें आप चुनते हैं। आपके संपर्क इसी फ़ोन पर रहते हैं।',
@@ -9133,6 +9189,13 @@ const hi: UiStrings = {
     personCount: { one: '{n} व्यक्ति', other: '{n} लोग' },
     alreadyAddedName: '{name}, पहले से जुड़ा है',
     alreadyInGroup: 'पहले से इस समूह में है',
+    splitWithBefore: 'जिनके साथ आप खर्च बाँटते हैं',
+    knownInGroup: 'पहले से {group} में है',
+    knownInGroups: {
+      one: 'आपके {n} समूह में है',
+      other: 'आपके {n} समूहों में है',
+    },
+    contactsLimited: 'आपने Waves को अपने कुछ ही संपर्क दिए हैं। और दिखाने के लिए सेटिंग्स खोलें।',
     removeName: '{name} को हटाएँ',
     remindZoneNote: '{zone} में पूछा जाता है — जहाँ यात्रा है, न कि जहाँ हर कोई है।',
     useMyTimezone: 'मेरा टाइमज़ोन इस्तेमाल करें ({zone})',
@@ -11172,6 +11235,24 @@ const ar: UiStrings = {
     addThemAllToWhichGroup: 'إلى أي مجموعة نضيفهم جميعًا؟',
     startAGroup: 'ابدأ مجموعة',
     pickDifferentPeople: 'اختر أشخاصًا آخرين',
+    someoneNotInContacts: 'شخص ليس في جهات اتصالك',
+    alreadyInCount: {
+      zero: 'لا أحد منهم هنا بعد',
+      one: 'واحد منهم هنا بالفعل',
+      two: 'اثنان منهم هنا بالفعل',
+      few: '{n} منهم هنا بالفعل',
+      many: '{n} منهم هنا بالفعل',
+      other: '{n} منهم هنا بالفعل',
+    },
+    everyoneAlreadyIn: 'كل من اخترتهم هنا بالفعل',
+    alreadyThereSkipped: {
+      zero: 'لم يكن أحد في تلك المجموعة من قبل.',
+      one: 'كان واحد منهم في تلك المجموعة من قبل.',
+      two: 'كان اثنان منهم في تلك المجموعة من قبل.',
+      few: 'كان {n} منهم في تلك المجموعة من قبل.',
+      many: 'كان {n} منهم في تلك المجموعة من قبل.',
+      other: 'كان {n} منهم في تلك المجموعة من قبل.',
+    },
     someone: 'أحدهم',
     archivedGroup: 'مؤرشَف',
     unavailableGroup: 'غير متاح',
@@ -11622,7 +11703,7 @@ const ar: UiStrings = {
     },
     clearSearch: 'امسح البحث',
     nobodyHere: 'لا أحد هنا',
-    noContactMatches: 'لا تطابق أي جهة اتصال ذلك.',
+    noContactMatches: 'لا تطابق أي جهة اتصال ذلك. جرّب اسمًا أو رقم هاتف أو بريدًا.',
     noneHasEmailOrNumber: 'لا يملك أي من جهات اتصالك بريدًا أو رقمًا.',
     onlyPickedAreSent: 'لا يُرسل إلى Waves إلا من تختارهم. تبقى جهات اتصالك على هذا الهاتف.',
     jumpToLetter: 'انتقل إلى حرف',
@@ -11651,6 +11732,17 @@ const ar: UiStrings = {
     },
     alreadyAddedName: '{name}، مضاف بالفعل',
     alreadyInGroup: 'موجود بالفعل في هذه المجموعة',
+    splitWithBefore: 'من تقاسم معهم المصاريف',
+    knownInGroup: 'موجود بالفعل في {group}',
+    knownInGroups: {
+      zero: 'ليس في أي من مجموعاتك',
+      one: 'في مجموعة واحدة من مجموعاتك',
+      two: 'في مجموعتين من مجموعاتك',
+      few: 'في {n} من مجموعاتك',
+      many: 'في {n} من مجموعاتك',
+      other: 'في {n} من مجموعاتك',
+    },
+    contactsLimited: 'أعطيت Waves بعض جهات اتصالك فقط. افتح الإعدادات ليرى المزيد.',
     removeName: 'إزالة {name}',
     remindZoneNote: 'يُسأل بتوقيت {zone} — حيث الرحلة، لا حيث كل شخص.',
     useMyTimezone: 'استخدم منطقتي الزمنية ({zone})',

--- a/apps/mobile/src/lib/contactMatch.ts
+++ b/apps/mobile/src/lib/contactMatch.ts
@@ -1,0 +1,201 @@
+/**
+ * Matching an address-book entry — against what you typed, and against a person
+ * Waves already has on file.
+ *
+ * All of it runs on the phone. Nothing here reads the network and nothing here
+ * is ever handed a server response about the address book: the "does Waves
+ * already know this person" question is answered against the ghosts *you* have
+ * already created in *your* groups, which are rows the device already holds
+ * (ADR-005). The usual version of that feature posts the whole book to a server
+ * and asks it who is a user; that endpoint does not exist and this file is
+ * deliberately the reason it does not need to (ADR-006).
+ *
+ * Two rules do the real work, and both exist because of how numbers are written
+ * down rather than how they are dialled:
+ *
+ *  - A name is folded before it is compared, so `José` is found by `jose` and
+ *    `Ramesh` by `ramesh`. Without it a search field is only useful to somebody
+ *    who types their friends' names with the accents on.
+ *  - A number is compared by its digits with the shorter one allowed to be a
+ *    suffix of the longer. The same Indian mobile is written `+91 98765 43210`
+ *    in one contact card, `09876543210` in the next and `9876543210` in a third;
+ *    string equality calls those three different people, and greys out nobody.
+ */
+
+/** The shape both a picked contact and a stored member reduce to here. */
+export interface AddressLike {
+  readonly email: string | null;
+  readonly phone: string | null;
+}
+
+/**
+ * Case- and accent-insensitive text for comparison only — never for display.
+ *
+ * NFD splits an accented letter into the letter and its mark, and the mark is
+ * then dropped, so the fold is script-agnostic: Tamil and Devanagari have no
+ * combining marks to lose and come back unchanged.
+ */
+export function fold(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLocaleLowerCase();
+}
+
+/**
+ * Just the digits, with any leading trunk zero dropped.
+ *
+ * The zero in `09876543210` is a dialling instruction for the local network,
+ * not part of the number, and it is the single most common reason the same
+ * person looks like two people.
+ */
+export function digitsOf(value: string): string {
+  return value.replace(/[^0-9]/g, '').replace(/^0+/, '');
+}
+
+/**
+ * Whether two written numbers are the same line.
+ *
+ * A short number has to match outright — a five-digit shortcode that happens to
+ * end a real number is a coincidence, not a match. From seven digits up the
+ * shorter is allowed to be the tail of the longer, which is exactly the
+ * with-country-code versus without-country-code case.
+ */
+export function samePhone(a: string | null, b: string | null): boolean {
+  const left = a ? digitsOf(a) : '';
+  const right = b ? digitsOf(b) : '';
+  if (!left || !right) return false;
+  const [shorter, longer] = left.length <= right.length ? [left, right] : [right, left];
+  if (shorter.length < 7) return shorter === longer;
+  return longer.endsWith(shorter);
+}
+
+/** Two addresses for the same person. Email is exact once folded; a number is not. */
+export function sameAddress(a: AddressLike, b: AddressLike): boolean {
+  if (a.email && b.email && fold(a.email) === fold(b.email)) return true;
+  return samePhone(a.phone, b.phone);
+}
+
+/**
+ * Whether a contact answers the search box.
+ *
+ * Name, email and number all count, because people reach for whichever one they
+ * remember. A query with digits in it is matched against the digits of the
+ * number so spacing and punctuation in either the contact card or the search
+ * box stop mattering; three digits is the floor, below which every number in
+ * the book matches and the list stops meaning anything.
+ */
+export function matchesContactQuery(
+  contact: { readonly name: string } & AddressLike,
+  query: string,
+): boolean {
+  const needle = fold(query.trim());
+  if (!needle) return true;
+  if (fold(contact.name).includes(needle)) return true;
+  if (contact.email && fold(contact.email).includes(needle)) return true;
+  const typed = digitsOf(query);
+  if (typed.length >= 3 && contact.phone) return digitsOf(contact.phone).includes(typed);
+  return false;
+}
+
+// ─────────────────────────────────────────── who Waves already has ──
+
+/** Somebody already in at least one of your groups, and which ones. */
+export interface KnownPerson extends AddressLike {
+  readonly name: string;
+  /** Every group they are a member of, so the picker can say "in 3 of yours". */
+  readonly groupIds: readonly string[];
+  /** Those groups' labels, in the same order, for the one-group case. */
+  readonly groupNames: readonly string[];
+}
+
+/**
+ * The whole set. A list rather than a map, because a phone number has no single
+ * canonical spelling to key on — `samePhone` decides, not string equality.
+ */
+export interface KnownIndex {
+  readonly people: readonly KnownPerson[];
+}
+
+/** One group's worth of input, so building the index stays a pure function. */
+export interface KnownGroupInput {
+  readonly id: string;
+  readonly label: string;
+  readonly members: readonly ({ readonly name: string } & AddressLike)[];
+}
+
+/**
+ * Fold the members of every group into one row per human.
+ *
+ * The same friend is usually a separate ghost row in each group, so the merge
+ * matters: without it the picker would say "already in Goa" for somebody who is
+ * in Goa, Flatmates and last year's wedding, and the count would always read
+ * one. Two rows are the same person when they share an address, or — for
+ * account-holders, who have no address to share here — when the name matches
+ * exactly. Name is the weaker rule and is used only where there is no address
+ * at all, because two flatmates called Ravi are two debts.
+ */
+export function buildKnownIndex(groups: readonly KnownGroupInput[]): KnownIndex {
+  const people: {
+    name: string;
+    email: string | null;
+    phone: string | null;
+    groupIds: string[];
+    groupNames: string[];
+  }[] = [];
+
+  for (const group of groups) {
+    for (const member of group.members) {
+      const name = member.name.trim();
+      if (!name) continue;
+      const addressed = Boolean(member.email || member.phone);
+      const existing = people.find((person) =>
+        addressed && (person.email || person.phone)
+          ? sameAddress(person, member)
+          : !person.email && !person.phone && !addressed && fold(person.name) === fold(name),
+      );
+      if (existing) {
+        // Keep the first address seen rather than the last: an earlier group is
+        // where this person was first written down, and letting a later blank
+        // overwrite a good number would lose the only thing that matches.
+        existing.email ??= member.email;
+        existing.phone ??= member.phone;
+        if (!existing.groupIds.includes(group.id)) {
+          existing.groupIds.push(group.id);
+          existing.groupNames.push(group.label);
+        }
+        continue;
+      }
+      people.push({
+        name,
+        email: member.email,
+        phone: member.phone,
+        groupIds: [group.id],
+        groupNames: [group.label],
+      });
+    }
+  }
+
+  return { people };
+}
+
+/**
+ * The person this contact already is, or null.
+ *
+ * Address first and name only as a fallback, in that order and never the other
+ * way round: two people called Amma in one family's address book are two
+ * different debts, and the number is what tells them apart.
+ */
+export function lookupKnown(
+  index: KnownIndex,
+  contact: { readonly name: string } & AddressLike,
+): KnownPerson | null {
+  const byAddress = index.people.find((person) => sameAddress(person, contact));
+  if (byAddress) return byAddress;
+  const folded = fold(contact.name.trim());
+  if (!folded) return null;
+  return (
+    index.people.find((person) => !person.email && !person.phone && fold(person.name) === folded) ??
+    null
+  );
+}

--- a/apps/mobile/src/lib/contactMatch.ts
+++ b/apps/mobile/src/lib/contactMatch.ts
@@ -43,6 +43,25 @@ export function fold(value: string): string {
 }
 
 /**
+ * One written decimal digit, in the numeral systems the app ships UI for.
+ *
+ * JavaScript's `\d` and `Number()` only understand ASCII digits, but address
+ * books on Arabic, Hindi and Tamil phones can contain local numerals. Search and
+ * duplicate detection are comparison-only paths, so folding them to ASCII is the
+ * right representation here and never changes what is displayed.
+ */
+function asciiDigit(char: string): string | null {
+  const code = char.codePointAt(0);
+  if (code === undefined) return null;
+  if (code >= 0x30 && code <= 0x39) return String(code - 0x30);
+  if (code >= 0x660 && code <= 0x669) return String(code - 0x660);
+  if (code >= 0x6f0 && code <= 0x6f9) return String(code - 0x6f0);
+  if (code >= 0x966 && code <= 0x96f) return String(code - 0x966);
+  if (code >= 0xbe6 && code <= 0xbef) return String(code - 0xbe6);
+  return null;
+}
+
+/**
  * Just the digits, with any leading trunk zero dropped.
  *
  * The zero in `09876543210` is a dialling instruction for the local network,
@@ -50,7 +69,9 @@ export function fold(value: string): string {
  * person looks like two people.
  */
 export function digitsOf(value: string): string {
-  return value.replace(/[^0-9]/g, '').replace(/^0+/, '');
+  let digits = '';
+  for (const char of value) digits += asciiDigit(char) ?? '';
+  return digits.replace(/^0+/, '');
 }
 
 /**

--- a/apps/mobile/test/contactMatch.test.ts
+++ b/apps/mobile/test/contactMatch.test.ts
@@ -1,0 +1,186 @@
+/**
+ * The rules that decide whether two written-down people are the same person.
+ *
+ * Worth testing on its own because the failures are invisible: a picker that
+ * quietly fails to recognise `+91 98765 43210` as the number already in a group
+ * looks like a working picker, and only turns into a duplicate member and a
+ * wrong balance later on. Every case below is a real spelling somebody's phone
+ * uses.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildKnownIndex,
+  digitsOf,
+  fold,
+  lookupKnown,
+  matchesContactQuery,
+  sameAddress,
+  samePhone,
+} from '../src/lib/contactMatch';
+
+describe('folding text', () => {
+  it('drops case and accents', () => {
+    expect(fold('José')).toBe('jose');
+    expect(fold('RENÉE')).toBe('renee');
+    expect(fold('Ravi')).toBe('ravi');
+  });
+
+  it('leaves scripts without combining marks alone', () => {
+    expect(fold('ரவி')).toBe('ரவி');
+    expect(fold('रवि')).toBe('रवि');
+  });
+});
+
+describe('reading a written number', () => {
+  it('keeps only digits', () => {
+    expect(digitsOf('+91 98765-43210')).toBe('919876543210');
+    expect(digitsOf('(650) 213 7379')).toBe('6502137379');
+  });
+
+  it('drops the trunk zero', () => {
+    expect(digitsOf('09876543210')).toBe('9876543210');
+  });
+});
+
+describe('the same line, written three ways', () => {
+  it('matches an Indian mobile with and without its country code', () => {
+    expect(samePhone('+919876543210', '9876543210')).toBe(true);
+    expect(samePhone('+91 98765 43210', '098765 43210')).toBe(true);
+    expect(samePhone('+919876543210', '+91 98765-43210')).toBe(true);
+  });
+
+  it('matches a US number written locally', () => {
+    expect(samePhone('+16502137379', '(650) 213-7379')).toBe(true);
+  });
+
+  it('keeps two different people apart', () => {
+    expect(samePhone('+919876543210', '+919876543211')).toBe(false);
+    expect(samePhone('+919876543210', '+441234567890')).toBe(false);
+  });
+
+  it('will not call a short code the tail of a real number', () => {
+    // Six digits is short enough that ending a long number is coincidence.
+    expect(samePhone('543210', '+919876543210')).toBe(false);
+    expect(samePhone('543210', '543210')).toBe(true);
+  });
+
+  it('is false when either side has no number', () => {
+    expect(samePhone(null, '+919876543210')).toBe(false);
+    expect(samePhone('+919876543210', '')).toBe(false);
+  });
+});
+
+describe('two addresses for one person', () => {
+  it('matches on a folded email', () => {
+    expect(
+      sameAddress(
+        { email: 'Ravi@Example.com', phone: null },
+        { email: 'ravi@example.com', phone: null },
+      ),
+    ).toBe(true);
+  });
+
+  it('matches on the number when the emails differ', () => {
+    expect(
+      sameAddress(
+        { email: 'ravi@work.com', phone: '+919876543210' },
+        { email: 'ravi@home.com', phone: '9876543210' },
+      ),
+    ).toBe(true);
+  });
+
+  it('does not match two people with nothing in common', () => {
+    expect(sameAddress({ email: 'a@x.com', phone: null }, { email: 'b@x.com', phone: null })).toBe(
+      false,
+    );
+  });
+});
+
+describe('searching the address book', () => {
+  const ravi = { name: 'Ravi Kumar', email: 'ravi@example.com', phone: '+919876543210' };
+  const jose = { name: 'José Álvarez', email: null, phone: '+34600123456' };
+
+  it('finds a name however the accents were typed', () => {
+    expect(matchesContactQuery(jose, 'jose')).toBe(true);
+    expect(matchesContactQuery(jose, 'álva')).toBe(true);
+    expect(matchesContactQuery(jose, 'ALVAREZ')).toBe(true);
+  });
+
+  it('finds an email', () => {
+    expect(matchesContactQuery(ravi, 'EXAMPLE.com')).toBe(true);
+  });
+
+  it('finds a number typed with or without spacing and country code', () => {
+    expect(matchesContactQuery(ravi, '9876543210')).toBe(true);
+    expect(matchesContactQuery(ravi, '98765 43210')).toBe(true);
+    expect(matchesContactQuery(ravi, '+91 98765')).toBe(true);
+    expect(matchesContactQuery(ravi, '098765')).toBe(true);
+  });
+
+  it('refuses a number that is not theirs', () => {
+    expect(matchesContactQuery(ravi, '5551234')).toBe(false);
+  });
+
+  it('treats an empty query as everybody', () => {
+    expect(matchesContactQuery(ravi, '   ')).toBe(true);
+  });
+});
+
+describe('the index of people already written down', () => {
+  const index = buildKnownIndex([
+    {
+      id: 'goa',
+      label: 'Goa trip',
+      members: [
+        { name: 'Ravi Kumar', email: null, phone: '+919876543210' },
+        { name: 'Priya', email: 'priya@example.com', phone: null },
+      ],
+    },
+    {
+      id: 'flat',
+      label: 'Flatmates',
+      members: [
+        // The same Ravi, written down without his country code this time.
+        { name: 'Ravi', email: null, phone: '9876543210' },
+        { name: 'Meera', email: null, phone: null },
+      ],
+    },
+  ]);
+
+  it('folds one person across the groups they are in', () => {
+    const ravi = lookupKnown(index, { name: 'Ravi K', email: null, phone: '098765 43210' });
+    expect(ravi?.groupIds).toEqual(['goa', 'flat']);
+    expect(ravi?.groupNames).toEqual(['Goa trip', 'Flatmates']);
+  });
+
+  it('names the single group somebody is in', () => {
+    const priya = lookupKnown(index, { name: 'Priya S', email: 'PRIYA@example.com', phone: null });
+    expect(priya?.groupNames).toEqual(['Goa trip']);
+  });
+
+  it('falls back to the name only for a member with no address at all', () => {
+    expect(lookupKnown(index, { name: 'Meera', email: null, phone: null })?.groupIds).toEqual([
+      'flat',
+    ]);
+  });
+
+  it('does not match a stranger who happens to share a first name', () => {
+    // Ravi is known by number, so a different Ravi with a different number is a
+    // different person — the name must not reach past the address.
+    expect(lookupKnown(index, { name: 'Ravi', email: null, phone: '+919999999999' })).toBeNull();
+  });
+
+  it('returns null for somebody nobody has written down', () => {
+    expect(lookupKnown(index, { name: 'Sam', email: 'sam@x.com', phone: null })).toBeNull();
+  });
+
+  it('skips members with no name at all', () => {
+    expect(
+      buildKnownIndex([
+        { id: 'g', label: 'G', members: [{ name: '  ', email: 'x@y.com', phone: null }] },
+      ]).people,
+    ).toEqual([]);
+  });
+});

--- a/apps/mobile/test/contactMatch.test.ts
+++ b/apps/mobile/test/contactMatch.test.ts
@@ -42,6 +42,12 @@ describe('reading a written number', () => {
   it('drops the trunk zero', () => {
     expect(digitsOf('09876543210')).toBe('9876543210');
   });
+
+  it('folds Arabic, Devanagari, and Tamil digits to ASCII', () => {
+    expect(digitsOf('+٩١ ٩٨٧٦٥ ٤٣٢١٠')).toBe('919876543210');
+    expect(digitsOf('+९१ ९८७६५ ४३२१०')).toBe('919876543210');
+    expect(digitsOf('+௯௧ ௯௮௭௬௫ ௪௩௨௧௦')).toBe('919876543210');
+  });
 });
 
 describe('the same line, written three ways', () => {
@@ -53,6 +59,12 @@ describe('the same line, written three ways', () => {
 
   it('matches a US number written locally', () => {
     expect(samePhone('+16502137379', '(650) 213-7379')).toBe(true);
+  });
+
+  it('matches local numeral phone cards to stored invite numbers', () => {
+    expect(samePhone('+٩١ ٩٨٧٦٥ ٤٣٢١٠', '9876543210')).toBe(true);
+    expect(samePhone('+९१ ९८७६५ ४३२१०', '9876543210')).toBe(true);
+    expect(samePhone('+௯௧ ௯௮௭௬௫ ௪௩௨௧௦', '9876543210')).toBe(true);
   });
 
   it('keeps two different people apart', () => {
@@ -119,6 +131,13 @@ describe('searching the address book', () => {
     expect(matchesContactQuery(ravi, '098765')).toBe(true);
   });
 
+  it('finds a number typed or stored with local numerals', () => {
+    expect(matchesContactQuery(ravi, '٩٨٧٦٥')).toBe(true);
+    expect(
+      matchesContactQuery({ name: 'மீரா', email: null, phone: '+௯௧ ௯௮௭௬௫ ௪௩௨௧௦' }, '98765'),
+    ).toBe(true);
+  });
+
   it('refuses a number that is not theirs', () => {
     expect(matchesContactQuery(ravi, '5551234')).toBe(false);
   });
@@ -153,6 +172,11 @@ describe('the index of people already written down', () => {
     const ravi = lookupKnown(index, { name: 'Ravi K', email: null, phone: '098765 43210' });
     expect(ravi?.groupIds).toEqual(['goa', 'flat']);
     expect(ravi?.groupNames).toEqual(['Goa trip', 'Flatmates']);
+  });
+
+  it('recognises an already-known person whose phone uses local numerals', () => {
+    const ravi = lookupKnown(index, { name: 'Ravi K', email: null, phone: '+٩١ ٩٨٧٦٥ ٤٣٢١٠' });
+    expect(ravi?.groupIds).toEqual(['goa', 'flat']);
   });
 
   it('names the single group somebody is in', () => {


### PR DESCRIPTION
## What this is

An open pass over the "From your contacts" screen — `apps/mobile/src/app/friends/contacts.tsx`, reached from the Friends tab. Most of the work lands in the shared `ContactPicker`, so `/contact-picker` (new group, group members, group settings) inherits the search and permission fixes; the memory and the escape hatch are opt-in props that only the Friends screen passes today.

## The problem

The picker offered every name in the address book identically. It had no idea whether a contact was already a member of the group you were about to pick, so the ordinary way to end up owing money to two copies of one friend was to add them twice and let the merge screen sort it out later. And the search was `name.toLowerCase().includes(query)` — it missed `José` for "jose", and missed a phone number the moment either the contact card or the search box had a space in it.

## What changed

**It knows who it already has.** Ghost members in your own groups carry the one email or number you gave when you invited them. A contact that matches one is named with the group it is in ("Already in Goa trip", "In 3 of your groups"), floats to a **People you split with** section at the head of the list, and is skipped rather than written a second time when you pick a group that already holds them. The "which group?" step now says how many of the people you picked are already in each group *before* you commit to one, and a group holding all of them stops being an option.

These rows stay selectable. Somebody in last year's trip is exactly who you want in this one — the label is information, not a lock. That is different from the existing `existing` prop, which genuinely does lock a row.

**Search that works.** Accent-folded names, and numbers compared by their digits with the shorter allowed to be the tail of the longer — so the same Indian mobile matches whether the card says `+91 98765 43210`, `09876543210` or `9876543210`. The rules live in `src/lib/contactMatch.ts` as pure functions with 23 tests, because the way they fail is silent: a picker that does not recognise a number looks exactly like a picker that works.

**Two smaller things.** A pinned row at the head of the list for the person who is not in the address book at all, pointing at the existing add-a-person flow rather than growing a second way to invent somebody. And iOS 18's *limited* contacts grant is now read off `accessPrivileges` and said out loud, instead of being shown as a suspiciously short address book.

Also, while in there: the group list at the last step was a network query on a screen you would plausibly use on a trip. It now reads the mirror like the rest of the app (ADR-005).

## Privacy

**No contact data leaves the device, and nothing here adds a way for it to.** The "who does Waves already know" question is answered entirely against rows the phone already holds — your own groups, out of the local mirror. There is still no endpoint that takes an address book and returns who uses it, and this change deliberately does not want one: it can only tell you about people you wrote down yourself. The only thing still sent is what was sent before — the name and one address of the people you ticked — and this change sends strictly less of it, because it skips the ones already in the group.

## Drawn from Mobbin

- [Monzo — Add people](https://mobbin.com/screens/0abf37d8-25dd-435f-ae0d-fac0085d664b), [Splitwise — Add group members](https://mobbin.com/screens/1a68d180-46b9-43fa-9ec5-2b7999b27fe7), [Snapchat — Select Friends](https://mobbin.com/screens/7b24bb2a-20e7-4df6-b0e4-c08679d7c5c9), [LINE](https://mobbin.com/screens/bda6effa-34dd-4ed2-b691-5dc45bf8df50): a Favourites/Recent section pinned above the alphabet rather than a flat A–Z.
- [Splitwise](https://mobbin.com/screens/1a68d180-46b9-43fa-9ec5-2b7999b27fe7) ("Add a new contact to Splitwise"), [Beli](https://mobbin.com/screens/a1488022-b92c-40f7-9e90-8d437f5526f8) ("Invite a friend"), [Polarsteps](https://mobbin.com/screens/55157302-c999-4b43-b463-56eab6a5e893) ("Invite with link"): the way out lives *inside* the list, at the top, not behind a back button.
- [Revolut](https://mobbin.com/screens/b7374b85-d964-4dd9-a95b-513c71a26e0c) ("Name, @Revtag, phone, email"), [PayPal](https://mobbin.com/screens/fb56ecb1-26cf-4afa-837d-358f7de04a2d), [WhatsApp](https://mobbin.com/screens/7484a21f-a674-4421-b796-8d3f4acd81f5) ("Search name or number"): search is expected to cover name, phone and email. Waves keeps the contact count in the placeholder (a deliberate existing choice), so the hint moved to the no-results state, where it is actually needed.

## Considered and deliberately left out

- **"Which of your contacts are on Waves"** — [Duolingo](https://mobbin.com/screens/57b1413c-ae55-4545-ac14-48e6639489e4), [Co–Star](https://mobbin.com/screens/fc4c0129-fb6b-42fd-abc5-0aaa891d7de5), [Citizen](https://mobbin.com/screens/1db19bb7-698e-4fdb-87ee-27aa6121220d) and [Airbuds](https://mobbin.com/screens/730a498d-b121-42fd-9448-d4f27a9de14a) all split the list into "on the app" and "invite". Every one of them needs the address book posted to a server. Not built, and not proposed: it turns an address book into a membership oracle (ADR-006). The local "who have *you* already written down" section is the honest half of the same idea.
- **Per-row Invite buttons** ([TikTok](https://mobbin.com/screens/55916c1a-7578-4c58-baa4-1e652d315d4e), [Upside](https://mobbin.com/screens/18f73aa3-600c-40c7-864e-850f56d5ac55), [Abode](https://mobbin.com/screens/c7cfec8b-1dd0-488f-a297-67b7ce26a064)) — one-at-a-time contradicts the multi-select the screen already has, and Waves invites by link per group, not per contact.
- **Alphabetical sections and a fast index rail** — evaluated as asked; already there and good, so left alone apart from teaching the heading to render a phrase.
- **Multi-select with a running count** — already there (the tick, the face strip, the counted confirm button). No change.
- **Moving the contact count out of the placeholder into a header subtitle** ([WhatsApp](https://mobbin.com/screens/7484a21f-a674-4421-b796-8d3f4acd81f5)'s `0/1,023`) — the existing placeholder choice is deliberate and documented, and the component does not own the header. Not worth the churn.
- **Reordering the flow to ask "which group?" first** so `existing` could lock rows — the current order lets you pick six people and answer the group question once, which the file argues for at length and I agree with. Naming the group per row gets the same information without the reorder.

## Not done

- **No new dependencies.** `accessPrivileges` is already on `expo-contacts@57`'s permission response; everything else uses components and tokens already in `@waves/ui`.
- **Four locales** (en/ta/hi/ar) for every new string, Arabic with its six plural forms; `strings.test.ts` enforces it.
- **Not visually verified.** I cannot run a native build, so nothing here has been seen on a device. The limited-permission banner in particular is only reachable on iOS 18+ and has never been rendered.
- `ChooseGroup` still renders its group list as `.map` inside a `ScrollView` rather than a FlashList. That is pre-existing, bounded by how many groups you are in, and nesting a same-direction FlashList inside that ScrollView would be worse. Flagging rather than changing it.

## Gates

`tsc --noEmit` clean, `expo lint` clean (3 pre-existing warnings in `phone.tsx`, untouched), `vitest run` from `apps/mobile`: 70 files, 891 tests, all passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Contact selection now highlights people previously added to groups and shows their group associations.
  * Added support for inviting someone not listed in the device’s contacts.
  * Added clearer handling for limited contact access on iOS.
  * Search now supports accent-insensitive names and phone-number matching.
  * Group selection shows which contacts are already members and prevents duplicate additions.
  * Results report both newly added and skipped contacts, including when all selected contacts were already members.
* **Localization**
  * Added translations for the new contact and membership messages across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->