### PR TITLE
Tap a person on the Balances tab to see every group you share

### DIFF
--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -26,6 +26,7 @@ import {
 import {
   memberLookup,
   useCancelSettlement,
+  useGhostMergePersonIds,
   useGroup,
   useDisputes,
   useGroupLedger,
@@ -44,8 +45,16 @@ import {
 } from '@/data/activity';
 import { nudgeToSettle } from '@/data/api';
 import { expenseTitle } from '@/data/expenseTitle';
+import { personKeyOf } from '@/data/peopleBalances';
 import { GroupSkeleton } from '@/components/Skeletons';
-import { deadLettered, formatParts, type MemberId } from '@waves/core';
+import {
+  balanceDirection,
+  copyFor,
+  deadLettered,
+  formatParts,
+  moneyAccessibilityLabel,
+  type MemberId,
+} from '@waves/core';
 import { useBlockedUsers } from '@/data/blocked';
 import {
   actorName,
@@ -479,6 +488,44 @@ export default function GroupScreen() {
     },
     [blockedIds, lookup, profile?.id, t.misc.someone],
   );
+
+  // Where a Balances row goes when it is tapped: that person, un-collapsed
+  // across every group you share with them.
+  //
+  // The key has to be spelled the way the database spells it — `personKeyOf` is
+  // the same COALESCE(profile_id, merge person_id, member_id) the
+  // `waves_person_group_balances` view keys on — because a second, client-side
+  // guess at who somebody is would point the screen at a stranger's ledger. A
+  // ghost the viewer has merged folds through their merge, exactly as the
+  // Friends list folds them, so the same tap lands on the same person from
+  // either screen.
+  //
+  // Null means the row is a dead end, and a dead end must not look tappable:
+  //   * yourself — there is no such thing as the groups you share with yourself;
+  //   * a member who exists only in the local queue, whose id the server has
+  //     never seen, and for whom the view would honestly answer "nothing" —
+  //     which reads as "you are square", the wrong thing to say about somebody
+  //     who has not been saved yet.
+  // A blocked person is *not* a dead end: Friends opens them too, with their
+  // name masked all the way through, and this passes the masked name along.
+  const mergePersonIds = useGhostMergePersonIds();
+  const personKeyFor = useCallback(
+    (member: MemberRow): string | null => {
+      // Both readings of "me", because `myMemberId` is derived from the members
+      // and is null for the frame before they land — long enough for your own
+      // row to be drawn as a doorway into yourself.
+      if (member.id === ledger.myMemberId) return null;
+      if (member.profile_id !== null && member.profile_id === profile?.id) return null;
+      if (member.pending) return null;
+      return personKeyOf({
+        profileId: member.profile_id,
+        mergePersonId: mergePersonIds.get(member.id) ?? null,
+        memberId: member.id,
+      });
+    },
+    [ledger.myMemberId, mergePersonIds, profile?.id],
+  );
+
   // The joined actor an activity row would carry on the cross-group feed, rebuilt
   // from this group's members — so the mirror-backed group feed can name who did
   // the thing rather than falling back to "someone".
@@ -807,51 +854,108 @@ export default function GroupScreen() {
     }
     if (item.kind === 'balance') {
       const { member, balance, isLast } = item;
+      // The name the row is allowed to say — already masked for a blocked
+      // person, and it travels with the tap so the destination opens under the
+      // same mask rather than flashing the real name while it loads.
+      const shownName = displayName(member, profile?.id, blockedIds, t.misc.someone);
+      const personKey = personKeyFor(member);
+      // What a screen reader hears once the row is one button: who, then the
+      // amount in the words `MoneyText` would have spoken on its own, then —
+      // for a guest — that they have not joined. Making the row accessible
+      // groups its text, so anything worth hearing has to be said here.
+      const rowLabel = [
+        shownName,
+        moneyAccessibilityLabel(
+          { minor: balance, currency },
+          balanceDirection(balance),
+          copyFor(locale).money,
+          { locale },
+        ),
+        isGhost(member) ? t.notJoinedYet : '',
+      ]
+        .filter(Boolean)
+        .join('. ');
       // Flat row: the money meaning is the sign on the amount and its
       // "you are owed / you owe" label, not the row's colour.
+      const row = (
+        <Row
+          style={{
+            gap: theme.spacing.md,
+            alignItems: 'center',
+            paddingVertical: theme.spacing.sm,
+          }}
+        >
+          <Avatar
+            name={displayName(member, null, blockedIds, t.misc.someone)}
+            ghost={isGhost(member) || isBlockedMember(member, blockedIds)}
+            size={40}
+          />
+          <View style={{ flex: 1 }}>
+            <Row style={{ gap: theme.spacing.sm }}>
+              <Text variant="subheading" numberOfLines={1} style={{ flexShrink: 1 }}>
+                {shownName}
+              </Text>
+              {member.role === 'admin' && !isGhost(member) ? (
+                <Badge label={t.people.admin} tone="brand" />
+              ) : null}
+            </Row>
+            <Text variant="caption" tone="muted" numberOfLines={1}>
+              {isGhost(member)
+                ? t.notJoinedYet
+                : isBlockedMember(member, blockedIds)
+                  ? // A VPA carries a name or phone — masked for a blocked person.
+                    '—'
+                  : (member.vpa ?? member.profile?.default_vpa ?? '—')}
+            </Text>
+          </View>
+          <Row style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
+            {/* Somebody who owes the group money can be nudged from the row that
+                says so, the way Friends already does. Ghosts have nowhere to
+                send it. The chip keeps its own press inside the row's: the
+                innermost pressable wins the touch, so nudging never navigates
+                — the same nesting the Friends list has always used. */}
+            {balance < 0n && !isGhost(member) && member.id !== ledger.myMemberId ? (
+              <RemindChip groupId={groupId} memberId={member.id} currency={currency} />
+            ) : null}
+            <MoneyText amount={balance} currency={currency} locale={locale} mode="balance" />
+            {member.pending ? <PendingMark /> : null}
+            {/* A fixed slot at the trailing edge, on every row whether or not it
+                leads anywhere, so the amounts stay in one column instead of
+                sliding left on the rows that have no chevron. The glyph itself
+                flips with the writing direction. */}
+            <View style={{ width: iconSize.md, alignItems: 'center' }}>
+              {personKey ? (
+                <Ionicons
+                  name={directionalIcon('chevron-forward')}
+                  size={iconSize.md}
+                  color={theme.color.textFaint}
+                />
+              ) : null}
+            </View>
+          </Row>
+        </Row>
+      );
       return (
         <View>
-          <Row
-            style={{
-              gap: theme.spacing.md,
-              alignItems: 'center',
-              paddingVertical: theme.spacing.sm,
-            }}
-          >
-            <Avatar
-              name={displayName(member, null, blockedIds, t.misc.someone)}
-              ghost={isGhost(member) || isBlockedMember(member, blockedIds)}
-              size={40}
-            />
-            <View style={{ flex: 1 }}>
-              <Row style={{ gap: theme.spacing.sm }}>
-                <Text variant="subheading" numberOfLines={1} style={{ flexShrink: 1 }}>
-                  {displayName(member, profile?.id, blockedIds, t.misc.someone)}
-                </Text>
-                {member.role === 'admin' && !isGhost(member) ? (
-                  <Badge label={t.people.admin} tone="brand" />
-                ) : null}
-              </Row>
-              <Text variant="caption" tone="muted" numberOfLines={1}>
-                {isGhost(member)
-                  ? t.notJoinedYet
-                  : isBlockedMember(member, blockedIds)
-                    ? // A VPA carries a name or phone — masked for a blocked person.
-                      '—'
-                    : (member.vpa ?? member.profile?.default_vpa ?? '—')}
-              </Text>
-            </View>
-            <Row style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
-              {/* Somebody who owes the group money can be nudged from the row that
-                  says so, the way Friends already does. Ghosts have nowhere to
-                  send it. */}
-              {balance < 0n && !isGhost(member) && member.id !== ledger.myMemberId ? (
-                <RemindChip groupId={groupId} memberId={member.id} currency={currency} />
-              ) : null}
-              <MoneyText amount={balance} currency={currency} locale={locale} mode="balance" />
-              {member.pending ? <PendingMark /> : null}
-            </Row>
-          </Row>
+          {personKey ? (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={rowLabel}
+              accessibilityHint={t.people.seeSharedGroups}
+              onPress={() =>
+                router.push(
+                  `/friends/person/${encodeURIComponent(personKey)}?name=${encodeURIComponent(
+                    shownName,
+                  )}` as never,
+                )
+              }
+              style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+            >
+              {row}
+            </Pressable>
+          ) : (
+            row
+          )}
           {!isLast ? <View style={{ height: 1, backgroundColor: theme.color.border }} /> : null}
         </View>
       );
@@ -1044,7 +1148,14 @@ export default function GroupScreen() {
           // Not the tab: switching tabs already hands `data` a different array,
           // and naming it here only made every mounted cell re-render a second
           // time for the same switch.
-          extraData={`${showDeleted}|${locale}`}
+          //
+          // A Balances row's destination is not in its `data` item — it comes
+          // from who you are in this group and from the ghost merges on the
+          // phone — so those go in here too, or a recycled row keeps whatever
+          // tappability it was drawn with. `myMemberId` arrives a beat after
+          // the members do, and a merge that syncs in mid-scroll only ever adds
+          // a row, so its size is enough to notice one landing.
+          extraData={`${showDeleted}|${locale}|${ledger.myMemberId ?? ''}|${mergePersonIds.size}`}
           keyExtractor={(item) => item.key}
           getItemType={(item) => item.kind}
           renderItem={renderFeedItem}

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -921,7 +921,9 @@ export default function GroupScreen() {
                 send it. Touch keeps the visible chip; screen readers get the
                 same affordance as a custom action on the row below, because a
                 nested accessible button can be hidden by an accessible parent. */}
-            {canRemind ? <RemindChip groupId={groupId} memberId={member.id} currency={currency} /> : null}
+            {canRemind ? (
+              <RemindChip groupId={groupId} memberId={member.id} currency={currency} />
+            ) : null}
             <MoneyText amount={balance} currency={currency} locale={locale} mode="balance" />
             {member.pending ? <PendingMark /> : null}
             {/* A fixed slot at the trailing edge, on every row whether or not it
@@ -947,10 +949,14 @@ export default function GroupScreen() {
               accessibilityRole="button"
               accessibilityLabel={rowLabel}
               accessibilityHint={t.people.seeSharedGroups}
-              accessibilityActions={canRemind ? [{ name: 'remind', label: t.people.remind }] : undefined}
+              accessibilityActions={
+                canRemind ? [{ name: 'remind', label: t.people.remind }] : undefined
+              }
               onAccessibilityAction={(event) => {
                 if (event.nativeEvent.actionName === 'remind') {
-                  nudgeToSettle({ groupId, toMemberId: member.id, currency }).catch(() => undefined);
+                  nudgeToSettle({ groupId, toMemberId: member.id, currency }).catch(
+                    () => undefined,
+                  );
                 }
               }}
               onPress={() =>

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -69,6 +69,7 @@ import {
 } from '@/data/types';
 import { fill, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
+import { canRemindFromBalanceRow } from '@/lib/balanceRowActions';
 import { paidBy } from '@/lib/payerLines';
 import { CategoryBadge } from '@/components/Category';
 import { OverflowMenu, type OverflowMenuItem } from '@/components/OverflowMenu';
@@ -859,6 +860,12 @@ export default function GroupScreen() {
       // same mask rather than flashing the real name while it loads.
       const shownName = displayName(member, profile?.id, blockedIds, t.misc.someone);
       const personKey = personKeyFor(member);
+      const canRemind = canRemindFromBalanceRow({
+        balance,
+        isGhost: isGhost(member),
+        memberId: member.id,
+        myMemberId: ledger.myMemberId,
+      });
       // What a screen reader hears once the row is one button: who, then the
       // amount in the words `MoneyText` would have spoken on its own, then —
       // for a guest — that they have not joined. Making the row accessible
@@ -911,12 +918,10 @@ export default function GroupScreen() {
           <Row style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
             {/* Somebody who owes the group money can be nudged from the row that
                 says so, the way Friends already does. Ghosts have nowhere to
-                send it. The chip keeps its own press inside the row's: the
-                innermost pressable wins the touch, so nudging never navigates
-                — the same nesting the Friends list has always used. */}
-            {balance < 0n && !isGhost(member) && member.id !== ledger.myMemberId ? (
-              <RemindChip groupId={groupId} memberId={member.id} currency={currency} />
-            ) : null}
+                send it. Touch keeps the visible chip; screen readers get the
+                same affordance as a custom action on the row below, because a
+                nested accessible button can be hidden by an accessible parent. */}
+            {canRemind ? <RemindChip groupId={groupId} memberId={member.id} currency={currency} /> : null}
             <MoneyText amount={balance} currency={currency} locale={locale} mode="balance" />
             {member.pending ? <PendingMark /> : null}
             {/* A fixed slot at the trailing edge, on every row whether or not it
@@ -942,6 +947,12 @@ export default function GroupScreen() {
               accessibilityRole="button"
               accessibilityLabel={rowLabel}
               accessibilityHint={t.people.seeSharedGroups}
+              accessibilityActions={canRemind ? [{ name: 'remind', label: t.people.remind }] : undefined}
+              onAccessibilityAction={(event) => {
+                if (event.nativeEvent.actionName === 'remind') {
+                  nudgeToSettle({ groupId, toMemberId: member.id, currency }).catch(() => undefined);
+                }
+              }}
               onPress={() =>
                 router.push(
                   `/friends/person/${encodeURIComponent(personKey)}?name=${encodeURIComponent(

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -511,6 +511,24 @@ export function useKnownPeopleCount(profileId: string | null): LocalRead<number>
 }
 
 /**
+ * member_id → the person id a viewer's own ghost merge folds that membership
+ * into (A38).
+ *
+ * The middle term of `personKeyOf`, and the reason a guest the viewer has said
+ * is one human resolves to one person rather than to whichever group's ghost
+ * happened to be tapped. Pull-only mirror data (the client never writes these),
+ * so there is no queue overlay to replay — and it is read from the mirror, not
+ * the network, so a tap works with no connection.
+ */
+export function useGhostMergePersonIds(): ReadonlyMap<string, string> {
+  const { mirror } = useSync();
+  return useMemo(
+    () => new Map(ghostMerges(mirror).map((merge) => [merge.member_id, merge.person_id])),
+    [mirror],
+  );
+}
+
+/**
  * Who owes you and who you owe, across every group — from the mirror (ADR-005).
  *
  * The local-first twin of `waves_people_i_owe` (A11/A36/A38). For each group the

--- a/apps/mobile/src/data/peopleBalances.ts
+++ b/apps/mobile/src/data/peopleBalances.ts
@@ -56,9 +56,27 @@ export function countOthersInGroup(members: readonly CountableMember[], profileI
   return present.filter((member) => member.profile_id !== profileId).length;
 }
 
-/** COALESCE(profile_id, merge person_id, member_id) — the SQL's person_key. */
-function personKey(contribution: PersonContribution): string {
-  return contribution.profileId ?? contribution.mergePersonId ?? contribution.memberId;
+/** The three facts that decide who somebody is — the arguments to {@link personKeyOf}. */
+export interface PersonIdentity {
+  /** Their profile id, or null for a ghost. */
+  profileId: string | null;
+  /** The person id of a viewer-recorded ghost merge (A38), else null. */
+  mergePersonId: string | null;
+  /** Their group_member id — per-group, and the last resort. */
+  memberId: string;
+}
+
+/**
+ * COALESCE(profile_id, merge person_id, member_id) — the SQL's person_key.
+ *
+ * The one place the app decides who a person *is*. `waves_people_i_owe` and
+ * `waves_person_group_balances` key on exactly this expression, so anything
+ * that wants to point at a person across groups — the Friends list, a group's
+ * Balances row — has to spell it the same way. A second, parallel guess at
+ * identity would quietly point somebody at a stranger's ledger.
+ */
+export function personKeyOf(person: PersonIdentity): string {
+  return person.profileId ?? person.mergePersonId ?? person.memberId;
 }
 
 /** Lexicographic max, ignoring null — mirrors the SQL `max(...)`. */
@@ -94,7 +112,7 @@ export function aggregatePeopleBalances(
   const groups = new Map<string, Group>();
 
   for (const c of contributions) {
-    const key = personKey(c);
+    const key = personKeyOf(c);
     const mapKey = `${key}|${c.currency}`;
     let group = groups.get(mapKey);
     if (!group) {

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1787,6 +1787,8 @@ export interface UiStrings {
     remind: string;
     reminded: string;
     remindedToday: string;
+    /** Spoken hint on a tappable person row: where the tap goes. */
+    seeSharedGroups: string;
   };
   /** Adding and editing an expense, and reading one off a bill. */
   expense: {
@@ -4166,6 +4168,7 @@ const en: UiStrings = {
     remind: 'Remind',
     reminded: 'Reminded',
     remindedToday: 'Nudged today',
+    seeSharedGroups: 'Opens the groups you share with them',
   },
   expense: {
     edit: 'Edit expense',
@@ -6577,6 +6580,7 @@ const ta: UiStrings = {
     remind: 'நினைவூட்டு',
     reminded: 'நினைவூட்டப்பட்டது',
     remindedToday: 'இன்று நினைவூட்டிவிட்டீர்கள்',
+    seeSharedGroups: 'நீங்கள் இருவரும் பகிரும் குழுக்களைத் திறக்கும்',
   },
   expense: {
     edit: 'செலவைத் திருத்து',
@@ -8996,6 +9000,7 @@ const hi: UiStrings = {
     remind: 'याद दिलाएँ',
     reminded: 'याद दिला दिया',
     remindedToday: 'आज याद दिला चुके',
+    seeSharedGroups: 'उनके साथ साझा किए गए समूह खोलता है',
   },
   expense: {
     edit: 'खर्च बदलें',
@@ -11467,6 +11472,7 @@ const ar: UiStrings = {
     remind: 'ذكّر',
     reminded: 'تم التذكير',
     remindedToday: 'ذُكّر اليوم',
+    seeSharedGroups: 'يفتح المجموعات المشتركة معكما',
   },
   expense: {
     edit: 'تعديل المصروف',

--- a/apps/mobile/src/lib/balanceRowActions.ts
+++ b/apps/mobile/src/lib/balanceRowActions.ts
@@ -1,0 +1,16 @@
+export interface BalanceRowActionState {
+  readonly balance: bigint;
+  readonly isGhost: boolean;
+  readonly memberId: string;
+  readonly myMemberId: string | null;
+}
+
+/**
+ * The nudge chip is visually inside a navigable balance row, but screen readers
+ * need it as its own action because nested accessible controls are unreliable,
+ * especially on iOS. Keep the eligibility rule in one pure place so touch and
+ * accessibility affordances cannot drift apart.
+ */
+export function canRemindFromBalanceRow(state: BalanceRowActionState): boolean {
+  return state.balance < 0n && !state.isGhost && state.memberId !== state.myMemberId;
+}

--- a/apps/mobile/test/balanceRowActions.test.ts
+++ b/apps/mobile/test/balanceRowActions.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { canRemindFromBalanceRow } from '../src/lib/balanceRowActions';
+
+describe('balance row accessibility actions', () => {
+  it('offers remind when a saved non-ghost financer owes the group', () => {
+    expect(
+      canRemindFromBalanceRow({
+        balance: -50000n,
+        isGhost: false,
+        memberId: 'financer-member',
+        myMemberId: 'user-member',
+      }),
+    ).toBe(true);
+  });
+
+  it('does not offer remind for a rider or traveller the user owes', () => {
+    expect(
+      canRemindFromBalanceRow({
+        balance: 50000n,
+        isGhost: false,
+        memberId: 'rider-member',
+        myMemberId: 'user-member',
+      }),
+    ).toBe(false);
+  });
+
+  it('does not offer remind for the current user row while members are loading or loaded', () => {
+    expect(
+      canRemindFromBalanceRow({
+        balance: -50000n,
+        isGhost: false,
+        memberId: 'user-member',
+        myMemberId: 'user-member',
+      }),
+    ).toBe(false);
+  });
+
+  it('does not offer remind for ghost rows that have no delivery target', () => {
+    expect(
+      canRemindFromBalanceRow({
+        balance: -50000n,
+        isGhost: true,
+        memberId: 'ghost-member',
+        myMemberId: 'user-member',
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Balance rows on the group screen were a dead end. They now open the person's cross-group view.

## What changed

Each row on the **Balances** tab is a `Pressable` that routes to `/friends/person/<person_key>` — the screen that already exists at `app/friends/person/[key].tsx` ("One person, across every group you share with them"), until now reachable only from the Friends tab. No new destination was built.

## Person identity

The derivation already existed, private: `personKey()` in `data/peopleBalances.ts`, the client twin of the SQL `COALESCE(gm.profile_id, mrg.person_id, gm.id)` behind `waves_person_group_balances`. It is now exported as `personKeyOf(PersonIdentity)` and called from both places, so there is still exactly one expression of person identity — a merged ghost resolves the same way everywhere.

Ghost merges are read from the local mirror via a new `useGhostMergePersonIds()` hook, so the tap resolves offline with no extra query.

## Row by row

| Case | Behaviour | Why |
| --- | --- | --- |
| Yourself | Not tappable | Guarded on both `myMemberId` and `profile_id` — `myMemberId` is null for a frame while members load, long enough to draw your own row as a doorway into yourself |
| Ghost | Tappable | Keys to its own member id, or the merge's person id; Friends already opens ghost rows |
| Blocked | Tappable, masked | Friends opens blocked people masked; the `name` param carries the mask so the real name never flashes while the destination loads |
| Pending (queue-only) | Not tappable | The server has never seen the id, so the RPC returns zero rows, which renders as "all settled" — the wrong thing to say about someone not yet saved |

## Notes

- `RemindChip` stays nested inside the row pressable; RN negotiates deepest-first, and this is the nesting the Friends tab already ships.
- Making the row accessible groups its children, which would have silenced the amount — the label now composes name + the same money string `MoneyText` was already speaking.
- `extraData` widened: tappability comes from outside the list item, so without it a recycled row keeps whatever affordance it was first drawn with.

One i18n key added (`people.seeSharedGroups`) in all four locales.

## Verification

`pnpm format`, `pnpm lint`, `pnpm --filter @waves/mobile typecheck` all pass; 954 tests pass.

Not device-tested. Worth confirming on a handset that `RemindChip` still takes its own tap inside the row.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Balance rows can now be tapped to view shared groups with a person.
  * Added accessibility labels, spoken navigation hints, and a screen-reader reminder action.
  * Person identities are consistently combined across groups, including merged guest records.
  * Added translations for the new accessibility text in English, Tamil, Hindi, and Arabic.
  * Reminders are available directly from eligible balance rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->