### PR TITLE
Apply a tag the moment it is made, and stop the value vanishing

### DIFF
--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -2506,8 +2506,21 @@ export default function AddExpenseScreen() {
         />
       ) : null}
 
-      {/* Make a tag on the spot, from the category sheet's "＋ New tag" row. */}
-      <TagEditorSheet open={editingTag} onClose={() => setEditingTag(false)} />
+      {/* Make a tag on the spot, from the category sheet's "＋ New tag" row —
+          and then wear it. Somebody who breaks off from tagging an expense to
+          invent a tag wanted that tag on this expense; the editor used to close
+          onto a row still showing the old category, with the thing they had
+          just made nowhere on screen and only findable by opening the sheet
+          again. Selecting it here is the rest of that one gesture. */}
+      <TagEditorSheet
+        open={editingTag}
+        onClose={() => setEditingTag(false)}
+        onCreated={(tagId, meta) => {
+          setCategory(tagId);
+          setCategoryMeta(meta);
+          setCategoryChosen(true);
+        }}
+      />
     </Screen>
   );
 }

--- a/apps/mobile/src/components/TagEditorSheet.tsx
+++ b/apps/mobile/src/components/TagEditorSheet.tsx
@@ -15,7 +15,7 @@ import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Alert, Pressable, ScrollView, TextInput, View } from 'react-native';
 
-import { TINTS, type CatalogEntry, type TintName } from '@waves/core';
+import { TINTS, type CatalogEntry, type CategoryMeta, type TintName } from '@waves/core';
 import { Button, iconSize, Row, Sheet, Text, useTheme } from '@waves/ui';
 
 import { CategoryBadge } from '@/components/Category';
@@ -26,10 +26,23 @@ import { useStrings } from '@/i18n';
 export function TagEditorSheet({
   open,
   onClose,
+  onCreated,
   editing,
 }: {
   open: boolean;
   onClose: () => void;
+  /**
+   * A tag was just made here, with the id to store and the display snapshot to
+   * carry onto whatever is being tagged.
+   *
+   * Somebody who opens this from a picker has come to tag the thing in front of
+   * them, not to tend their catalog — so the caller applies what they made
+   * rather than closing onto an unchanged screen and leaving them to find it.
+   * Optional: the tags manager creates tags for their own sake and wants
+   * nothing selected. Never fired for an edit, which changes the catalog, not
+   * the choice a screen is already carrying.
+   */
+  onCreated?: (tagId: string, meta: CategoryMeta) => void;
   /** The custom tag to edit, or null to create a fresh one. */
   editing?: CatalogEntry | null;
 }) {
@@ -39,7 +52,12 @@ export function TagEditorSheet({
               so its fields initialise from the tag being edited without a
               setState-in-effect to seed them. */}
       {open ? (
-        <TagEditorForm key={editing?.tagId ?? 'new'} editing={editing ?? null} onClose={onClose} />
+        <TagEditorForm
+          key={editing?.tagId ?? 'new'}
+          editing={editing ?? null}
+          onClose={onClose}
+          onCreated={onCreated}
+        />
       ) : null}
     </Sheet>
   );
@@ -50,9 +68,11 @@ export function TagEditorSheet({
 function TagEditorForm({
   editing,
   onClose,
+  onCreated,
 }: {
   editing: CatalogEntry | null;
   onClose: () => void;
+  onCreated?: (tagId: string, meta: CategoryMeta) => void;
 }) {
   const theme = useTheme();
   const { t } = useStrings();
@@ -79,7 +99,17 @@ function TagEditorForm({
         sortOrder: editing?.sortOrder,
         hidden: editing?.hidden ?? false,
       },
-      { onSuccess: onClose },
+      {
+        onSuccess: (tagId) => {
+          // Hand the new tag back before closing. The snapshot is built from
+          // the fields as saved rather than read back from the catalog: the
+          // upsert is queued locally and the catalog is a mirror of it, so
+          // reading it here would be a race against the caller's next render
+          // for a value this form already holds exactly.
+          if (!editing) onCreated?.(tagId, { label: trimmed, icon, tint });
+          onClose();
+        },
+      },
     );
   };
 

--- a/apps/mobile/src/components/expense/SheetOverlay.tsx
+++ b/apps/mobile/src/components/expense/SheetOverlay.tsx
@@ -116,13 +116,33 @@ export function SettingRow({
       {/* Both sides shrink and clip rather than wrap: the names here are whole
           questions ("What kind of expense") and in Tamil or Arabic either half
           can outrun a narrow phone. A row that grows to two lines would break
-          the list's rhythm for the one language it happened in. */}
-      <Text variant="body" numberOfLines={1} style={{ flexShrink: 1 }}>
+          the list's rhythm for the one language it happened in.
+
+          They must shrink *in proportion*, which is why the value's side is
+          `flexGrow`/`flexShrink`/`flexBasis: 'auto'` and not the `flex: 1` it
+          started as. `flex: 1` in React Native means a zero flex-basis, so once
+          the label's own text outran the row there was no free space left to
+          grow back from, and the value settled at zero width — the row drew the
+          question and the chevron with nothing between them, which is worse
+          than a truncated answer and exactly what a long Tamil label or a large
+          font scale produced. With a content basis on both halves the shrink is
+          shared and each keeps a readable fraction. `minWidth: 0` on both is
+          what lets either shrink below its text at all. */}
+      <Text variant="body" numberOfLines={1} style={{ flexShrink: 1, minWidth: 0 }}>
         {label}
       </Text>
-      <Row style={{ gap: theme.spacing.xs, flex: 1, minWidth: 0, justifyContent: 'flex-end' }}>
+      <Row
+        style={{
+          gap: theme.spacing.xs,
+          flexGrow: 1,
+          flexShrink: 1,
+          flexBasis: 'auto',
+          minWidth: 0,
+          justifyContent: 'flex-end',
+        }}
+      >
         {leading}
-        <Text variant="body" tone="muted" numberOfLines={1} style={{ flexShrink: 1 }}>
+        <Text variant="body" tone="muted" numberOfLines={1} style={{ flexShrink: 1, minWidth: 0 }}>
           {value}
         </Text>
       </Row>


### PR DESCRIPTION
Two regressions from #713, both in the "more details" list on add-expense.

### A new tag was lost on the way back

Tapping "＋ New tag" in the category sheet opens the tag editor. `useUpsertTag` returns the id it just created, but `TagEditorSheet` discarded it (`onSuccess: onClose`), so the editor closed onto a row still showing the *old* category — the tag you had just invented was nowhere on screen, and only findable by opening the sheet again.

This was survivable before #713 because the chip lane stayed visible and the new chip simply appeared in it. Folding that lane into a single row took the affordance away without replacing it.

`TagEditorSheet` now takes an optional `onCreated(tagId, meta)` and add-expense applies what you made. The snapshot is built from the fields as saved rather than read back from the catalog — the upsert is queued locally and the catalog mirrors it, so reading it there would be a race for a value the form already holds exactly. Never fired for an edit, and optional, so the tags manager and the capture screen are untouched.

### `SettingRow` drew no value at all when the label ran long

The value's side was `flex: 1`, which in React Native means `flexBasis: 0`. Once the label's own text outran the row, free space went negative, `flexGrow` stopped applying, and the value settled at **zero width** — the row rendered the question and the chevron with nothing between them. That is worse than a truncated answer: the setting looks unset.

Both halves now carry a content basis (`flexBasis: 'auto'`) with `flexShrink: 1` and `minWidth: 0`, so the shrink is shared and each keeps a readable fraction.

Reproduces with a long Tamil label, and in any language at large font scale. The stale comment claiming the two sides "clip rather than wrap" has been corrected — clipping was never guaranteed.

### Checks

`pnpm --filter @waves/mobile typecheck` clean, `pnpm lint` clean (3 pre-existing warnings in `phone.tsx`), 957 mobile tests pass, Prettier clean across `apps/`, `packages/`, `supabase/`.

Nothing that gets saved to an expense changed.
