### PR TITLE
fix(db): take the admin console API back off the signed-in surface

### DIFF
--- a/packages/db/prisma/migrations/20260908120000_revoke_admin_voice_attempts_grant/migration.sql
+++ b/packages/db/prisma/migrations/20260908120000_revoke_admin_voice_attempts_grant/migration.sql
@@ -1,0 +1,42 @@
+-- The one `waves_admin_*` function a signed-in user can still call.
+--
+-- `20260904200000_authenticated_surface_on_hosted` closed a 66-function hole by
+-- revoking EXECUTE from `authenticated` across the schema and then re-granting,
+-- one line per function, from a local build of the same migration chain. That
+-- replay was faithful — which is the problem. The baseline had granted this
+-- function to `anon` and `authenticated` (`20260904000000` :11298-11299), so the
+-- replay reproduced the grant rather than questioning it, and
+-- `waves_admin_voice_attempts` came back as the only member of the admin console
+-- API reachable by any signed-in user. A guest counts as `authenticated`.
+--
+-- **This is not currently a data leak, and the migration should not be described
+-- as fixing one.** Three things independently stop it, and it was checked by
+-- calling the function as `authenticated` rather than by reading the grants:
+--
+--   1. The function is `LANGUAGE sql STABLE` with no `SECURITY DEFINER`, so it
+--      runs with the caller's own rights, not the owner's.
+--   2. `authenticated` holds INSERT and nothing else on `voice_attempts`
+--      (`20260904160000` :104).
+--   3. RLS is on with exactly one policy, `voice_attempts_insert_own`, and no
+--      SELECT policy at all.
+--
+-- The call therefore fails with `permission denied for table voice_attempts`.
+--
+-- It is revoked anyway, because the grant is load-bearing on all three of those
+-- holding forever. Voice attempts are verbatim transcripts of what somebody said
+-- out loud — names, amounts, places — beside the `profile_id` that identifies
+-- who said it. The day anyone adds a SELECT policy or a SELECT grant to that
+-- table for a perfectly good reason, this function becomes a full-table dump of
+-- every user's transcripts with nothing left standing in the way, and the person
+-- adding the policy has no reason to look for a stray grant on an admin RPC.
+--
+-- Nothing breaks: the admin console reaches this through the service-role key
+-- (`apps/admin/src/lib/data.ts`), which is unaffected.
+--
+-- `anon` is already covered — `20260904160000` revoked ALL functions from it —
+-- but it is named here too so the intent survives the next replay, which is
+-- exactly the failure mode that produced this line in the first place.
+
+REVOKE ALL ON FUNCTION public.waves_admin_voice_attempts(p_limit integer) FROM anon;
+REVOKE ALL ON FUNCTION public.waves_admin_voice_attempts(p_limit integer) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.waves_admin_voice_attempts(p_limit integer) TO service_role;

--- a/packages/db/test/admin-surface.test.ts
+++ b/packages/db/test/admin-surface.test.ts
@@ -1,0 +1,98 @@
+/**
+ * The admin console API is service-role only, and stays that way.
+ *
+ * Under ADR-013 the grant *is* the boundary: the `waves_admin_*` functions carry
+ * no internal caller check, because the only thing that may call them is a
+ * process holding the service-role key (`apps/admin/src/lib/data.ts`). That
+ * design is fine right up until one of them acquires a grant it should not have,
+ * at which point there is nothing else in the way.
+ *
+ * This is asserted as a whole set rather than function by function, because the
+ * failure it guards against is *addition* — and the repo has already produced
+ * that failure twice by two different routes:
+ *
+ *   * Supabase ships default privileges on `public` that grant EXECUTE to `anon`
+ *     and `authenticated` as each function is created, so a new admin RPC is
+ *     reachable the moment it exists unless its migration says otherwise.
+ *   * `20260904200000_authenticated_surface_on_hosted` re-granted the whole
+ *     schema by replaying a local build — faithfully reproducing a stray
+ *     `GRANT ... TO authenticated` on `waves_admin_voice_attempts` that had been
+ *     in the baseline since the squash. A replay copies mistakes as carefully as
+ *     it copies intent.
+ *
+ * A per-function test would have caught neither. This one fails on the next
+ * admin RPC that arrives with the default grant attached, which is the point.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { connect } from './helpers.js';
+
+let client: Client;
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client?.end();
+});
+
+describe('the admin console surface', () => {
+  it('has admin RPCs to check at all', async () => {
+    // Guards the two tests below against passing vacuously if the naming
+    // convention ever changes and the pattern stops matching anything.
+    const { rows } = await client.query<{ count: string }>(`
+      SELECT count(*)::text AS count
+        FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+       WHERE n.nspname = 'public'
+         AND p.proname LIKE 'waves\\_admin\\_%'
+    `);
+    expect(Number(rows[0]?.count)).toBeGreaterThan(10);
+  });
+
+  it('grants no admin RPC to anon or authenticated', async () => {
+    const { rows } = await client.query<{ proname: string; grantee: string }>(`
+      SELECT p.proname, r.rolname AS grantee
+        FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        CROSS JOIN (VALUES ('anon'), ('authenticated')) AS roles(rolname)
+        JOIN pg_roles r ON r.rolname = roles.rolname
+       WHERE n.nspname = 'public'
+         AND p.proname LIKE 'waves\\_admin\\_%'
+         AND has_function_privilege(r.rolname, p.oid, 'EXECUTE')
+       ORDER BY p.proname, r.rolname
+    `);
+
+    // Named in the failure so the diff says which function and which role,
+    // rather than only that a count moved.
+    expect(rows.map((row) => `${row.proname} -> ${row.grantee}`)).toEqual([]);
+  });
+
+  it('keeps voice transcripts unreadable by a signed-in caller', async () => {
+    // The belt to the grant's braces, and the reason the grant mattered even
+    // while it was harmless: `waves_admin_voice_attempts` is not SECURITY
+    // DEFINER, so it can only ever read what its caller could read directly.
+    // If a SELECT policy or grant is ever added to `voice_attempts`, this fails
+    // and points at the transcripts before anyone can reach them.
+    const { rows } = await client.query<{
+      is_definer: boolean;
+      auth_select: boolean;
+      select_policies: string;
+    }>(`
+      SELECT
+        (SELECT p.prosecdef FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+          WHERE n.nspname = 'public' AND p.proname = 'waves_admin_voice_attempts') AS is_definer,
+        has_table_privilege('authenticated', 'public.voice_attempts', 'SELECT') AS auth_select,
+        (SELECT count(*)::text FROM pg_policies
+          WHERE schemaname = 'public' AND tablename = 'voice_attempts'
+            AND cmd IN ('SELECT', 'ALL')) AS select_policies
+    `);
+
+    expect(rows[0]?.is_definer).toBe(false);
+    expect(rows[0]?.auth_select).toBe(false);
+    expect(rows[0]?.select_policies).toBe('0');
+  });
+});


### PR DESCRIPTION
## Not a leak — and revoked anyway

An audit flagged `waves_admin_voice_attempts` as callable by any signed-in user and reported it as a live exposure of every user's voice transcripts. **It is not.** I checked by calling the function as `authenticated` rather than by reading the grant table:

```
permission denied for table voice_attempts
```

Three things stop it independently:

| | |
|---|---|
| The function is **not** `SECURITY DEFINER` | It runs with the caller's rights, so it can only read what the caller could read directly |
| `authenticated` has **INSERT only** on `voice_attempts` | `20260904160000` :104 |
| RLS is on with **no SELECT policy** | Only `voice_attempts_insert_own` exists |

So nothing was reachable, and this PR should not be read as fixing a vulnerability.

## Why revoke it then

The grant is load-bearing on all three of those holding forever, and the thing behind them is not small: `voice_attempts` holds verbatim transcripts of what somebody said out loud — names, amounts, places — next to the `profile_id` of who said it.

Whoever eventually adds a SELECT policy to that table for a perfectly good reason has no reason to go hunting for a stray EXECUTE grant on an admin RPC. On that day this becomes a full-table dump of every user's transcripts with nothing left in the way.

## How it got there

`20260904200000_authenticated_surface_on_hosted` closed a 66-function hole by revoking EXECUTE across the schema and re-granting one line per function, replayed from a local build of the same migration chain. The baseline had granted this function to `anon` and `authenticated` since the squash — so the replay reproduced it faithfully. **A replay copies mistakes as carefully as it copies intent.** It is the only `waves_admin_*` function in that re-grant list.

`anon` was already covered (`20260904160000` revoked all functions from it), but it is named again here so the intent survives the next replay — which is the exact failure mode that produced the line in the first place.

Nothing breaks: the admin console reaches these through the service-role key (`apps/admin/src/lib/data.ts`).

## The test is the actual deliverable

`packages/db/test/admin-surface.test.ts` asserts the **property**, not the instance: no `waves_admin_*` function is executable by `anon` or `authenticated`. A per-function test would have caught neither of the two ways this repo has already produced this bug — Supabase's default privileges granting EXECUTE on every newly created function, and the replay above.

Three cases:

1. **Vacuity guard** — the `waves_admin_%` pattern must still match more than ten functions, so a naming-convention change fails loudly instead of making the suite pass on an empty set.
2. **The property** — offending rows are reported as `function -> role`, so a failure names what and who.
3. **Belt to the braces** — if a SELECT policy or grant ever reaches `voice_attempts`, that fails and points at the transcripts before anyone can read them.

**Verified to fail before the revoke.** With the grant restored:

```
AssertionError: expected [ Array(1) ] to deeply equal []
+   "waves_admin_voice_attempts -> authenticated"
```

A guard that has never failed proves nothing, so I made it fail on purpose, then restored the revoke.

## Gates

38/38 across `admin-surface`, `anon-surface` and `definer-boundary`, run against the migration applied to the local test Postgres.

## Deploy

Migration pending on prod. No app code changes, so nothing to OTA.
