### PR TITLE
Tell the truth about why an offline voice model won't download

### DIFF
--- a/apps/mobile/src/app/settings/offline-voice.tsx
+++ b/apps/mobile/src/app/settings/offline-voice.tsx
@@ -30,6 +30,28 @@
  *    to recover with. So iPhone gets the four languages the mic asks for, no
  *    claim about any of them, and the one thing a person can actually do —
  *    where in Settings the dictation languages live.
+ *
+ * Two things about the shape of the page are worth saying, because both were
+ * wrong before.
+ *
+ * **The list folds.** The four languages Waves speaks are the reason anybody
+ * opens this screen; the other two groups are the phone's own inventory, which
+ * on Android runs to dozens of rows. Those two now start shut, each behind a
+ * header that says how many it is holding. The app's four never fold — a
+ * screen whose entire point is "download Tamil" that opens with Tamil hidden is
+ * a worse screen than one that scrolls.
+ *
+ * **A refusal is decoded, not flattened.** The download call rejects with a
+ * code, and on Android 14+ that code is the `SpeechRecognizer` error constant
+ * handed through untouched. This screen used to read exactly one of them and
+ * say "your phone couldn't download that one" to everything else — including,
+ * routinely, Tamil. Every app language is offered a Download button whether or
+ * not the recogniser has ever heard of it (it cannot be known in advance; see
+ * `SpeechLocales.locales`, which is a union that quietly folds in the
+ * network-only languages), so the tap *is* the probe, and the probe's answer is
+ * the only place the truth lives. `offlineDownloadReason` reads it. "There is
+ * no model for this language" and "the model exists and did not arrive" are now
+ * different sentences, because they are different problems.
  */
 
 import { useEffect, useRef, useState } from 'react';
@@ -37,9 +59,10 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { FlashList } from '@shopify/flash-list';
 import { useQuery } from '@tanstack/react-query';
 import { router } from 'expo-router';
-import { Platform, View } from 'react-native';
+import { Platform, Pressable, View } from 'react-native';
 
 import {
+  Avatar,
   Badge,
   Button,
   Callout,
@@ -54,10 +77,16 @@ import {
   Text,
   useScreenClearance,
   useTheme,
+  type Theme,
 } from '@waves/ui';
 
-import { deviceLocale, LANGUAGE_NAMES, LANGUAGES, useStrings } from '@/i18n';
-import { offlineVoiceModels, type OfflineVoiceModel } from '@/lib/dictation';
+import { deviceLocale, LANGUAGE_NAMES, LANGUAGES, plural, useStrings } from '@/i18n';
+import {
+  offlineDownloadReason,
+  offlineVoiceModels,
+  type OfflineDownloadReason,
+  type OfflineVoiceModel,
+} from '@/lib/dictation';
 import { useReducedMotion } from '@/lib/reducedMotion';
 import { speechModels } from '@/lib/speechModels';
 
@@ -78,13 +107,17 @@ const DOWNLOAD_WATCHDOG_MS = 3 * 60_000;
  * What a row is doing since it was last tapped.
  *
  * `working` is the only state that draws a bar. The rest are sentences the
- * phone's own answer earned — including `failed`, which is a fact about this
- * device and not an error worth a red screen.
+ * phone's own answer earned — `done` for a model that landed, `settled` for the
+ * several ways it can be neither here nor lost, and `failed`, which is a fact
+ * about this device and not an error worth a red screen.
  */
 interface RowProgress {
-  readonly phase: 'working' | 'settled' | 'failed';
+  readonly phase: 'working' | 'done' | 'settled' | 'failed';
   readonly message: string;
 }
+
+/** The two groups that fold away; the app's own languages never do. */
+type FoldKey = 'installed' | 'other';
 
 /**
  * `Intl.DisplayNames` per app language, built at most once each.
@@ -114,18 +147,19 @@ function localeName(tag: string, locale: string): string | null {
   }
 }
 
-/** Whether a rejected download was the platform refusing, not the network. */
-function refusedAsUnsupported(caught: unknown): boolean {
-  const code = (caught as { code?: unknown } | null)?.code;
-  return code === 'not_supported';
-}
-
 export default function OfflineVoiceScreen() {
   const theme = useTheme();
   const clearance = useScreenClearance();
   const reduceMotion = useReducedMotion();
   const { t, locale } = useStrings();
   const [progress, setProgress] = useState<Record<string, RowProgress>>({});
+  // Both shut to begin with. The phone's inventory is dozens of rows of things
+  // nobody came here for, and burying the four that matter under it is what the
+  // screen used to do.
+  const [openSections, setOpenSections] = useState<Record<FoldKey, boolean>>({
+    installed: false,
+    other: false,
+  });
 
   // Which tags have a native download in flight, and every watchdog still
   // pending. Refs, not state: the lock has to be readable and writable *now*, in
@@ -176,6 +210,35 @@ export default function OfflineVoiceScreen() {
     setProgress((current) => ({ ...current, [tag]: row }));
   };
 
+  /**
+   * The phone's reason for refusing, in words a person can act on.
+   *
+   * Every branch names something different to go and do, which is the whole
+   * point of decoding the code rather than swallowing it. `language-missing` is
+   * the one this screen was built blind to: the recogniser has no model for that
+   * language at all, so no amount of retrying, waiting for Wi-Fi or freeing
+   * space will produce one.
+   */
+  const reasonText = (reason: OfflineDownloadReason): string => {
+    switch (reason) {
+      case 'too-old':
+        return t.offlineVoice.tooOld;
+      case 'language-missing':
+        return t.offlineVoice.languageMissing;
+      case 'not-downloaded':
+        return t.offlineVoice.notDownloaded;
+      case 'network':
+        return t.offlineVoice.networkFailed;
+      case 'busy':
+        return t.offlineVoice.serviceBusy;
+      case 'started':
+        return t.offlineVoice.handedOff;
+      case 'refused':
+      default:
+        return t.offlineVoice.failed;
+    }
+  };
+
   const download = async (model: OfflineVoiceModel): Promise<void> => {
     // The lock is a ref rather than a read of `progress`, because two taps
     // inside one frame share a render closure: a state read there sees the
@@ -199,7 +262,7 @@ export default function OfflineVoiceScreen() {
     try {
       const status = await speechModels.download(model.tag);
       setRow(model.tag, {
-        phase: 'settled',
+        phase: status === 'download_success' ? 'done' : 'settled',
         message:
           status === 'download_success'
             ? t.offlineVoice.ready
@@ -211,9 +274,14 @@ export default function OfflineVoiceScreen() {
       // a dialog or a queued job would just redraw the same "not downloaded".
       if (status === 'download_success') await locales.refetch();
     } catch (caught) {
+      const reason = offlineDownloadReason(caught);
+      // `started` arrives as a rejection and is not a failure: the service took
+      // the request and only declined to narrate it. Drawing it in red under a
+      // sentence about not being able to download would be the screen lying
+      // about something that is at that moment working.
       setRow(model.tag, {
-        phase: 'failed',
-        message: refusedAsUnsupported(caught) ? t.offlineVoice.tooOld : t.offlineVoice.failed,
+        phase: reason === 'started' ? 'settled' : 'failed',
+        message: reasonText(reason),
       });
     } finally {
       clearTimeout(watchdog);
@@ -247,6 +315,34 @@ export default function OfflineVoiceScreen() {
               ? { tone: 'info', text: t.offlineVoice.empty }
               : null;
 
+  /**
+   * A group that folds: its header always, its rows only when open.
+   *
+   * An empty group draws nothing at all — not even a header saying zero, which
+   * is a row of furniture standing in for information.
+   */
+  const foldedSection = (
+    key: FoldKey,
+    title: string,
+    hint: string | undefined,
+    group: OfflineVoiceModel[],
+  ): ListItem[] => {
+    if (group.length === 0) return [];
+    const open = openSections[key];
+    return [
+      // The hint explains the rows, so it keeps them company rather than
+      // sitting under a shut header explaining nothing visible.
+      {
+        kind: 'header',
+        key,
+        title,
+        hint: open ? hint : undefined,
+        fold: { key, open, count: group.length },
+      },
+      ...(open ? group.map((model): ListItem => ({ kind: 'model', key: model.tag, model })) : []),
+    ];
+  };
+
   // One flat list of headers and rows rather than three lists in a scroll view:
   // the "other languages" group is every locale the recogniser knows, which on
   // Android runs to dozens, and only a virtualised list keeps that cheap.
@@ -258,21 +354,13 @@ export default function OfflineVoiceScreen() {
       hint: t.offlineVoice.appSectionHint,
     },
     ...models.app.map((model): ListItem => ({ kind: 'model', key: model.tag, model })),
-    ...(models.alsoInstalled.length > 0
-      ? [{ kind: 'header' as const, key: 'installed', title: t.offlineVoice.alsoInstalled }]
-      : []),
-    ...models.alsoInstalled.map((model): ListItem => ({ kind: 'model', key: model.tag, model })),
-    ...(models.downloadable.length > 0
-      ? [
-          {
-            kind: 'header' as const,
-            key: 'other',
-            title: t.offlineVoice.otherLanguages,
-            hint: canDownload ? t.offlineVoice.otherLanguagesHint : undefined,
-          },
-        ]
-      : []),
-    ...models.downloadable.map((model): ListItem => ({ kind: 'model', key: model.tag, model })),
+    ...foldedSection('installed', t.offlineVoice.alsoInstalled, undefined, models.alsoInstalled),
+    ...foldedSection(
+      'other',
+      t.offlineVoice.otherLanguages,
+      canDownload ? t.offlineVoice.otherLanguagesHint : undefined,
+      models.downloadable,
+    ),
   ];
 
   return (
@@ -312,7 +400,11 @@ export default function OfflineVoiceScreen() {
       <FlashList<ListItem>
         data={showList ? items : []}
         keyExtractor={(item) => `${item.kind}-${item.key}`}
-        extraData={[locale, theme.scheme, progress, locales.dataUpdatedAt]}
+        // A heading and a model card are nothing like each other in height, and
+        // folding a section shuffles which is which — recycling one into the
+        // other is how a list starts measuring wrong.
+        getItemType={(item) => item.kind}
+        extraData={[locale, theme.scheme, progress, openSections, locales.dataUpdatedAt]}
         drawDistance={1500}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
@@ -336,30 +428,34 @@ export default function OfflineVoiceScreen() {
             ) : null}
           </View>
         }
-        renderItem={({ item }) =>
-          item.kind === 'header' ? (
-            <View style={{ paddingTop: theme.spacing.lg }}>
-              <SectionHeader title={item.title} />
-              {item.hint ? (
-                <Text
-                  variant="caption"
-                  tone="muted"
-                  style={{ marginTop: -theme.spacing.sm, marginBottom: theme.spacing.md }}
-                >
-                  {item.hint}
-                </Text>
-              ) : null}
-            </View>
-          ) : (
-            <ModelRow
-              model={item.model}
-              progress={progress[item.model.tag]}
-              canDownload={canDownload}
-              reduceMotion={reduceMotion}
-              onDownload={() => void download(item.model)}
+        renderItem={({ item }) => {
+          if (item.kind === 'model') {
+            return (
+              <ModelRow
+                model={item.model}
+                progress={progress[item.model.tag]}
+                canDownload={canDownload}
+                reduceMotion={reduceMotion}
+                onDownload={() => void download(item.model)}
+              />
+            );
+          }
+          // Read out of the item before the closure, so the toggle carries the
+          // section's own key rather than reaching back through a maybe-absent
+          // field to find it.
+          const fold = item.fold;
+          return (
+            <SectionFold
+              item={item}
+              onToggle={
+                fold
+                  ? () =>
+                      setOpenSections((current) => ({ ...current, [fold.key]: !current[fold.key] }))
+                  : undefined
+              }
             />
-          )
-        }
+          );
+        }}
         ListFooterComponent={
           <Text variant="micro" tone="muted" style={{ paddingVertical: theme.spacing.xl }}>
             {t.offlineVoice.footnote}
@@ -372,8 +468,146 @@ export default function OfflineVoiceScreen() {
 
 /** A section heading or one model — the two things the list draws. */
 type ListItem =
-  | { kind: 'header'; key: string; title: string; hint?: string }
+  | {
+      kind: 'header';
+      key: string;
+      title: string;
+      hint?: string;
+      /** Absent on a heading that does not fold, which is the app's own four. */
+      fold?: { key: FoldKey; open: boolean; count: number };
+    }
   | { kind: 'model'; key: string; model: OfflineVoiceModel };
+
+/**
+ * A section heading, tappable when its group folds.
+ *
+ * The count is the only thing a shut section can honestly show, so it is what
+ * it shows: the header is not hiding "some more languages", it is hiding
+ * sixty-three of them, and that number is what decides whether anybody opens it.
+ *
+ * It is handed to a screen reader as the control's *value* rather than glued to
+ * its name, so the announcement stays three separate facts — "Other languages,
+ * 63 languages, collapsed" — instead of one run-on label. What is lost is the
+ * heading role: React Native cannot make one element both a heading and a
+ * button, and a control somebody has to be able to press wins over a landmark
+ * they can jump to. The unfolding sections keep the plain heading.
+ */
+function SectionFold({
+  item,
+  onToggle,
+}: {
+  item: Extract<ListItem, { kind: 'header' }>;
+  onToggle: (() => void) | undefined;
+}) {
+  const theme = useTheme();
+  const { t, locale } = useStrings();
+
+  const hint = item.hint ? (
+    <Text
+      variant="caption"
+      tone="muted"
+      style={{ marginTop: -theme.spacing.sm, marginBottom: theme.spacing.md }}
+    >
+      {item.hint}
+    </Text>
+  ) : null;
+
+  if (!item.fold) {
+    return (
+      <View style={{ paddingTop: theme.spacing.lg }}>
+        <SectionHeader title={item.title} />
+        {hint}
+      </View>
+    );
+  }
+
+  const { open, count } = item.fold;
+  const countText = plural(locale, count, t.offlineVoice.sectionCount);
+
+  return (
+    <View style={{ paddingTop: theme.spacing.lg }}>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={item.title}
+        accessibilityValue={{ text: countText }}
+        accessibilityState={{ expanded: open }}
+        onPress={onToggle}
+        hitSlop={8}
+        style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+      >
+        <SectionHeader
+          title={item.title}
+          action={
+            <Row style={{ gap: theme.spacing.sm }}>
+              <Text variant="caption" tone="muted">
+                {countText}
+              </Text>
+              {/* Up and down, never forward and back: a fold opens downward in
+                  Arabic exactly as it does in English, so there is nothing here
+                  for `directionalIcon` to mirror. */}
+              <Ionicons
+                name={open ? 'chevron-up' : 'chevron-down'}
+                size={iconSize.md}
+                color={theme.color.textMuted}
+              />
+            </Row>
+          }
+        />
+      </Pressable>
+      {open ? hint : null}
+    </View>
+  );
+}
+
+/** The glyph, colour and text tone a row's progress line is drawn in. */
+function progressLook(
+  theme: Theme,
+  phase: RowProgress['phase'],
+): {
+  icon:
+    'cloud-download-outline' | 'checkmark-circle' | 'alert-circle' | 'information-circle-outline';
+  color: string;
+  tone: 'muted' | 'positive' | 'negative';
+} {
+  switch (phase) {
+    case 'working':
+      return { icon: 'cloud-download-outline', color: theme.color.brand, tone: 'muted' };
+    case 'done':
+      return { icon: 'checkmark-circle', color: theme.color.positive, tone: 'positive' };
+    case 'failed':
+      return { icon: 'alert-circle', color: theme.color.negative, tone: 'negative' };
+    case 'settled':
+    default:
+      return { icon: 'information-circle-outline', color: theme.color.textMuted, tone: 'muted' };
+  }
+}
+
+/**
+ * A state, said twice: once as a shape and a colour, once in words.
+ *
+ * Neither carries it alone. The glyph is for the eye running down the column,
+ * the badge is for everybody the glyph does not reach — somebody who cannot
+ * tell the green disc from the grey one, and every screen reader.
+ */
+function StateMark({
+  icon,
+  color,
+  label,
+  tone,
+}: {
+  icon: 'checkmark-circle' | 'cloud-offline-outline' | 'help-circle-outline';
+  color: string;
+  label: string;
+  tone: 'positive' | 'neutral';
+}) {
+  const theme = useTheme();
+  return (
+    <Row style={{ gap: theme.spacing.sm, flexShrink: 0 }}>
+      <Ionicons name={icon} size={iconSize.lg} color={color} />
+      <Badge label={label} tone={tone} />
+    </Row>
+  );
+}
 
 function ModelRow({
   model,
@@ -403,10 +637,32 @@ function ModelRow({
       ? model.tag
       : null;
   const working = progress?.phase === 'working';
+  const look = progress ? progressLook(theme, progress.phase) : null;
 
   return (
     <Card style={{ marginBottom: theme.spacing.md, gap: theme.spacing.md }}>
       <Row style={{ gap: theme.spacing.md }}>
+        {/* Deliberately not a flag. A language is not a country — Tamil, Hindi,
+            Arabic and English are each spoken across many of them, and picking
+            one flag to stand for the rest is the oldest mistake in
+            localisation. The mark is the language's own script instead, த and ह
+            and ا, which is the shape somebody scanning this list is actually
+            looking for. A locale Waves does not speak gets a neutral globe
+            rather than a Latin initial guessed off a tag.
+
+            Hidden from a screen reader on purpose: the title beside it says the
+            same word, and hearing it twice is not twice the information. */}
+        <View accessibilityElementsHidden importantForAccessibility="no-hide-descendants">
+          <Avatar
+            name={model.language ? title : model.tag}
+            size={44}
+            mark={
+              model.language
+                ? undefined
+                : (color) => <Ionicons name="globe-outline" size={iconSize.lg} color={color} />
+            }
+          />
+        </View>
         <View style={{ flex: 1, gap: 2 }}>
           <Text variant="subheading" numberOfLines={1}>
             {title}
@@ -417,31 +673,65 @@ function ModelRow({
             </Text>
           ) : null}
         </View>
-        {/* `unknown` draws nothing at all. A phone that cannot be asked what it
-            holds gets no tick and no button — the notice in the header says
-            where its dictation languages actually come from. */}
+        {/* `unknown` gets a question mark and says so. It used to draw nothing,
+            which read as an answer of its own — a row with no tick looks
+            uninstalled. "Can't tell" is the true statement, and the notice in
+            the header explains why iPhone cannot be asked. What it still does
+            not get is a button, because there is nothing here to press. */}
         {model.state === 'installed' ? (
-          <Badge label={t.offlineVoice.installed} tone="positive" />
+          <StateMark
+            icon="checkmark-circle"
+            color={theme.color.positive}
+            label={t.offlineVoice.installed}
+            tone="positive"
+          />
         ) : model.state === 'missing' ? (
           canDownload ? (
             <Button
               label={t.offlineVoice.download}
               size="sm"
               variant="secondary"
+              icon={
+                <Ionicons
+                  name="cloud-download-outline"
+                  size={iconSize.md}
+                  color={theme.color.brand}
+                />
+              }
               disabled={working}
               onPress={onDownload}
             />
           ) : (
-            <Badge label={t.offlineVoice.notInstalled} tone="neutral" />
+            <StateMark
+              icon="cloud-offline-outline"
+              color={theme.color.textMuted}
+              label={t.offlineVoice.notInstalled}
+              tone="neutral"
+            />
           )
-        ) : null}
+        ) : (
+          <StateMark
+            icon="help-circle-outline"
+            color={theme.color.textMuted}
+            label={t.offlineVoice.cannotTell}
+            tone="neutral"
+          />
+        )}
       </Row>
 
-      {progress ? (
+      {progress && look ? (
         <View style={{ gap: theme.spacing.sm }}>
-          <Text variant="caption" tone={progress.phase === 'failed' ? 'negative' : 'muted'}>
-            {working ? `${progress.message} ${t.offlineVoice.noProgress}` : progress.message}
-          </Text>
+          <Row style={{ gap: theme.spacing.sm, alignItems: 'flex-start' }}>
+            <Ionicons
+              name={look.icon}
+              size={iconSize.md}
+              color={look.color}
+              style={{ marginTop: 2 }}
+            />
+            <Text variant="caption" tone={look.tone} style={{ flex: 1 }}>
+              {working ? `${progress.message} ${t.offlineVoice.noProgress}` : progress.message}
+            </Text>
+          </Row>
           {/* Indeterminate on purpose: Android hands the app a percentage and
               the library never passes it on, so there is no number to draw. */}
           {working ? <ProgressBar animated={!reduceMotion} /> : null}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1011,9 +1011,14 @@ export interface UiStrings {
     /** Everything else the recogniser knows about. */
     otherLanguages: string;
     otherLanguagesHint: string;
+    /** How many rows a folded section holds — the whole of what it says while
+     *  it is shut, since the point of folding it is not reading the rest. */
+    sectionCount: PluralForms;
     /** Per-row state. */
     installed: string;
     notInstalled: string;
+    /** A phone that cannot be asked what it holds, so the row claims nothing. */
+    cannotTell: string;
     download: string;
     /** Under a row while the phone fetches a model. Android hands the app no
      *  percentage — the bar is indeterminate and this says why. */
@@ -1023,6 +1028,19 @@ export interface UiStrings {
     ready: string;
     dialogOpened: string;
     scheduled: string;
+    /**
+     * The reasons a download can end badly, decoded from the phone's own error
+     * code by `offlineDownloadReason`. They are separate strings because they
+     * are separate things to go and do: no model exists at all, a model exists
+     * and did not arrive, the connection, the service being busy, or a download
+     * that in fact started and cannot be watched. `failed` is now only the case
+     * where the phone refused without saying why.
+     */
+    languageMissing: string;
+    notDownloaded: string;
+    networkFailed: string;
+    serviceBusy: string;
+    handedOff: string;
     failed: string;
     /** A download still unanswered long after it began — Android's listener may
      *  simply never fire, and the row stops asserting rather than spin forever. */
@@ -3481,8 +3499,10 @@ const en: UiStrings = {
     alsoInstalled: 'Also on this phone',
     otherLanguages: 'Other languages',
     otherLanguagesHint: 'Your phone can fetch any of these.',
+    sectionCount: { one: '{n} language', other: '{n} languages' },
     installed: 'On this phone',
     notInstalled: 'Not downloaded',
+    cannotTell: 'Can’t tell',
     download: 'Download',
     downloading: 'Your phone is downloading this.',
     noProgress: 'Android doesn’t say how far along it is.',
@@ -3490,7 +3510,16 @@ const en: UiStrings = {
     dialogOpened:
       'Your phone has taken over with its own download screen. Finish there, then come back and refresh.',
     scheduled: 'Queued. Your phone will finish it, usually once you’re on Wi‑Fi.',
-    failed: 'Your phone couldn’t download that one.',
+    languageMissing:
+      'Your phone’s speech service has no offline model for this language, so there is nothing to fetch. Updating “Speech Recognition & Synthesis” from the Play Store sometimes adds one; until then this language needs a connection.',
+    notDownloaded:
+      'Your phone has this language but hasn’t fetched it yet. It usually waits for Wi‑Fi — try again once you’re on it.',
+    networkFailed: 'The download couldn’t get through. Check your connection and try again.',
+    serviceBusy:
+      'Your phone’s speech service is busy. Close anything else using the mic and try again.',
+    handedOff:
+      'Your phone started the download but won’t report on it. Give it a few minutes, then refresh.',
+    failed: 'Your phone’s speech service refused the download and didn’t say why.',
     stillWorking:
       'Your phone hasn’t said whether this finished. Give it a while, then refresh to see if it landed.',
     tooOld:
@@ -5857,8 +5886,10 @@ const ta: UiStrings = {
     alsoInstalled: 'இந்த ஃபோனில் ஏற்கெனவே உள்ளவை',
     otherLanguages: 'மற்ற மொழிகள்',
     otherLanguagesHint: 'இவற்றில் எதையும் உங்கள் ஃபோன் கொண்டுவரும்.',
+    sectionCount: { one: '{n} மொழி', other: '{n} மொழிகள்' },
     installed: 'ஃபோனில் உள்ளது',
     notInstalled: 'பதிவிறக்கப்படவில்லை',
+    cannotTell: 'சொல்ல முடியவில்லை',
     download: 'பதிவிறக்கு',
     downloading: 'உங்கள் ஃபோன் இதைப் பதிவிறக்குகிறது.',
     noProgress: 'எவ்வளவு முடிந்தது என்பதை Android சொல்வதில்லை.',
@@ -5866,7 +5897,17 @@ const ta: UiStrings = {
     dialogOpened:
       'உங்கள் ஃபோன் தன் சொந்தப் பதிவிறக்கத் திரையைத் திறந்துவிட்டது. அங்கே முடித்துவிட்டு, திரும்பி வந்து புதுப்பிக்கவும்.',
     scheduled: 'வரிசையில் உள்ளது. பொதுவாக Wi‑Fi இணைப்பில் உங்கள் ஃபோன் இதை முடிக்கும்.',
-    failed: 'அதை உங்கள் ஃபோனால் பதிவிறக்க முடியவில்லை.',
+    languageMissing:
+      'உங்கள் ஃபோனின் பேச்சுச் சேவையிடம் இந்த மொழிக்கான ஆஃப்லைன் மாதிரியே இல்லை, எனவே பதிவிறக்க எதுவும் இல்லை. Play Store-இல் “Speech Recognition & Synthesis” ஐப் புதுப்பித்தால் சில சமயங்களில் ஒன்று சேரும்; அதுவரை இந்த மொழிக்கு இணைப்பு தேவை.',
+    notDownloaded:
+      'இந்த மொழி உங்கள் ஃபோனுக்குத் தெரியும், ஆனால் இன்னும் கொண்டுவரவில்லை. பொதுவாக Wi‑Fi வரும் வரை காத்திருக்கும் — இணைந்ததும் மீண்டும் முயலுங்கள்.',
+    networkFailed:
+      'பதிவிறக்கம் சென்று சேரவில்லை. உங்கள் இணைப்பைச் சரிபார்த்து மீண்டும் முயலுங்கள்.',
+    serviceBusy:
+      'உங்கள் ஃபோனின் பேச்சுச் சேவை பணியில் உள்ளது. மைக்கைப் பயன்படுத்தும் மற்றவற்றை மூடிவிட்டு மீண்டும் முயலுங்கள்.',
+    handedOff:
+      'உங்கள் ஃபோன் பதிவிறக்கத்தைத் தொடங்கிவிட்டது, ஆனால் அதைப் பற்றிச் சொல்லாது. சில நிமிடங்கள் கழித்துப் புதுப்பிக்கவும்.',
+    failed: 'உங்கள் ஃபோனின் பேச்சுச் சேவை பதிவிறக்கத்தை மறுத்தது, காரணம் சொல்லவில்லை.',
     stillWorking:
       'இது முடிந்ததா என்பதை உங்கள் ஃபோன் இன்னும் சொல்லவில்லை. கொஞ்சம் நேரம் கழித்து, வந்து சேர்ந்ததா எனப் புதுப்பித்துப் பாருங்கள்.',
     tooOld:
@@ -8306,8 +8347,10 @@ const hi: UiStrings = {
     alsoInstalled: 'इस फ़ोन पर पहले से मौजूद',
     otherLanguages: 'दूसरी भाषाएँ',
     otherLanguagesHint: 'इनमें से कोई भी आपका फ़ोन ला सकता है।',
+    sectionCount: { one: '{n} भाषा', other: '{n} भाषाएँ' },
     installed: 'फ़ोन पर मौजूद',
     notInstalled: 'डाउनलोड नहीं है',
+    cannotTell: 'बता नहीं सकते',
     download: 'डाउनलोड करें',
     downloading: 'आपका फ़ोन इसे डाउनलोड कर रहा है।',
     noProgress: 'Android यह नहीं बताता कि कितना हुआ।',
@@ -8315,7 +8358,16 @@ const hi: UiStrings = {
     dialogOpened:
       'आपके फ़ोन ने अपनी डाउनलोड स्क्रीन खोल दी है। वहीं पूरा करें, फिर लौटकर ताज़ा करें।',
     scheduled: 'क़तार में है। आपका फ़ोन इसे पूरा कर देगा, आम तौर पर Wi‑Fi पर।',
-    failed: 'आपका फ़ोन उसे डाउनलोड नहीं कर सका।',
+    languageMissing:
+      'आपके फ़ोन की स्पीच सेवा के पास इस भाषा का ऑफ़लाइन मॉडल है ही नहीं, इसलिए लाने को कुछ नहीं है। Play Store से “Speech Recognition & Synthesis” अपडेट करने पर कभी‑कभी एक जुड़ जाता है; तब तक इस भाषा को कनेक्शन चाहिए।',
+    notDownloaded:
+      'आपका फ़ोन यह भाषा जानता है, पर अभी लाया नहीं है। आम तौर पर वह Wi‑Fi का इंतज़ार करता है — जुड़ते ही फिर कोशिश करें।',
+    networkFailed: 'डाउनलोड पहुँच ही नहीं पाया। अपना कनेक्शन जाँचकर फिर कोशिश करें।',
+    serviceBusy:
+      'आपके फ़ोन की स्पीच सेवा व्यस्त है। माइक इस्तेमाल कर रही दूसरी चीज़ें बंद करके फिर कोशिश करें।',
+    handedOff:
+      'आपके फ़ोन ने डाउनलोड शुरू कर दिया है पर उसकी ख़बर नहीं देगा। कुछ मिनट बाद ताज़ा करें।',
+    failed: 'आपके फ़ोन की स्पीच सेवा ने डाउनलोड से इनकार कर दिया और वजह नहीं बताई।',
     stillWorking:
       'आपके फ़ोन ने अब तक नहीं बताया कि यह पूरा हुआ या नहीं। थोड़ी देर बाद ताज़ा करके देखें कि आया या नहीं।',
     tooOld:
@@ -10729,15 +10781,31 @@ const ar: UiStrings = {
     alsoInstalled: 'موجودة على هذا الهاتف',
     otherLanguages: 'لغات أخرى',
     otherLanguagesHint: 'يستطيع هاتفك جلب أيٍّ منها.',
+    sectionCount: {
+      zero: '{n} لغة',
+      one: 'لغة واحدة',
+      two: 'لغتان',
+      few: '{n} لغات',
+      many: '{n} لغة',
+      other: '{n} لغة',
+    },
     installed: 'على الهاتف',
     notInstalled: 'غير مُنزَّلة',
+    cannotTell: 'يتعذّر معرفة ذلك',
     download: 'تنزيل',
     downloading: 'هاتفك ينزّل هذا الآن.',
     noProgress: 'لا يخبر Android بمقدار ما اكتمل.',
     ready: 'اكتمل التنزيل. يمكن للميكروفون استخدامه الآن.',
     dialogOpened: 'فتح هاتفك شاشة التنزيل الخاصة به. أكمِل هناك ثم عُد وحدِّث القائمة.',
     scheduled: 'في الانتظار. سيُكمل هاتفك التنزيل، غالبًا عند اتصاله بشبكة Wi‑Fi.',
-    failed: 'تعذّر على هاتفك تنزيل ذلك.',
+    languageMissing:
+      'لا تملك خدمة الكلام في هاتفك نموذجًا يعمل دون اتصال لهذه اللغة، فليس هناك ما يُجلب. تحديث «Speech Recognition & Synthesis» من متجر Play يضيف لغة أحيانًا؛ وحتى ذلك الحين تحتاج هذه اللغة إلى اتصال.',
+    notDownloaded:
+      'هاتفك يعرف هذه اللغة لكنه لم يجلبها بعد. عادةً ينتظر شبكة Wi‑Fi — أعد المحاولة بعد الاتصال بها.',
+    networkFailed: 'لم يصل التنزيل. تحقّق من اتصالك وأعد المحاولة.',
+    serviceBusy: 'خدمة الكلام في هاتفك مشغولة. أغلق ما يستخدم الميكروفون وأعد المحاولة.',
+    handedOff: 'بدأ هاتفك التنزيل لكنه لن يُبلغ عنه. امهله بضع دقائق ثم حدِّث القائمة.',
+    failed: 'رفضت خدمة الكلام في هاتفك التنزيل ولم تذكر السبب.',
     stillWorking:
       'لم يقل هاتفك بعدُ إن كان هذا قد اكتمل. امهله قليلًا ثم حدِّث القائمة لترى إن كان قد وصل.',
     tooOld:

--- a/apps/mobile/src/lib/dictation.ts
+++ b/apps/mobile/src/lib/dictation.ts
@@ -16,10 +16,19 @@ import type { DictationErrorStrings, Language } from '@/i18n';
  *
  * The device's own tag wins when it agrees with the language the app is showing
  * — somebody on `en-GB` should be recognised as `en-GB`, not corrected to
- * Indian English. When it disagrees, or carries no region, India is the
- * fallback: Waves is India-first, and `ta`/`hi` with no region is a recogniser
- * lottery on Android.
+ * Indian English. When it disagrees, or carries no region, the fallback is the
+ * app language's nearest supported default: India for en/ta/hi, and Saudi Arabia
+ * for Arabic. `ar-IN` is not a real speech locale on Android, so using India for
+ * every language made Arabic voice and offline-model rows fail before the user
+ * could do anything useful.
  */
+const SPEECH_FALLBACK_REGION: Readonly<Record<Language, string>> = {
+  en: 'IN',
+  ta: 'IN',
+  hi: 'IN',
+  ar: 'SA',
+};
+
 export function speechLocale(language: Language, deviceLocale: string): string {
   const parts = deviceLocale.trim().split(/[-_]/);
   const tag = parts[0];
@@ -27,7 +36,7 @@ export function speechLocale(language: Language, deviceLocale: string): string {
   // three-digit UN M.49 code is a real region the recogniser can match.
   const region = parts.slice(1).find((part) => /^([A-Za-z]{2}|\d{3})$/.test(part));
   if (tag?.toLowerCase() === language && region) return `${language}-${region.toUpperCase()}`;
-  return `${language}-IN`;
+  return `${language}-${SPEECH_FALLBACK_REGION[language]}`;
 }
 
 /**

--- a/apps/mobile/src/lib/dictation.ts
+++ b/apps/mobile/src/lib/dictation.ts
@@ -217,6 +217,86 @@ export function offlineVoiceModels(
 }
 
 /**
+ * Why a request to fetch an on-device model ended the way it did.
+ *
+ * This exists because the honest answer to "why did Tamil fail?" was being
+ * thrown away one layer down. `androidTriggerOfflineModelDownload` rejects with
+ * a code, and on Android 14+ that code is `error_<n>` where `n` is a
+ * `SpeechRecognizer.ERROR_*` constant handed straight through from
+ * `ModelDownloadListener.onError`. The screen used to test for exactly one code
+ * (`not_supported`, the pre-Android-13 refusal) and collapse every other cause
+ * into "your phone couldn't download that one" — a sentence that is true of a
+ * dead network, a busy service, a language the recogniser has never heard of
+ * and a download that in fact started fine. Four different things to do, one
+ * dead end.
+ *
+ * The distinctions that earn their own word:
+ *
+ *  - `language-missing` (12, ERROR_LANGUAGE_NOT_SUPPORTED) — "not available to
+ *    be used with the current recognizer". There is no model to fetch and there
+ *    never will be on this phone as it stands. This is the one that matters:
+ *    the screen offers a Download button for all four app languages whether or
+ *    not the recogniser has ever heard of them, and it cannot know better in
+ *    advance (see {@link offlineVoiceModels} and the probe note in
+ *    `speechModels.ts` — the supported list is a union that includes
+ *    network-only languages, so a tag appearing there is no promise of a model).
+ *    The tap *is* the probe, and this is the probe answering "no".
+ *  - `not-downloaded` (13, ERROR_LANGUAGE_UNAVAILABLE) — the opposite, and it
+ *    reads identically to a user: "supported, but not yet downloaded". The
+ *    model exists; this attempt did not land it. Worth trying again.
+ *  - `started` (15, ERROR_CANNOT_LISTEN_TO_DOWNLOAD_EVENTS) — not a failure at
+ *    all. The service took the request and cannot report on it. Calling that
+ *    "couldn't download" is simply false.
+ *  - `network` (1, 2, 4, 11), `busy` (8) — ordinary, retryable, and each has a
+ *    different thing for a person to go and do.
+ *  - `too-old` — the module's own pre-API-33 refusal, which the screen already
+ *    prevents by not drawing a button; kept because a rejection is a rejection.
+ *  - `refused` — everything else, including a code that is not a code. A future
+ *    Android constant lands here and gets a sentence that is still true.
+ */
+export type OfflineDownloadReason =
+  'too-old' | 'language-missing' | 'not-downloaded' | 'started' | 'network' | 'busy' | 'refused';
+
+/**
+ * The reason behind a rejected download, read off the thrown value.
+ *
+ * Kept here rather than in `speechModels.ts` for the reason the rest of this
+ * file is: it is pure decision-making over a string, it is easy to get subtly
+ * wrong, and a device is a terrible place to find that out.
+ */
+export function offlineDownloadReason(caught: unknown): OfflineDownloadReason {
+  const code = (caught as { code?: unknown } | null | undefined)?.code;
+  if (code === 'not_supported') return 'too-old';
+  if (typeof code !== 'string') return 'refused';
+  const error = /^error_(\d+)$/.exec(code);
+  if (!error) return 'refused';
+  switch (Number(error[1])) {
+    // ERROR_NETWORK_TIMEOUT, ERROR_NETWORK, ERROR_SERVER, ERROR_SERVER_DISCONNECTED.
+    case 1:
+    case 2:
+    case 4:
+    case 11:
+      return 'network';
+    // ERROR_RECOGNIZER_BUSY.
+    case 8:
+      return 'busy';
+    // ERROR_LANGUAGE_NOT_SUPPORTED.
+    case 12:
+      return 'language-missing';
+    // ERROR_LANGUAGE_UNAVAILABLE.
+    case 13:
+      return 'not-downloaded';
+    // ERROR_CANNOT_LISTEN_TO_DOWNLOAD_EVENTS.
+    case 15:
+      return 'started';
+    // ERROR_CLIENT (5), ERROR_INSUFFICIENT_PERMISSIONS (9),
+    // ERROR_CANNOT_CHECK_SUPPORT (14), and whatever a later Android adds.
+    default:
+      return 'refused';
+  }
+}
+
+/**
  * What the field should read while somebody is speaking.
  *
  * `before` is whatever was in the field when the mic was tapped, and it is

--- a/apps/mobile/src/lib/speechModels.ts
+++ b/apps/mobile/src/lib/speechModels.ts
@@ -28,6 +28,17 @@ export type OfflineModelDownload = 'download_success' | 'opened_dialog' | 'downl
 
 /** The locales the recogniser knows about, and the ones it already holds. */
 export interface SpeechLocales {
+  /**
+   * Every language the recogniser will answer in — and the trap in this screen.
+   *
+   * The native side builds it as `supportedOnDeviceLanguages ∪
+   * installedOnDeviceLanguages ∪ onlineLanguages` and hands over the union with
+   * no seam, so a tag here may be one the phone can only do *over the network*.
+   * Google's cloud recogniser speaks a few hundred languages; the on-device one
+   * speaks a fraction of them. So this list says what can be recognised, never
+   * what can be downloaded, and the difference only surfaces at the tap — as a
+   * rejection carrying `error_12`. See {@link SpeechModelsApi.download}.
+   */
   readonly locales: string[];
   readonly installedLocales: string[];
 }
@@ -58,7 +69,18 @@ export interface SpeechModelsApi {
   canDownload: () => boolean;
   /** Ask the phone for its locale lists. Rejects on a service that is busy. */
   listLocales: () => Promise<SpeechLocales>;
-  /** Ask the phone to fetch the model for `tag`. See {@link OfflineModelDownload}. */
+  /**
+   * Ask the phone to fetch the model for `tag`. See {@link OfflineModelDownload}.
+   *
+   * A rejection here is not noise: the thrown value carries a `code`, and that
+   * code is the reason. `not_supported` is the module's own pre-API-33 refusal;
+   * anything shaped `error_<n>` is a `SpeechRecognizer.ERROR_*` constant passed
+   * through from `ModelDownloadListener.onError` untouched — 12 for a language
+   * the recogniser does not have a model for at all, 13 for one it has but has
+   * not fetched, 15 for a download that started and cannot be watched. Decode it
+   * with `offlineDownloadReason` in `dictation.ts` rather than treating every
+   * rejection as one failure; they are not one failure.
+   */
   download: (tag: string) => Promise<OfflineModelDownload>;
 }
 

--- a/apps/mobile/test/dictation.test.ts
+++ b/apps/mobile/test/dictation.test.ts
@@ -32,16 +32,23 @@ describe('speechLocale', () => {
     expect(speechLocale(Language.Ta, 'ta-LK')).toBe('ta-LK');
   });
 
-  it('falls back to India when the tag carries no region', () => {
+  it('falls back to a served default when the tag carries no region', () => {
     // Bare "ta" is a lottery on Android — some recognisers take it, some
-    // return language-not-supported.
+    // return language-not-supported. Arabic cannot use the India fallback,
+    // because `ar-IN` is not a recognizer-served locale.
     expect(speechLocale(Language.Ta, 'ta')).toBe('ta-IN');
     expect(speechLocale(Language.Hi, 'hi')).toBe('hi-IN');
+    expect(speechLocale(Language.Ar, 'ar')).toBe('ar-SA');
   });
 
   it('follows the app language, not the phone, when they disagree', () => {
     // The app is showing Tamil, so Tamil is what the user is about to speak.
     expect(speechLocale(Language.Ta, 'en-US')).toBe('ta-IN');
+    expect(speechLocale(Language.Ar, 'en-US')).toBe('ar-SA');
+  });
+
+  it('keeps an Arabic phone region when the app is Arabic', () => {
+    expect(speechLocale(Language.Ar, 'ar-AE')).toBe('ar-AE');
   });
 
   it('survives the shapes a locale tag actually arrives in', () => {
@@ -171,7 +178,7 @@ describe('offlineVoiceModels', () => {
     // The rows somebody came to this screen to fix are the missing ones, so
     // they cannot be filtered out for being missing.
     const models = offlineVoiceModels(languages, 'en-IN', [], [], 'reported');
-    expect(models.app.map((model) => model.tag)).toEqual(['en-IN', 'ta-IN', 'hi-IN', 'ar-IN']);
+    expect(models.app.map((model) => model.tag)).toEqual(['en-IN', 'ta-IN', 'hi-IN', 'ar-SA']);
     expect(models.app.every((model) => model.state === 'missing')).toBe(true);
   });
 
@@ -237,7 +244,7 @@ describe('offlineVoiceModels', () => {
       ['en-IN', 'fr-FR'],
       'unknowable',
     );
-    expect(models.app.map((model) => model.tag)).toEqual(['en-IN', 'ta-IN', 'hi-IN', 'ar-IN']);
+    expect(models.app.map((model) => model.tag)).toEqual(['en-IN', 'ta-IN', 'hi-IN', 'ar-SA']);
     expect(models.app.every((model) => model.state === 'unknown')).toBe(true);
     expect(models.alsoInstalled).toEqual([]);
     expect(models.downloadable).toEqual([]);

--- a/apps/mobile/test/dictation.test.ts
+++ b/apps/mobile/test/dictation.test.ts
@@ -12,6 +12,7 @@ import {
   dictationError,
   englishSpeechLocale,
   mergeTranscript,
+  offlineDownloadReason,
   offlineVoiceModels,
   onDeviceLocaleInstalled,
   speechLocale,
@@ -248,5 +249,54 @@ describe('offlineVoiceModels', () => {
     expect(models.app).toHaveLength(4);
     expect(models.alsoInstalled).toEqual([]);
     expect(models.downloadable).toEqual([]);
+  });
+});
+
+describe('offlineDownloadReason', () => {
+  // The rejection Expo hands back is a coded error: `{ code, message }`. These
+  // are the codes the native module actually produces.
+  const rejected = (code: unknown): unknown => ({ code, message: 'whatever' });
+
+  it('tells "there is no such model" apart from "the model did not arrive"', () => {
+    // The whole reason this function exists. Tapping Tamil on a phone whose
+    // recogniser has no Tamil model rejects with ERROR_LANGUAGE_NOT_SUPPORTED
+    // (12); a phone that has one and failed to fetch it rejects with
+    // ERROR_LANGUAGE_UNAVAILABLE (13). One is "this will never work here", the
+    // other is "try again on Wi-Fi", and the screen used to say the same dead
+    // sentence to both.
+    expect(offlineDownloadReason(rejected('error_12'))).toBe('language-missing');
+    expect(offlineDownloadReason(rejected('error_13'))).toBe('not-downloaded');
+  });
+
+  it('does not call a started download a failure', () => {
+    // ERROR_CANNOT_LISTEN_TO_DOWNLOAD_EVENTS (15) arrives as a rejection, but it
+    // means the service took the request and will not narrate it.
+    expect(offlineDownloadReason(rejected('error_15'))).toBe('started');
+  });
+
+  it('names the retryable causes separately', () => {
+    // ERROR_NETWORK_TIMEOUT, ERROR_NETWORK, ERROR_SERVER, ERROR_SERVER_DISCONNECTED.
+    for (const code of ['error_1', 'error_2', 'error_4', 'error_11']) {
+      expect(offlineDownloadReason(rejected(code))).toBe('network');
+    }
+    // ERROR_RECOGNIZER_BUSY.
+    expect(offlineDownloadReason(rejected('error_8'))).toBe('busy');
+  });
+
+  it('keeps the platform’s own pre-Android-13 refusal', () => {
+    expect(offlineDownloadReason(rejected('not_supported'))).toBe('too-old');
+  });
+
+  it('still answers for a code it has never seen, or no code at all', () => {
+    // A future Android constant, an error thrown before the native call, a
+    // rejection with nothing on it — none of these may throw here, and none may
+    // be mistaken for one of the specific causes above.
+    expect(offlineDownloadReason(rejected('error_99'))).toBe('refused');
+    expect(offlineDownloadReason(rejected('error_'))).toBe('refused');
+    expect(offlineDownloadReason(rejected('error_12x'))).toBe('refused');
+    expect(offlineDownloadReason(rejected(12))).toBe('refused');
+    expect(offlineDownloadReason(new Error('boom'))).toBe('refused');
+    expect(offlineDownloadReason(null)).toBe('refused');
+    expect(offlineDownloadReason(undefined)).toBe('refused');
   });
 });


### PR DESCRIPTION
Tapping Tamil on the Offline voice screen said "Your phone couldn't download that one" and left you there. That sentence was the catch-all for every failure, so it was true of nothing in particular.

## The cause

Traced through `expo-speech-recognition@57.0.0`'s Kotlin. On Android 14+, `androidTriggerOfflineModelDownload` rejects with `error_<int>` where the int is a raw `SpeechRecognizer.ERROR_*` constant (values read out of `android.jar` with `javap`, not from memory): `LANGUAGE_NOT_SUPPORTED = 12`, `LANGUAGE_UNAVAILABLE = 13`, `CANNOT_LISTEN_TO_DOWNLOAD_EVENTS = 15`, network `1/2/4/11`, `RECOGNIZER_BUSY = 8`.

The screen's `refusedAsUnsupported()` only tested for `not_supported`, the *pre-API-33* refusal — a case `canDownload()` already stops from drawing a button. So every real Android 14+ error fell through to the one catch-all string.

**Why Tamil is offered at all:** `getSupportedLocales` builds `locales` natively as `supportedOnDevice ∪ installedOnDevice ∪ **online**`, with no seam. Google's cloud recogniser speaks Tamil; the on-device (SODA) recogniser on most handsets does not. And `androidTriggerOfflineModelDownload` calls `createOnDeviceSpeechRecognizer`, a different service from the one `listLocales` probes. So "Tamil is listed" never implied "Tamil has an on-device model", and with this library version there is no JS-visible way to ask. The tap *is* the probe; its error code is the only place the truth lives.

## What changed

- New pure `offlineDownloadReason(caught)` in `dictation.ts` decodes the code into `too-old | language-missing | not-downloaded | started | network | busy | refused`, each with its own message.
- **Behavioural fix:** `error_15` was drawn as a red failure. It means the download *started* and cannot be watched. It now reads as neutral — the screen was previously calling a working download broken.
- `error_12` says your phone's speech service has no offline model for that language, and points at updating "Speech Recognition & Synthesis" in the Play Store. Deliberately no invented `Settings → …` breadcrumb: a Play Store app name is verifiable, a per-OEM settings path is not.
- Success gets its own `done` phase instead of sharing one with the ambiguous outcomes.

## Collapse and icons

- `alsoInstalled` and `downloadable` fold, shut by default; the four app languages never fold. Header is a `Pressable` with the count and a chevron, `accessibilityState={{ expanded }}`, count carried as `accessibilityValue` so a reader says "Other languages, 63 languages, collapsed". Empty group emits no header. Added `getItemType` since folding shuffles headers and rows through one recycler.
- Rows carry the language's own script initial (த ह ا E) through the existing `Avatar`, **not flags** — a language is not a country. Anonymous locales get a neutral globe.
- State is an icon *plus* a badge, never colour alone. The `unknown` state (iPhone) previously drew nothing, which read as "not installed"; it now says "Can't tell", which is the true claim.

New i18n keys in all four locales, including full six-form Arabic plurals for the section count. `failed` reworded to the narrower "refused and didn't say why".

## Known, not fixed

`speechLocale` falls back to `<language>-IN` for every language, so **Arabic resolves to `ar-IN`** — a locale no recogniser serves. Same class of bug, but that function is shared with the live mic path and pinned by existing tests, so it is a behaviour change beyond this fix. Worth a follow-up.

## Verification

`pnpm format`, `pnpm lint`, `pnpm --filter @waves/mobile typecheck` pass; 959 tests pass, `dictation.test.ts` now 32 including 5 new `offlineDownloadReason` cases.

Everything about the cause is proved from source. **Nothing is proved on a handset** — no device attached. This does not fix the Tamil download; it makes the failure legible and actionable, and fixes the adjacent `error_15` case that was reporting a working download as broken.