### PR TITLE
Let the location picker's two actions have their own line

### DIFF
--- a/apps/mobile/src/components/LocationPickerSheet.tsx
+++ b/apps/mobile/src/components/LocationPickerSheet.tsx
@@ -265,11 +265,14 @@ export function LocationPickerSheet({
                 />
               </View>
 
-              {/* Zoom controls, stacked at the trailing edge. */}
+              {/* Zoom controls, stacked at the trailing edge — `end`, not
+                  `right`, so "trailing" is true in Arabic too. `right` pins them
+                  to the same side of the glass in both directions, which put
+                  them under the reading hand in RTL. */}
               <View
                 style={{
                   position: 'absolute',
-                  right: theme.spacing.lg,
+                  end: theme.spacing.lg,
                   top: theme.spacing.lg,
                   gap: theme.spacing.sm,
                 }}
@@ -300,17 +303,21 @@ export function LocationPickerSheet({
                 ))}
               </View>
 
-              {/* Attribution — required by the tile licence (OSM data, CARTO tiles). */}
+              {/* Attribution — required by the tile licence (OSM data, CARTO
+                  tiles). Pinned to the trailing corner and rounded on the corner
+                  that faces into the map, both of which flip with the direction:
+                  under RTL a `borderTopLeftRadius` would have rounded the corner
+                  against the screen edge instead. */}
               <View
                 pointerEvents="none"
                 style={{
                   position: 'absolute',
-                  right: 0,
+                  end: 0,
                   bottom: 0,
                   paddingHorizontal: 4,
                   paddingVertical: 2,
                   backgroundColor: 'rgba(255, 255, 255, 0.7)',
-                  borderTopLeftRadius: theme.radius.sm,
+                  borderTopStartRadius: theme.radius.sm,
                 }}
               >
                 <Text variant="micro" style={{ color: '#333', fontSize: 9 }}>
@@ -336,30 +343,36 @@ export function LocationPickerSheet({
           <Text variant="micro" tone="muted" align="center">
             {t.location.pickerHint}
           </Text>
-          <Row style={{ gap: theme.spacing.md }}>
-            <View style={{ flex: 1 }}>
-              <Button
-                label={t.location.useCurrentLocation}
-                variant="secondary"
-                disabled={locating || saving}
-                onPress={() => void snapToCurrentLocation()}
-                icon={
-                  locating ? (
-                    <ActivityIndicator color={theme.color.brand} />
-                  ) : (
-                    <Ionicons name="locate" size={iconSize.md} color={theme.color.brand} />
-                  )
-                }
-              />
-            </View>
-            <View style={{ flex: 1 }}>
-              <Button
-                label={t.location.usePlace}
-                disabled={saving || locating}
-                onPress={() => void confirm()}
-              />
-            </View>
-          </Row>
+          {/* Stacked, not side by side. These two labels are wildly unequal —
+              "Use my current location" against "Use this place" — so splitting
+              the footer into equal halves left the long one about 105pt of text
+              room after the button's own padding and the locate glyph, which is
+              roughly a third of what it needs. It wrapped inside a button whose
+              height is fixed, while its short neighbour sat in the same width
+              with room to spare: two controls the same size, one crammed and one
+              loose, and no shared edge between their labels. Full width each
+              gives both a single line and one left and right edge down the
+              footer. The confirm sits closest to the thumb. */}
+          <Button
+            label={t.location.useCurrentLocation}
+            variant="secondary"
+            fullWidth
+            disabled={locating || saving}
+            onPress={() => void snapToCurrentLocation()}
+            icon={
+              locating ? (
+                <ActivityIndicator color={theme.color.brand} />
+              ) : (
+                <Ionicons name="locate" size={iconSize.md} color={theme.color.brand} />
+              )
+            }
+          />
+          <Button
+            label={t.location.usePlace}
+            fullWidth
+            disabled={saving || locating}
+            onPress={() => void confirm()}
+          />
         </View>
       </View>
     </Modal>


### PR DESCRIPTION
From a device review of the location picker: *"Choose location. Use my current location. Use this place. The alignments are not good."*

## The footer split into halves that suited neither label

`LocationPickerSheet.tsx` put the two actions in a `Row` with `flex: 1` on each, so they took equal widths for very unequal labels.

On a 411pt screen: the footer's `xl` padding leaves 371pt, the `md` gap takes 12, so each half is **179.5pt**. Subtract the button's own `paddingHorizontal: xxl` (24 either side), the 18pt locate glyph and its 8pt gap, and **"Use my current location" has about 105pt of text room** for a string that needs roughly 160. It wrapped — inside a button whose height is fixed at 48.

Meanwhile "Use this place" needs about 95pt and had 131pt. So the footer showed two controls of identical width, one crammed and one loose, with no shared edge between their labels. That is the misalignment.

Both are now `fullWidth` and stacked, so each label gets the whole 371pt on one line and the two share a left and a right edge down the footer. The confirm stays last, nearest the thumb.

## Two directional fixes, both places the code contradicted its own comment

- The zoom stack was commented "stacked at the trailing edge" but positioned with `right`, which pins it to the same side of the glass in either direction — so in Arabic it sat under the reading hand rather than at the trailing edge. Now `end`.
- The tile attribution moves the same way, and its inward corner now rounds with `borderTopStartRadius` instead of `borderTopLeftRadius`. Pinned to the trailing corner under RTL, the old value rounded the corner against the screen edge rather than the one facing into the map.

**Deliberately left as-is:** the tile offsets (`left: tile.left`) are positions in geographic space and must not mirror, and the centre-pin overlay's `left: 0, right: 0` is symmetric, so mirroring it is a no-op.

No behaviour changed — same actions, same handlers, same saved `{lat, lng, name}`. No new strings, so all four locales are unaffected.

## Verification

- `pnpm --filter @waves/mobile typecheck` — pass
- `pnpm lint` — pass (3 pre-existing `import/first` warnings in the untouched `phone.tsx`)
- `pnpm --filter @waves/mobile test` — 77 files, **971 tests**, all pass
- Prettier — clean across all tracked files, checked the way CI does (`git ls-files … | xargs prettier --check`) rather than with a bare glob, which flags ~136 untracked build artifacts CI never sees

**Not seen on a device.** There is no handset or emulator attached to this session, so the widths above are arithmetic from the design tokens, not measurements, and the RTL mirroring is reasoned from React Native's handling of `end` and `borderTopStartRadius`. Worth confirming in Arabic and with a long label at large font scale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Map zoom controls and license attribution now align correctly in right-to-left layouts.
  - Location picker actions are now displayed as full-width stacked buttons.
  - The confirmation action is positioned closer to the thumb for easier access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->