### PR TITLE
Fold category and payment into a list of picker rows

### DIFF
--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -49,6 +49,7 @@ import {
   Callout,
   Card,
   ChipRow,
+  Divider,
   EmptyState,
   iconSize,
   MoneyText,
@@ -58,10 +59,10 @@ import {
   useTheme,
 } from '@waves/ui';
 
-import { CategoryPicker } from '@/components/Category';
+import { CategoryRow, CategorySheet } from '@/components/Category';
 import { ExpenseReceipts } from '@/components/ExpenseReceipts';
 import { TagEditorSheet } from '@/components/TagEditorSheet';
-import { PaymentMethodPicker } from '@/components/PaymentMethodPicker';
+import { PaymentMethodRow, PaymentMethodSheet } from '@/components/PaymentMethodPicker';
 import { LocationField } from '@/components/LocationField';
 import { captureLocationIfGranted } from '@/lib/location';
 import { friendlyError } from '@/lib/errors';
@@ -460,8 +461,15 @@ export default function AddExpenseScreen() {
   const [category, setCategory] = useState<string | null>(CategoryId.Food);
   const [categoryMeta, setCategoryMeta] = useState<CategoryMeta | null>(null);
   const [categoryChosen, setCategoryChosen] = useState(false);
-  // The create-tag sheet, opened from the picker's "＋ New tag" chip.
+  // The create-tag sheet, opened from the category sheet's "＋ New tag" row.
   const [editingTag, setEditingTag] = useState(false);
+  // The two "more details" rows open their options in sheets, and those sheets
+  // are rendered at the screen root rather than beside their rows: the sheet is
+  // absolutely positioned against its nearest positioned ancestor, and a row
+  // inside the scroll view would anchor it to the scrolled content instead of
+  // the screen. The same reason the currency sheet lives down there.
+  const [pickingCategory, setPickingCategory] = useState(false);
+  const [pickingPayment, setPickingPayment] = useState(false);
   /**
    * Names to bias the recogniser towards. "You" and "Someone" are placeholders
    * this screen prints, not things anybody says out loud, so they would only
@@ -2151,31 +2159,27 @@ export default function AddExpenseScreen() {
           </Pressable>
 
           <View style={{ gap: theme.spacing.xl, display: showDetails ? 'flex' : 'none' }}>
-            {/* Pre-picked from the description, because a menu between somebody and
-              saving a dinner is how a column ends up empty — and an empty column
-              is a spending chart nobody can draw (TDR §8). */}
-            <View style={{ gap: theme.spacing.md }}>
-              <Text variant="caption" tone="muted">
-                {t.whatFor}
-              </Text>
-              <CategoryPicker
-                value={category}
-                onChange={(picked, meta) => {
-                  setCategory(picked);
-                  setCategoryMeta(meta);
-                  setCategoryChosen(true);
-                }}
-                onCreate={() => setEditingTag(true)}
-              />
-            </View>
+            {/* The two tags an expense carries, as a list rather than two lanes
+              of chips.
 
-            {/* How it was paid — a tag on the expense, defaulting to cash. */}
-            <View style={{ gap: theme.spacing.md }}>
-              <Text variant="caption" tone="muted">
-                {t.captures.paidWith}
-              </Text>
-              <PaymentMethodPicker value={paymentMethod} onChange={setPaymentMethod} />
-            </View>
+              Both are questions with one short answer, and both are already
+              answered when the fold opens — the category is guessed from the
+              note (a menu between somebody and saving a dinner is how a column
+              ends up empty, and an empty column is a spending chart nobody can
+              draw, TDR §8), and the rail defaults to cash. Two rows of chips
+              spent a screenful showing every answer that was *not* chosen; two
+              rows name the field, say what it is set to, and keep the options
+              behind a sheet for the times somebody wants to change one. The same
+              card of divided rows the capture screen uses for its meta. */}
+            <Card style={{ paddingVertical: theme.spacing.xs, gap: 0 }}>
+              <CategoryRow
+                value={category}
+                meta={categoryMeta}
+                onPress={() => setPickingCategory(true)}
+              />
+              <Divider />
+              <PaymentMethodRow value={paymentMethod} onPress={() => setPickingPayment(true)} />
+            </Card>
 
             {/* Where it happened (A43) — optional, opt-in, never a background track. */}
             <LocationField value={location} onChange={setLocation} />
@@ -2468,7 +2472,41 @@ export default function AddExpenseScreen() {
         </SheetOverlay>
       ) : null}
 
-      {/* Make a tag on the spot, from the picker's "＋ New tag" chip. */}
+      {/* What kind of expense, from the "more details" list. Picking one closes
+          the sheet — one tap, one answer, which is the whole point of moving
+          this off a lane of chips. "＋ New tag" swaps this sheet for the tag
+          editor rather than stacking one over the other. */}
+      {pickingCategory ? (
+        <CategorySheet
+          value={category}
+          onChange={(picked, meta) => {
+            setCategory(picked);
+            setCategoryMeta(meta);
+            // A tap of their own, so the description guess stops moving it.
+            setCategoryChosen(true);
+            setPickingCategory(false);
+          }}
+          onCreate={() => {
+            setPickingCategory(false);
+            setEditingTag(true);
+          }}
+          onClose={() => setPickingCategory(false)}
+        />
+      ) : null}
+
+      {/* How it was paid — a tag on the expense, defaulting to cash. */}
+      {pickingPayment ? (
+        <PaymentMethodSheet
+          value={paymentMethod}
+          onChange={(picked) => {
+            setPaymentMethod(picked);
+            setPickingPayment(false);
+          }}
+          onClose={() => setPickingPayment(false)}
+        />
+      ) : null}
+
+      {/* Make a tag on the spot, from the category sheet's "＋ New tag" row. */}
       <TagEditorSheet open={editingTag} onClose={() => setEditingTag(false)} />
     </Screen>
   );

--- a/apps/mobile/src/components/Category.tsx
+++ b/apps/mobile/src/components/Category.tsx
@@ -7,11 +7,17 @@
  * custom tag from the {label, icon, tint} snapshot carried on the expense
  * (`meta`), so a groupmate without the author's catalog still sees it.
  *
- * `CategoryPicker` is the row of chips under the description on the add-expense
- * and capture screens. It now draws the person's whole catalog — built-ins plus
- * their own tags, in their chosen order — and ends with a "＋ New tag" chip. It
- * is pre-selected from what was typed (`guessCategory`), and the moment somebody
+ * `CategoryPicker` is the row of chips under the description on the capture and
+ * personal screens. It draws the person's whole catalog — built-ins plus their
+ * own tags, in their chosen order — and ends with a "＋ New tag" chip. It is
+ * pre-selected from what was typed (`guessCategory`), and the moment somebody
  * taps a chip themselves the guess stops overriding them.
+ *
+ * `CategoryRow` + `CategorySheet` are the same catalog said as a list instead:
+ * a settings row that names the field and shows what is chosen, and the sheet
+ * of options behind it. The group add-expense form folds its details into a
+ * list of such rows, where a lane of chips read as a second form rather than as
+ * one more setting with an answer.
  */
 
 import Ionicons from '@expo/vector-icons/Ionicons';
@@ -20,6 +26,7 @@ import { Pressable, ScrollView, View } from 'react-native';
 import { guessIcon, normaliseTint, resolveCategory, type CategoryMeta } from '@waves/core';
 import { iconSize, Text, useTheme } from '@waves/ui';
 
+import { ChoiceRow, SettingRow, SheetOverlay } from '@/components/expense/SheetOverlay';
 import { useCategoryCatalog } from '@/data/hooks';
 import { useStrings } from '@/i18n';
 
@@ -156,5 +163,116 @@ export function CategoryPicker({
         </Pressable>
       ) : null}
     </ScrollView>
+  );
+}
+
+/**
+ * The chosen category as one row of a settings list: the field's name, then the
+ * tag's own glyph and label, then a chevron into {@link CategorySheet}.
+ *
+ * The value is read from the person's catalog first — that is where a renamed
+ * or re-coloured built-in lives — and only falls back to resolving the stored
+ * key when the catalog has not loaded yet, or when the tag is one this device no
+ * longer has (an old expense keeps its `meta` snapshot for exactly that).
+ */
+export function CategoryRow({
+  value,
+  meta,
+  onPress,
+}: {
+  value: string | null;
+  /** The custom tag's denormalised display, when the value is a custom tag. */
+  meta?: CategoryMeta | null;
+  onPress: () => void;
+}) {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const { visible } = useCategoryCatalog((id) => t.categories[id as keyof typeof t.categories]);
+
+  const entry = visible.find((it) => it.key === value);
+  const resolved = resolveCategory(value, meta ?? null);
+  const label =
+    entry?.label ??
+    (resolved.builtinId
+      ? t.categories[resolved.builtinId as keyof typeof t.categories]
+      : resolved.label);
+  const tint = theme.tint[entry ? normaliseTint(entry.tint) : resolved.tint];
+
+  return (
+    <SettingRow
+      label={t.whatFor}
+      value={label}
+      leading={
+        <Ionicons
+          name={(entry?.icon ?? resolved.icon) as keyof typeof Ionicons.glyphMap}
+          size={iconSize.md}
+          color={tint.ink}
+        />
+      }
+      onPress={onPress}
+    />
+  );
+}
+
+/**
+ * The catalog as a sheet of options — the same entries, order and "＋ New tag"
+ * escape hatch the chip picker offers, one per line with a check against the
+ * one in force.
+ *
+ * `onChange` hands back the same pair the chip picker does: the key to store and,
+ * for a custom tag only, the display snapshot to carry onto the expense. A
+ * built-in's own overrides are the author's, not the expense's, so it stores no
+ * snapshot — which is why the badge below is built from a display meta the row
+ * never passes on.
+ */
+export function CategorySheet({
+  value,
+  onChange,
+  onCreate,
+  onClose,
+}: {
+  value: string | null;
+  onChange: (key: string, meta: CategoryMeta | null) => void;
+  /** Opens the create-tag editor; the "＋ New tag" row shows only when set. */
+  onCreate?: () => void;
+  onClose: () => void;
+}) {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const { visible } = useCategoryCatalog((id) => t.categories[id as keyof typeof t.categories]);
+
+  return (
+    <SheetOverlay title={t.whatFor} onClose={onClose}>
+      <View style={{ gap: theme.spacing.xs }}>
+        {visible.map((entry) => {
+          const display: CategoryMeta = {
+            label: entry.label,
+            icon: entry.icon,
+            tint: normaliseTint(entry.tint),
+          };
+          return (
+            <ChoiceRow
+              key={entry.key}
+              label={entry.label}
+              selected={entry.key === value}
+              leading={<CategoryBadge category={entry.key} meta={display} size={32} />}
+              onPress={() => onChange(entry.key, entry.custom ? display : null)}
+            />
+          );
+        })}
+
+        {onCreate ? (
+          <ChoiceRow
+            label={t.tags.newTag}
+            leading={
+              <View style={{ width: 32, alignItems: 'center' }}>
+                <Ionicons name="add" size={iconSize.md} color={theme.color.brand} />
+              </View>
+            }
+            onPress={onCreate}
+          />
+        ) : null}
+      </View>
+    </SheetOverlay>
   );
 }

--- a/apps/mobile/src/components/ExpenseReceipts.tsx
+++ b/apps/mobile/src/components/ExpenseReceipts.tsx
@@ -646,6 +646,16 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
           // No receipt yet (and, per the guard above, the viewer may add one). A
           // lone 96px tile left a wide empty band under it; a full-width row that
           // reads "Add receipt" fills the space and makes the affordance obvious.
+          //
+          // Flush against the gutter, with no box of its own. This used to be a
+          // dashed card carrying `lg` of side padding, which set its camera glyph
+          // 16pt further in than every other leading glyph on the form it sits in
+          // — the note field's receipt icon, the "just for me" lock — so the one
+          // control wearing a border was also the one that looked out of line.
+          // The border is what the padding was there for, and neither is doing
+          // work the row needs: it is full width, it has a tinted glyph and two
+          // lines of type, and that is already more affordance than the rows it
+          // now lines up with.
           <Pressable
             onPress={handleAddPress}
             disabled={preparing !== null}
@@ -655,13 +665,7 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
               flexDirection: 'row',
               alignItems: 'center',
               gap: theme.spacing.md,
-              paddingVertical: theme.spacing.md,
-              paddingHorizontal: theme.spacing.lg,
-              borderRadius: theme.radius.lg,
-              borderWidth: 1,
-              borderColor: theme.color.border,
-              borderStyle: 'dashed',
-              backgroundColor: theme.color.surfaceMuted,
+              paddingVertical: theme.spacing.sm,
               opacity: pressed ? 0.6 : 1,
             })}
           >
@@ -672,7 +676,10 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
                 borderRadius: theme.radius.md,
                 alignItems: 'center',
                 justifyContent: 'center',
-                backgroundColor: theme.color.surface,
+                // Tinted rather than plain surface: with the surrounding card
+                // gone, a surface-on-background square would have all but
+                // disappeared against the form.
+                backgroundColor: theme.color.brandSoft,
               }}
             >
               {preparing !== null ? (

--- a/apps/mobile/src/components/PaymentMethodPicker.tsx
+++ b/apps/mobile/src/components/PaymentMethodPicker.tsx
@@ -162,7 +162,11 @@ export function PaymentMethodRow({
       value={label(value)}
       leading={
         method ? (
-          <Ionicons name={PAYMENT_METHOD_ICONS[method]} size={iconSize.md} color={theme.color.textMuted} />
+          <Ionicons
+            name={PAYMENT_METHOD_ICONS[method]}
+            size={iconSize.md}
+            color={theme.color.textMuted}
+          />
         ) : null
       }
       onPress={onPress}
@@ -187,29 +191,31 @@ export function PaymentMethodSheet({
   return (
     <SheetOverlay title={t.captures.paidWith} onClose={onClose}>
       <View style={{ gap: theme.spacing.xs }}>
-        {offeredPaymentMethods({ upiSupported: deviceSupportsUpi(), current: value }).map((method) => {
-          const active = value === method;
-          return (
-            <ChoiceRow
-              key={method}
-              label={label(method)}
-              selected={active}
-              leading={
-                // A fixed-width box so every label starts on the same line
-                // however wide its glyph draws, the way the currency sheet's
-                // symbols are boxed.
-                <View style={{ width: 32, alignItems: 'center' }}>
-                  <Ionicons
-                    name={PAYMENT_METHOD_ICONS[method]}
-                    size={iconSize.md}
-                    color={active ? theme.color.brand : theme.color.textMuted}
-                  />
-                </View>
-              }
-              onPress={() => onChange(method)}
-            />
-          );
-        })}
+        {offeredPaymentMethods({ upiSupported: deviceSupportsUpi(), current: value }).map(
+          (method) => {
+            const active = value === method;
+            return (
+              <ChoiceRow
+                key={method}
+                label={label(method)}
+                selected={active}
+                leading={
+                  // A fixed-width box so every label starts on the same line
+                  // however wide its glyph draws, the way the currency sheet's
+                  // symbols are boxed.
+                  <View style={{ width: 32, alignItems: 'center' }}>
+                    <Ionicons
+                      name={PAYMENT_METHOD_ICONS[method]}
+                      size={iconSize.md}
+                      color={active ? theme.color.brand : theme.color.textMuted}
+                    />
+                  </View>
+                }
+                onPress={() => onChange(method)}
+              />
+            );
+          },
+        )}
       </View>
     </SheetOverlay>
   );

--- a/apps/mobile/src/components/PaymentMethodPicker.tsx
+++ b/apps/mobile/src/components/PaymentMethodPicker.tsx
@@ -11,14 +11,20 @@
  *
  * Shared so the capture screen, add-expense, and add-person all speak the same
  * language for the same field.
+ *
+ * `PaymentMethodRow` + `PaymentMethodSheet` are the same rails as a list: a
+ * settings row naming the field and showing the rail in force, and the options
+ * behind it. Same ids, same labels, same order — only the presentation differs,
+ * for forms that read as a list of settings rather than a stack of chip lanes.
  */
 
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { Pressable, ScrollView } from 'react-native';
+import { Pressable, ScrollView, View } from 'react-native';
 
 import { type PaymentMethod } from '@waves/core';
 import { iconSize, Text, useTheme } from '@waves/ui';
 
+import { ChoiceRow, SettingRow, SheetOverlay } from '@/components/expense/SheetOverlay';
 import { deviceSupportsUpi, useStrings } from '@/i18n';
 
 const PAYMENT_METHODS: readonly {
@@ -50,12 +56,14 @@ type PaymentMethodPickerProps =
       allowDeselect: true;
     };
 
-export function PaymentMethodPicker(props: PaymentMethodPickerProps) {
-  const { value } = props;
-  const theme = useTheme();
+/**
+ * The rail's name, in the phone's language. A hook rather than a free function
+ * because the strings come from context, and every presentation of this field —
+ * chips, row, sheet — must name a rail the same way.
+ */
+function usePaymentMethodLabel(): (id: PaymentMethod) => string {
   const { t } = useStrings();
-
-  const label = (id: PaymentMethod): string => {
+  return (id) => {
     switch (id) {
       case 'cash':
         return t.captures.payCash;
@@ -69,9 +77,19 @@ export function PaymentMethodPicker(props: PaymentMethodPickerProps) {
         return t.captures.payForex;
     }
   };
+}
 
+/** The rails worth offering here — regional ones only where the rail exists. */
+function offeredMethods(): typeof PAYMENT_METHODS {
   const upiSupported = deviceSupportsUpi();
-  const methods = PAYMENT_METHODS.filter((method) => !method.regional || upiSupported);
+  return PAYMENT_METHODS.filter((method) => !method.regional || upiSupported);
+}
+
+export function PaymentMethodPicker(props: PaymentMethodPickerProps) {
+  const { value } = props;
+  const theme = useTheme();
+  const label = usePaymentMethodLabel();
+  const methods = offeredMethods();
 
   return (
     <ScrollView
@@ -123,5 +141,84 @@ export function PaymentMethodPicker(props: PaymentMethodPickerProps) {
         );
       })}
     </ScrollView>
+  );
+}
+
+/**
+ * The rail in force as one row of a settings list: the field's name, the rail's
+ * glyph and label, a chevron into {@link PaymentMethodSheet}.
+ *
+ * Only the non-deselectable shape: a list row has to show *something* on its
+ * right, and "not said" is a state the chip lane can express by having nothing
+ * lit but a row cannot. The screens that allow "not said" keep the chips.
+ */
+export function PaymentMethodRow({
+  value,
+  onPress,
+}: {
+  value: PaymentMethod;
+  onPress: () => void;
+}) {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const label = usePaymentMethodLabel();
+  const method = offeredMethods().find((it) => it.id === value);
+
+  return (
+    <SettingRow
+      label={t.captures.paidWith}
+      value={label(value)}
+      leading={
+        method ? (
+          <Ionicons name={method.icon} size={iconSize.md} color={theme.color.textMuted} />
+        ) : null
+      }
+      onPress={onPress}
+    />
+  );
+}
+
+/** The same rails as a sheet of options, one per line, checked where chosen. */
+export function PaymentMethodSheet({
+  value,
+  onChange,
+  onClose,
+}: {
+  value: PaymentMethod | null;
+  onChange: (value: PaymentMethod) => void;
+  onClose: () => void;
+}) {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const label = usePaymentMethodLabel();
+
+  return (
+    <SheetOverlay title={t.captures.paidWith} onClose={onClose}>
+      <View style={{ gap: theme.spacing.xs }}>
+        {offeredMethods().map((method) => {
+          const active = value === method.id;
+          return (
+            <ChoiceRow
+              key={method.id}
+              label={label(method.id)}
+              selected={active}
+              leading={
+                // A fixed-width box so every label starts on the same line
+                // however wide its glyph draws, the way the currency sheet's
+                // symbols are boxed.
+                <View style={{ width: 32, alignItems: 'center' }}>
+                  <Ionicons
+                    name={method.icon}
+                    size={iconSize.md}
+                    color={active ? theme.color.brand : theme.color.textMuted}
+                  />
+                </View>
+              }
+              onPress={() => onChange(method.id)}
+            />
+          );
+        })}
+      </View>
+    </SheetOverlay>
   );
 }

--- a/apps/mobile/src/components/PaymentMethodPicker.tsx
+++ b/apps/mobile/src/components/PaymentMethodPicker.tsx
@@ -26,19 +26,15 @@ import { iconSize, Text, useTheme } from '@waves/ui';
 
 import { ChoiceRow, SettingRow, SheetOverlay } from '@/components/expense/SheetOverlay';
 import { deviceSupportsUpi, useStrings } from '@/i18n';
+import { offeredPaymentMethods } from '@/lib/paymentMethods';
 
-const PAYMENT_METHODS: readonly {
-  id: PaymentMethod;
-  icon: keyof typeof Ionicons.glyphMap;
-  /** True for a rail that only some regions have — filtered by device support. */
-  regional?: boolean;
-}[] = [
-  { id: 'cash', icon: 'cash-outline' },
-  { id: 'upi', icon: 'phone-portrait-outline', regional: true },
-  { id: 'credit', icon: 'card-outline' },
-  { id: 'debit', icon: 'card' },
-  { id: 'forex', icon: 'swap-horizontal-outline' },
-];
+const PAYMENT_METHOD_ICONS: Readonly<Record<PaymentMethod, keyof typeof Ionicons.glyphMap>> = {
+  cash: 'cash-outline',
+  upi: 'phone-portrait-outline',
+  credit: 'card-outline',
+  debit: 'card',
+  forex: 'swap-horizontal-outline',
+};
 
 /**
  * Two shapes, one picker. The group add-expense screen always has a method
@@ -79,17 +75,11 @@ function usePaymentMethodLabel(): (id: PaymentMethod) => string {
   };
 }
 
-/** The rails worth offering here — regional ones only where the rail exists. */
-function offeredMethods(): typeof PAYMENT_METHODS {
-  const upiSupported = deviceSupportsUpi();
-  return PAYMENT_METHODS.filter((method) => !method.regional || upiSupported);
-}
-
 export function PaymentMethodPicker(props: PaymentMethodPickerProps) {
   const { value } = props;
   const theme = useTheme();
   const label = usePaymentMethodLabel();
-  const methods = offeredMethods();
+  const methods = offeredPaymentMethods({ upiSupported: deviceSupportsUpi(), current: value });
 
   return (
     <ScrollView
@@ -99,18 +89,18 @@ export function PaymentMethodPicker(props: PaymentMethodPickerProps) {
       contentContainerStyle={{ gap: theme.spacing.sm, paddingRight: theme.spacing.xl }}
     >
       {methods.map((method) => {
-        const active = value === method.id;
+        const active = value === method;
         return (
           <Pressable
-            key={method.id}
+            key={method}
             accessibilityRole="radio"
             accessibilityState={{ selected: active }}
-            accessibilityLabel={label(method.id)}
+            accessibilityLabel={label(method)}
             onPress={() => {
               if (props.allowDeselect) {
-                props.onChange(active ? null : method.id);
+                props.onChange(active ? null : method);
               } else {
-                props.onChange(method.id);
+                props.onChange(method);
               }
             }}
             style={({ pressed }) => ({
@@ -130,12 +120,12 @@ export function PaymentMethodPicker(props: PaymentMethodPickerProps) {
             })}
           >
             <Ionicons
-              name={method.icon}
+              name={PAYMENT_METHOD_ICONS[method]}
               size={iconSize.md}
               color={active ? theme.color.brand : theme.color.textMuted}
             />
             <Text variant="body" style={{ color: active ? theme.color.brand : theme.color.text }}>
-              {label(method.id)}
+              {label(method)}
             </Text>
           </Pressable>
         );
@@ -162,7 +152,9 @@ export function PaymentMethodRow({
   const theme = useTheme();
   const { t } = useStrings();
   const label = usePaymentMethodLabel();
-  const method = offeredMethods().find((it) => it.id === value);
+  const method = offeredPaymentMethods({ upiSupported: deviceSupportsUpi(), current: value }).find(
+    (it) => it === value,
+  );
 
   return (
     <SettingRow
@@ -170,7 +162,7 @@ export function PaymentMethodRow({
       value={label(value)}
       leading={
         method ? (
-          <Ionicons name={method.icon} size={iconSize.md} color={theme.color.textMuted} />
+          <Ionicons name={PAYMENT_METHOD_ICONS[method]} size={iconSize.md} color={theme.color.textMuted} />
         ) : null
       }
       onPress={onPress}
@@ -195,12 +187,12 @@ export function PaymentMethodSheet({
   return (
     <SheetOverlay title={t.captures.paidWith} onClose={onClose}>
       <View style={{ gap: theme.spacing.xs }}>
-        {offeredMethods().map((method) => {
-          const active = value === method.id;
+        {offeredPaymentMethods({ upiSupported: deviceSupportsUpi(), current: value }).map((method) => {
+          const active = value === method;
           return (
             <ChoiceRow
-              key={method.id}
-              label={label(method.id)}
+              key={method}
+              label={label(method)}
               selected={active}
               leading={
                 // A fixed-width box so every label starts on the same line
@@ -208,13 +200,13 @@ export function PaymentMethodSheet({
                 // symbols are boxed.
                 <View style={{ width: 32, alignItems: 'center' }}>
                   <Ionicons
-                    name={method.icon}
+                    name={PAYMENT_METHOD_ICONS[method]}
                     size={iconSize.md}
                     color={active ? theme.color.brand : theme.color.textMuted}
                   />
                 </View>
               }
-              onPress={() => onChange(method.id)}
+              onPress={() => onChange(method)}
             />
           );
         })}

--- a/apps/mobile/src/components/expense/SheetOverlay.tsx
+++ b/apps/mobile/src/components/expense/SheetOverlay.tsx
@@ -21,7 +21,7 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 
-import { iconSize, Text, useTheme } from '@waves/ui';
+import { directionalIcon, iconSize, Row, Text, useTheme } from '@waves/ui';
 
 import { useStrings } from '@/i18n';
 
@@ -71,6 +71,68 @@ export function FieldRow({
         </Text>
       </View>
       <Ionicons name="chevron-forward" size={iconSize.md} color={theme.color.textFaint} />
+    </Pressable>
+  );
+}
+
+/**
+ * A settings-style tap-row: the field's name on the left, what is currently
+ * chosen on the right — its glyph and its label — and a chevron into the sheet
+ * that changes it.
+ *
+ * The one-line sibling of {@link FieldRow}. That one stacks the name over its
+ * value, which suits meta a person reads on the way past (which group, which
+ * date). This one keeps the pair on a single line, which is what a short answer
+ * picked from a sheet wants: a column of names you scan down the left and the
+ * answers down the right, so two settings read as a list of two rather than as
+ * two more blocks in a long form.
+ */
+export function SettingRow({
+  label,
+  value,
+  leading,
+  onPress,
+}: {
+  label: string;
+  value: string;
+  /** The chosen option's glyph, drawn immediately before its label. */
+  leading?: ReactNode;
+  onPress: () => void;
+}): React.JSX.Element {
+  const theme = useTheme();
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={`${label}: ${value}`}
+      onPress={onPress}
+      style={({ pressed }) => ({
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: theme.spacing.md,
+        paddingVertical: theme.spacing.md,
+        opacity: pressed ? 0.6 : 1,
+      })}
+    >
+      {/* Both sides shrink and clip rather than wrap: the names here are whole
+          questions ("What kind of expense") and in Tamil or Arabic either half
+          can outrun a narrow phone. A row that grows to two lines would break
+          the list's rhythm for the one language it happened in. */}
+      <Text variant="body" numberOfLines={1} style={{ flexShrink: 1 }}>
+        {label}
+      </Text>
+      <Row style={{ gap: theme.spacing.xs, flex: 1, minWidth: 0, justifyContent: 'flex-end' }}>
+        {leading}
+        <Text variant="body" tone="muted" numberOfLines={1} style={{ flexShrink: 1 }}>
+          {value}
+        </Text>
+      </Row>
+      {/* The chevron is content, not layout: RN mirrors the row itself in RTL
+          but leaves the glyph pointing whichever way it was drawn. */}
+      <Ionicons
+        name={directionalIcon('chevron-forward')}
+        size={iconSize.md}
+        color={theme.color.textFaint}
+      />
     </Pressable>
   );
 }
@@ -210,7 +272,13 @@ export function ChoiceRow({
 }: {
   leading: ReactNode;
   label: string;
-  selected: boolean;
+  /**
+   * Whether this is the chosen option. Omit for a row that is an *action*
+   * rather than one of the choices — "New tag" at the foot of the category
+   * sheet — so a screen reader is told it is a button and not that it is an
+   * option you have not selected.
+   */
+  selected?: boolean;
   onPress: () => void;
 }): React.JSX.Element {
   const theme = useTheme();
@@ -218,7 +286,7 @@ export function ChoiceRow({
     <Pressable
       accessibilityRole="button"
       accessibilityLabel={label}
-      accessibilityState={{ selected }}
+      accessibilityState={selected === undefined ? undefined : { selected }}
       onPress={onPress}
       style={({ pressed }) => ({
         flexDirection: 'row',

--- a/apps/mobile/src/lib/paymentMethods.ts
+++ b/apps/mobile/src/lib/paymentMethods.ts
@@ -1,0 +1,13 @@
+import { type PaymentMethod } from '@waves/core';
+
+export const PAYMENT_METHOD_ORDER: readonly PaymentMethod[] = ['cash', 'upi', 'credit', 'debit', 'forex'];
+
+export function offeredPaymentMethods({
+  upiSupported,
+  current,
+}: {
+  readonly upiSupported: boolean;
+  readonly current: PaymentMethod | null;
+}): PaymentMethod[] {
+  return PAYMENT_METHOD_ORDER.filter((method) => method !== 'upi' || upiSupported || current === 'upi');
+}

--- a/apps/mobile/src/lib/paymentMethods.ts
+++ b/apps/mobile/src/lib/paymentMethods.ts
@@ -1,6 +1,12 @@
 import { type PaymentMethod } from '@waves/core';
 
-export const PAYMENT_METHOD_ORDER: readonly PaymentMethod[] = ['cash', 'upi', 'credit', 'debit', 'forex'];
+export const PAYMENT_METHOD_ORDER: readonly PaymentMethod[] = [
+  'cash',
+  'upi',
+  'credit',
+  'debit',
+  'forex',
+];
 
 export function offeredPaymentMethods({
   upiSupported,
@@ -9,5 +15,7 @@ export function offeredPaymentMethods({
   readonly upiSupported: boolean;
   readonly current: PaymentMethod | null;
 }): PaymentMethod[] {
-  return PAYMENT_METHOD_ORDER.filter((method) => method !== 'upi' || upiSupported || current === 'upi');
+  return PAYMENT_METHOD_ORDER.filter(
+    (method) => method !== 'upi' || upiSupported || current === 'upi',
+  );
 }

--- a/apps/mobile/test/paymentMethods.test.ts
+++ b/apps/mobile/test/paymentMethods.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { offeredPaymentMethods } from '../src/lib/paymentMethods';
+
+describe('offeredPaymentMethods', () => {
+  it('hides UPI for a new user or traveller expense outside UPI regions', () => {
+    expect(offeredPaymentMethods({ upiSupported: false, current: 'cash' })).toEqual([
+      'cash',
+      'credit',
+      'debit',
+      'forex',
+    ]);
+  });
+
+  it('keeps a saved UPI method visible for a financer editing an old expense', () => {
+    expect(offeredPaymentMethods({ upiSupported: false, current: 'upi' })).toEqual([
+      'cash',
+      'upi',
+      'credit',
+      'debit',
+      'forex',
+    ]);
+  });
+
+  it('offers UPI normally where the rider can pay over that rail', () => {
+    expect(offeredPaymentMethods({ upiSupported: true, current: null })).toEqual([
+      'cash',
+      'upi',
+      'credit',
+      'debit',
+      'forex',
+    ]);
+  });
+});


### PR DESCRIPTION
Two changes on the edit-expense screen, both from a device review.

## The "Add receipt" row was the one control wearing a box

**Offender:** `components/ExpenseReceipts.tsx:649` — the *empty-gallery* row. Not the scan/photo row in add-expense (that only renders on a new expense), and not the gallery's `+` tile, which was already flush.

The row was a boxed surface: a dashed border, a radius, `surfaceMuted`, and `paddingHorizontal: lg` — inside a form whose blocks are all unboxed and start at the scroll gutter. That inner `lg` put its camera glyph 16pt further in than every neighbouring leading glyph (the note field's `receipt-outline`, the "just for me" lock, the block captions — all at x=0). The one control with a border was also the one out of line.

Dropped the box and the horizontal padding so it sits flush. The 40pt glyph tile moved from `surface` to `brandSoft` so it still reads as an affordance now the muted card behind it is gone. No negative margins; only `paddingVertical` changed (`md` → `sm`) to match the surrounding rhythm.

## Category and "paid with" become a list

Inside the **More details** fold, the two caption-plus-chip-lane blocks are replaced by one `Card` of divided rows — field name left, chosen value with its glyph right, chevron — each opening a sheet of options. This is the `Card` + `Divider` idiom `app/capture.tsx:590` already uses for its meta rows. `LocationField` and `CurrencyRate` stay outside the card, where they were.

**No option list is duplicated.** `CategoryRow`/`CategorySheet` read the same `useCategoryCatalog` the chip picker does. The payment label switch and the regional filter were lifted into `usePaymentMethodLabel()` / `offeredMethods()`, shared by all three presentations.

**Existing callers are untouched.** `CategoryPicker` and `PaymentMethodPicker` (and its `allowDeselect` union) are unchanged, still serving capture, budgets, personal entry/recurring and CategoryBudgets.

**Behaviour preserved.** `onChange` still returns `(key, meta)` with `meta` non-null only for custom tags, and `onCreate` still fires — so `setCategory`, `setCategoryMeta`, `setCategoryChosen(true)` and `setEditingTag(true)` all behave as before, including creating a custom tag from inside the sheet. `showDetails` / `detailsNonDefault` are untouched and still keyed on `categoryChosen` and `paymentMethod !== 'cash'`.

## Details

- `components/expense/SheetOverlay.tsx` gains `SettingRow`, the one-line sibling of the existing `FieldRow`. `ChoiceRow.selected` became optional so an *action* row ("New tag") is announced as a button rather than as an unselected option.
- **i18n: zero new keys.** Every string reuses an existing one — `t.whatFor`, `t.captures.paidWith`, `t.categories.*`, `t.captures.pay*`, `t.tags.newTag`, `t.common.close` — so all four locales are already covered and nothing is hardcoded.
- **RTL:** rows are `flexDirection: 'row'` (RN mirrors them); the chevron uses `directionalIcon('chevron-forward')`.
- **A11y:** rows are `accessibilityRole="button"` labelled `"{field}: {value}"`; sheet options are `ChoiceRow`, which sets `accessibilityState={{ selected }}` so only the chosen option reports selected.

## Verification

`pnpm format`, `pnpm lint` and `pnpm --filter @waves/mobile typecheck` all pass.

Not device-tested — no handset attached. The sheet presentation and the receipt row's new alignment are reasoned from the code, not seen.