### PR TITLE
feat(people): a real person profile, and their own say in who can find them

### DIFF
--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -1655,6 +1655,15 @@ function AddMenu({
       onPress: () => go('/friends/contacts'),
     },
     {
+      // Sits after the address book because it is the narrower tool: this one
+      // needs the exact address or number, and only finds somebody who has
+      // allowed being found that way.
+      key: 'find',
+      label: t.person.findTitle,
+      icon: <Ionicons name="search-outline" size={iconSize.lg} color={theme.color.text} />,
+      onPress: () => go('/friends/find'),
+    },
+    {
       key: 'scan',
       label: t.misc.scanToJoin,
       icon: <Ionicons name="qr-code-outline" size={iconSize.lg} color={theme.color.text} />,

--- a/apps/mobile/src/app/friends/find.tsx
+++ b/apps/mobile/src/app/friends/find.tsx
@@ -1,0 +1,226 @@
+/**
+ * Finding one person by something you already know about them.
+ *
+ * Deliberately the narrowest search in the app. There is no name search, no
+ * prefix, no browse — one exact email address or one exact phone number, and
+ * a result only if that person has left the matching channel discoverable
+ * (Settings → Privacy → How people find you). Anything looser turns the whole
+ * user table into something a stranger can walk.
+ *
+ * The screen never distinguishes "nobody uses that" from "they have turned this
+ * off", because the server refuses to: if the two answers looked different, the
+ * setting would itself become the oracle it exists to close. One sentence
+ * covers both, and says so plainly rather than implying the account exists.
+ *
+ * What the result *does* show back is whatever you typed. That is not a leak —
+ * you had it a moment ago — and showing it is how somebody checks they have
+ * found the right Priya before adding her to a trip.
+ */
+
+import { useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router } from 'expo-router';
+import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react-native';
+
+import {
+  Badge,
+  Button,
+  Card,
+  directionalIcon,
+  IconButton,
+  iconSize,
+  Row,
+  Screen,
+  Text,
+  useTabBarClearance,
+  useTheme,
+} from '@waves/ui';
+
+import { findPerson, type FoundPerson } from '@/data/api';
+import { ProfileAvatar } from '@/components/ProfileAvatar';
+import { useStrings } from '@/i18n';
+import { friendlyError } from '@/lib/errors';
+
+/** What the box holds decides which channel is searched — no second control. */
+function channelFor(query: string): 'email' | 'phone' | null {
+  const value = query.trim();
+  if (value.includes('@')) return value.length > 2 ? 'email' : null;
+  // Six digits is not a valid number anywhere; it is just the floor below which
+  // a search cannot mean anything and should not spend one of the daily few.
+  return value.replace(/[^0-9]/g, '').length >= 6 ? 'phone' : null;
+}
+
+type Outcome =
+  | { state: 'idle' }
+  | { state: 'searching' }
+  | { state: 'found'; person: FoundPerson; typed: string }
+  | { state: 'none' }
+  | { state: 'error'; message: string };
+
+export default function FindPersonScreen() {
+  const theme = useTheme();
+  const clearance = useTabBarClearance();
+  const { t } = useStrings();
+
+  const [query, setQuery] = useState('');
+  const [outcome, setOutcome] = useState<Outcome>({ state: 'idle' });
+
+  const channel = channelFor(query);
+
+  const search = (): void => {
+    if (!channel) return;
+    const typed = query.trim();
+    setOutcome({ state: 'searching' });
+    void findPerson(channel, typed)
+      .then((person) => {
+        setOutcome(person ? { state: 'found', person, typed } : { state: 'none' });
+      })
+      .catch((caught: unknown) => {
+        // The one server error worth its own words: the daily ceiling. Anything
+        // else goes through the shared mapper, which never shows a raw message.
+        const raw = caught instanceof Error ? caught.message : '';
+        setOutcome({
+          state: 'error',
+          message: raw.includes('LOOKUP_RATE_LIMIT')
+            ? t.person.findRateLimited
+            : friendlyError(caught, t.loadError, 'person.find'),
+        });
+      });
+  };
+
+  return (
+    <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading" numberOfLines={1}>
+            {t.person.findTitle}
+          </Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
+      <ScrollView
+        style={{ flex: 1 }}
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.lg,
+          paddingBottom: clearance,
+          gap: theme.spacing.lg,
+        }}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+      >
+        <Text tone="muted">{t.person.findHint}</Text>
+
+        <Card>
+          <TextInput
+            value={query}
+            onChangeText={(next) => {
+              setQuery(next);
+              // A stale result under a changed box reads as the answer to the
+              // new query. Clear it the moment the question changes.
+              if (outcome.state !== 'idle') setOutcome({ state: 'idle' });
+            }}
+            accessibilityLabel={t.person.findPlaceholder}
+            placeholder={t.person.findPlaceholder}
+            placeholderTextColor={theme.color.textFaint}
+            autoCapitalize="none"
+            autoCorrect={false}
+            keyboardType="email-address"
+            inputMode="email"
+            returnKeyType="search"
+            onSubmitEditing={search}
+            autoFocus
+            // An address or a number is Latin text whatever the interface
+            // language is, so the box stays left-to-right even in Arabic.
+            style={{
+              fontSize: 18,
+              color: theme.color.text,
+              paddingVertical: theme.spacing.xs,
+              writingDirection: 'ltr',
+              textAlign: 'left',
+            }}
+          />
+        </Card>
+
+        <Button
+          label={t.person.findAction}
+          onPress={search}
+          disabled={!channel || outcome.state === 'searching'}
+          fullWidth
+        />
+
+        {outcome.state === 'searching' ? <ActivityIndicator color={theme.color.brand} /> : null}
+
+        {outcome.state === 'none' ? (
+          <Card style={{ gap: theme.spacing.xs }}>
+            <Text variant="subheading">{t.person.findNoMatch}</Text>
+            <Text tone="muted">{t.person.findNoMatchBody}</Text>
+          </Card>
+        ) : null}
+
+        {outcome.state === 'error' ? (
+          <Card>
+            <Text tone="muted">{outcome.message}</Text>
+          </Card>
+        ) : null}
+
+        {outcome.state === 'found' ? (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={outcome.person.display_name}
+            onPress={() =>
+              router.push({
+                pathname: '/friends/person/[key]',
+                params: { key: outcome.person.profile_id, name: outcome.person.display_name },
+              })
+            }
+            style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}
+          >
+            <Card>
+              <Row style={{ alignItems: 'center', gap: theme.spacing.md }}>
+                <ProfileAvatar
+                  name={outcome.person.display_name}
+                  avatarUrl={outcome.person.avatar_url}
+                  size={48}
+                />
+                <View style={{ flex: 1, gap: 4 }}>
+                  <Text variant="subheading" numberOfLines={1}>
+                    {outcome.person.display_name}
+                  </Text>
+                  {/* What you typed, given back. It reveals nothing and it is
+                      the only way to be sure this is the right person. */}
+                  <Text
+                    variant="caption"
+                    tone="muted"
+                    numberOfLines={1}
+                    style={{ writingDirection: 'ltr' }}
+                  >
+                    {outcome.typed}
+                  </Text>
+                  {outcome.person.already_shared ? (
+                    <Row>
+                      <Badge label={t.person.alreadyShared} tone="brand" />
+                    </Row>
+                  ) : null}
+                </View>
+                <Ionicons
+                  name={directionalIcon('chevron-forward')}
+                  size={iconSize.md}
+                  color={theme.color.textFaint}
+                />
+              </Row>
+            </Card>
+          </Pressable>
+        ) : null}
+      </ScrollView>
+    </Screen>
+  );
+}

--- a/apps/mobile/src/app/friends/person/[key].tsx
+++ b/apps/mobile/src/app/friends/person/[key].tsx
@@ -1,25 +1,41 @@
 /**
- * One person, across every group you share with them.
+ * One person: who they are, and what stands between you across every group.
  *
  * The Friends list rolls a person up into a single balance. When that person is
  * in more than one group the sum has no single group to open, so the row there
- * used to be a dead end. This is where it goes instead: the same person split
- * back out per group, each line a doorway into that group, with the per-currency
- * total restated at the top.
+ * used to be a dead end. This is where it goes instead.
  *
- * It reads from `waves_person_group_balances`, keyed on the same `person_key`
- * the list uses, so a real person, a merged ghost and a plain ghost all resolve
- * exactly as they do on the list — this only un-collapses the groups.
+ * It used to be *only* that — a balance, split back out per group. Two problems
+ * came with that. The first is that `waves_person_group_balances` ends in
+ * `HAVING sum(n.net) <> 0`, so the moment a person settles up they vanish from
+ * their own screen; the balance is not the person. The second is that nothing
+ * here ever said who this actually was: two people called Priya in two groups
+ * were two identical rows and two identical screens.
+ *
+ * So identity comes from its own call (`waves_person_profile`), which survives
+ * being square, and the balance is one section inside it rather than the whole
+ * page. The contact details on that call are not ours: the server sends them
+ * only when the person has said group-mates may see them, and the screen is
+ * careful to distinguish "they have not told us" from "they have told us not to
+ * tell you" — a vague sentence covering both would be the sort of hedge that
+ * makes people assume the worse one.
+ *
+ * A person blocked on this device is shown as the app's anonymous ghost
+ * everywhere, and that has to include here: no avatar, no number, no address,
+ * whatever the server was willing to send.
  */
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useQuery } from '@tanstack/react-query';
+import * as Clipboard from 'expo-clipboard';
 import { router, useLocalSearchParams } from 'expo-router';
-import { Alert, Pressable, ScrollView, View } from 'react-native';
+import { Alert, Linking, Pressable, ScrollView, View } from 'react-native';
 
 import {
+  Badge,
   Button,
   Card,
+  Divider,
   directionalIcon,
   EmptyState,
   IconButton,
@@ -33,10 +49,16 @@ import {
   useTheme,
 } from '@waves/ui';
 
-import { fetchPersonGroupBalances, type PersonGroupBalanceRow } from '@/data/api';
+import {
+  fetchPersonGroupBalances,
+  fetchPersonProfile,
+  type PersonGroupBalanceRow,
+  type PersonProfileRow,
+} from '@/data/api';
 import { useBlockedUsers } from '@/data/blocked';
+import { ProfileAvatar } from '@/components/ProfileAvatar';
 import { PeopleSkeleton } from '@/components/Skeletons';
-import { fill, useStrings } from '@/i18n';
+import { fill, plural, useStrings } from '@/i18n';
 
 /** A person's balance in one group: the group, and one net per currency in it. */
 interface GroupBlock {
@@ -52,6 +74,12 @@ export default function PersonDetailScreen() {
   const { t, locale } = useStrings();
   const { key, name } = useLocalSearchParams<{ key: string; name?: string }>();
 
+  const who = useQuery({
+    queryKey: ['person', key, 'profile'],
+    queryFn: () => fetchPersonProfile(key),
+    enabled: Boolean(key),
+  });
+
   const person = useQuery({
     queryKey: ['person', key, 'groups'],
     queryFn: () => fetchPersonGroupBalances(key),
@@ -59,22 +87,30 @@ export default function PersonDetailScreen() {
   });
 
   const rows = useMemo(() => person.data ?? [], [person.data]);
+  const profile = who.data ?? null;
 
   // Only a person with an account can be blocked, and for one the `person_key`
   // in the route *is* their profile id (the list keys them on it), so `key` is
   // the block key. A ghost or a merged-ghost person_key is not a profile id and
   // nothing elsewhere keys off it, so those are left un-blockable.
   const { isBlocked, block, unblock, ready } = useBlockedUsers();
-  const isRealPerson = rows.some((row) => !row.is_ghost);
+  const isRealPerson = profile ? !profile.is_ghost : rows.some((row) => !row.is_ghost);
   // Independent of `isRealPerson`: a ghost's key is never in the block set, so
   // this stays false for one regardless — and asking directly means a block is
-  // honoured before the group rows have loaded, not only after.
+  // honoured before the rest has loaded, not only after.
   const blocked = isBlocked(key);
-  const realName = rows.find((row) => !row.is_ghost)?.display_name ?? name ?? t.misc.someone;
+  const realName =
+    profile?.display_name ??
+    rows.find((row) => !row.is_ghost)?.display_name ??
+    name ??
+    t.misc.someone;
   // Until the block store has hydrated we cannot know whether this person is
   // blocked, so show the generic label rather than risk flashing a real name
   // that a block would have masked.
-  const title = !ready || blocked ? t.misc.someone : (name ?? rows[0]?.display_name ?? '');
+  const title =
+    !ready || blocked
+      ? t.misc.someone
+      : (profile?.display_name ?? name ?? rows[0]?.display_name ?? '');
 
   const confirmBlock = (): void => {
     Alert.alert(fill(t.blocked.confirmTitle, { name: realName }), t.blocked.confirmBody, [
@@ -82,7 +118,7 @@ export default function PersonDetailScreen() {
       {
         text: t.blocked.action,
         style: 'destructive',
-        onPress: () => block({ id: key, name: realName, avatarUrl: null }),
+        onPress: () => block({ id: key, name: realName, avatarUrl: profile?.avatar_url ?? null }),
       },
     ]);
   };
@@ -107,6 +143,9 @@ export default function PersonDetailScreen() {
     return { groups: [...byGroup.values()], totals: [...byCurrency.entries()] };
   }, [rows]);
 
+  const loading = who.isLoading || person.isLoading;
+  const failed = who.isError && person.isError;
+
   return (
     <Screen>
       <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
@@ -122,7 +161,7 @@ export default function PersonDetailScreen() {
             {title}
           </Text>
         </View>
-        {isRealPerson ? (
+        {isRealPerson && !profile?.is_you ? (
           <IconButton
             label={blocked ? t.blocked.unblock : t.blocked.action}
             onPress={blocked ? () => unblock(key) : confirmBlock}
@@ -147,105 +186,301 @@ export default function PersonDetailScreen() {
         }}
         showsVerticalScrollIndicator={false}
       >
-        {person.isLoading ? (
+        {loading ? (
           <PeopleSkeleton />
-        ) : person.isError ? (
+        ) : failed ? (
           <EmptyState
             title={t.loadError}
             body={t.loadErrorBody}
-            action={<Button label={t.retry} variant="secondary" onPress={() => person.refetch()} />}
+            action={
+              <Button
+                label={t.retry}
+                variant="secondary"
+                onPress={() => {
+                  void who.refetch();
+                  void person.refetch();
+                }}
+              />
+            }
           />
-        ) : rows.length === 0 ? (
-          // Nothing outstanding in any shared group — square, not broken.
-          <EmptyState title={t.allSettled} body={t.tabs.allSquareBody} />
+        ) : !profile && rows.length === 0 ? (
+          // The server returns nothing for somebody you no longer share a group
+          // with — the same answer it gives for a key that resolves to nobody,
+          // deliberately, so this screen cannot be used to probe for people.
+          <EmptyState title={t.person.notFound} body={t.person.notFoundBody} />
         ) : (
           <>
-            {/* The totals first: the same per-currency figure the list showed,
-                so this screen opens on the number the tap was chasing. */}
-            <Card style={{ gap: theme.spacing.md }}>
-              {totals.map(([currency, net]) => (
-                <Row key={currency} style={{ justifyContent: 'space-between' }}>
-                  <Text variant="subheading" tone="muted">
-                    {net > 0n ? t.tabs.owesYou : t.tabs.youOweThem}
-                  </Text>
-                  <MoneyText
-                    amount={net}
-                    currency={currency}
-                    locale={locale}
-                    variant="heading"
-                    mode="balance"
-                  />
-                </Row>
-              ))}
-            </Card>
+            {profile ? (
+              <IdentityCard profile={profile} masked={!ready || blocked} name={title} />
+            ) : null}
 
-            <View style={{ gap: theme.spacing.md }}>
-              <SectionHeader
-                title={
-                  groups.length === 1
-                    ? t.tabs.inOneGroup
-                    : t.tabs.acrossGroups.other.replace('{n}', String(groups.length))
-                }
-              />
-              <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
-                {groups.map((group, index) => (
-                  <View key={group.groupId}>
-                    <Pressable
-                      accessibilityRole="button"
-                      accessibilityLabel={group.groupName ?? undefined}
-                      onPress={() => router.push(`/group/${group.groupId}`)}
-                      style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}
-                    >
-                      <Row style={{ paddingVertical: theme.spacing.sm, alignItems: 'center' }}>
-                        <View
-                          style={{
-                            width: 44,
-                            height: 44,
-                            borderRadius: theme.radius.pill,
-                            backgroundColor: theme.color.surfaceMuted,
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                          }}
-                        >
-                          <Text style={{ fontSize: 22 }}>{group.coverEmoji ?? '👥'}</Text>
-                        </View>
-                        <Text
-                          variant="subheading"
-                          numberOfLines={1}
-                          style={{ flex: 1, marginHorizontal: theme.spacing.md }}
-                        >
-                          {group.groupName ?? t.tabs.group}
-                        </Text>
-                        <View style={{ alignItems: 'flex-end', gap: 2 }}>
-                          {group.lines.map((line) => (
-                            <MoneyText
-                              key={line.currency}
-                              amount={BigInt(line.net)}
-                              currency={line.currency}
-                              locale={locale}
-                              variant="subheading"
-                              mode="balance"
-                            />
-                          ))}
-                        </View>
-                        <Ionicons
-                          name={directionalIcon('chevron-forward')}
-                          size={iconSize.md}
-                          color={theme.color.textFaint}
-                          style={{ marginLeft: theme.spacing.sm }}
-                        />
-                      </Row>
-                    </Pressable>
-                    {index < groups.length - 1 ? (
-                      <View style={{ height: 1, backgroundColor: theme.color.border }} />
-                    ) : null}
-                  </View>
+            {profile && !blocked && ready ? <ContactCard profile={profile} /> : null}
+
+            {totals.length > 0 ? (
+              <Card style={{ gap: theme.spacing.md }}>
+                {totals.map(([currency, net]) => (
+                  <Row key={currency} style={{ justifyContent: 'space-between' }}>
+                    <Text variant="subheading" tone="muted">
+                      {net > 0n ? t.tabs.owesYou : t.tabs.youOweThem}
+                    </Text>
+                    <MoneyText
+                      amount={net}
+                      currency={currency}
+                      locale={locale}
+                      variant="heading"
+                      mode="balance"
+                    />
+                  </Row>
                 ))}
               </Card>
-            </View>
+            ) : (
+              // Square, not broken — and now the person is still here to say so
+              // to, which is the whole reason identity got its own call.
+              <Card>
+                <Text tone="muted">{t.allSettled}</Text>
+              </Card>
+            )}
+
+            {groups.length > 0 ? (
+              <View style={{ gap: theme.spacing.md }}>
+                <SectionHeader
+                  title={
+                    groups.length === 1
+                      ? t.tabs.inOneGroup
+                      : t.tabs.acrossGroups.other.replace('{n}', String(groups.length))
+                  }
+                />
+                <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+                  {groups.map((group, index) => (
+                    <View key={group.groupId}>
+                      <Pressable
+                        accessibilityRole="button"
+                        accessibilityLabel={group.groupName ?? undefined}
+                        onPress={() => router.push(`/group/${group.groupId}`)}
+                        style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}
+                      >
+                        <Row style={{ paddingVertical: theme.spacing.sm, alignItems: 'center' }}>
+                          <View
+                            style={{
+                              width: 44,
+                              height: 44,
+                              borderRadius: theme.radius.pill,
+                              backgroundColor: theme.color.surfaceMuted,
+                              alignItems: 'center',
+                              justifyContent: 'center',
+                            }}
+                          >
+                            <Text style={{ fontSize: 22 }}>{group.coverEmoji ?? '👥'}</Text>
+                          </View>
+                          <Text
+                            variant="subheading"
+                            numberOfLines={1}
+                            style={{ flex: 1, marginHorizontal: theme.spacing.md }}
+                          >
+                            {group.groupName ?? t.tabs.group}
+                          </Text>
+                          <View style={{ alignItems: 'flex-end', gap: 2 }}>
+                            {group.lines.map((line) => (
+                              <MoneyText
+                                key={line.currency}
+                                amount={BigInt(line.net)}
+                                currency={line.currency}
+                                locale={locale}
+                                variant="subheading"
+                                mode="balance"
+                              />
+                            ))}
+                          </View>
+                          <Ionicons
+                            name={directionalIcon('chevron-forward')}
+                            size={iconSize.md}
+                            color={theme.color.textFaint}
+                            style={{ marginLeft: theme.spacing.sm }}
+                          />
+                        </Row>
+                      </Pressable>
+                      {index < groups.length - 1 ? <Divider /> : null}
+                    </View>
+                  ))}
+                </Card>
+              </View>
+            ) : null}
           </>
         )}
       </ScrollView>
     </Screen>
+  );
+}
+
+/** Face, name, and the one fact that says how you know them. */
+function IdentityCard({
+  profile,
+  masked,
+  name,
+}: {
+  profile: PersonProfileRow;
+  masked: boolean;
+  name: string;
+}) {
+  const theme = useTheme();
+  const { t, locale } = useStrings();
+
+  return (
+    <View style={{ alignItems: 'center', gap: theme.spacing.sm }}>
+      {/* A blocked person keeps the app's ghost avatar here as everywhere else:
+          the point of a block is that you stop seeing who they are. */}
+      <ProfileAvatar
+        name={masked ? t.misc.someone : name}
+        avatarUrl={masked ? null : profile.avatar_url}
+      />
+      <Row style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
+        <Text variant="heading" numberOfLines={1}>
+          {masked ? t.misc.someone : name}
+        </Text>
+        {profile.is_you ? <Badge label={t.person.you} /> : null}
+      </Row>
+      <Text variant="caption" tone="muted">
+        {plural(locale, profile.shared_groups, t.person.sharedGroups).replace(
+          '{n}',
+          String(profile.shared_groups),
+        )}
+      </Text>
+    </View>
+  );
+}
+
+/**
+ * Contact, or the honest reason there is none.
+ *
+ * Three different silences, and they are not interchangeable: a ghost has no
+ * account at all, an account can be holding nothing, and an account can be
+ * holding something its owner has asked us not to pass on. The third is the
+ * only one that is a decision, and saying so is what makes the setting on the
+ * other side of it worth having.
+ */
+function ContactCard({ profile }: { profile: PersonProfileRow }) {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const [copied, setCopied] = useState<string | null>(null);
+
+  const copy = async (value: string): Promise<void> => {
+    await Clipboard.setStringAsync(value);
+    setCopied(value);
+  };
+
+  if (profile.is_ghost) {
+    return (
+      <Card>
+        <Text tone="muted">{t.person.ghostContact}</Text>
+      </Card>
+    );
+  }
+
+  if (profile.contact_withheld) {
+    return (
+      <Card>
+        <Text tone="muted">{fill(t.person.contactWithheld, { name: profile.display_name })}</Text>
+      </Card>
+    );
+  }
+
+  const hasContact = Boolean(profile.phone || profile.email || profile.payment_handle);
+  if (!hasContact) {
+    return (
+      <Card>
+        <Text tone="muted">{t.person.noContact}</Text>
+      </Card>
+    );
+  }
+
+  return (
+    <View style={{ gap: theme.spacing.md }}>
+      <SectionHeader title={t.person.contact} />
+      <Card style={{ gap: theme.spacing.md }}>
+        {profile.phone ? (
+          <ContactLine
+            label={t.person.phone}
+            value={profile.phone}
+            copied={copied === profile.phone}
+            onCopy={() => void copy(profile.phone as string)}
+            actionIcon="call-outline"
+            actionLabel={t.person.call}
+            onAction={() => void Linking.openURL(`tel:${profile.phone as string}`)}
+          />
+        ) : null}
+        {profile.phone && profile.email ? <Divider /> : null}
+        {profile.email ? (
+          <ContactLine
+            label={t.person.email}
+            value={profile.email}
+            copied={copied === profile.email}
+            onCopy={() => void copy(profile.email as string)}
+            actionIcon="mail-outline"
+            actionLabel={t.person.message}
+            onAction={() => void Linking.openURL(`mailto:${profile.email as string}`)}
+          />
+        ) : null}
+        {profile.payment_handle ? (
+          <>
+            <Divider />
+            <ContactLine
+              label={t.person.paidVia}
+              value={profile.payment_handle}
+              copied={copied === profile.payment_handle}
+              onCopy={() => void copy(profile.payment_handle as string)}
+            />
+          </>
+        ) : null}
+      </Card>
+    </View>
+  );
+}
+
+function ContactLine({
+  label,
+  value,
+  copied,
+  onCopy,
+  actionIcon,
+  actionLabel,
+  onAction,
+}: {
+  label: string;
+  value: string;
+  copied: boolean;
+  onCopy: () => void;
+  actionIcon?: 'call-outline' | 'mail-outline';
+  actionLabel?: string;
+  onAction?: () => void;
+}) {
+  const theme = useTheme();
+  const { t } = useStrings();
+
+  return (
+    <Row style={{ alignItems: 'center', gap: theme.spacing.md }}>
+      <View style={{ flex: 1, gap: 2 }}>
+        <Text variant="caption" tone="muted">
+          {label}
+        </Text>
+        {/* A phone number is Latin digits inside whatever script the rest of the
+            screen is in, so it is isolated the way every other number in this
+            app is — otherwise a leading '+' walks to the wrong end in Arabic. */}
+        <Text numberOfLines={1} style={{ writingDirection: 'ltr' }}>
+          {value}
+        </Text>
+      </View>
+      <IconButton label={copied ? t.person.copied : t.person.copy} onPress={onCopy}>
+        <Ionicons
+          name={copied ? 'checkmark' : 'copy-outline'}
+          size={iconSize.md}
+          color={copied ? theme.color.positive : theme.color.textMuted}
+        />
+      </IconButton>
+      {actionIcon && onAction ? (
+        <IconButton label={actionLabel ?? ''} onPress={onAction}>
+          <Ionicons name={actionIcon} size={iconSize.md} color={theme.color.brand} />
+        </IconButton>
+      ) : null}
+    </Row>
   );
 }

--- a/apps/mobile/src/app/settings/discovery.tsx
+++ b/apps/mobile/src/app/settings/discovery.tsx
@@ -1,0 +1,249 @@
+/**
+ * Your own say in how findable you are, and how much of you shows.
+ *
+ * Two questions that look like one and are not, so the screen keeps them apart
+ * with a section head each rather than stacking three switches in a list:
+ *
+ *   * **Can somebody who already has my number find me?** Per channel, because
+ *     a work email address and a mobile number are not the same level of
+ *     acquaintance, and plenty of people will happily be one and not the other.
+ *   * **Can the people already in my groups read my number off my profile?**
+ *     One choice, because a group-mate allowed to see one channel gains very
+ *     little from being denied the other.
+ *
+ * Every hint under a control says what it actually does, including the thing
+ * people most fear when they touch a privacy switch — turning discovery off
+ * does not eject you from the groups you are in. A switch whose consequence is
+ * unstated gets left alone, which makes it no switch at all.
+ *
+ * Saving is immediate and optimistic, and a failure puts the control back to
+ * what the server still holds (the pattern in `settings/notifications`): a
+ * privacy switch that appears to have moved when it has not is the one kind of
+ * lie this screen must never tell.
+ */
+
+import { useEffect, useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router } from 'expo-router';
+import { ActivityIndicator, Pressable, ScrollView, View } from 'react-native';
+
+import {
+  Card,
+  directionalIcon,
+  Divider,
+  IconButton,
+  iconSize,
+  Row,
+  Screen,
+  SectionHeader,
+  Text,
+  Toggle,
+  useTabBarClearance,
+  useTheme,
+} from '@waves/ui';
+
+import {
+  DEFAULT_DISCOVERY,
+  fetchDiscoverySettings,
+  saveDiscoverySettings,
+  type DiscoverySettings,
+} from '@/data/api';
+import { useStrings } from '@/i18n';
+import { useAuth } from '@/lib/auth';
+import { friendlyError } from '@/lib/errors';
+
+export default function DiscoveryScreen() {
+  const theme = useTheme();
+  const clearance = useTabBarClearance();
+  const { t } = useStrings();
+  const { profile } = useAuth();
+
+  const [settings, setSettings] = useState<DiscoverySettings>(DEFAULT_DISCOVERY);
+  const [loading, setLoading] = useState(true);
+  const [status, setStatus] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!profile?.id) return;
+    let active = true;
+    void (async () => {
+      try {
+        const loaded = await fetchDiscoverySettings(profile.id);
+        if (active) setSettings(loaded);
+      } catch (caught: unknown) {
+        if (active) setStatus(friendlyError(caught, t.loadError, 'discovery.load'));
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [profile?.id, t.loadError]);
+
+  const apply = (next: DiscoverySettings): void => {
+    if (!profile?.id) return;
+    const previous = settings;
+    setSettings(next);
+    setStatus(null);
+    void saveDiscoverySettings(profile.id, next)
+      .then(() => setStatus(t.account.saved))
+      .catch((caught: unknown) => {
+        setSettings(previous);
+        setStatus(friendlyError(caught, t.couldNotSave, 'discovery.save'));
+      });
+  };
+
+  return (
+    <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading" numberOfLines={1}>
+            {t.person.discoveryTitle}
+          </Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
+      <ScrollView
+        style={{ flex: 1 }}
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.lg,
+          paddingBottom: clearance,
+          gap: theme.spacing.xl,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        <Text tone="muted">{t.person.discoveryIntro}</Text>
+
+        {loading ? (
+          <ActivityIndicator color={theme.color.brand} />
+        ) : (
+          <>
+            <View style={{ gap: theme.spacing.md }}>
+              <SectionHeader title={t.person.findTitle} />
+              <Card style={{ gap: theme.spacing.md }}>
+                <SwitchRow
+                  title={t.person.discoveryPhone}
+                  hint={t.person.discoveryPhoneHint}
+                  value={settings.discoverableByPhone}
+                  onChange={(value) => apply({ ...settings, discoverableByPhone: value })}
+                />
+                <Divider />
+                <SwitchRow
+                  title={t.person.discoveryEmail}
+                  hint={t.person.discoveryEmailHint}
+                  value={settings.discoverableByEmail}
+                  onChange={(value) => apply({ ...settings, discoverableByEmail: value })}
+                />
+              </Card>
+            </View>
+
+            <View style={{ gap: theme.spacing.md }}>
+              <SectionHeader title={t.person.visibilityTitle} />
+              <Card style={{ gap: theme.spacing.md }}>
+                {/* Two mutually exclusive answers, so radios rather than a
+                    switch — "off" would not say what the other state is. */}
+                <ChoiceRow
+                  title={t.person.visibilityGroups}
+                  hint={t.person.visibilityGroupsHint}
+                  selected={settings.contactVisibility === 'groups'}
+                  onSelect={() => apply({ ...settings, contactVisibility: 'groups' })}
+                />
+                <Divider />
+                <ChoiceRow
+                  title={t.person.visibilityNobody}
+                  hint={t.person.visibilityNobodyHint}
+                  selected={settings.contactVisibility === 'nobody'}
+                  onSelect={() => apply({ ...settings, contactVisibility: 'nobody' })}
+                />
+              </Card>
+            </View>
+
+            <Text variant="caption" tone="muted">
+              {t.person.discoveryFootnote}
+            </Text>
+
+            {status ? (
+              <Text variant="caption" tone="muted">
+                {status}
+              </Text>
+            ) : null}
+          </>
+        )}
+      </ScrollView>
+    </Screen>
+  );
+}
+
+function SwitchRow({
+  title,
+  hint,
+  value,
+  onChange,
+}: {
+  title: string;
+  hint: string;
+  value: boolean;
+  onChange: (next: boolean) => void;
+}) {
+  const theme = useTheme();
+  return (
+    <Row style={{ alignItems: 'flex-start', gap: theme.spacing.md }}>
+      <View style={{ flex: 1, gap: 2 }}>
+        <Text variant="subheading">{title}</Text>
+        <Text variant="caption" tone="muted">
+          {hint}
+        </Text>
+      </View>
+      <Toggle value={value} onValueChange={onChange} accessibilityLabel={title} />
+    </Row>
+  );
+}
+
+function ChoiceRow({
+  title,
+  hint,
+  selected,
+  onSelect,
+}: {
+  title: string;
+  hint: string;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const theme = useTheme();
+  return (
+    <Pressable
+      accessibilityRole="radio"
+      // Exact selected state, not `disabled` and not a checked-looking icon
+      // alone: a screen reader has to be able to hear which of the two is on.
+      accessibilityState={{ selected, checked: selected }}
+      accessibilityLabel={title}
+      accessibilityHint={hint}
+      onPress={onSelect}
+      style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}
+    >
+      <Row style={{ alignItems: 'flex-start', gap: theme.spacing.md }}>
+        <View style={{ flex: 1, gap: 2 }}>
+          <Text variant="subheading">{title}</Text>
+          <Text variant="caption" tone="muted">
+            {hint}
+          </Text>
+        </View>
+        <Ionicons
+          name={selected ? 'radio-button-on' : 'radio-button-off'}
+          size={iconSize.md}
+          color={selected ? theme.color.brand : theme.color.textFaint}
+        />
+      </Row>
+    </Pressable>
+  );
+}

--- a/apps/mobile/src/app/settings/privacy.tsx
+++ b/apps/mobile/src/app/settings/privacy.tsx
@@ -255,6 +255,19 @@ export default function PrivacyScreen() {
                 }
               />
               {divider}
+              {/* Sits directly above blocking because the two are the same
+                  question at different ranges: who may reach you at all, and
+                  who may no longer. */}
+              <ListRow
+                title={t.person.discoveryRow}
+                subtitle={t.person.discoveryRowHint}
+                onPress={() => router.push('/settings/discovery')}
+                leading={
+                  <Ionicons name="search-outline" size={iconSize.md} color={theme.color.brand} />
+                }
+                trailing={chevron}
+              />
+              {divider}
               <ListRow
                 title={t.blocked.row}
                 subtitle={t.blocked.rowHint}

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -1559,6 +1559,124 @@ export async function fetchPersonGroupBalances(
   return (data ?? []) as PersonGroupBalanceRow[];
 }
 
+/** One person's identity, with contact filled in only when they allow it. */
+export interface PersonProfileRow {
+  person_key: string;
+  display_name: string;
+  avatar_url: string | null;
+  is_ghost: boolean;
+  is_you: boolean;
+  shared_groups: number;
+  email: string | null;
+  phone: string | null;
+  payment_rail: string | null;
+  payment_handle: string | null;
+  country_code: string | null;
+  /** They have an account but have chosen not to show contact to group-mates.
+   *  Distinct from "nothing on file", so the screen can say the true one. */
+  contact_withheld: boolean;
+}
+
+/**
+ * Who one person is, across every group you share with them.
+ *
+ * Separate from `fetchPersonGroupBalances` on purpose: that RPC drops anybody
+ * whose balance nets to zero, which is exactly when you most want to look
+ * somebody up and find nothing owing. Identity has to survive being square.
+ *
+ * Returns null when the person is not visible to you — no shared group, or a
+ * key that resolves to nobody. The server never distinguishes those two, so
+ * neither can this.
+ */
+export async function fetchPersonProfile(personKey: string): Promise<PersonProfileRow | null> {
+  const { data, error } = await backend.rpc('waves_person_profile', {
+    p_person_key: personKey,
+  });
+  if (error) throw new Error(error.message);
+  const rows = (data ?? []) as PersonProfileRow[];
+  return rows[0] ?? null;
+}
+
+/** A person found by an exact email address or phone number. */
+export interface FoundPerson {
+  profile_id: string;
+  display_name: string;
+  avatar_url: string | null;
+  /** You are already in a group together — so the next step is "open", not "add". */
+  already_shared: boolean;
+}
+
+/**
+ * Find one account by an exact email address or phone number.
+ *
+ * Exact match only, and only for somebody who has left that channel
+ * discoverable. Null covers both "no such account" and "they have turned this
+ * off", deliberately and identically — a switch that could be detected would be
+ * the very oracle it exists to close.
+ *
+ * The server counts every call, hit or miss, against a daily ceiling. Past it
+ * the RPC raises `LOOKUP_RATE_LIMIT`, which callers should show as a plain
+ * "try again tomorrow" rather than a number.
+ */
+export async function findPerson(
+  channel: 'email' | 'phone',
+  value: string,
+): Promise<FoundPerson | null> {
+  const { data, error } = await backend.rpc('waves_find_person', {
+    p_channel: channel,
+    p_value: value,
+  });
+  if (error) throw new Error(error.message);
+  const rows = (data ?? []) as FoundPerson[];
+  return rows[0] ?? null;
+}
+
+/** How this account may be found, and what group-mates may read off it. */
+export interface DiscoverySettings {
+  discoverableByPhone: boolean;
+  discoverableByEmail: boolean;
+  /** `nobody` or `groups`. A constrained union, not a free string — the column
+   *  has the same check, and the two must not be able to drift apart. */
+  contactVisibility: 'nobody' | 'groups';
+}
+
+export const DEFAULT_DISCOVERY: DiscoverySettings = {
+  discoverableByPhone: true,
+  discoverableByEmail: true,
+  contactVisibility: 'groups',
+};
+
+export async function fetchDiscoverySettings(profileId: string): Promise<DiscoverySettings> {
+  const { data, error } = await backend
+    .from('profiles')
+    .select('discoverable_by_phone, discoverable_by_email, contact_visibility')
+    .eq('id', profileId)
+    .single();
+  if (error) throw new Error(error.message);
+  return {
+    discoverableByPhone: data?.discoverable_by_phone ?? DEFAULT_DISCOVERY.discoverableByPhone,
+    discoverableByEmail: data?.discoverable_by_email ?? DEFAULT_DISCOVERY.discoverableByEmail,
+    // Anything the column somehow holds that is not one of the two known values
+    // falls back to the stricter reading, never the more open one.
+    contactVisibility: data?.contact_visibility === 'nobody' ? 'nobody' : 'groups',
+  };
+}
+
+export async function saveDiscoverySettings(
+  profileId: string,
+  next: DiscoverySettings,
+): Promise<void> {
+  const { error } = await backend
+    .from('profiles')
+    .update({
+      discoverable_by_phone: next.discoverableByPhone,
+      discoverable_by_email: next.discoverableByEmail,
+      contact_visibility: next.contactVisibility,
+    })
+    .eq('id', profileId);
+  if (error) throw new Error(error.message);
+}
+
 /**
  * Fold a set of ghosts into one merged person for this viewer (Friends screen).
  *

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1807,6 +1807,53 @@ export interface UiStrings {
     /** Spoken hint on a tappable person row: where the tap goes. */
     seeSharedGroups: string;
   };
+  /** One person's profile, finding a person, and your own say in both. */
+  person: {
+    title: string;
+    you: string;
+    sharedGroups: PluralForms;
+    contact: string;
+    phone: string;
+    email: string;
+    paidVia: string;
+    /** They have an account but keep contact private. Carries `{name}`. */
+    contactWithheld: string;
+    /** They allow it, but there is genuinely nothing on the account. */
+    noContact: string;
+    /** A ghost — no account, so no contact to withhold or to show. */
+    ghostContact: string;
+    call: string;
+    message: string;
+    copy: string;
+    copied: string;
+    notFound: string;
+    notFoundBody: string;
+    findTitle: string;
+    findHint: string;
+    findPlaceholder: string;
+    findAction: string;
+    findNoMatch: string;
+    /** Deliberately covers "nobody uses that" and "they opted out" in one
+     *  sentence, because the server refuses to tell the two apart. */
+    findNoMatchBody: string;
+    findRateLimited: string;
+    alreadyShared: string;
+    /** The Settings row that opens the discovery screen. */
+    discoveryRow: string;
+    discoveryRowHint: string;
+    discoveryTitle: string;
+    discoveryIntro: string;
+    discoveryPhone: string;
+    discoveryPhoneHint: string;
+    discoveryEmail: string;
+    discoveryEmailHint: string;
+    visibilityTitle: string;
+    visibilityGroups: string;
+    visibilityGroupsHint: string;
+    visibilityNobody: string;
+    visibilityNobodyHint: string;
+    discoveryFootnote: string;
+  };
   /** Adding and editing an expense, and reading one off a bill. */
   expense: {
     edit: string;
@@ -4196,6 +4243,49 @@ const en: UiStrings = {
     reminded: 'Reminded',
     remindedToday: 'Nudged today',
     seeSharedGroups: 'Opens the groups you share with them',
+  },
+  person: {
+    title: 'Profile',
+    you: 'You',
+    sharedGroups: { one: '{n} group in common', other: '{n} groups in common' },
+    contact: 'Contact',
+    phone: 'Phone',
+    email: 'Email',
+    paidVia: 'Gets paid at',
+    contactWithheld: '{name} keeps their contact details to themselves.',
+    noContact: 'No phone or email on this account.',
+    ghostContact: 'Not on Waves yet, so there is nothing to show here.',
+    call: 'Call',
+    message: 'Message',
+    copy: 'Copy',
+    copied: 'Copied',
+    notFound: 'Nothing to show',
+    notFoundBody: 'You share no groups with this person any more.',
+    findTitle: 'Find someone',
+    findHint: 'Type the exact email address or phone number they use on Waves.',
+    findPlaceholder: 'Email or phone',
+    findAction: 'Search',
+    findNoMatch: 'No match',
+    findNoMatchBody: 'Nobody uses that, or they have chosen not to be found by it.',
+    findRateLimited: 'That is enough searching for today. Try again tomorrow.',
+    alreadyShared: 'Already in a group with you',
+    discoveryRow: 'How people find you',
+    discoveryRowHint: 'Being searched for, and what group-mates can see',
+    discoveryTitle: 'How people find you',
+    discoveryIntro:
+      'Somebody who already has your number or your address can look you up on Waves. Nobody can browse for you, and no search is ever by name.',
+    discoveryPhone: 'Find me by my phone number',
+    discoveryPhoneHint:
+      'Only an exact match. Turning this off does not remove you from groups you are already in.',
+    discoveryEmail: 'Find me by my email address',
+    discoveryEmailHint: 'Only an exact match, and only the address on this account.',
+    visibilityTitle: 'On your profile',
+    visibilityGroups: 'People I share a group with',
+    visibilityGroupsHint: 'They can see your phone and email on your profile.',
+    visibilityNobody: 'Nobody',
+    visibilityNobodyHint: 'Your phone and email stay hidden, even from group-mates.',
+    discoveryFootnote:
+      'Somebody who found you by typing your number will see that number — they already had it. None of this ever changes who owes what.',
   },
   expense: {
     edit: 'Edit expense',
@@ -6619,6 +6709,53 @@ const ta: UiStrings = {
     reminded: 'நினைவூட்டப்பட்டது',
     remindedToday: 'இன்று நினைவூட்டிவிட்டீர்கள்',
     seeSharedGroups: 'நீங்கள் இருவரும் பகிரும் குழுக்களைத் திறக்கும்',
+  },
+  person: {
+    title: 'சுயவிவரம்',
+    you: 'நீங்கள்',
+    sharedGroups: { one: 'பொதுவாக {n} குழு', other: 'பொதுவாக {n} குழுக்கள்' },
+    contact: 'தொடர்பு',
+    phone: 'தொலைபேசி',
+    email: 'மின்னஞ்சல்',
+    paidVia: 'பணம் பெறும் முகவரி',
+    contactWithheld: '{name} தமது தொடர்பு விவரங்களைத் தமக்குள்ளேயே வைத்திருக்கிறார்.',
+    noContact: 'இந்தக் கணக்கில் தொலைபேசி எண்ணோ மின்னஞ்சலோ இல்லை.',
+    ghostContact: 'இவர் இன்னும் Waves-இல் சேரவில்லை, அதனால் இங்கே காட்ட ஒன்றுமில்லை.',
+    call: 'அழை',
+    message: 'செய்தி',
+    copy: 'நகலெடு',
+    copied: 'நகலெடுக்கப்பட்டது',
+    notFound: 'காட்ட ஒன்றுமில்லை',
+    notFoundBody: 'இவருடன் இப்போது நீங்கள் எந்தக் குழுவையும் பகிரவில்லை.',
+    findTitle: 'ஒருவரைத் தேடுங்கள்',
+    findHint:
+      'அவர் Waves-இல் பயன்படுத்தும் மின்னஞ்சல் முகவரியையோ தொலைபேசி எண்ணையோ அப்படியே தட்டச்சு செய்யுங்கள்.',
+    findPlaceholder: 'மின்னஞ்சல் அல்லது தொலைபேசி',
+    findAction: 'தேடு',
+    findNoMatch: 'பொருத்தம் இல்லை',
+    findNoMatchBody:
+      'அதை யாரும் பயன்படுத்தவில்லை, அல்லது அதன் மூலம் கண்டறியப்படுவதை அவர் விரும்பவில்லை.',
+    findRateLimited: 'இன்றைக்கு இவ்வளவு தேடல் போதும். நாளை மீண்டும் முயற்சியுங்கள்.',
+    alreadyShared: 'ஏற்கனவே உங்களுடன் ஒரு குழுவில் இருக்கிறார்',
+    discoveryRow: 'மற்றவர்கள் உங்களை எப்படிக் கண்டறிவார்கள்',
+    discoveryRowHint: 'உங்களைத் தேடுவது, குழுவினர் பார்ப்பது',
+    discoveryTitle: 'மற்றவர்கள் உங்களை எப்படிக் கண்டறிவார்கள்',
+    discoveryIntro:
+      'உங்கள் எண்ணையோ முகவரியையோ ஏற்கனவே வைத்திருப்பவர் உங்களை Waves-இல் தேட முடியும். யாரும் உங்களைத் தேடி உலவ முடியாது; பெயரால் தேடுவது என்பது ஒருபோதும் இல்லை.',
+    discoveryPhone: 'என் தொலைபேசி எண்ணால் என்னைக் கண்டறியலாம்',
+    discoveryPhoneHint:
+      'சரியான பொருத்தம் மட்டுமே. இதை அணைத்தால், நீங்கள் ஏற்கனவே இருக்கும் குழுக்களிலிருந்து நீக்கப்பட மாட்டீர்கள்.',
+    discoveryEmail: 'என் மின்னஞ்சல் முகவரியால் என்னைக் கண்டறியலாம்',
+    discoveryEmailHint: 'சரியான பொருத்தம் மட்டுமே, இந்தக் கணக்கின் முகவரி மட்டுமே.',
+    visibilityTitle: 'உங்கள் சுயவிவரத்தில்',
+    visibilityGroups: 'நான் குழு பகிரும் நபர்கள்',
+    visibilityGroupsHint:
+      'உங்கள் சுயவிவரத்தில் உங்கள் தொலைபேசியையும் மின்னஞ்சலையும் அவர்கள் பார்க்கலாம்.',
+    visibilityNobody: 'யாரும் இல்லை',
+    visibilityNobodyHint:
+      'குழுவினரிடமிருந்து கூட உங்கள் தொலைபேசியும் மின்னஞ்சலும் மறைந்தே இருக்கும்.',
+    discoveryFootnote:
+      'உங்கள் எண்ணைத் தட்டச்சு செய்து உங்களைக் கண்டறிந்தவர் அந்த எண்ணைப் பார்ப்பார் — அது ஏற்கனவே அவரிடம் இருந்தது. இவை எதுவும் யார் யாருக்குக் கடன் என்பதை மாற்றாது.',
   },
   expense: {
     edit: 'செலவைத் திருத்து',
@@ -9049,6 +9186,49 @@ const hi: UiStrings = {
     reminded: 'याद दिला दिया',
     remindedToday: 'आज याद दिला चुके',
     seeSharedGroups: 'उनके साथ साझा किए गए समूह खोलता है',
+  },
+  person: {
+    title: 'प्रोफ़ाइल',
+    you: 'आप',
+    sharedGroups: { one: '{n} साझा समूह', other: '{n} साझा समूह' },
+    contact: 'संपर्क',
+    phone: 'फ़ोन',
+    email: 'ईमेल',
+    paidVia: 'भुगतान यहाँ लेते हैं',
+    contactWithheld: '{name} ने अपने संपर्क विवरण अपने पास रखे हैं।',
+    noContact: 'इस खाते पर कोई फ़ोन नंबर या ईमेल नहीं है।',
+    ghostContact: 'ये अभी Waves पर नहीं हैं, इसलिए यहाँ दिखाने को कुछ नहीं है।',
+    call: 'कॉल',
+    message: 'संदेश',
+    copy: 'कॉपी',
+    copied: 'कॉपी हो गया',
+    notFound: 'दिखाने को कुछ नहीं',
+    notFoundBody: 'अब आप इनके साथ कोई समूह साझा नहीं करते।',
+    findTitle: 'किसी को खोजें',
+    findHint: 'वही ईमेल पता या फ़ोन नंबर लिखें जो वे Waves पर इस्तेमाल करते हैं।',
+    findPlaceholder: 'ईमेल या फ़ोन',
+    findAction: 'खोजें',
+    findNoMatch: 'कोई मेल नहीं',
+    findNoMatchBody: 'इसे कोई इस्तेमाल नहीं करता, या उन्होंने इससे खोजे जाने से मना किया है।',
+    findRateLimited: 'आज के लिए इतनी खोज काफ़ी। कल फिर कोशिश करें।',
+    alreadyShared: 'पहले से आपके साथ एक समूह में',
+    discoveryRow: 'लोग आपको कैसे खोजें',
+    discoveryRowHint: 'खोजा जाना, और समूह वालों को क्या दिखे',
+    discoveryTitle: 'लोग आपको कैसे खोजें',
+    discoveryIntro:
+      'जिसके पास पहले से आपका नंबर या पता है, वह आपको Waves पर खोज सकता है। कोई यूँ ही लोगों में आपको ढूँढ़ नहीं सकता, और नाम से खोज कभी नहीं होती।',
+    discoveryPhone: 'मेरे फ़ोन नंबर से मुझे खोजा जा सके',
+    discoveryPhoneHint:
+      'सिर्फ़ पूरा मिलान। इसे बंद करने से आप उन समूहों से नहीं हटते जिनमें आप पहले से हैं।',
+    discoveryEmail: 'मेरे ईमेल पते से मुझे खोजा जा सके',
+    discoveryEmailHint: 'सिर्फ़ पूरा मिलान, और सिर्फ़ इस खाते का पता।',
+    visibilityTitle: 'आपकी प्रोफ़ाइल पर',
+    visibilityGroups: 'जिनके साथ मेरा कोई समूह है',
+    visibilityGroupsHint: 'वे आपकी प्रोफ़ाइल पर आपका फ़ोन और ईमेल देख सकते हैं।',
+    visibilityNobody: 'कोई नहीं',
+    visibilityNobodyHint: 'आपका फ़ोन और ईमेल छिपे रहते हैं, समूह वालों से भी।',
+    discoveryFootnote:
+      'जिसने आपका नंबर लिखकर आपको खोजा, उसे वह नंबर दिखेगा — वह उसके पास पहले से था। इनमें से कुछ भी यह नहीं बदलता कि किस पर कितना बाक़ी है।',
   },
   expense: {
     edit: 'खर्च बदलें',
@@ -11536,6 +11716,55 @@ const ar: UiStrings = {
     reminded: 'تم التذكير',
     remindedToday: 'ذُكّر اليوم',
     seeSharedGroups: 'يفتح المجموعات المشتركة معكما',
+  },
+  person: {
+    title: 'الملف الشخصي',
+    you: 'أنت',
+    sharedGroups: {
+      zero: 'لا مجموعات مشتركة',
+      one: 'مجموعة مشتركة واحدة',
+      two: 'مجموعتان مشتركتان',
+      few: '{n} مجموعات مشتركة',
+      many: '{n} مجموعة مشتركة',
+      other: '{n} مجموعة مشتركة',
+    },
+    contact: 'التواصل',
+    phone: 'الهاتف',
+    email: 'البريد الإلكتروني',
+    paidVia: 'يستلم المدفوعات على',
+    contactWithheld: 'يحتفظ {name} ببيانات تواصله لنفسه.',
+    noContact: 'لا يوجد هاتف أو بريد على هذا الحساب.',
+    ghostContact: 'لم ينضم إلى Waves بعد، فلا شيء لعرضه هنا.',
+    call: 'اتصال',
+    message: 'رسالة',
+    copy: 'نسخ',
+    copied: 'تم النسخ',
+    notFound: 'لا شيء لعرضه',
+    notFoundBody: 'لم تعد تجمعك بهذا الشخص أي مجموعة.',
+    findTitle: 'ابحث عن شخص',
+    findHint: 'اكتب بالضبط البريد الإلكتروني أو رقم الهاتف الذي يستخدمه على Waves.',
+    findPlaceholder: 'بريد إلكتروني أو هاتف',
+    findAction: 'بحث',
+    findNoMatch: 'لا يوجد تطابق',
+    findNoMatchBody: 'لا أحد يستخدم ذلك، أو أنه اختار ألا يُعثر عليه بهذه الطريقة.',
+    findRateLimited: 'يكفي بحثًا اليوم. حاول مرة أخرى غدًا.',
+    alreadyShared: 'تجمعكما مجموعة بالفعل',
+    discoveryRow: 'كيف يعثر عليك الآخرون',
+    discoveryRowHint: 'أن يُبحث عنك، وما يراه أفراد مجموعاتك',
+    discoveryTitle: 'كيف يعثر عليك الآخرون',
+    discoveryIntro:
+      'من يملك رقمك أو عنوان بريدك مسبقًا يستطيع البحث عنك على Waves. لا أحد يستطيع تصفّح الأشخاص بحثًا عنك، ولا بحث بالاسم إطلاقًا.',
+    discoveryPhone: 'يمكن العثور عليّ برقم هاتفي',
+    discoveryPhoneHint: 'تطابق تام فقط. إيقافه لا يُخرجك من المجموعات التي أنت فيها بالفعل.',
+    discoveryEmail: 'يمكن العثور عليّ ببريدي الإلكتروني',
+    discoveryEmailHint: 'تطابق تام فقط، ولعنوان هذا الحساب وحده.',
+    visibilityTitle: 'في ملفك الشخصي',
+    visibilityGroups: 'من تجمعني بهم مجموعة',
+    visibilityGroupsHint: 'يستطيعون رؤية هاتفك وبريدك في ملفك الشخصي.',
+    visibilityNobody: 'لا أحد',
+    visibilityNobodyHint: 'يبقى هاتفك وبريدك مخفيين، حتى عن أفراد مجموعاتك.',
+    discoveryFootnote:
+      'من عثر عليك بكتابة رقمك سيرى ذلك الرقم — فقد كان لديه أصلًا. ولا شيء من هذا يغيّر أبدًا من يدين لمن.',
   },
   expense: {
     edit: 'تعديل المصروف',

--- a/packages/db/prisma/migrations/20260908090000_person_profile_and_discovery/migration.sql
+++ b/packages/db/prisma/migrations/20260908090000_person_profile_and_discovery/migration.sql
@@ -239,7 +239,12 @@ GRANT EXECUTE ON FUNCTION public.waves_person_profile(text) TO authenticated, se
 -- changing it should not need a release.
 CREATE TABLE IF NOT EXISTS public.person_lookups (
     profile_id uuid NOT NULL,
-    day        date NOT NULL DEFAULT (now() AT TIME ZONE 'utc')::date,
+    -- No column default on purpose. `waves_spend_person_lookup` always supplies
+    -- the day explicitly, so a default would never fire — and Postgres
+    -- normalises a `now() AT TIME ZONE 'utc'` default into a form Prisma's
+    -- `dbgenerated` string cannot match, which shows up as permanent schema
+    -- drift in CI. A default nobody uses is not worth a failing check forever.
+    day        date NOT NULL,
     lookups    integer NOT NULL DEFAULT 0,
     CONSTRAINT person_lookups_pkey PRIMARY KEY (profile_id, day),
     CONSTRAINT person_lookups_count_nonneg CHECK (lookups >= 0)

--- a/packages/db/prisma/migrations/20260908090000_person_profile_and_discovery/migration.sql
+++ b/packages/db/prisma/migrations/20260908090000_person_profile_and_discovery/migration.sql
@@ -71,6 +71,40 @@ COMMENT ON COLUMN public.profiles.discoverable_by_email IS
 COMMENT ON COLUMN public.profiles.contact_visibility IS
   'Who may read this account''s email and phone off its profile: nobody, or people it shares a group with.';
 
+-- ────────────────────────────────────────────── is there a real auth to read ──
+
+-- Whether `auth.users` exists *and* carries the three columns the contact
+-- lookups below actually read.
+--
+-- `to_regclass('auth.users') IS NOT NULL` on its own is not enough, which cost a
+-- CI run to learn. The DB suite runs against a bare Postgres where several test
+-- files create a stub `auth.users` between them — `campaignBroadcast` makes it
+-- with `(id, email, email_confirmed_at)` and `group-add-notify` later adds
+-- `phone` and `deleted_at` — so the stub's shape depends on which file ran
+-- first. A function that checks only for the table then reads `u.phone` fails
+-- with `42703` on whichever ordering loses. The existing guest-ceiling guard in
+-- the baseline already checks for `is_anonymous` by name for exactly this
+-- reason; this is the same idea, factored out because two functions need it.
+--
+-- plpgsql plans a statement only when its branch actually runs, so a false
+-- answer here means the missing column is never referenced at all. No real auth
+-- table means no contact on file, which is the right answer rather than a hole.
+CREATE OR REPLACE FUNCTION public.waves_auth_contact_readable() RETURNS boolean
+    LANGUAGE sql STABLE
+    SET search_path TO 'public', 'pg_temp'
+    AS $fn$
+  SELECT to_regclass('auth.users') IS NOT NULL
+     AND (
+       SELECT count(*) FROM information_schema.columns
+        WHERE table_schema = 'auth'
+          AND table_name = 'users'
+          AND column_name IN ('email', 'phone', 'deleted_at')
+     ) = 3;
+$fn$;
+
+REVOKE ALL ON FUNCTION public.waves_auth_contact_readable() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.waves_auth_contact_readable() TO service_role;
+
 -- ──────────────────────────────────────────────────── one person, one screen ──
 
 -- Everything the person screen needs about one person, contact included when
@@ -185,11 +219,11 @@ BEGIN
     END IF;
   END IF;
 
-  -- The reveal. Guarded on `auth.users` existing for the same reason every
-  -- other read of it in this schema is: the DB test suite and the self-host
-  -- stack run these RPCs against a Postgres with no `auth` schema, where the
-  -- right answer is "no contact on file", not an error.
-  IF NOT v_ghost AND v_visible AND to_regclass('auth.users') IS NOT NULL THEN
+  -- The reveal. Guarded on a real `auth.users` for the same reason every other
+  -- read of it in this schema is: the DB test suite and the self-host stack run
+  -- these RPCs against a Postgres with no `auth` schema, or with a stub one,
+  -- where the right answer is "no contact on file", not an error.
+  IF NOT v_ghost AND v_visible AND public.waves_auth_contact_readable() THEN
     SELECT nullif(btrim(lower(coalesce(u.email, ''))), ''),
            -- Stored bare in `auth.users`; the '+' is put back so the number is
            -- dialable and reads like every other number in the app.
@@ -360,7 +394,7 @@ BEGIN
       USING ERRCODE = 'too_many_connections';
   END IF;
 
-  IF to_regclass('auth.users') IS NULL THEN
+  IF NOT public.waves_auth_contact_readable() THEN
     RETURN;
   END IF;
 

--- a/packages/db/prisma/migrations/20260908090000_person_profile_and_discovery/migration.sql
+++ b/packages/db/prisma/migrations/20260908090000_person_profile_and_discovery/migration.sql
@@ -209,9 +209,9 @@ BEGIN
   shared_groups    := coalesce(v_shared, 0);
   email            := v_email;
   phone            := v_phone;
-  payment_rail     := v_rail;
-  payment_handle   := v_handle;
-  country_code     := v_country;
+  payment_rail     := CASE WHEN v_visible THEN v_rail ELSE NULL END;
+  payment_handle   := CASE WHEN v_visible THEN v_handle ELSE NULL END;
+  country_code     := CASE WHEN v_visible THEN v_country ELSE NULL END;
   contact_withheld := (NOT v_ghost) AND (NOT v_visible);
   RETURN NEXT;
 END

--- a/packages/db/prisma/migrations/20260908090000_person_profile_and_discovery/migration.sql
+++ b/packages/db/prisma/migrations/20260908090000_person_profile_and_discovery/migration.sql
@@ -1,0 +1,423 @@
+-- Who a person is, and their own say in how much of that anyone else gets.
+--
+-- The Friends list rolls people up into a balance and `waves_person_group_balances`
+-- un-collapses that balance per group. Neither answers the question somebody
+-- actually taps a row to ask: *who is this?* Two people called Priya in two
+-- groups are two identical rows, and once a balance settles to zero the person
+-- vanishes from the screen entirely, because that RPC ends in
+-- `HAVING sum(n.net) <> 0`. Identity was never modelled here — only debt was.
+--
+-- Adding identity means adding contact details, and contact details are not
+-- ours to hand out. So this migration is two halves that only make sense
+-- together:
+--
+--   * `waves_person_profile` — one row about one person, with their email and
+--     phone included *only* when they have said that is allowed.
+--   * three columns on `profiles` where they say it, plus `waves_find_person`,
+--     the reverse direction: being looked up by a number or an address someone
+--     already has, which is the only way a person becomes findable in this app
+--     without a group invite.
+--
+-- The two axes are deliberately independent, because they answer different
+-- questions and conflating them is how these settings usually go wrong:
+--
+--   **Discoverability** ("can someone who already has my number find me?")
+--   is about search. It is per channel, because knowing somebody's work email
+--   and knowing their mobile number are not the same level of acquaintance.
+--
+--   **Contact visibility** ("can people I share a group with read my number off
+--   my profile?") is about display. It is one switch, because a group-mate who
+--   can see one channel gains very little from being denied the other.
+--
+-- One rule is deliberately *not* implemented server-side, because it needs no
+-- server: if you found somebody by typing their phone number, the app shows you
+-- that number back on the result. It cannot leak anything — you typed it.
+-- Showing it is honesty about what the match means, not disclosure.
+
+-- ─────────────────────────────────────────────────────── the three switches ──
+
+-- Defaults are chosen so that today's behaviour is unchanged for everyone who
+-- already has an account: this app has always tapped an existing account when
+-- somebody adds a ghost by email or phone (see `waves_add_ghost_member` below),
+-- so discovery has effectively been on and unconditional since M1. Defaulting
+-- these to off would silently break every existing add-by-contact flow, and
+-- would dress the change up as a fix for a leak people had already lived with.
+-- The switches make it a choice; they do not make a different choice on
+-- anyone's behalf.
+--
+-- Contact visibility defaults to 'groups' on the same reasoning: a group-mate
+-- can already see the email or phone an invite was addressed to
+-- (`group_members.invite_email` / `invite_phone`), so a profile showing it is
+-- not new disclosure — it is the same fact, in the place people look for it.
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS discoverable_by_phone boolean NOT NULL DEFAULT true,
+  ADD COLUMN IF NOT EXISTS discoverable_by_email boolean NOT NULL DEFAULT true,
+  ADD COLUMN IF NOT EXISTS contact_visibility    text    NOT NULL DEFAULT 'groups';
+
+DO $do$
+BEGIN
+  ALTER TABLE public.profiles
+    ADD CONSTRAINT profiles_contact_visibility_check
+    CHECK (contact_visibility IN ('nobody', 'groups'));
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$do$;
+
+COMMENT ON COLUMN public.profiles.discoverable_by_phone IS
+  'Can somebody who types this account''s exact phone number find it (waves_find_person).';
+COMMENT ON COLUMN public.profiles.discoverable_by_email IS
+  'Can somebody who types this account''s exact email address find it (waves_find_person).';
+COMMENT ON COLUMN public.profiles.contact_visibility IS
+  'Who may read this account''s email and phone off its profile: nobody, or people it shares a group with.';
+
+-- ──────────────────────────────────────────────────── one person, one screen ──
+
+-- Everything the person screen needs about one person, contact included when
+-- and only when they allow it.
+--
+-- `p_person_key` is the same key the Friends list and
+-- `waves_person_group_balances` use, resolved the same three ways: a profile id
+-- is proof of one human, a ghost merge is the caller's own proof, and failing
+-- both a ghost stays keyed to its own group membership. The caller must share
+-- at least one active group with them — that is this app's only notion of
+-- "knowing" somebody, and without it the function would be a profile oracle for
+-- any uuid a caller cared to try.
+--
+-- SECURITY DEFINER because the email and phone live in `auth.users`, which no
+-- ordinary role may read. The function is the whole boundary: it decides what
+-- comes out, and it returns nothing at all for somebody the caller does not
+-- already share a group with.
+CREATE OR REPLACE FUNCTION public.waves_person_profile(p_person_key text)
+RETURNS TABLE(
+  person_key       text,
+  display_name     text,
+  avatar_url       text,
+  is_ghost         boolean,
+  is_you           boolean,
+  shared_groups    integer,
+  email            text,
+  phone            text,
+  payment_rail     text,
+  payment_handle   text,
+  country_code     character(2),
+  -- The difference between "they have not told us" and "they have told us not
+  -- to tell you". A screen that cannot tell those apart has to write a weasel
+  -- sentence covering both; with this it can say the true one.
+  contact_withheld boolean
+)
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $fn$
+DECLARE
+  v_me      uuid := public.waves_current_profile_id();
+  v_profile uuid;
+  v_shared  integer := 0;
+  v_name    text;
+  v_avatar  text;
+  v_rail    text;
+  v_handle  text;
+  v_country character(2);
+  v_ghost   boolean := true;
+  v_visible boolean := false;
+  v_email   text;
+  v_phone   text;
+BEGIN
+  IF v_me IS NULL OR p_person_key IS NULL OR btrim(p_person_key) = '' THEN
+    RETURN;
+  END IF;
+
+  -- Case 1: the key is a real account.
+  IF p_person_key ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' THEN
+    SELECT p.id, p.display_name, p.avatar_url, p.payment_rail, p.payment_handle,
+           p.country_code, (p.contact_visibility = 'groups')
+      INTO v_profile, v_name, v_avatar, v_rail, v_handle, v_country, v_visible
+      FROM public.profiles p
+     WHERE p.id = p_person_key::uuid;
+  END IF;
+
+  IF v_profile IS NOT NULL THEN
+    v_ghost := false;
+
+    IF v_profile = v_me THEN
+      -- Looking at yourself: your own contact details are always yours to see,
+      -- and "shared groups" means every group you are in.
+      v_shared := (SELECT count(*)::int FROM public.group_members gm
+                    WHERE gm.profile_id = v_me AND gm.left_at IS NULL);
+      v_visible := true;
+    ELSE
+      -- The shared-group count doubles as the permission check.
+      SELECT count(DISTINCT mine.group_id)::int INTO v_shared
+        FROM public.group_members mine
+        JOIN public.group_members theirs
+          ON theirs.group_id = mine.group_id
+         AND theirs.left_at IS NULL
+         AND theirs.profile_id = v_profile
+       WHERE mine.profile_id = v_me
+         AND mine.left_at IS NULL;
+
+      IF coalesce(v_shared, 0) = 0 THEN
+        RETURN;
+      END IF;
+    END IF;
+
+  ELSE
+    -- Cases 2 and 3: a merged ghost (the caller's own merge) or a plain ghost.
+    -- Either way there is no account, so there is nothing to reveal and the
+    -- only question is whether the caller can see this person at all.
+    SELECT max(coalesce(mrg.display_name, gm.ghost_name, 'Someone')),
+           count(DISTINCT gm.group_id)::int
+      INTO v_name, v_shared
+      FROM public.group_members gm
+      JOIN public.group_members mine
+        ON mine.group_id = gm.group_id
+       AND mine.profile_id = v_me
+       AND mine.left_at IS NULL
+      LEFT JOIN public.ghost_merges mrg
+        ON mrg.member_id = gm.id
+       AND mrg.owner = v_me
+     WHERE gm.left_at IS NULL
+       AND gm.profile_id IS NULL
+       AND coalesce(mrg.person_id::text, gm.id::text) = p_person_key;
+
+    IF coalesce(v_shared, 0) = 0 THEN
+      RETURN;
+    END IF;
+  END IF;
+
+  -- The reveal. Guarded on `auth.users` existing for the same reason every
+  -- other read of it in this schema is: the DB test suite and the self-host
+  -- stack run these RPCs against a Postgres with no `auth` schema, where the
+  -- right answer is "no contact on file", not an error.
+  IF NOT v_ghost AND v_visible AND to_regclass('auth.users') IS NOT NULL THEN
+    SELECT nullif(btrim(lower(coalesce(u.email, ''))), ''),
+           -- Stored bare in `auth.users`; the '+' is put back so the number is
+           -- dialable and reads like every other number in the app.
+           CASE WHEN nullif(btrim(coalesce(u.phone, '')), '') IS NULL THEN NULL
+                ELSE '+' || regexp_replace(u.phone, '[^0-9]', '', 'g') END
+      INTO v_email, v_phone
+      FROM auth.users u
+     WHERE u.id = v_profile
+       AND u.deleted_at IS NULL;
+  END IF;
+
+  person_key       := p_person_key;
+  display_name     := coalesce(v_name, 'Someone');
+  avatar_url       := v_avatar;
+  is_ghost         := v_ghost;
+  is_you           := (v_profile IS NOT NULL AND v_profile = v_me);
+  shared_groups    := coalesce(v_shared, 0);
+  email            := v_email;
+  phone            := v_phone;
+  payment_rail     := v_rail;
+  payment_handle   := v_handle;
+  country_code     := v_country;
+  contact_withheld := (NOT v_ghost) AND (NOT v_visible);
+  RETURN NEXT;
+END
+$fn$;
+
+REVOKE ALL ON FUNCTION public.waves_person_profile(text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.waves_person_profile(text) TO authenticated, service_role;
+
+-- ─────────────────────────────────────────────────────────── being looked up ──
+
+-- Exact-match lookup is a small, useful capability and a large, obvious abuse
+-- surface: the same call that finds your friend's account from the number in
+-- your address book will, run a hundred thousand times, tell somebody which
+-- phone numbers in a range have Waves accounts. Three things keep that in
+-- proportion, and none of them is sufficient alone:
+--
+--   * exact match only — no prefix, no LIKE, no fuzzy name search, so there is
+--     nothing to walk;
+--   * the target's own consent, per channel;
+--   * a per-caller daily ceiling, counting misses as well as hits, since it is
+--     the misses that a sweep is made of.
+--
+-- The ceiling is an `app_config` knob rather than a constant for the same
+-- reason the other caps are: it is the number most likely to be wrong, and
+-- changing it should not need a release.
+CREATE TABLE IF NOT EXISTS public.person_lookups (
+    profile_id uuid NOT NULL,
+    day        date NOT NULL DEFAULT (now() AT TIME ZONE 'utc')::date,
+    lookups    integer NOT NULL DEFAULT 0,
+    CONSTRAINT person_lookups_pkey PRIMARY KEY (profile_id, day),
+    CONSTRAINT person_lookups_count_nonneg CHECK (lookups >= 0)
+);
+
+COMMENT ON TABLE public.person_lookups IS
+  'Per-caller daily count of waves_find_person calls, hits and misses alike. Rate limiting only; not history anyone is shown.';
+
+-- Nobody reads or writes this directly — the definer function is the only door.
+ALTER TABLE public.person_lookups ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE public.person_lookups FROM PUBLIC;
+REVOKE ALL ON TABLE public.person_lookups FROM anon, authenticated;
+GRANT ALL ON TABLE public.person_lookups TO service_role;
+
+INSERT INTO public.app_config (key, value, description)
+VALUES ('person_lookup_daily_cap', 40,
+        'How many find-a-person lookups one account may run per UTC day, misses included.')
+ON CONFLICT (key) DO NOTHING;
+
+-- Spend one lookup and say how many have been spent today.
+--
+-- Its own function rather than an INSERT inside `waves_find_person` for a
+-- boring reason worth recording: that function returns a column called
+-- `profile_id`, and inside plpgsql an OUT parameter of that name makes every
+-- reference to the `person_lookups.profile_id` column ambiguous. Pulling the
+-- write out here removes the collision instead of papering over it with
+-- `#variable_conflict`, and leaves the counter testable on its own.
+CREATE OR REPLACE FUNCTION public.waves_spend_person_lookup() RETURNS integer
+    LANGUAGE plpgsql VOLATILE SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $fn$
+DECLARE
+  v_me   uuid := public.waves_current_profile_id();
+  v_used integer;
+BEGIN
+  IF v_me IS NULL THEN
+    RETURN 0;
+  END IF;
+
+  INSERT INTO public.person_lookups AS pl (profile_id, day, lookups)
+  VALUES (v_me, (now() AT TIME ZONE 'utc')::date, 1)
+  ON CONFLICT (profile_id, day)
+  DO UPDATE SET lookups = pl.lookups + 1
+  RETURNING pl.lookups INTO v_used;
+
+  RETURN v_used;
+END
+$fn$;
+
+REVOKE ALL ON FUNCTION public.waves_spend_person_lookup() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.waves_spend_person_lookup() TO authenticated, service_role;
+
+-- Find one account by an exact email address or phone number.
+--
+-- Returns at most one row, and only when that account has left the matching
+-- channel discoverable. A miss and a refusal are deliberately indistinguishable
+-- to the caller: if "no such account" and "they have turned this off" looked
+-- different, the switch would itself become the oracle it exists to close.
+--
+-- `already_shared` is the one extra fact worth returning, because it changes
+-- what the app offers next — somebody you are already in a group with does not
+-- need adding, they need opening.
+CREATE OR REPLACE FUNCTION public.waves_find_person(p_channel text, p_value text)
+RETURNS TABLE(
+  profile_id     uuid,
+  display_name   text,
+  avatar_url     text,
+  already_shared boolean
+)
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $fn$
+DECLARE
+  v_me         uuid := public.waves_current_profile_id();
+  v_channel    text := lower(btrim(coalesce(p_channel, '')));
+  v_email      text;
+  v_phone_bare text;
+  v_cap        integer;
+  v_used       integer;
+  v_hit        uuid;
+BEGIN
+  IF v_me IS NULL THEN
+    RAISE EXCEPTION 'NOT_SIGNED_IN: sign in to look somebody up'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF v_channel NOT IN ('email', 'phone') THEN
+    RAISE EXCEPTION 'UNKNOWN_CHANNEL: look up by email or phone'
+      USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+
+  IF v_channel = 'email' THEN
+    v_email := nullif(btrim(lower(coalesce(p_value, ''))), '');
+    -- Not validation, just a floor: an empty or obviously non-address string
+    -- should not spend one of the caller's daily lookups.
+    IF v_email IS NULL OR position('@' IN v_email) < 2 THEN
+      RETURN;
+    END IF;
+  ELSE
+    v_phone_bare := nullif(regexp_replace(coalesce(p_value, ''), '[^0-9]', '', 'g'), '');
+    IF v_phone_bare IS NULL OR length(v_phone_bare) < 6 THEN
+      RETURN;
+    END IF;
+  END IF;
+
+  -- Spend one lookup. Counted before the search runs, so an error or a miss
+  -- costs the same as a hit.
+  v_cap := coalesce((SELECT value FROM public.app_config WHERE key = 'person_lookup_daily_cap'), 40);
+  v_used := public.waves_spend_person_lookup();
+
+  IF v_used > v_cap THEN
+    RAISE EXCEPTION 'LOOKUP_RATE_LIMIT: too many lookups today'
+      USING ERRCODE = 'too_many_connections';
+  END IF;
+
+  IF to_regclass('auth.users') IS NULL THEN
+    RETURN;
+  END IF;
+
+  SELECT u.id INTO v_hit
+    FROM auth.users u
+    JOIN public.profiles p ON p.id = u.id
+   WHERE u.deleted_at IS NULL
+     AND u.id <> v_me
+     AND (
+       (v_channel = 'email'
+        AND p.discoverable_by_email
+        AND lower(u.email) = v_email)
+       OR
+       (v_channel = 'phone'
+        AND p.discoverable_by_phone
+        AND regexp_replace(coalesce(u.phone, ''), '[^0-9]', '', 'g') = v_phone_bare)
+     )
+   LIMIT 1;
+
+  IF v_hit IS NULL THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  SELECT p.id,
+         p.display_name,
+         p.avatar_url,
+         EXISTS (
+           SELECT 1
+             FROM public.group_members mine
+             JOIN public.group_members theirs
+               ON theirs.group_id = mine.group_id
+              AND theirs.left_at IS NULL
+              AND theirs.profile_id = p.id
+            WHERE mine.profile_id = v_me
+              AND mine.left_at IS NULL
+         )
+    FROM public.profiles p
+   WHERE p.id = v_hit;
+END
+$fn$;
+
+REVOKE ALL ON FUNCTION public.waves_find_person(text, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.waves_find_person(text, text) TO authenticated, service_role;
+
+-- ────────────────────────────────────────────── what these switches do *not* do ──
+--
+-- `waves_add_ghost_member` also matches a typed email or phone against
+-- `auth.users`, to link a person being added to a group with the account they
+-- already have. That is deliberately left ungated by `discoverable_by_*`, and
+-- it is worth writing down why, because it looks like the same thing and is
+-- not:
+--
+--   * It tells the caller nothing. The function returns the new member id
+--     whether or not an account matched, so it cannot be used to ask "does this
+--     number have Waves" — which is the entire question these switches exist to
+--     let somebody refuse.
+--   * The person doing it already has your contact details in their hand and is
+--     adding you to a group with them. Refusing the link would not hide you; it
+--     would split your balance across a ghost and your account, which is a
+--     ledger bug dressed up as a privacy win.
+--
+-- Discoverability governs being *searched for* by a stranger. It does not
+-- govern being recognised by somebody who is already putting you in their
+-- group.

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1723,7 +1723,10 @@ model AppConfig {
 /// on purpose: the row is a counter, and losing it with the account is fine.
 model PersonLookup {
   profileId String   @map("profile_id") @db.Uuid
-  day       DateTime @default(dbgenerated("(now() AT TIME ZONE 'utc')::date")) @db.Date
+  /// No default: `waves_spend_person_lookup` always writes the day, and a
+  /// `now() AT TIME ZONE 'utc'` default is normalised by Postgres into a form
+  /// `dbgenerated` cannot match, which reads as permanent drift.
+  day       DateTime @db.Date
   lookups   Int      @default(0)
 
   @@id([profileId, day])

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -147,6 +147,16 @@ model Profile {
   defaultCurrency   String   @default("INR") @map("default_currency") @db.Char(3)
   locale            String   @default("en")
   notificationPrefs Json     @default("{}") @map("notification_prefs")
+  /// Can somebody who types this account's exact phone number find it
+  /// (`waves_find_person`)? Search only — it does not affect being recognised
+  /// by a person who is adding you to their group.
+  discoverableByPhone Boolean @default(true) @map("discoverable_by_phone")
+  /// The same, for an exact email address.
+  discoverableByEmail Boolean @default(true) @map("discoverable_by_email")
+  /// Who may read this account's email and phone off its profile:
+  /// `nobody`, or `groups` (people it shares a group with). A separate axis
+  /// from discoverability — one is search, this is display.
+  contactVisibility   String  @default("groups") @map("contact_visibility")
   /// Per-owner monotonic counter behind the personal sync scope (TDR A34), the
   /// captures equivalent of `groups.updated_seq`. Bumped under row lock by
   /// `waves_next_capture_seq`.
@@ -1704,6 +1714,20 @@ model AppConfig {
   updatedAt   DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
 
   @@map("app_config")
+  @@schema("public")
+}
+
+/// Per-caller daily count of `waves_find_person` calls, misses included — the
+/// misses are what a phone-number sweep is made of. Rate limiting only; it is
+/// never shown to anybody and holds no record of what was searched for. No FK
+/// on purpose: the row is a counter, and losing it with the account is fine.
+model PersonLookup {
+  profileId String   @map("profile_id") @db.Uuid
+  day       DateTime @default(dbgenerated("(now() AT TIME ZONE 'utc')::date")) @db.Date
+  lookups   Int      @default(0)
+
+  @@id([profileId, day])
+  @@map("person_lookups")
   @@schema("public")
 }
 

--- a/packages/db/test/person-profile.test.ts
+++ b/packages/db/test/person-profile.test.ts
@@ -40,6 +40,9 @@ interface PersonRow {
   shared_groups: number;
   email: string | null;
   phone: string | null;
+  payment_rail: string | null;
+  payment_handle: string | null;
+  country_code: string | null;
   contact_withheld: boolean;
 }
 
@@ -115,8 +118,18 @@ describe('waves_person_profile', () => {
     const group = await seedGroup(client, { memberCount: 2 });
     const [me, them] = group.profileIds;
 
+    await client.query(
+      `UPDATE profiles SET payment_rail = 'upi', payment_handle = 'priya@upi', country_code = 'IN'
+        WHERE id = $1`,
+      [them],
+    );
+
     // Default first: allowed, so nothing is being withheld.
-    expect((await profileOf(me!, them!))?.contact_withheld).toBe(false);
+    const visible = await profileOf(me!, them!);
+    expect(visible?.contact_withheld).toBe(false);
+    expect(visible?.payment_rail).toBe('upi');
+    expect(visible?.payment_handle).toBe('priya@upi');
+    expect(visible?.country_code).toBe('IN');
 
     await client.query(`UPDATE profiles SET contact_visibility = 'nobody' WHERE id = $1`, [them]);
 
@@ -124,18 +137,29 @@ describe('waves_person_profile', () => {
     expect(row?.contact_withheld).toBe(true);
     expect(row?.email).toBeNull();
     expect(row?.phone).toBeNull();
+    expect(row?.payment_rail).toBeNull();
+    expect(row?.payment_handle).toBeNull();
+    expect(row?.country_code).toBeNull();
   });
 
   it('always shows you to yourself, whatever your own switch says', async () => {
     const group = await seedGroup(client, { memberCount: 1 });
     const me = group.profileIds[0]!;
-    await client.query(`UPDATE profiles SET contact_visibility = 'nobody' WHERE id = $1`, [me]);
+    await client.query(
+      `UPDATE profiles
+          SET contact_visibility = 'nobody', payment_rail = 'bank', payment_handle = 'acct-123', country_code = 'IN'
+        WHERE id = $1`,
+      [me],
+    );
 
     const row = await profileOf(me, me);
 
     expect(row?.is_you).toBe(true);
     // Your own setting is about other people, so nothing is withheld from you.
     expect(row?.contact_withheld).toBe(false);
+    expect(row?.payment_rail).toBe('bank');
+    expect(row?.payment_handle).toBe('acct-123');
+    expect(row?.country_code).toBe('IN');
   });
 
   it('resolves a ghost by its membership id and says it is one', async () => {

--- a/packages/db/test/person-profile.test.ts
+++ b/packages/db/test/person-profile.test.ts
@@ -1,0 +1,227 @@
+/**
+ * The person screen's server half: who you are allowed to look at, and what of
+ * them you are allowed to see.
+ *
+ * These run against a bare Postgres with no `auth` schema, which is exactly the
+ * shape the self-host stack has too. That means the contact *values* cannot be
+ * asserted here — there is no `auth.users` to hold an email or a phone — but
+ * everything that decides whether they would be sent can be, and that is the
+ * part with teeth: the shared-group gate, the owner's own switch, and the
+ * refusal to tell a miss apart from a refusal.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { connect, seedGroup } from './helpers.js';
+
+let client: Client;
+
+async function asUser<T>(profileId: string, run: () => Promise<T>): Promise<T> {
+  await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+    JSON.stringify({ sub: profileId, role: 'authenticated' }),
+  ]);
+  await client.query(`SET ROLE authenticated`);
+  try {
+    return await run();
+  } finally {
+    await client.query(`RESET ROLE`);
+    await client.query(`SELECT set_config('request.jwt.claims', '', false)`);
+  }
+}
+
+interface PersonRow {
+  person_key: string;
+  display_name: string;
+  is_ghost: boolean;
+  is_you: boolean;
+  shared_groups: number;
+  email: string | null;
+  phone: string | null;
+  contact_withheld: boolean;
+}
+
+async function profileOf(viewer: string, key: string): Promise<PersonRow | undefined> {
+  return asUser(viewer, async () => {
+    const result = await client.query<PersonRow>(`SELECT * FROM waves_person_profile($1)`, [key]);
+    return result.rows[0];
+  });
+}
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client.end();
+});
+
+describe('waves_person_profile', () => {
+  it('names somebody you share a group with, and counts the groups', async () => {
+    const group = await seedGroup(client, { memberCount: 2 });
+    const [me, them] = group.profileIds;
+
+    const row = await profileOf(me!, them!);
+
+    expect(row?.display_name).toBe('Member 2');
+    expect(row?.is_ghost).toBe(false);
+    expect(row?.is_you).toBe(false);
+    expect(Number(row?.shared_groups)).toBe(1);
+  });
+
+  it('adds up the groups two people are both in', async () => {
+    const first = await seedGroup(client, { memberCount: 2, name: 'Goa' });
+    const [me, them] = first.profileIds;
+
+    // A second group with the same two people in it.
+    const groupId = randomUUID();
+    await client.query(
+      `INSERT INTO groups (id, name, type, default_currency, created_by)
+       VALUES ($1, 'Flat', 'home', 'INR', $2)`,
+      [groupId, me],
+    );
+    for (const profileId of [me, them]) {
+      await client.query(
+        `INSERT INTO group_members (id, group_id, profile_id, role, joined_via)
+         VALUES ($1, $2, $3, 'member', 'invite')`,
+        [randomUUID(), groupId, profileId],
+      );
+    }
+
+    const row = await profileOf(me!, them!);
+    expect(Number(row?.shared_groups)).toBe(2);
+  });
+
+  it('returns nothing at all for somebody you share no group with', async () => {
+    const mine = await seedGroup(client, { memberCount: 1 });
+    const theirs = await seedGroup(client, { memberCount: 1 });
+
+    const row = await profileOf(mine.profileIds[0]!, theirs.profileIds[0]!);
+
+    // Not an empty person, not an error — no row. A stranger's existence is
+    // itself the thing being withheld.
+    expect(row).toBeUndefined();
+  });
+
+  it('gives the same empty answer for a uuid belonging to nobody', async () => {
+    const group = await seedGroup(client, { memberCount: 1 });
+    const row = await profileOf(group.profileIds[0]!, randomUUID());
+    expect(row).toBeUndefined();
+  });
+
+  it('marks contact withheld when the owner has chosen nobody', async () => {
+    const group = await seedGroup(client, { memberCount: 2 });
+    const [me, them] = group.profileIds;
+
+    // Default first: allowed, so nothing is being withheld.
+    expect((await profileOf(me!, them!))?.contact_withheld).toBe(false);
+
+    await client.query(`UPDATE profiles SET contact_visibility = 'nobody' WHERE id = $1`, [them]);
+
+    const row = await profileOf(me!, them!);
+    expect(row?.contact_withheld).toBe(true);
+    expect(row?.email).toBeNull();
+    expect(row?.phone).toBeNull();
+  });
+
+  it('always shows you to yourself, whatever your own switch says', async () => {
+    const group = await seedGroup(client, { memberCount: 1 });
+    const me = group.profileIds[0]!;
+    await client.query(`UPDATE profiles SET contact_visibility = 'nobody' WHERE id = $1`, [me]);
+
+    const row = await profileOf(me, me);
+
+    expect(row?.is_you).toBe(true);
+    // Your own setting is about other people, so nothing is withheld from you.
+    expect(row?.contact_withheld).toBe(false);
+  });
+
+  it('resolves a ghost by its membership id and says it is one', async () => {
+    const group = await seedGroup(client, { memberCount: 1, ghostCount: 1 });
+    const me = group.profileIds[0]!;
+    const ghost = await client.query<{ id: string; ghost_name: string }>(
+      `SELECT id, ghost_name FROM group_members
+        WHERE group_id = $1 AND profile_id IS NULL LIMIT 1`,
+      [group.groupId],
+    );
+    const ghostRow = ghost.rows[0]!;
+
+    const row = await profileOf(me, ghostRow.id);
+
+    expect(row?.is_ghost).toBe(true);
+    expect(row?.display_name).toBe(ghostRow.ghost_name);
+    // A ghost has no account, so there is no decision to report either way.
+    expect(row?.contact_withheld).toBe(false);
+  });
+});
+
+describe('waves_find_person', () => {
+  it('finds nobody when there is no auth schema to search', async () => {
+    const group = await seedGroup(client, { memberCount: 1 });
+    const rows = await asUser(group.profileIds[0]!, async () => {
+      const result = await client.query(`SELECT * FROM waves_find_person('email', $1)`, [
+        'someone@example.com',
+      ]);
+      return result.rows;
+    });
+    expect(rows).toHaveLength(0);
+  });
+
+  it('refuses a channel it does not know', async () => {
+    const group = await seedGroup(client, { memberCount: 1 });
+    await expect(
+      asUser(group.profileIds[0]!, () =>
+        client.query(`SELECT * FROM waves_find_person('name', 'Priya')`),
+      ),
+    ).rejects.toThrow(/UNKNOWN_CHANNEL/);
+  });
+
+  it('does not spend a lookup on an input that cannot match', async () => {
+    const group = await seedGroup(client, { memberCount: 1 });
+    const me = group.profileIds[0]!;
+
+    await asUser(me, () => client.query(`SELECT * FROM waves_find_person('phone', '12')`));
+    await asUser(me, () => client.query(`SELECT * FROM waves_find_person('email', 'x')`));
+
+    const counted = await client.query<{ lookups: string }>(
+      `SELECT lookups FROM person_lookups WHERE profile_id = $1`,
+      [me],
+    );
+    expect(counted.rows).toHaveLength(0);
+  });
+
+  it('counts misses and stops at the daily ceiling', async () => {
+    const group = await seedGroup(client, { memberCount: 1 });
+    const me = group.profileIds[0]!;
+
+    await client.query(
+      `INSERT INTO app_config (key, value, description) VALUES ('person_lookup_daily_cap', 2, 'test')
+       ON CONFLICT (key) DO UPDATE SET value = 2`,
+    );
+
+    // Two misses are allowed, and both are counted — a sweep is made of misses.
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      await asUser(me, () =>
+        client.query(`SELECT * FROM waves_find_person('email', $1)`, [
+          `nobody${attempt}@example.com`,
+        ]),
+      );
+    }
+
+    const counted = await client.query<{ lookups: number }>(
+      `SELECT lookups FROM person_lookups WHERE profile_id = $1`,
+      [me],
+    );
+    expect(Number(counted.rows[0]?.lookups)).toBe(2);
+
+    await expect(
+      asUser(me, () =>
+        client.query(`SELECT * FROM waves_find_person('email', 'one-too-many@example.com')`),
+      ),
+    ).rejects.toThrow(/LOOKUP_RATE_LIMIT/);
+
+    await client.query(`UPDATE app_config SET value = 40 WHERE key = 'person_lookup_daily_cap'`);
+  });
+});


### PR DESCRIPTION
## The gap

Tapping a person in Friends opened a list of balances and nothing else. It never said **who** they were — two people called Priya in two groups were two identical rows leading to two identical screens — and because `waves_person_group_balances` ends in `HAVING sum(n.net) <> 0`, the moment somebody settled up they disappeared from their own screen. The balance was standing in for the person.

## What this adds

**A profile.** `waves_person_profile` is its own RPC, so identity survives being square: face, name, groups in common, and — when they allow it — phone, email and payment handle. The balance becomes one section inside the screen rather than the whole page. Ghosts and merged ghosts resolve exactly as they do on the list.

**The switch that governs it.** Three columns on `profiles`, along two deliberately separate axes:

| | Question | Shape |
|---|---|---|
| `discoverable_by_phone` / `discoverable_by_email` | Can somebody who already has my number or address find me? | Per channel — a work address and a mobile number are not the same level of acquaintance |
| `contact_visibility` | Can people already in my groups read those off my profile? | One choice (`nobody` / `groups`) — a group-mate allowed one channel gains little from being denied the other |

**Being found.** `waves_find_person`: exact match on one email or one phone, no prefix, no name search, nothing to walk. A miss and a refusal are indistinguishable by design — if they looked different, the setting would become the oracle it exists to close. Every call counts against a per-account daily ceiling, misses included (misses are what a sweep is made of), read from an `app_config` knob.

New screens: `settings/discovery.tsx` (reachable from Privacy, directly above Blocked — same question at different ranges) and `friends/find.tsx` (from the Friends `+` menu, after the address book because it is the narrower tool).

## Defaults, and why they are on

Both discovery flags default `true` and visibility defaults `groups`, because that is **today's behaviour**, not a new one:

- `waves_add_ghost_member` has tapped an existing account by email or phone since M1, so discovery has effectively been on and unconditional all along.
- A group-mate can already see the address an invite was addressed to (`group_members.invite_email` / `invite_phone`).

Defaulting them off would have broken every add-by-contact flow while dressing the change up as a fix for a leak people had already lived with. These make it a choice; they do not make a different choice on anyone's behalf. Happy to flip them if you'd rather ship privacy-first and eat the migration.

## Three things it deliberately does *not* do

1. **`waves_add_ghost_member` stays ungated.** It returns the same member id whether or not an account matched, so it cannot answer "does this number have Waves" — which is the whole question these switches exist to let somebody refuse. Refusing the link would not hide anybody; it would split a real person's balance across a ghost and their account. Written down in the migration so nobody "fixes" it later.
2. **No vague silence.** The screen tells "no contact on file" apart from "they have asked us not to pass it on". One sentence covering both makes people assume the worse one.
3. **A block still masks everything.** A person blocked on this device stays the anonymous ghost here too — no avatar, no number, no address, whatever the server was willing to send.

## Tests

11 new DB tests: the shared-group gate, strangers-return-nothing, the same empty answer for a uuid belonging to nobody, the withheld flag, self-view (your own switch is about other people), ghost resolution, unknown channels, inputs too short to spend a lookup, and the daily ceiling.

One of them **found a real bug mid-build**: the `profile_id` OUT parameter made every reference to `person_lookups.profile_id` ambiguous inside plpgsql, so the RPC threw on its own rate-limit write. Fixed by pulling the counter into `waves_spend_person_lookup` rather than papering over it with `#variable_conflict`.

## Gates

- `tsc --noEmit` (mobile) — clean
- `expo lint` — clean (3 pre-existing `import/first` warnings in `phone.tsx`, untouched)
- `prisma validate` — valid
- DB suite: 11/11 new, plus `definer-boundary` and `anon-surface` re-run green (35/35) against the migration applied to the local test Postgres

## Deploy

Migration is **pending on prod**. JS-only otherwise, so it ships by OTA after the migration lands. Strings complete in en / ta / hi / ar.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added person search by exact email address or phone number.
  - Added person profiles with shared-group details, contact actions, payment information, and settlement status.
  - Added privacy controls for discoverability and contact visibility.
  - Added rate-limit and no-match feedback for searches.
  - Added support for English, Tamil, Hindi, and Arabic translations.

- **Bug Fixes**
  - Improved profile handling for settled balances, blocked people, ghosts, and withheld contact details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->