### PR TITLE
Rebuild the admin console on one design system, and close three config gaps

### DIFF
--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -9,23 +9,59 @@ grouped `en-IN` because that is the market the business is in. Amounts still go
 through `@waves/core`'s formatter rather than a local one, so the console can
 never disagree with the ledger about what a number means.
 
-Minimum responsive. It is read at a desk; the phone case is checking a figure
-while away from one, so nothing is unreadable or unreachable and nothing more.
+**Desktop only, and stated rather than implied.** `body { min-width: 1024px }`
+and no breakpoints under it: a narrow screen gets the real layout and pans,
+which is honest, instead of a reflowed one that pretends. The login page opts
+back out of that floor, because signing in from a phone to check the console is
+up is a real thing to do. Desktop-only is about viewport width and nothing
+else — keyboard reachability, visible focus, semantic tables and contrast all
+still apply, and `src/app/globals.css` opens with why.
+
+## The design system
+
+The visual language is lifted from the [d-board](https://d-board-omega.vercel.app/)
+reference dashboard, with its tokens read out of the compiled stylesheet rather
+than eyeballed. The whole vocabulary lives in `src/app/globals.css` and the
+components that use it in `src/components/ui.tsx`; a screen should be
+assembling those, not inventing a `<section>` with a new class.
+
+| Token     | Value                                                 |
+| --------- | ----------------------------------------------------- |
+| Neutrals  | Tailwind `gray` — 50 page, white card, 100 hairline   |
+| Accent    | Tailwind `blue` — 500 fills, **600 for text**         |
+| Radius    | `rounded-lg` cards, `rounded-md` inputs               |
+| Rail      | 16rem, collapsing to 4rem, 4px accent bar on active   |
+| Bars      | 4rem — logo block, section head and topbar agree      |
+| Table row | `px-3 py-2`, uppercase `text-xs` head                 |
+| Charts    | blue / violet / emerald / amber / red at the 500 step |
+
+Three deliberate departures from the reference, all the same direction. It
+ships `*, :focus { outline: none !important }` — replaced here with a visible
+focus ring, written as the first rule in the file so nothing can quietly beat
+it. It uses `blue-500` as link text at 3.7:1 — anything blue that has to be
+_read_ uses `blue-600` here. And it hides scrollbars, which a console full of
+wide tables cannot afford.
 
 ## What it can see
 
-Six functions in `20260808190000_admin_analytics`, and nothing else. Not one of
-them returns a description, a note, a display name, a payment handle or a
-profile id.
+The `waves_admin_*` functions, plus a short list of tables that hold
+configuration this console owns. Not one of the functions returns a
+description, a note, a display name or a payment handle.
 
-| Function               | Answers                                              |
-| ---------------------- | ---------------------------------------------------- |
-| `waves_admin_overview` | People, groups, expenses, settlements, active counts |
-| `waves_admin_daily`    | A row per day for 30 days, including empty ones      |
-| `waves_admin_geo`      | Counts per country                                   |
-| `waves_admin_money`    | Volume per currency, never converted                 |
-| `waves_admin_ai_cost`  | The receipt pipeline's bill (ADR-008/011)            |
-| `waves_admin_logins`   | Sign-ins per day, while Supabase still has them      |
+| Function                                              | Answers                                              |
+| ----------------------------------------------------- | ---------------------------------------------------- |
+| `waves_admin_overview`                                | People, groups, expenses, settlements, active counts |
+| `waves_admin_daily`                                   | A row per day for 30 days, including empty ones      |
+| `waves_admin_geo`                                     | Counts per country                                   |
+| `waves_admin_money`                                   | Volume per currency, never converted                 |
+| `waves_admin_ai_cost`                                 | The receipt pipeline's bill (ADR-008/011)            |
+| `waves_admin_logins`                                  | Sign-ins per day, while Supabase still has them      |
+| `waves_admin_users`                                   | The signup directory, one page at a time             |
+| `waves_admin_flag_results`                            | People and behaviour per experiment arm              |
+| `waves_admin_campaign_*`                              | Funnel, revenue and email status per campaign        |
+| `waves_admin_feedback`                                | What people wrote in, with no author                 |
+| `waves_admin_voice_attempts`                          | Dictations the parser could not use                  |
+| `waves_admin_promo_codes` / `waves_admin_grant_promo` | Codes and comps                                      |
 
 They are revoked from `PUBLIC`, `anon` and `authenticated`, and granted to
 `service_role` alone. That REVOKE is load-bearing: Postgres grants EXECUTE to
@@ -33,6 +69,32 @@ PUBLIC on every new function and Supabase's roles inherit PUBLIC, so without it
 any anonymous guest could read the whole business through the anon key that
 ships inside the mobile binary. `packages/db/test/adminAnalytics.test.ts` fails
 if that ever regresses.
+
+> **`waves_admin_voice_attempts` is the exception, and it is a live bug.** The
+> baseline grants it to `anon` and `authenticated`, and
+> `20260904200000_authenticated_surface_on_hosted` re-grants it to
+> `authenticated` after its blanket revoke. It is `SECURITY DEFINER` over a
+> table no client can select, and it returns verbatim speech transcripts and
+> profile ids — so any signed-in account can read them today. That is a
+> migration to write, not a console change, and it is not fixed here.
+
+### The tables it reads directly
+
+Configuration the console owns, rather than an aggregate over somebody's data:
+`app_config`, `service_config`, `app_releases`, `country_settings`,
+`feature_flags`, `rate_limit_settings`, `rate_limit_rules`, `campaigns`,
+`promo_codes`, `packs`, `pack_requests` and `agent_writes`. A row that only
+ever held a setting the operator typed has nothing to hide from the operator.
+Anything that _aggregates over people_ still goes through a `waves_admin_*`
+function, so what this console can see about users stays one reviewable list in
+one migration.
+
+`app_config` and `service_config` are read **generically** — the whole table,
+no key list — and rendered a row each, with the row's own `description` column
+as the help text. A knob a migration adds appears here with no change to the
+console; `person_lookup_daily_cap` will. What the console cannot do is _create_
+one: both saves are an `UPDATE`, because a key no code reads is a number with
+no effect.
 
 Two things it will not pretend to know:
 
@@ -42,6 +104,29 @@ Two things it will not pretend to know:
   empty chart means the retention window passed, not that nobody signed in.
   `last_sign_in_at` is deliberately unused: it is one snapshot per user, and
   grouping it by day draws a convincing chart of nothing.
+
+## What it still has no screen for
+
+Every one of these needs a `waves_admin_*` function in a migration first,
+because each is an aggregate over real people's data and the rule above says
+those do not get a direct table read. Listed so the next person does not have
+to rediscover them:
+
+- **Storage accounting** — who is over `free_storage_cap_bytes`, and the
+  `storage_orphans` sweep backlog. The cap is editable on Limits with no way to
+  see its effect.
+- **Billing** — `subscriptions` and `group_passes`. Revenue exists here only as
+  a per-campaign cohort figure; there is no list and no way to fix a status.
+- **Delivery health** — `notifications` retries and exhaustion, `email_events`,
+  and `email_suppressions` with no unsuppress path. A bounce storm is invisible.
+- **Moderation** — `expense_comments.flagged_at` and `expense_disputes` are
+  recorded and shown to nobody but the group's own admin.
+- **Groups** — no browse, no inspect, no support surface at all.
+- **Rate-limit hits** — the rules are tunable, the resulting 429s are not
+  observable.
+- **Job health** — six scheduled functions and **no run-history table anywhere**,
+  so "when did auto-archive last run" is a question the database cannot answer.
+  A screen for it would have to invent the data; it does not exist instead.
 
 ## Running it locally
 

--- a/apps/admin/src/app/agent-writes/page.tsx
+++ b/apps/admin/src/app/agent-writes/page.tsx
@@ -1,0 +1,231 @@
+import { format, money, type CurrencyCode } from '@waves/core';
+
+import { Badge, Card, Empty, Lede, PageHeader, TableScroll, Tile } from '@/components/ui';
+import { agentWrites, appConfig, type AgentWriteRow } from '@/lib/data';
+
+export const dynamic = 'force-dynamic';
+
+const LIMIT = 200;
+
+function amount(minor: string | null, currency: string | null): string {
+  if (minor === null || currency === null) return '—';
+  try {
+    return format(money(BigInt(minor), currency as CurrencyCode), { compactFraction: true });
+  } catch {
+    return `${minor} ${currency}`;
+  }
+}
+
+/** `expense.add` → an action verb and a noun, kept in the app's own words. */
+function tone(action: string): 'ok' | 'warn' | 'danger' | 'neutral' {
+  if (action.endsWith('.delete')) return 'danger';
+  if (action.endsWith('.edit')) return 'warn';
+  if (action.endsWith('.add')) return 'ok';
+  return 'neutral';
+}
+
+/**
+ * What automated clients have been doing.
+ *
+ * The two caps that bound agent writes have been turnable on the Limits page
+ * since the day they landed; the writes they bound had no reader anywhere. An
+ * audit trail nobody can read is a log file, not an audit — so this is the
+ * screen that closes it, and it deliberately shows the caps beside the totals
+ * they apply to, because a cap read on a different page from its effect is a
+ * number nobody can judge.
+ *
+ * Read-only, and no `revoke` button. The trust decision lives with the person
+ * whose ledger it is (`waves_my_agent_writes` is theirs), not with whoever is
+ * looking at this page — this is here so an operator can see a client
+ * misbehaving across many accounts at once, which is the one thing no
+ * individual person can see for themselves.
+ */
+export default async function AgentWrites() {
+  const [rows, knobs] = await Promise.all([agentWrites(LIMIT), appConfig()]);
+
+  const capFor = (key: string) => knobs.find((knob) => knob.key === key)?.value ?? null;
+  const perWrite = capFor('agent_expense_cap_minor');
+  const perDay = capFor('agent_daily_cap_minor');
+
+  const clients = summarise(rows);
+  const withAmount = rows.filter((row) => row.amount_minor !== null).length;
+
+  return (
+    <main className="page">
+      <PageHeader eyebrow="Signals" title="Agent writes" />
+
+      <Lede>
+        Every write an outside client made on somebody&rsquo;s ledger, newest first — the audit half
+        of letting an agent post an expense. No account is named here: an individual&rsquo;s own
+        trail is theirs to read in the app, and the question this page exists to answer is the one
+        nobody can answer for themselves, which is whether a single client is misbehaving across
+        many accounts at once. The last {LIMIT} writes.
+      </Lede>
+
+      <div className="autofit">
+        <Tile
+          label="Writes shown"
+          value={rows.length.toLocaleString('en-IN')}
+          sub={`newest ${LIMIT}`}
+        />
+        <Tile label="Clients seen" value={clients.length.toLocaleString('en-IN')} />
+        <Tile
+          label="Carrying an amount"
+          value={withAmount.toLocaleString('en-IN')}
+          sub={`${rows.length - withAmount} did not move money`}
+        />
+        <Tile
+          label="Cap per write"
+          value={perWrite === null ? '—' : perWrite.toLocaleString('en-IN')}
+          sub="agent_expense_cap_minor, minor units"
+        />
+        <Tile
+          label="Cap per day"
+          value={perDay === null ? '—' : perDay.toLocaleString('en-IN')}
+          sub="agent_daily_cap_minor, minor units"
+        />
+      </div>
+
+      <h2 className="section">By client</h2>
+      <Card
+        bare
+        note="Counted over the writes on this page only, so a client that was busy last month and quiet since will not appear. This is a recent-behaviour view, not a lifetime total."
+      >
+        {clients.length === 0 ? (
+          <Empty
+            title="No agent has written anything"
+            migration="20260907140000_agent_writes_and_caps"
+          >
+            Either no client has been authorised yet, or none has posted.
+          </Empty>
+        ) : (
+          <TableScroll>
+            <table>
+              <caption className="sr-only">Recent writes grouped by client</caption>
+              <thead>
+                <tr>
+                  <th scope="col">Client</th>
+                  <th scope="col" className="n">
+                    Writes
+                  </th>
+                  <th scope="col">Actions</th>
+                  <th scope="col">Most recent</th>
+                </tr>
+              </thead>
+              <tbody>
+                {clients.map((client) => (
+                  <tr key={client.id}>
+                    <th scope="row">
+                      <code>{client.id}</code>
+                    </th>
+                    <td className="n">{client.writes.toLocaleString('en-IN')}</td>
+                    <td>
+                      <span className="row" style={{ gap: '0.25rem' }}>
+                        {client.actions.map((action) => (
+                          <Badge key={action} tone={tone(action)}>
+                            {action}
+                          </Badge>
+                        ))}
+                      </span>
+                    </td>
+                    <td className="muted">
+                      {new Date(client.latest).toLocaleString('en-IN', {
+                        dateStyle: 'medium',
+                        timeStyle: 'short',
+                      })}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </TableScroll>
+        )}
+      </Card>
+
+      <h2 className="section">Every write</h2>
+      <Card bare>
+        {rows.length === 0 ? (
+          <Empty title="Nothing recorded" migration="20260907140000_agent_writes_and_caps" />
+        ) : (
+          <TableScroll>
+            <table>
+              <caption className="sr-only">Agent writes, newest first</caption>
+              <thead>
+                <tr>
+                  <th scope="col">When</th>
+                  <th scope="col">Client</th>
+                  <th scope="col">Action</th>
+                  <th scope="col" className="n">
+                    Amount
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row.id}>
+                    <td className="muted">
+                      {new Date(row.created_at).toLocaleString('en-IN', {
+                        dateStyle: 'medium',
+                        timeStyle: 'short',
+                      })}
+                    </td>
+                    <td>
+                      <code>{row.client_id}</code>
+                    </td>
+                    <td>
+                      <Badge tone={tone(row.action)}>{row.action}</Badge>
+                    </td>
+                    <td className="n">{amount(row.amount_minor, row.currency)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </TableScroll>
+        )}
+      </Card>
+    </main>
+  );
+}
+
+interface ClientSummary {
+  id: string;
+  writes: number;
+  actions: string[];
+  latest: string;
+}
+
+/**
+ * Fold the rows into one line per client.
+ *
+ * Done here rather than in SQL on purpose: this is a hundred-row page, the
+ * aggregate is a `Map`, and the alternative is a migration adding a
+ * `waves_admin_*` function to save a loop. Should this page ever want a
+ * lifetime total instead of "the last two hundred writes", that *is* the point
+ * at which it needs a function, because the answer stops fitting in a page.
+ */
+function summarise(rows: readonly AgentWriteRow[]): ClientSummary[] {
+  const byClient = new Map<string, { writes: number; actions: Set<string>; latest: string }>();
+
+  for (const row of rows) {
+    const entry = byClient.get(row.client_id) ?? {
+      writes: 0,
+      actions: new Set<string>(),
+      latest: row.created_at,
+    };
+    entry.writes += 1;
+    entry.actions.add(row.action);
+    // Rows arrive newest first, so the first one seen for a client is its most
+    // recent — but never assume the order of somebody else's result set.
+    if (row.created_at > entry.latest) entry.latest = row.created_at;
+    byClient.set(row.client_id, entry);
+  }
+
+  return [...byClient.entries()]
+    .map(([id, entry]) => ({
+      id,
+      writes: entry.writes,
+      actions: [...entry.actions].sort(),
+      latest: entry.latest,
+    }))
+    .sort((a, b) => b.writes - a.writes);
+}

--- a/apps/admin/src/app/campaigns/page.tsx
+++ b/apps/admin/src/app/campaigns/page.tsx
@@ -3,6 +3,10 @@ import { redirect } from 'next/navigation';
 
 import { format, money, type CurrencyCode } from '@waves/core';
 
+import { CsrfField } from '@/components/CsrfField';
+import { Icon } from '@/components/icons';
+import { Badge, Card, Empty, Field, Lede, Outcome, PageHeader, TableScroll } from '@/components/ui';
+import { guardMutation } from '@/lib/csrf';
 import {
   broadcastCampaign,
   campaignEmailStats,
@@ -15,8 +19,6 @@ import {
   type CampaignRevenueRow,
   type FunnelRow,
 } from '@/lib/data';
-import { guardMutation } from '@/lib/csrf';
-import { CsrfField } from '@/components/CsrfField';
 
 export const dynamic = 'force-dynamic';
 
@@ -137,56 +139,66 @@ export default async function Campaigns({
     redirect(`/campaigns?done=${encodeURIComponent(message)}`);
   }
 
+  const running = all.filter(
+    (c) => new Date(c.starts_at) <= new Date() && new Date(c.ends_at) > new Date(),
+  ).length;
+
   return (
-    <main>
-      <header className="top">
-        <h1>Campaigns</h1>{' '}
-      </header>
+    <main className="page">
+      <PageHeader
+        eyebrow="Growth"
+        title="Campaigns"
+        actions={
+          <span className="small muted">
+            {running} live of {all.length}
+          </span>
+        }
+      />
+      <Outcome error={error} done={done} />
 
-      {error ? <p className="error">{error}</p> : null}
-      {done ? <p className="faint">{done}</p> : null}
-
-      <p className="note" style={{ padding: 0 }}>
+      <Lede>
         Every campaign withholds itself from a slice of its own audience. That holdout is the only
         reason &ldquo;did this work&rdquo; has an answer: a comped subscription earns nothing by
         construction, so the impact is whether the people who were offered it went on to pay more
         than the people who were not.
-      </p>
+      </Lede>
 
       {all.length === 0 ? (
-        <section style={{ marginTop: 20 }}>
-          <p className="note">
-            None yet. If you expected some, the <code>20260808220000_campaigns</code> migration may
-            not be deployed to this project.
-          </p>
-        </section>
+        <Card bare>
+          <Empty title="No campaigns yet" migration="20260808220000_campaigns">
+            Nothing has been sent to anybody.
+          </Empty>
+        </Card>
       ) : null}
 
-      {all.map((campaign) => {
-        const result = results.get(campaign.id);
-        const funnel = result?.funnel ?? [];
-        const revenue = result?.revenue ?? [];
-        const emailStats: CampaignEmailStatRow[] = result?.email ?? [];
-        const emailCount = (status: string) =>
-          Number(emailStats.find((row) => row.status === status)?.count ?? 0);
-        const targeted = funnel.find((row) => row.cohort === 'targeted');
-        const currencies = [...new Set(revenue.map((row) => row.currency))];
-        const live =
-          new Date(campaign.starts_at) <= new Date() && new Date(campaign.ends_at) > new Date();
+      <div className="stack">
+        {all.map((campaign) => {
+          const result = results.get(campaign.id);
+          const funnel = result?.funnel ?? [];
+          const revenue = result?.revenue ?? [];
+          const emailStats: CampaignEmailStatRow[] = result?.email ?? [];
+          const emailCount = (status: string) =>
+            Number(emailStats.find((row) => row.status === status)?.count ?? 0);
+          const targeted = funnel.find((row) => row.cohort === 'targeted');
+          const currencies = [...new Set(revenue.map((row) => row.currency))];
+          const live =
+            new Date(campaign.starts_at) <= new Date() && new Date(campaign.ends_at) > new Date();
 
-        return (
-          <div key={campaign.id}>
-            <h2>
-              {campaign.name} {live ? '· live' : '· ended'}
-            </h2>
-            <section>
-              <p className="note">
+          return (
+            <Card
+              key={campaign.id}
+              title={campaign.name}
+              eyebrow="Campaign"
+              actions={live ? <Badge tone="ok">Live</Badge> : <Badge>Ended</Badge>}
+              bare
+            >
+              <p className="card-note">
                 <strong>{campaign.title}</strong>
-                {campaign.body ? ` — ${campaign.body}` : ''}
-                <br />
+                {' · '}
+                {campaign.body ? <>{campaign.body} · </> : null}
                 {campaign.promo_code ? (
                   <>
-                    Code <code>{campaign.promo_code}</code> ·{' '}
+                    code <code>{campaign.promo_code}</code> ·{' '}
                   </>
                 ) : null}
                 {campaign.holdout_percent}% holdout ·{' '}
@@ -194,76 +206,102 @@ export default async function Campaigns({
                 {new Date(campaign.ends_at).toLocaleDateString('en-IN')}
               </p>
 
-              <div className="scroll">
+              <p className="card-subhead">Funnel</p>
+              <TableScroll>
                 <table>
+                  <caption className="sr-only">{campaign.name}: funnel per cohort</caption>
                   <thead>
                     <tr>
-                      <th>Cohort</th>
-                      <th>People</th>
-                      <th>Saw it</th>
-                      <th>Redeemed</th>
-                      <th>Paid</th>
-                      <th>Pay rate</th>
+                      <th scope="col">Cohort</th>
+                      <th scope="col" className="n">
+                        People
+                      </th>
+                      <th scope="col" className="n">
+                        Saw it
+                      </th>
+                      <th scope="col" className="n">
+                        Redeemed
+                      </th>
+                      <th scope="col" className="n">
+                        Paid
+                      </th>
+                      <th scope="col" className="n">
+                        Pay rate
+                      </th>
                     </tr>
                   </thead>
                   <tbody>
                     {funnel.map((row) => (
                       <tr key={row.cohort}>
-                        <td>{row.cohort}</td>
-                        <td>{num(row.people)}</td>
-                        <td>{num(row.seen)}</td>
-                        <td>{num(row.redeemed)}</td>
-                        <td>{num(row.paid)}</td>
-                        <td>{pct(Number(row.paid), Number(row.people))}</td>
+                        <th scope="row" style={{ fontWeight: 600 }}>
+                          {row.cohort}
+                        </th>
+                        <td className="n">{num(row.people)}</td>
+                        <td className="n">{num(row.seen)}</td>
+                        <td className="n">{num(row.redeemed)}</td>
+                        <td className="n">{num(row.paid)}</td>
+                        <td className="n">{pct(Number(row.paid), Number(row.people))}</td>
                       </tr>
                     ))}
                   </tbody>
                 </table>
-              </div>
+              </TableScroll>
 
               {currencies.length === 0 ? (
-                <p className="note">No purchases in either arm yet.</p>
+                <p className="card-note">No purchases in either arm yet.</p>
               ) : (
-                <div className="scroll">
-                  <table>
-                    <thead>
-                      <tr>
-                        <th>Currency</th>
-                        <th>Targeted</th>
-                        <th>Holdout</th>
-                        <th>Incremental</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {currencies.map((currency) => {
-                        const lift = incremental(revenue, funnel, currency);
-                        const forCohort = (cohort: string) =>
-                          revenue.find((row) => row.cohort === cohort && row.currency === currency)
-                            ?.revenue_minor ?? '0';
-                        return (
-                          <tr key={currency}>
-                            <td>{currency}</td>
-                            <td>{amount(forCohort('targeted'), currency)}</td>
-                            <td>{amount(forCohort('holdout'), currency)}</td>
-                            <td
-                              style={{
-                                color:
-                                  lift === null
-                                    ? 'var(--muted)'
-                                    : lift >= 0n
-                                      ? 'var(--positive)'
-                                      : 'var(--negative)',
-                                fontWeight: 600,
-                              }}
-                            >
-                              {lift === null ? '—' : amount(String(lift), currency)}
-                            </td>
-                          </tr>
-                        );
-                      })}
-                    </tbody>
-                  </table>
-                  <p className="note">
+                <>
+                  <p className="card-subhead">Revenue</p>
+                  <TableScroll>
+                    <table>
+                      <caption className="sr-only">
+                        {campaign.name}: incremental revenue per currency
+                      </caption>
+                      <thead>
+                        <tr>
+                          <th scope="col">Currency</th>
+                          <th scope="col" className="n">
+                            Targeted
+                          </th>
+                          <th scope="col" className="n">
+                            Holdout
+                          </th>
+                          <th scope="col" className="n">
+                            Incremental
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {currencies.map((currency) => {
+                          const lift = incremental(revenue, funnel, currency);
+                          const forCohort = (cohort: string) =>
+                            revenue.find(
+                              (row) => row.cohort === cohort && row.currency === currency,
+                            )?.revenue_minor ?? '0';
+                          return (
+                            <tr key={currency}>
+                              <th scope="row" style={{ fontWeight: 600 }}>
+                                {currency}
+                              </th>
+                              <td className="n">{amount(forCohort('targeted'), currency)}</td>
+                              <td className="n">{amount(forCohort('holdout'), currency)}</td>
+                              {/* Colour is the *second* signal: the sign is
+                                  already in the number, so a red minus still
+                                  reads as a minus without the red. */}
+                              <td
+                                className={
+                                  lift === null ? 'n muted' : lift >= 0n ? 'n pos' : 'n neg'
+                                }
+                              >
+                                {lift === null ? '—' : amount(String(lift), currency)}
+                              </td>
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                  </TableScroll>
+                  <p className="card-note">
                     Incremental is revenue per person in the targeted arm minus revenue per person
                     in the holdout, times the targeted population. Per person because the arms are
                     different sizes. It goes negative when the giveaway cannibalised purchases
@@ -276,11 +314,13 @@ export default async function Campaigns({
                       </>
                     ) : null}
                   </p>
-                </div>
+                </>
               )}
-              <div style={{ marginTop: 16 }}>
-                <p className="note" style={{ padding: 0 }}>
-                  <strong>Email</strong> — sent {num(emailCount('sent'))}
+
+              <p className="card-subhead">Email</p>
+              <div className="card-body">
+                <p className="small muted" style={{ margin: '0 0 0.75rem' }}>
+                  Sent {num(emailCount('sent'))}
                   {emailCount('failed') > 0 ? `, ${num(emailCount('failed'))} failed` : ''}
                   {emailCount('queued') > 0 ? `, ${num(emailCount('queued'))} in flight` : ''}. The
                   holdout is never mailed, so this reaches the targeted cohort only.
@@ -289,41 +329,39 @@ export default async function Campaigns({
                   <form action={broadcast}>
                     <CsrfField />
                     <input type="hidden" name="id" value={campaign.id} />
-                    <button type="submit">Send email to targeted cohort</button>
+                    <button type="submit" className="btn">
+                      {Icon.send}
+                      <span>Send to targeted cohort</span>
+                    </button>
                   </form>
                 ) : (
-                  <p className="note">
+                  <p className="small muted" style={{ margin: 0 }}>
                     Email only sends while a campaign is live. This one is not running now.
                   </p>
                 )}
               </div>
-            </section>
-          </div>
-        );
-      })}
+            </Card>
+          );
+        })}
+      </div>
 
-      <h2>New campaign</h2>
-      <section>
-        <form action={create} className="flag">
+      <h2 className="section">New campaign</h2>
+      <Card bare>
+        <form action={create} className="form card-body">
           <CsrfField />
-          <label>
-            <span>Name (internal)</span>
+          <Field label="Name" hint="internal">
             <input type="text" name="name" placeholder="Diwali 2026" />
-          </label>
-          <label>
-            <span>Title</span>
+          </Field>
+          <Field label="Title">
             <input type="text" name="title" placeholder="Two months of Plus, free" required />
-          </label>
-          <label>
-            <span>Body</span>
+          </Field>
+          <Field label="Body" full>
             <input type="text" name="body" placeholder="Because you have been here a while" />
-          </label>
-          <label>
-            <span>Button</span>
+          </Field>
+          <Field label="Button">
             <input type="text" name="cta" placeholder="Claim it" defaultValue="Claim it" />
-          </label>
-          <label>
-            <span>Promo code</span>
+          </Field>
+          <Field label="Promo code">
             <select name="code" defaultValue="">
               <option value="">None</option>
               {codes.map((code) => (
@@ -332,22 +370,22 @@ export default async function Campaigns({
                 </option>
               ))}
             </select>
-          </label>
-          <label>
-            <span>Ends</span>
+          </Field>
+          <Field label="Ends">
             <input type="date" name="ends" required />
-          </label>
-          <label>
-            <span>Countries</span>
-            <input type="text" name="countries" placeholder="IN, AE — blank for all" />
-          </label>
-          <label>
-            <span>Holdout %</span>
+          </Field>
+          <Field label="Countries" hint="blank for all">
+            <input type="text" name="countries" placeholder="IN, AE" />
+          </Field>
+          <Field label="Holdout %">
             <input type="number" name="holdout" min={1} max={90} defaultValue={10} />
-          </label>
-          <button type="submit">Create campaign</button>
+          </Field>
+          <button type="submit" className="btn">
+            {Icon.plus}
+            <span>Create campaign</span>
+          </button>
         </form>
-      </section>
+      </Card>
     </main>
   );
 }

--- a/apps/admin/src/app/countries/page.tsx
+++ b/apps/admin/src/app/countries/page.tsx
@@ -3,9 +3,11 @@ import { redirect } from 'next/navigation';
 
 import { COUNTRIES, countryFlag, dialingCodeForCountry } from '@waves/core';
 
-import { countrySettings, saveCountrySettings } from '@/lib/data';
-import { guardMutation } from '@/lib/csrf';
 import { CsrfField } from '@/components/CsrfField';
+import { Icon } from '@/components/icons';
+import { Card, Lede, Outcome, PageHeader } from '@/components/ui';
+import { guardMutation } from '@/lib/csrf';
+import { countrySettings, saveCountrySettings } from '@/lib/data';
 
 export const dynamic = 'force-dynamic';
 
@@ -25,7 +27,12 @@ export default async function Countries({
   const { error, saved } = await searchParams;
   const rows = await countrySettings();
   const disabled = new Set(rows.filter((row) => !row.enabled).map((row) => row.code));
-  const enabledCount = DIALABLE.length - disabled.size;
+  // Counted over the boxes actually on screen. `country_settings` can hold a
+  // row for a country this build has no dial code for — one dropped from
+  // `COUNTRIES`, or one switched off before it was — and subtracting the
+  // table's size from the list's would report a number that disagreed with
+  // the ticks underneath it.
+  const enabledCount = DIALABLE.filter((country) => !disabled.has(country.code)).length;
 
   async function save(formData: FormData) {
     'use server';
@@ -51,41 +58,56 @@ export default async function Countries({
   }
 
   return (
-    <main>
-      <header className="top">
-        <h1>Countries</h1>{' '}
-      </header>
+    <main className="page">
+      <PageHeader
+        eyebrow="Configuration"
+        title="Countries"
+        actions={
+          <span className="small muted">
+            {enabledCount} of {DIALABLE.length} offered
+          </span>
+        }
+      />
+      <Outcome error={error} done={saved ? 'Saved.' : undefined} />
 
-      {error ? <p className="error">{error}</p> : null}
-      {saved ? <p className="faint">Saved.</p> : null}
-
-      <p className="note" style={{ padding: 0 }}>
+      <Lede>
         Which countries the phone sign-in offers. Untick one to hide it from the dial-code picker —
         a market we are not live in, or one we have paused. A country with no setting is offered, so
-        an empty list shows everything. {enabledCount} of {DIALABLE.length} on.
-      </p>
+        an empty table shows everything.
+      </Lede>
 
-      <section style={{ marginTop: 20 }}>
-        <form action={save} className="flag">
+      <Card bare>
+        <form action={save}>
           <CsrfField />
-          <div className="country-grid">
-            {DIALABLE.map((country) => (
-              <label key={country.code} className="country-row">
-                <input
-                  type="checkbox"
-                  name={country.code}
-                  defaultChecked={!disabled.has(country.code)}
-                />
-                <span>
-                  {countryFlag(country.code)} {country.name}{' '}
-                  <span className="faint">{dialingCodeForCountry(country.code)}</span>
-                </span>
-              </label>
-            ))}
+          {/* A fieldset with a legend, because a hundred and ninety loose
+              checkboxes with no group name is a hundred and ninety questions
+              with no question. */}
+          <fieldset className="card-body">
+            <legend className="sr-only">Countries offered at sign-in</legend>
+            <div className="check-grid">
+              {DIALABLE.map((country) => (
+                <label key={country.code} className="check plain">
+                  <input
+                    type="checkbox"
+                    name={country.code}
+                    defaultChecked={!disabled.has(country.code)}
+                  />
+                  <span>
+                    <span aria-hidden>{countryFlag(country.code)}</span> {country.name}{' '}
+                    <span className="muted small">{dialingCodeForCountry(country.code)}</span>
+                  </span>
+                </label>
+              ))}
+            </div>
+          </fieldset>
+          <div className="card-body" style={{ paddingTop: 0 }}>
+            <button type="submit" className="btn">
+              {Icon.save}
+              <span>Save countries</span>
+            </button>
           </div>
-          <button type="submit">Save</button>
         </form>
-      </section>
+      </Card>
     </main>
   );
 }

--- a/apps/admin/src/app/error.tsx
+++ b/apps/admin/src/app/error.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { Icon } from '@/components/icons';
+
+/**
+ * What a page shows when its server component threw.
+ *
+ * `data.ts` throws with the failing function's name in the message — "reading
+ * app_config failed: …" — and that is exactly the sentence somebody debugging
+ * a console at 2am needs. So it is shown, rather than swallowed into "Something
+ * went wrong": the audience here is one operator with a database password, not
+ * the public, and there is nothing to leak to. It is still labelled clearly as
+ * the raw error so it is never mistaken for a message written for a reader.
+ *
+ * A Client Component because that is what an App Router error boundary is.
+ */
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    // The message is on screen; the stack only exists in the console.
+    console.error(error);
+  }, [error]);
+
+  return (
+    <main className="page">
+      <header className="page-head">
+        <div>
+          <div className="eyebrow">Something failed</div>
+          <h1>This page could not be loaded</h1>
+        </div>
+      </header>
+
+      <div className="banner banner-danger" role="alert">
+        {Icon.alert}
+        <div>
+          <strong>The database call did not come back.</strong>
+          <p style={{ margin: '0.5rem 0 0' }}>
+            <code>{error.message}</code>
+          </p>
+        </div>
+      </div>
+
+      <p className="lede">
+        The usual causes, in order of likelihood: the migration that creates what this page reads is
+        not deployed to this project; <code>SUPABASE_URL</code> or{' '}
+        <code>SUPABASE_SERVICE_ROLE_KEY</code> is missing or wrong; or the project is asleep.
+        Nothing was written — every page here reads before it offers to change anything.
+      </p>
+
+      <button type="button" className="btn" onClick={reset}>
+        Try again
+      </button>
+    </main>
+  );
+}

--- a/apps/admin/src/app/feedback/page.tsx
+++ b/apps/admin/src/app/feedback/page.tsx
@@ -1,12 +1,22 @@
+import { Badge, Card, Empty, Lede, PageHeader, Tile, type Tone } from '@/components/ui';
 import { feedback } from '@/lib/data';
 
 export const dynamic = 'force-dynamic';
+
+const KINDS = ['general', 'bug', 'idea', 'deletion'] as const;
 
 const KIND_LABEL: Record<string, string> = {
   general: 'General',
   bug: 'Broken',
   idea: 'Idea',
   deletion: 'Left',
+};
+
+const KIND_TONE: Record<string, Tone> = {
+  general: 'neutral',
+  bug: 'danger',
+  idea: 'ok',
+  deletion: 'accent',
 };
 
 export default async function FeedbackPage() {
@@ -17,35 +27,52 @@ export default async function FeedbackPage() {
   }, {});
 
   return (
-    <main>
-      <header className="top">
-        <h1>Feedback</h1>{' '}
-      </header>
+    <main className="page">
+      <PageHeader
+        eyebrow="Signals"
+        title="Feedback"
+        actions={<span className="small muted">newest {rows.length}</span>}
+      />
 
-      <div className="tiles">
-        {(['general', 'bug', 'idea', 'deletion'] as const).map((kind) => (
-          <div className="tile" key={kind}>
-            <span className="label">{KIND_LABEL[kind]}</span>
-            <div className="value">{counts[kind] ?? 0}</div>
-          </div>
+      <Lede>
+        There is no author column here and no way to ask for one. Knowing who complained is not
+        needed in order to act on a complaint. Where it says <em>account deleted</em>, the person
+        has since erased themselves — their words are kept on purpose, because why somebody leaves
+        is the most useful thing they ever write, and cascading it away at that moment would destroy
+        exactly that.
+      </Lede>
+
+      <div className="cols-4">
+        {KINDS.map((kind) => (
+          <Tile key={kind} label={KIND_LABEL[kind]!} value={counts[kind] ?? 0} />
         ))}
       </div>
 
-      <h2>Newest first</h2>
-      <section>
+      <h2 className="section">Newest first</h2>
+      <Card bare>
         {rows.length === 0 ? (
-          <p className="note">
-            Nothing yet. If you expected some, the <code>20260808230000_feedback_and_erasure</code>{' '}
-            migration may not be deployed to this project.
-          </p>
+          <Empty title="Nothing yet" migration="20260808230000_feedback_and_erasure">
+            Nobody has written in.
+          </Empty>
         ) : (
-          <ul className="feedback">
+          <ul className="feed">
             {rows.map((row) => (
               <li key={row.id}>
                 <div className="meta">
-                  <span className={`tag tag-${row.kind}`}>{KIND_LABEL[row.kind] ?? row.kind}</span>
-                  {row.rating ? <span>{'★'.repeat(row.rating)}</span> : null}
-                  <span>{new Date(row.created_at).toLocaleString('en-IN')}</span>
+                  <Badge tone={KIND_TONE[row.kind] ?? 'neutral'}>
+                    {KIND_LABEL[row.kind] ?? row.kind}
+                  </Badge>
+                  {row.rating ? (
+                    <span aria-label={`${row.rating} out of 5`}>
+                      <span aria-hidden>{'★'.repeat(row.rating)}</span>
+                    </span>
+                  ) : null}
+                  <time dateTime={row.created_at}>
+                    {new Date(row.created_at).toLocaleString('en-IN', {
+                      dateStyle: 'medium',
+                      timeStyle: 'short',
+                    })}
+                  </time>
                   {row.platform ? <span>{row.platform}</span> : null}
                   {row.app_version ? <span>v{row.app_version}</span> : null}
                   {row.country_code ? <span>{row.country_code}</span> : null}
@@ -57,15 +84,7 @@ export default async function FeedbackPage() {
             ))}
           </ul>
         )}
-      </section>
-
-      <p className="note" style={{ padding: '14px 0 0' }}>
-        There is no author column here and no way to ask for one. Knowing who complained is not
-        needed in order to act on a complaint. Where it says <em>account deleted</em>, the person
-        has since erased themselves — their words are kept on purpose, because why somebody leaves
-        is the most useful thing they ever write and cascading it away at that moment would destroy
-        exactly that.
-      </p>
+      </Card>
     </main>
   );
 }

--- a/apps/admin/src/app/flags/page.tsx
+++ b/apps/admin/src/app/flags/page.tsx
@@ -1,9 +1,21 @@
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 
-import { flagResults, flags, saveFlag, type FlagResultRow } from '@/lib/data';
-import { guardMutation } from '@/lib/csrf';
 import { CsrfField } from '@/components/CsrfField';
+import { Icon } from '@/components/icons';
+import {
+  Badge,
+  Card,
+  Check,
+  Empty,
+  Field,
+  Lede,
+  Outcome,
+  PageHeader,
+  TableScroll,
+} from '@/components/ui';
+import { guardMutation } from '@/lib/csrf';
+import { flagResults, flags, saveFlag, type FlagResultRow } from '@/lib/data';
 
 export const dynamic = 'force-dynamic';
 
@@ -57,149 +69,186 @@ export default async function Flags({
   }
 
   return (
-    <main>
-      <header className="top">
-        <h1>Experiments</h1>{' '}
-      </header>
+    <main className="page">
+      <PageHeader
+        eyebrow="Configuration"
+        title="Experiments"
+        actions={
+          <span className="small muted">
+            {running.length} running of {all.length}
+          </span>
+        }
+      />
+      <Outcome error={error} done={saved ? 'Saved.' : undefined} />
 
-      {error ? <p className="error">{error}</p> : null}
-      {saved ? <p className="faint">Saved.</p> : null}
-
-      <p className="note" style={{ padding: 0 }}>
+      <Lede>
         Nobody&rsquo;s assignment is stored. A person&rsquo;s arm is hashed from the flag key and
         their profile id, by the same rule in the app and in the database, so the split needs no
         round trip and an experiment can be read retrospectively — including for the days before it
         occurred to anybody to look.
-      </p>
+      </Lede>
 
       {all.length === 0 ? (
-        <section style={{ marginTop: 20 }}>
-          <p className="note">
-            No flags yet. If you expected some, the
-            <code> 20260808200000_feature_flags </code> migration may not be deployed to this
-            project.
-          </p>
-        </section>
+        <Card bare>
+          <Empty title="No flags yet" migration="20260808200000_feature_flags">
+            Nothing in <code>feature_flags</code> to switch.
+          </Empty>
+        </Card>
       ) : null}
 
-      {all.map((flag) => {
-        const rows = results.get(flag.key) ?? [];
-        const enrolled = rows.reduce((sum, row) => sum + Number(row.people), 0);
+      <div className="stack">
+        {all.map((flag) => {
+          const rows = results.get(flag.key) ?? [];
+          const enrolled = rows.reduce((sum, row) => sum + Number(row.people), 0);
 
-        return (
-          <div key={flag.key}>
-            <h2>{flag.key}</h2>
-            <section>
-              <form action={save} className="flag">
+          return (
+            <Card
+              key={flag.key}
+              title={flag.key}
+              // The description is already an editable field two lines down;
+              // an eyebrow is a category, not a second copy of the sentence.
+              eyebrow="Feature flag"
+              actions={
+                flag.enabled ? (
+                  <Badge tone="ok">On · {flag.rollout_percent}%</Badge>
+                ) : (
+                  <Badge>Off</Badge>
+                )
+              }
+              bare
+            >
+              <form action={save} className="form card-body">
                 <CsrfField />
                 <input type="hidden" name="key" value={flag.key} />
-                <label>
-                  <span>Description</span>
-                  <input type="text" name="description" defaultValue={flag.description} />
-                </label>
-                <label className="inline">
-                  <input type="checkbox" name="enabled" defaultChecked={flag.enabled} />
-                  <span>Enabled</span>
-                </label>
-                <label>
-                  <span>Rollout %</span>
+                <Field label="Description">
+                  <input
+                    type="text"
+                    name="description"
+                    defaultValue={flag.description}
+                    size={34}
+                    aria-label={`Description of ${flag.key}`}
+                  />
+                </Field>
+                <Field label="Rollout %">
                   <input
                     type="number"
                     name="rollout"
                     min={0}
                     max={100}
                     defaultValue={flag.rollout_percent}
+                    aria-label={`Rollout percentage for ${flag.key}`}
                   />
-                </label>
-                <label>
-                  <span>Arms (comma separated)</span>
-                  <input type="text" name="variants" defaultValue={flag.variants.join(', ')} />
-                </label>
-                <button type="submit">Save</button>
+                </Field>
+                <Field label="Arms" hint="comma separated">
+                  <input
+                    type="text"
+                    name="variants"
+                    defaultValue={flag.variants.join(', ')}
+                    size={22}
+                    aria-label={`Arms of ${flag.key}`}
+                  />
+                </Field>
+                <Check name="enabled" label="Enabled" defaultChecked={flag.enabled} />
+                <button type="submit" className="btn">
+                  {Icon.save}
+                  <span>Save</span>
+                </button>
               </form>
 
-              {flag.enabled ? (
-                rows.length === 0 ? (
-                  <p className="note">
-                    Nobody is enrolled. At {flag.rollout_percent}% rollout that is expected if there
-                    are few accounts.
-                  </p>
-                ) : (
-                  <div className="scroll">
+              {!flag.enabled ? (
+                <p className="card-note">
+                  Off. Everybody sees whatever the app did before this flag.
+                </p>
+              ) : rows.length === 0 ? (
+                <p className="card-note">
+                  Nobody is enrolled. At {flag.rollout_percent}% rollout that is expected if there
+                  are few accounts.
+                </p>
+              ) : (
+                <>
+                  <p className="card-subhead">Results</p>
+                  <TableScroll>
                     <table>
+                      <caption className="sr-only">Results per arm of {flag.key}</caption>
                       <thead>
                         <tr>
-                          <th>Arm</th>
-                          <th>People</th>
-                          <th>Share</th>
-                          <th>Expenses created</th>
-                          <th>Per person</th>
-                          <th>Active 30d</th>
+                          <th scope="col">Arm</th>
+                          <th scope="col" className="n">
+                            People
+                          </th>
+                          <th scope="col" className="n">
+                            Share
+                          </th>
+                          <th scope="col" className="n">
+                            Expenses created
+                          </th>
+                          <th scope="col" className="n">
+                            Per person
+                          </th>
+                          <th scope="col" className="n">
+                            Active 30d
+                          </th>
                         </tr>
                       </thead>
                       <tbody>
                         {rows.map((row) => (
                           <tr key={row.variant}>
-                            <td>{row.variant}</td>
-                            <td>{num(row.people)}</td>
-                            <td>
+                            <th scope="row" style={{ fontWeight: 600 }}>
+                              {row.variant}
+                            </th>
+                            <td className="n">{num(row.people)}</td>
+                            <td className="n">
                               {enrolled === 0
                                 ? '—'
                                 : `${Math.round((Number(row.people) / enrolled) * 100)}%`}
                             </td>
-                            <td>{num(row.expenses_created)}</td>
-                            <td>
+                            <td className="n">{num(row.expenses_created)}</td>
+                            <td className="n">
                               {Number(row.people) === 0
                                 ? '—'
                                 : (Number(row.expenses_created) / Number(row.people)).toFixed(2)}
                             </td>
-                            <td>{num(row.active_30d)}</td>
+                            <td className="n">{num(row.active_30d)}</td>
                           </tr>
                         ))}
                       </tbody>
                     </table>
-                    <p className="note">
-                      People outside the rollout are not shown. They are not a control group — the
-                      experiment never touched them, and putting them beside the arms invites the
-                      one comparison that is wrong.
-                    </p>
-                  </div>
-                )
-              ) : (
-                <p className="note">Off. Everybody sees whatever the app did before this flag.</p>
+                  </TableScroll>
+                  <p className="card-note">
+                    People outside the rollout are not shown. They are not a control group — the
+                    experiment never touched them, and putting them beside the arms invites the one
+                    comparison that is wrong.
+                  </p>
+                </>
               )}
-            </section>
-          </div>
-        );
-      })}
+            </Card>
+          );
+        })}
+      </div>
 
-      <h2>New flag</h2>
-      <section>
-        <form action={save} className="flag">
+      <h2 className="section">New flag</h2>
+      <Card bare>
+        <form action={save} className="form card-body">
           <CsrfField />
-          <label>
-            <span>Key</span>
+          <Field label="Key">
             <input type="text" name="key" placeholder="itemized_receipts" required />
-          </label>
-          <label>
-            <span>Description</span>
-            <input type="text" name="description" />
-          </label>
-          <label className="inline">
-            <input type="checkbox" name="enabled" />
-            <span>Enabled</span>
-          </label>
-          <label>
-            <span>Rollout %</span>
+          </Field>
+          <Field label="Description">
+            <input type="text" name="description" size={30} />
+          </Field>
+          <Field label="Rollout %">
             <input type="number" name="rollout" min={0} max={100} defaultValue={0} />
-          </label>
-          <label>
-            <span>Arms (comma separated)</span>
-            <input type="text" name="variants" defaultValue="control, treatment" />
-          </label>
-          <button type="submit">Create</button>
+          </Field>
+          <Field label="Arms" hint="comma separated">
+            <input type="text" name="variants" defaultValue="control, treatment" size={22} />
+          </Field>
+          <Check name="enabled" label="Enabled" />
+          <button type="submit" className="btn">
+            {Icon.plus}
+            <span>Create</span>
+          </button>
         </form>
-      </section>
+      </Card>
     </main>
   );
 }

--- a/apps/admin/src/app/globals.css
+++ b/apps/admin/src/app/globals.css
@@ -1,62 +1,188 @@
 /**
- * A console, not a product. It borrows Waves's brand colour and nothing else:
- * this screen is read in one sitting by one person looking for a number, so it
- * is dense, quiet, and gets out of the way.
+ * The console's design system.
+ *
+ * The vocabulary is lifted from the d-board reference dashboard — a Tailwind
+ * build whose tokens were read out of its compiled stylesheet rather than
+ * guessed at: the neutral ramp is Tailwind's `gray`, the accent is `blue`,
+ * cards are `rounded-lg` with a hairline `gray-100` border and no shadow,
+ * tables are `px-3 py-2` rows under an uppercase `text-xs` head, and the rail
+ * marks its active row with a 4px bar rather than a filled pill.
+ *
+ * Three deliberate departures from the reference, all in the same direction:
+ *
+ * 1. The reference ships `*, :focus { outline: none !important }`. That is a
+ *    keyboard user locked out of a console that only has a keyboard's worth of
+ *    controls. Focus here is a visible two-tone ring on every interactive
+ *    thing, and it is the first rule in the file so nothing can quietly win
+ *    against it.
+ * 2. `blue-500` (#3b82f6) is 3.7:1 on white — fine as a fill, a failure as
+ *    text. Anything blue that has to be *read* uses `blue-600` (#2563eb,
+ *    5.2:1); `blue-500` stays for bars, rails and button grounds.
+ * 3. `::-webkit-scrollbar { display: none }` is in the reference too. A
+ *    console full of wide tables needs its scrollbars.
+ *
+ * Desktop only, and stated once here rather than apologised for in each
+ * screen: there are no width breakpoints below `--w-min`. Read at a desk.
  */
 
 :root {
-  --bg: #f6f7fb;
-  --surface: #ffffff;
-  --border: #e6e5ef;
-  --text: #14131f;
-  --muted: #6a6880;
-  --faint: #9997ac;
-  --brand: #6d5ef8;
-  --positive: #0f9d63;
-  --negative: #d1453b;
-  --radius: 14px;
+  color-scheme: light;
 
-  /* Chart + accent palette, shared with the ECharts options so a slice and its
-     legend cannot disagree. Fixed hues rather than tokens: a chart colour that
-     flipped with the OS theme would recolour the data. */
-  --c-blue: #4e8cf5;
-  --c-green: #35c28e;
-  --c-amber: #f5b74e;
-  --c-red: #f2685f;
-  --c-purple: #6d5ef8;
+  /* ── neutrals: Tailwind gray ─────────────────────────────────────────── */
+  --bg: #f9fafb; /* gray-50  — the page */
+  --surface: #ffffff; /* white    — cards, rail, topbar */
+  --surface-sunken: #f3f4f6; /* gray-100 — search pill, inert wells */
+  --hairline: #f3f4f6; /* gray-100 — card + table borders */
+  --line: #e5e7eb; /* gray-200 — input borders, dividers that must be seen */
+  --ink: #111827; /* gray-900 — headings, values */
+  --ink-2: #374151; /* gray-700 — form labels, body */
+  --muted: #6b7280; /* gray-500 — 4.8:1 on white; captions, table heads */
 
-  /* The sidebar keeps its own dark palette in either theme — it is chrome, not
-     content, and the reference it copies is a dark rail beside a light page. */
-  --side-bg: #141329;
-  --side-text: #9b9bc0;
-  --side-faint: #63637f;
-  --side-active: #ffffff;
-  --side-active-bg: #6d5ef8;
-  --side-hover-bg: #ffffff14;
+  /* ── accent: Tailwind blue ───────────────────────────────────────────── */
+  --accent: #3b82f6; /* blue-500 — fills, rails, chart line */
+  --accent-strong: #2563eb; /* blue-600 — accent *text*, hover ground */
+  --accent-deep: #1d4ed8; /* blue-700 — pressed, code text */
+  --accent-wash: #eff6ff; /* blue-50  — ghost hover */
+  --accent-soft: #dbeafe; /* blue-100 — soft badge ground */
+  --on-accent: #ffffff;
+
+  /* ── semantics ───────────────────────────────────────────────────────── */
+  --ok: #15803d; /* green-700 — 4.8:1 on white */
+  --ok-soft: #dcfce7; /* green-100 */
+  --warn: #b45309; /* amber-700 */
+  --warn-soft: #fef3c7; /* amber-100 */
+  --danger: #b91c1c; /* red-700 */
+  --danger-soft: #fee2e2; /* red-100 */
+
+  /* ── chart hues ──────────────────────────────────────────────────────── */
+  /* Fixed, and fixed on purpose: a series that changed colour with the OS
+     theme would be recolouring the data. ECharts paints to its own tree and
+     cannot read these, so `charts/palette.ts` carries the same five hex
+     values — the two files are each other's only source of truth. */
+  --c-blue: #3b82f6;
+  --c-green: #10b981;
+  --c-amber: #f59e0b;
+  --c-red: #ef4444;
+  --c-purple: #8b5cf6;
+
+  /* ── shape ───────────────────────────────────────────────────────────── */
+  --r-card: 0.5rem; /* rounded-lg */
+  --r-input: 0.375rem; /* rounded-md */
+  --r-pill: 9999px;
+
+  /* ── metrics ─────────────────────────────────────────────────────────── */
+  --rail-w: 16rem; /* w-64 */
+  --rail-w-collapsed: 4rem; /* w-16 */
+  --bar-h: 4rem; /* h-16 — logo block, section head, topbar all agree */
+  --row-h: 2.5rem; /* h-10 — a rail item */
+  --w-min: 1024px; /* the narrowest desk this is designed for */
+
+  --shadow-rail: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+  --shadow-pop: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --bg: #0e0d16;
-    --surface: #171622;
-    --border: #2a2840;
-    --text: #f4f3ff;
-    --muted: #9e9eb8;
-    --faint: #6b6b85;
-    --brand: #9b83ff;
-    --positive: #34d399;
-    --negative: #ff7b72;
-    --side-bg: #0b0a16;
+    color-scheme: dark;
+
+    --bg: #111827; /* gray-900 */
+    --surface: #1f2937; /* gray-800 — a card has to be lighter than its page */
+    --surface-sunken: #111827;
+    --hairline: #374151; /* gray-700 */
+    --line: #4b5563; /* gray-600 */
+    --ink: #f9fafb;
+    --ink-2: #e5e7eb;
+    --muted: #9ca3af; /* gray-400 — 7.0:1 on gray-800 */
+
+    --accent: #60a5fa; /* blue-400 — the readable end in the dark */
+    --accent-strong: #93c5fd;
+    --accent-deep: #bfdbfe;
+    --accent-wash: #1e3a8a33;
+    --accent-soft: #1e40af;
+    --on-accent: #0b1120;
+
+    --ok: #4ade80;
+    --ok-soft: #14532d;
+    --warn: #fbbf24;
+    --warn-soft: #451a03;
+    --danger: #f87171;
+    --danger-soft: #450a0a;
+
+    --shadow-rail: 0 10px 15px -3px rgb(0 0 0 / 0.5), 0 4px 6px -4px rgb(0 0 0 / 0.5);
+    --shadow-pop: 0 4px 6px -1px rgb(0 0 0 / 0.5), 0 2px 4px -2px rgb(0 0 0 / 0.5);
   }
 }
 
-* {
+/* ═══ base ═══════════════════════════════════════════════════════════════ */
+
+*,
+*::before,
+*::after {
   box-sizing: border-box;
 }
 
-:where(a, button, input, select, textarea, [role='button'], .side-link, .seg button):focus-visible {
-  outline: 3px solid var(--brand);
-  outline-offset: 3px;
+/* First rule that touches focus, and the only one. See the header note. */
+:where(a, button, input, select, textarea, summary, [tabindex]):focus-visible {
+  outline: 2px solid var(--accent-strong);
+  outline-offset: 2px;
+  border-radius: var(--r-input);
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--bg);
+  color: var(--ink);
+  font-family:
+    var(--font-ui, ui-sans-serif),
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    'Helvetica Neue',
+    Arial,
+    sans-serif;
+  font-size: 0.875rem; /* text-sm — the reference's body size */
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  min-width: var(--w-min);
+}
+
+/* Every figure in this console is a column of digits under another column of
+   digits. Lining them up is not decoration. */
+.num,
+td,
+th,
+.stat-value,
+.tile-value,
+.kpi-value {
+  font-variant-numeric: tabular-nums;
+}
+
+a {
+  color: var(--accent-strong);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
+  font-size: 0.8125rem;
+  background: var(--surface-sunken);
+  color: var(--accent-deep);
+  border-radius: 0.25rem;
+  padding: 0.125rem 0.3125rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  code {
+    background: #111827;
+    color: var(--accent-strong);
+  }
 }
 
 .sr-only {
@@ -77,132 +203,215 @@
   *::after {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
-    scroll-behavior: auto !important;
     transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }
 
-html,
-body {
-  margin: 0;
-  padding: 0;
-  background: var(--bg);
-  color: var(--text);
-  /* Same system-font stack as apps/web (globals.css --font-sans), so admin and
-     the web client resolve to the same UI font on every platform. */
-  font-family:
-    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-  font-size: 15px;
-  -webkit-font-smoothing: antialiased;
-}
+/* ═══ shell ══════════════════════════════════════════════════════════════ */
 
-main {
-  max-width: 1240px;
-  margin: 0 auto;
-  padding: 24px 28px 96px;
-}
-
-header.top {
+.wrapper {
   display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 16px;
-  margin-bottom: 22px;
-}
-
-/* ── app shell: dark rail + light content column ── */
-
-.shell {
-  display: flex;
+  flex-direction: row;
+  align-items: stretch;
   min-height: 100vh;
 }
 
-.sidebar {
-  width: 236px;
-  flex-shrink: 0;
-  align-self: flex-start;
+.rail {
+  flex: 0 0 auto;
+  width: var(--rail-w);
   position: sticky;
   top: 0;
+  align-self: flex-start;
   height: 100vh;
-  overflow-y: auto;
-  background: var(--side-bg);
-  color: var(--side-text);
-  padding: 18px 14px 32px;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  overflow: hidden auto;
+  background: var(--surface);
+  color: var(--ink);
+  border-right: 1px solid var(--hairline);
+  box-shadow: var(--shadow-rail);
+  transition: width 0.25s ease-in-out;
+  scrollbar-width: thin;
 }
 
-.sidebar .brand {
+.wrapper[data-collapsed='true'] .rail {
+  width: var(--rail-w-collapsed);
+}
+
+.rail-logo {
   display: flex;
   align-items: center;
-  gap: 10px;
-  font-size: 17px;
+  gap: 0.625rem;
+  height: var(--bar-h);
+  flex: 0 0 var(--bar-h);
+  padding: 0 1rem;
+  font-size: 1rem;
   font-weight: 700;
-  color: #fff;
-  letter-spacing: -0.01em;
-  padding: 6px 8px 18px;
-}
-
-.sidebar .brand .mark {
-  width: 30px;
-  height: 30px;
-  border-radius: 9px;
-  background: linear-gradient(135deg, #6d5ef8, #a78bfa);
-  display: grid;
-  place-items: center;
-  color: #fff;
-  font-size: 15px;
-  flex-shrink: 0;
-}
-
-.side-group {
-  font-size: 10.5px;
-  font-weight: 700;
-  letter-spacing: 0.09em;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: var(--side-faint);
-  padding: 16px 10px 6px;
+  color: var(--accent-strong);
+  text-decoration: none;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
-.side-link {
+.rail-logo svg {
+  width: 28px;
+  height: 28px;
+  flex: 0 0 28px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.wrapper[data-collapsed='true'] .rail-logo span {
+  opacity: 0;
+  visibility: hidden;
+}
+
+.rail-section {
   display: flex;
   align-items: center;
-  gap: 11px;
-  padding: 9px 11px;
-  border-radius: 10px;
-  color: var(--side-text);
+  height: var(--bar-h);
+  flex: 0 0 var(--bar-h);
+  padding: 0 1rem;
+  font-size: 0.75rem;
+  font-weight: 400;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted);
+  white-space: nowrap;
+  position: relative;
+}
+
+/* Collapsed, the words go and a hairline stands in for them — otherwise the
+   groups run together into one undifferentiated column of glyphs. */
+.rail-section::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: calc(var(--bar-h) / 2);
+  height: 1px;
+  background: var(--hairline);
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out;
+}
+
+.wrapper[data-collapsed='true'] .rail-section {
+  height: 2rem;
+  flex-basis: 2rem;
+}
+
+.wrapper[data-collapsed='true'] .rail-section::before {
+  opacity: 1;
+  top: 1rem;
+}
+
+.wrapper[data-collapsed='true'] .rail-section span {
+  opacity: 0;
+  visibility: hidden;
+}
+
+.rail-item {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0;
+  height: var(--row-h);
+  flex: 0 0 var(--row-h);
+  color: var(--ink-2);
   text-decoration: none;
-  font-size: 14px;
-  font-weight: 500;
-  line-height: 1;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
-.side-link svg {
-  width: 18px;
-  height: 18px;
-  flex-shrink: 0;
-  stroke: currentColor;
+.rail-item > svg {
+  width: var(--rail-w-collapsed);
+  flex: 0 0 var(--rail-w-collapsed);
+  height: 20px;
   fill: none;
-  stroke-width: 1.7;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
-.side-link:hover {
-  background: var(--side-hover-bg);
-  color: #ececfb;
+/* The 4px bar is the reference's whole idea of "you are here". */
+.rail-item::after {
+  content: '';
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 4px;
+  background: var(--accent);
+  display: none;
 }
 
-.side-link[aria-current='page'] {
-  background: var(--side-active-bg);
-  color: var(--side-active);
+.rail-item:hover,
+.rail-item[aria-current='page'] {
+  color: var(--accent-strong);
+}
+
+.rail-item:hover::after,
+.rail-item[aria-current='page']::after {
+  display: block;
+}
+
+.rail-item[aria-current='page'] {
   font-weight: 600;
 }
 
-.content {
-  flex: 1;
+.wrapper[data-collapsed='true'] .rail-item .title {
+  opacity: 0;
+  visibility: hidden;
+}
+
+.rail-foot {
+  margin-top: auto;
+  padding: 1rem;
+  font-size: 0.75rem;
+  color: var(--muted);
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.wrapper[data-collapsed='true'] .rail-foot {
+  display: none;
+}
+
+.main {
+  flex: 1 1 auto;
   min-width: 0;
   display: flex;
   flex-direction: column;
+}
+
+.content-slot {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+/* Off-screen until tabbed to, then the first thing on the page. */
+.skip-link {
+  position: absolute;
+  left: 0.5rem;
+  top: -4rem;
+  z-index: 20;
+  padding: 0.5rem 1rem;
+  background: var(--surface);
+  color: var(--accent-strong);
+  border: 1px solid var(--accent-strong);
+  border-radius: var(--r-card);
+  font-weight: 700;
+  text-decoration: none;
+  transition: top 0.15s ease-in-out;
+}
+
+.skip-link:focus-visible {
+  top: 0.5rem;
 }
 
 .topbar {
@@ -211,660 +420,1022 @@ header.top {
   z-index: 5;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 0 28px;
-  height: 60px;
-  background: color-mix(in srgb, var(--surface) 88%, transparent);
-  backdrop-filter: saturate(1.4) blur(8px);
-  border-bottom: 1px solid var(--border);
-}
-
-.topbar .crumb {
-  font-size: 13px;
-  color: var(--faint);
-}
-
-.topbar .crumb b {
-  color: var(--text);
-  font-weight: 600;
-}
-
-.topbar .pill {
-  font-size: 12px;
-  color: var(--muted);
-  background: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  padding: 6px 12px;
-  white-space: nowrap;
-}
-
-/* ── hero + stat cards ── */
-
-.hero {
-  background: linear-gradient(120deg, #6d5ef8, #8b6ff9 55%, #a78bfa);
-  color: #fff;
-  border-radius: var(--radius);
-  padding: 22px 24px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 20px;
-  margin-bottom: 18px;
-}
-
-.hero .big {
-  font-size: 34px;
-  font-weight: 800;
-  letter-spacing: -0.02em;
-  font-variant-numeric: tabular-nums;
-  line-height: 1.05;
-}
-
-.hero .lead {
-  font-size: 13px;
-  opacity: 0.85;
-  margin-top: 2px;
-}
-
-.hero .who {
-  font-size: 15px;
-  font-weight: 700;
-  margin-bottom: 3px;
-}
-
-.stats {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
-  gap: 14px;
-}
-
-.stat {
+  gap: 0.5rem;
+  height: var(--bar-h);
+  flex: 0 0 var(--bar-h);
+  padding: 0 1rem;
   background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 16px 18px;
+  border-bottom: 1px solid var(--hairline);
 }
 
-.stat .ico {
-  width: 40px;
-  height: 40px;
-  border-radius: 11px;
-  display: grid;
-  place-items: center;
-  margin-bottom: 14px;
-}
-
-.stat .ico svg {
-  width: 20px;
-  height: 20px;
-  stroke-width: 1.8;
-  fill: none;
-}
-
-.stat .label {
-  font-size: 13px;
-  color: var(--muted);
-}
-
-.stat .figure {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 8px;
-  margin-top: 5px;
-}
-
-.stat .value {
-  font-size: 27px;
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  font-variant-numeric: tabular-nums;
-}
-
-.chip {
-  font-size: 12px;
-  font-weight: 600;
-  padding: 2px 7px;
-  border-radius: 999px;
-  white-space: nowrap;
-}
-
-.chip.up {
-  color: var(--positive);
-  background: color-mix(in srgb, var(--positive) 14%, transparent);
-}
-
-.chip.down {
-  color: var(--negative);
-  background: color-mix(in srgb, var(--negative) 14%, transparent);
-}
-
-.chip.flat {
-  color: var(--muted);
-  background: var(--bg);
-}
-
-/* soft icon tints, one per accent */
-.tint-blue {
-  background: color-mix(in srgb, var(--c-blue) 15%, transparent);
-  color: var(--c-blue);
-}
-.tint-green {
-  background: color-mix(in srgb, var(--c-green) 15%, transparent);
-  color: var(--c-green);
-}
-.tint-amber {
-  background: color-mix(in srgb, var(--c-amber) 18%, transparent);
-  color: var(--c-amber);
-}
-.tint-red {
-  background: color-mix(in srgb, var(--c-red) 15%, transparent);
-  color: var(--c-red);
-}
-.tint-purple {
-  background: color-mix(in srgb, var(--c-purple) 15%, transparent);
-  color: var(--c-purple);
-}
-
-/* ── card surface + chart layout ── */
-
-.card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  overflow: hidden;
-}
-
-.card > .card-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 16px 18px 4px;
-}
-
-.card > .card-head h3 {
-  font-size: 15px;
-  font-weight: 700;
-  margin: 0;
-  letter-spacing: -0.01em;
-}
-
-.card .card-sub {
-  font-size: 12px;
-  color: var(--faint);
-  padding: 0 18px 8px;
-}
-
-.grid-2 {
-  display: grid;
-  grid-template-columns: 1fr 1.4fr;
-  gap: 14px;
-  align-items: start;
-}
-
-.echart {
-  width: 100%;
-  padding: 6px 10px 12px;
-}
-
-.seg {
+.icon-button {
   display: inline-flex;
-  gap: 2px;
-  background: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: 9px;
-  padding: 2px;
-}
-
-.seg button {
-  font: inherit;
-  font-size: 12px;
-  font-weight: 600;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
   border: none;
+  border-radius: var(--r-input);
   background: transparent;
-  color: var(--muted);
-  padding: 5px 11px;
-  border-radius: 7px;
+  color: var(--ink-2);
   cursor: pointer;
 }
 
-.seg button[aria-pressed='true'] {
-  background: var(--surface);
-  color: var(--brand);
-  box-shadow: 0 1px 2px rgba(20, 19, 31, 0.08);
+.icon-button:hover {
+  background: var(--surface-sunken);
+  color: var(--accent-strong);
 }
 
-h1 {
-  font-size: 20px;
-  margin: 0;
-  letter-spacing: -0.01em;
+.icon-button svg {
+  width: 20px;
+  height: 20px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
-h2 {
-  font-size: 13px;
-  font-weight: 600;
+.crumb {
+  font-size: 0.75rem;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.05em;
   color: var(--muted);
-  margin: 36px 0 12px;
+  margin-left: 0.5rem;
 }
 
-section {
+.crumb b {
+  color: var(--ink);
+  font-weight: 700;
+}
+
+.topbar-spacer {
+  margin-left: auto;
+}
+
+/* The topbar search: the reference's rounded-full pill on a sunken ground. */
+.searchbox {
+  position: relative;
+  width: 18rem;
+}
+
+/* `input[type='search']` in the form block below has the same specificity as a
+   bare `.searchbox input` and comes later in the file, so it would win and put
+   the placeholder underneath the magnifier. The attribute selector here breaks
+   the tie by weight rather than by source order, which is the thing that will
+   not quietly come back the next time these blocks are reordered. */
+.searchbox input[type='search'] {
+  width: 100%;
+  height: 2.5rem;
+  padding: 0 1.25rem 0 2.5rem;
+  font: inherit;
+  color: var(--ink);
+  background: var(--surface-sunken);
+  border: 1px solid var(--hairline);
+  border-radius: var(--r-pill);
+  appearance: none;
+}
+
+.searchbox svg {
+  position: absolute;
+  left: 0.875rem;
+  top: 0.625rem;
+  width: 1rem;
+  height: 1rem;
+  fill: none;
+  stroke: var(--muted);
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  pointer-events: none;
+}
+
+.page {
+  width: 100%;
+  padding: 1.5rem 1.5rem 5rem;
+}
+
+/* ═══ page header ════════════════════════════════════════════════════════ */
+
+.page-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.eyebrow {
+  font-size: 0.75rem;
+  font-weight: 300;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--muted);
+}
+
+.page-head h1 {
+  font-size: 1.25rem; /* text-xl */
+  font-weight: 700;
+  margin: 0;
+  color: var(--ink);
+}
+
+.page-head .actions {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* A paragraph of standing explanation under a page title. Every screen here
+   has one, because every screen here is about a number somebody could
+   misread. */
+.lede {
+  max-width: 68ch;
+  margin: 0 0 1.5rem;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+h2.section {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+  margin: 2rem 0 0.75rem;
+}
+
+h2.section:first-of-type {
+  margin-top: 1.5rem;
+}
+
+/* ═══ card ═══════════════════════════════════════════════════════════════ */
+
+.card {
   background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
+  border: 1px solid var(--hairline);
+  border-radius: var(--r-card);
   overflow: hidden;
 }
 
-/* ── tiles ── */
-
-.tiles {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 12px;
+.card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 1rem 1rem 0.5rem;
 }
 
-.tile {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 14px 16px;
-}
-
-.tile .label {
-  font-size: 12px;
-  color: var(--muted);
-  display: block;
-  margin-bottom: 6px;
-}
-
-.tile .value {
-  font-size: 26px;
+.card-head h3 {
+  font-size: 0.875rem;
   font-weight: 700;
-  letter-spacing: -0.02em;
-  font-variant-numeric: tabular-nums;
+  margin: 0;
+  color: var(--ink);
 }
 
-.tile .sub {
-  font-size: 12px;
-  color: var(--faint);
-  margin-top: 4px;
+.card-head .eyebrow {
+  margin-bottom: 0.125rem;
 }
 
-/* ── tables ── */
+.card-body {
+  padding: 1rem;
+}
 
-.scroll {
+.card-body:not(:first-child) {
+  padding-top: 0;
+}
+
+.card-note {
+  padding: 0.75rem 1rem 1rem;
+  margin: 0;
+  font-size: 0.75rem;
+  line-height: 1.6;
+  color: var(--muted);
+}
+
+.card-note:first-child {
+  padding-top: 1rem;
+}
+
+/**
+ * A label over one table inside a card that holds several.
+ *
+ * Two bare tables stacked in one card read as a single table with a stray
+ * header row halfway down — which on the campaigns screen meant the revenue
+ * columns appeared to be more rows of the funnel. This is the break, and the
+ * top rule is what actually does the work; the words are what makes the break
+ * mean something.
+ */
+.card-subhead {
+  padding: 1rem 1rem 0.25rem;
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted);
+  border-top: 1px solid var(--hairline);
+}
+
+.card-subhead:first-child,
+.card-head + .card-subhead,
+.card-note + .card-subhead {
+  border-top: none;
+}
+
+.card-note + .card-subhead {
+  padding-top: 0.5rem;
+}
+
+.card-subhead + .card-body {
+  padding-top: 0.5rem;
+}
+
+.card + .card,
+.card + .stack-gap,
+.stack > * + * {
+  margin-top: 1rem;
+}
+
+.stack {
+  display: block;
+}
+
+/* ═══ grids ══════════════════════════════════════════════════════════════ */
+
+.cols-4,
+.cols-3,
+.cols-2 {
+  display: grid;
+  gap: 0.75rem;
+  align-items: start;
+}
+
+.cols-4 {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+.cols-3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+.cols-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+/* The dashboard's chart row: a donut wants less width than 30 days of line. */
+.cols-chart {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.6fr);
+  gap: 0.75rem;
+  align-items: stretch;
+}
+
+.cols-chart > .card {
+  display: flex;
+  flex-direction: column;
+}
+
+.autofit {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+  gap: 0.75rem;
+}
+
+/* ═══ stat card ══════════════════════════════════════════════════════════ */
+
+.stat {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 1rem;
+  background: var(--surface);
+  border: 1px solid var(--hairline);
+  border-radius: var(--r-card);
+}
+
+.stat-label {
+  font-size: 0.75rem;
+  font-weight: 300;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--muted);
+}
+
+.stat-value {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--ink);
+  line-height: 1.3;
+}
+
+.stat-sub {
+  font-size: 0.75rem;
+  color: var(--muted);
+  margin-top: 0.125rem;
+}
+
+.stat-sub.up {
+  color: var(--ok);
+}
+.stat-sub.down {
+  color: var(--danger);
+}
+
+.stat > svg {
+  width: 24px;
+  height: 24px;
+  flex: 0 0 24px;
+  fill: none;
+  stroke: var(--muted);
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+/* A quieter figure than `.stat`, for the count rows above a list. */
+.tile {
+  padding: 1rem;
+  background: var(--surface);
+  border: 1px solid var(--hairline);
+  border-radius: var(--r-card);
+}
+
+.tile-label {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 300;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--muted);
+}
+
+.tile-value {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.tile-sub {
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+/* ═══ badge ══════════════════════════════════════════════════════════════ */
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  text-align: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  padding: 0.125rem 0.5rem;
+  border-radius: var(--r-card);
+  background: var(--surface-sunken);
+  color: var(--ink-2);
+  white-space: nowrap;
+}
+
+.badge-accent {
+  background: var(--accent-soft);
+  color: var(--accent-deep);
+}
+.badge-ok {
+  background: var(--ok-soft);
+  color: var(--ok);
+}
+.badge-warn {
+  background: var(--warn-soft);
+  color: var(--warn);
+}
+.badge-danger {
+  background: var(--danger-soft);
+  color: var(--danger);
+}
+
+@media (prefers-color-scheme: dark) {
+  .badge-accent,
+  .badge-ok,
+  .badge-warn,
+  .badge-danger {
+    color: var(--ink);
+  }
+  .badge-accent {
+    color: #dbeafe;
+  }
+}
+
+/* A live/ended dot, for a status that is a state rather than a category. */
+.dot {
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: var(--r-pill);
+  margin-right: 0.375rem;
+  background: var(--muted);
+}
+
+.dot.on {
+  background: var(--c-green);
+}
+.dot.off {
+  background: var(--muted);
+}
+
+/* ═══ buttons ════════════════════════════════════════════════════════════ */
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  padding: 0.5rem 1rem;
+  border: 1px solid transparent;
+  border-radius: var(--r-card);
+  background: var(--accent-strong);
+  color: var(--on-accent);
+  text-decoration: none;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.btn:hover {
+  background: var(--accent-deep);
+}
+
+.btn svg {
+  width: 16px;
+  height: 16px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.btn-outline {
+  background: transparent;
+  border-color: var(--accent-strong);
+  color: var(--accent-strong);
+}
+
+.btn-outline:hover {
+  background: var(--accent-wash);
+  border-color: var(--accent-deep);
+  color: var(--accent-deep);
+}
+
+.btn-ghost {
+  background: transparent;
+  color: var(--accent-strong);
+}
+
+.btn-ghost:hover {
+  background: var(--accent-wash);
+  color: var(--accent-deep);
+}
+
+.btn-quiet {
+  background: transparent;
+  border-color: var(--line);
+  color: var(--ink-2);
+}
+
+.btn-quiet:hover {
+  background: var(--surface-sunken);
+  color: var(--ink);
+}
+
+.btn-danger {
+  background: transparent;
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
+.btn-danger:hover {
+  background: var(--danger-soft);
+}
+
+.btn-sm {
+  padding: 0.25rem 0.625rem;
+}
+
+.btn[disabled],
+.btn[aria-disabled='true'] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ═══ forms ══════════════════════════════════════════════════════════════ */
+
+.form {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.75rem 1rem;
+}
+
+.form-full {
+  flex: 1 1 100%;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.field > span,
+.field-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--ink-2);
+  white-space: nowrap;
+}
+
+.field-hint {
+  font-size: 0.75rem;
+  font-weight: 400;
+  color: var(--muted);
+}
+
+input[type='text'],
+input[type='number'],
+input[type='date'],
+input[type='search'],
+input[type='password'],
+input[type='email'],
+input[type='url'],
+select,
+textarea {
+  font: inherit;
+  color: var(--ink);
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--r-input);
+  padding: 0.4375rem 0.625rem;
+  min-width: 0;
+}
+
+textarea {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  resize: vertical;
+}
+
+input:hover,
+select:hover,
+textarea:hover {
+  border-color: var(--muted);
+}
+
+input::placeholder,
+textarea::placeholder {
+  color: var(--muted);
+}
+
+input[type='number'] {
+  width: 6rem;
+}
+
+/* Some of these knobs are byte counts and minor-unit caps — eight and nine
+   digits — and 6rem clips them mid-number, which is the one thing a field
+   holding a limit must never do. */
+input[type='number'].wide {
+  width: 9.5rem;
+}
+
+input[type='checkbox'],
+input[type='radio'] {
+  width: 1rem;
+  height: 1rem;
+  accent-color: var(--accent-strong);
+  margin: 0;
+}
+
+.check {
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--ink-2);
+  padding-bottom: 0.5rem;
+  white-space: nowrap;
+}
+
+.check.plain {
+  padding-bottom: 0;
+}
+
+fieldset {
+  border: none;
+  margin: 0;
+  padding: 0;
+  min-width: 0;
+}
+
+legend {
+  padding: 0;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--ink-2);
+}
+
+/* ═══ table ══════════════════════════════════════════════════════════════ */
+
+.table-scroll {
   overflow-x: auto;
 }
 
 table {
   width: 100%;
   border-collapse: collapse;
-  font-variant-numeric: tabular-nums;
-}
-
-th,
-td {
-  text-align: right;
-  padding: 9px 14px;
-  border-bottom: 1px solid var(--border);
-  white-space: nowrap;
-}
-
-th:first-child,
-td:first-child {
   text-align: left;
+  table-layout: auto;
+}
+
+thead th {
+  padding: 0.5rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted);
+  border-bottom: 1px solid var(--hairline);
+  white-space: nowrap;
+  background: var(--surface);
+}
+
+tbody td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--hairline);
+  white-space: nowrap;
+  color: var(--ink-2);
+  vertical-align: top;
 }
 
 tbody tr:last-child td {
   border-bottom: none;
 }
 
-th {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+tbody tr:hover td {
+  background: var(--bg);
 }
 
-/* ── sparkline-ish bars ── */
+/* Numbers right, words left — set per column rather than globally, because a
+   table here mixes both and a blanket rule got the words wrong. */
+th.n,
+td.n {
+  text-align: right;
+}
 
+td.wrap {
+  white-space: normal;
+  max-width: 42rem;
+}
+
+td strong,
+.row-title {
+  color: var(--ink);
+  font-weight: 600;
+}
+
+.row-sub {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--muted);
+  font-weight: 400;
+}
+
+.row-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+/* ═══ empty / error / loading ════════════════════════════════════════════ */
+
+.empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 3rem 1.5rem;
+  text-align: center;
+  color: var(--muted);
+}
+
+.empty svg {
+  width: 32px;
+  height: 32px;
+  fill: none;
+  stroke: var(--muted);
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  opacity: 0.7;
+}
+
+.empty-title {
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.empty p {
+  margin: 0;
+  max-width: 46ch;
+  line-height: 1.6;
+}
+
+/* One banner shape, four tones. Announced politely rather than assertively:
+   these follow a redirect, so the whole page has already changed. */
+.banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  border: 1px solid transparent;
+  border-radius: var(--r-card);
+  line-height: 1.5;
+}
+
+.banner svg {
+  width: 18px;
+  height: 18px;
+  flex: 0 0 18px;
+  margin-top: 0.125rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.banner-ok {
+  background: var(--ok-soft);
+  color: var(--ok);
+  border-color: currentColor;
+}
+
+.banner-danger {
+  background: var(--danger-soft);
+  color: var(--danger);
+  border-color: currentColor;
+}
+
+.banner-info {
+  background: var(--accent-wash);
+  color: var(--accent-deep);
+  border-color: var(--accent-soft);
+}
+
+@media (prefers-color-scheme: dark) {
+  .banner-info {
+    color: var(--accent-strong);
+  }
+}
+
+/* The skeleton a Suspense boundary shows while a server component is still
+   fetching. Static blocks, not a shimmer: the pulse is switched off entirely
+   under reduced motion by the global rule above. */
+.skel {
+  background: var(--hairline);
+  border-radius: var(--r-input);
+  animation: skel-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes skel-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.55;
+  }
+}
+
+.skel-line {
+  height: 0.75rem;
+}
+
+/* ═══ charts ═════════════════════════════════════════════════════════════ */
+
+.echart {
+  width: 100%;
+  padding: 0.25rem 0.5rem 0.75rem;
+  margin: 0;
+  flex: 1 1 auto;
+}
+
+.seg {
+  display: inline-flex;
+  gap: 0.125rem;
+  padding: 0.125rem;
+  background: var(--surface-sunken);
+  border: 1px solid var(--hairline);
+  border-radius: var(--r-card);
+}
+
+.seg button {
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  padding: 0.25rem 0.625rem;
+  border-radius: 0.375rem;
+  cursor: pointer;
+}
+
+.seg button:hover {
+  color: var(--accent-strong);
+}
+
+.seg button[aria-pressed='true'] {
+  background: var(--surface);
+  color: var(--accent-strong);
+  box-shadow: var(--shadow-pop);
+}
+
+/* Day bars, still hand-drawn. A dependency that renders one rectangle is a
+   dependency that has to be upgraded forever. */
 .bars {
   display: flex;
   align-items: flex-end;
   gap: 2px;
-  height: 72px;
-  padding: 16px;
+  height: 5rem;
+  padding: 1rem;
 }
 
 .bars .bar {
   flex: 1;
   min-width: 2px;
-  background: var(--brand);
+  background: var(--accent);
   border-radius: 2px 2px 0 0;
-  opacity: 0.85;
 }
 
 .bars .bar.zero {
-  background: var(--border);
-  opacity: 1;
+  background: var(--hairline);
 }
 
-/* ── misc ── */
+/* ═══ misc ═══════════════════════════════════════════════════════════════ */
 
 .muted {
   color: var(--muted);
 }
-.faint {
-  color: var(--faint);
-  font-size: 12px;
-}
 
-.note {
-  padding: 14px 16px;
-  color: var(--muted);
-  font-size: 13px;
-  line-height: 1.5;
-}
-
-a {
-  color: var(--brand);
+.small {
+  font-size: 0.75rem;
 }
 
 .row {
   display: flex;
-  gap: 12px;
+  gap: 0.75rem;
   align-items: center;
   flex-wrap: wrap;
 }
 
-/* ── login ── */
-
-.login {
-  max-width: 340px;
-  margin: 18vh auto;
-  padding: 0 24px;
+.spread {
+  justify-content: space-between;
 }
 
-.login form {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  margin-top: 18px;
-}
-
-input[type='password'] {
-  font: inherit;
-  padding: 11px 13px;
-  border-radius: 10px;
-  border: 1px solid var(--border);
-  background: var(--surface);
-  color: var(--text);
-}
-
-button {
-  font: inherit;
+.pos {
+  color: var(--ok);
   font-weight: 600;
-  padding: 11px 16px;
-  border-radius: 10px;
-  border: none;
-  background: var(--brand);
-  color: #fff;
-  cursor: pointer;
 }
-
-.error {
-  color: var(--negative);
-  font-size: 13px;
-}
-
-/* ── nav ── */
-
-.nav {
-  display: flex;
-  gap: 14px;
-  font-size: 13px;
-}
-
-.nav a {
-  text-decoration: none;
-  color: var(--muted);
-}
-
-.nav a[aria-current='page'] {
-  color: var(--brand);
+.neg {
+  color: var(--danger);
   font-weight: 600;
 }
 
-/* ── flag editor ── */
-
-form.flag {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-end;
-  gap: 12px;
-  padding: 16px;
-}
-
-form.flag label {
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
-  font-size: 12px;
-  color: var(--muted);
-}
-
-form.flag label.inline {
-  flex-direction: row;
-  align-items: center;
-  gap: 7px;
-  padding-bottom: 10px;
-}
-
-form.flag select,
-form.flag input[type='date'],
-form.flag input[type='text'],
-form.flag input[type='number'] {
-  font: inherit;
-  padding: 8px 11px;
-  border-radius: 9px;
-  border: 1px solid var(--border);
-  background: var(--bg);
-  color: var(--text);
-}
-
-form.flag input[type='number'] {
-  width: 92px;
-}
-
-form.flag button {
-  padding: 9px 16px;
-}
-
-/* ── country list ── */
-
-/* A checkbox per market, reflowing into as many columns as fit — read at a
-   desk, so a dense grid rather than a long single column. */
-.country-grid {
+/* A dense grid of checkboxes — one per market, one per anything. */
+.check-grid {
   width: 100%;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 6px 18px;
+  grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));
+  gap: 0.25rem 1rem;
 }
 
-/* Match the specificity of `form.flag label` (which sets column) so the row
-   layout actually wins — a bare `.country-row` loses to it and stacks. */
-form.flag label.country-row {
-  flex-direction: row;
-  align-items: center;
-  gap: 9px;
-  font-size: 13px;
-  color: var(--text);
-  padding: 5px 0;
-}
+/* ═══ feed (feedback, voice attempts) ════════════════════════════════════ */
 
-.country-row input[type='checkbox'] {
-  width: 16px;
-  height: 16px;
-  accent-color: var(--accent, #4ca82c);
-}
-
-/**
- * Minimum responsive, and that is the whole ambition.
- *
- * This is read at a desk. The phone case that matters is checking a number
- * while away from one, so the requirement is only that nothing is unreadable
- * or unreachable — not that it is redesigned. The tiles already reflow on
- * their own (`auto-fit`) and every table already scrolls inside its own
- * container, so this is just tightening the gutters and stopping the header
- * from squeezing the date into a column of single characters.
- */
-/* The two-up charts stack before they get too narrow to read. */
-@media (max-width: 920px) {
-  .grid-2 {
-    grid-template-columns: 1fr;
-  }
-}
-
-/* Below a tablet the rail turns into a scrolling strip across the top, so every
-   destination stays one tap away without an off-canvas drawer to maintain. */
-@media (max-width: 820px) {
-  .shell {
-    flex-direction: column;
-  }
-
-  .sidebar {
-    position: static;
-    width: 100%;
-    height: auto;
-    flex-direction: row;
-    align-items: center;
-    gap: 4px;
-    overflow-x: auto;
-    padding: 10px 12px;
-  }
-
-  .sidebar .brand {
-    padding: 0 12px 0 4px;
-  }
-
-  .sidebar .brand span:not(.mark) {
-    display: none;
-  }
-
-  .side-group {
-    display: none;
-  }
-
-  .side-link {
-    white-space: nowrap;
-  }
-
-  .side-link span {
-    display: none;
-  }
-
-  .topbar {
-    padding: 0 14px;
-  }
-
-  .topbar .crumb {
-    display: none;
-  }
-}
-
-@media (max-width: 640px) {
-  main {
-    padding: 20px 14px 64px;
-  }
-
-  .hero {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 10px;
-  }
-
-  header.top {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 4px;
-  }
-
-  .tiles {
-    grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
-  }
-
-  .tile .value {
-    font-size: 22px;
-  }
-
-  h2 {
-    margin: 28px 0 10px;
-  }
-
-  th,
-  td {
-    padding: 8px 10px;
-  }
-}
-
-/* ── feedback list ── */
-
-ul.feedback {
+ul.feed {
   list-style: none;
   margin: 0;
   padding: 0;
 }
 
-ul.feedback li {
-  padding: 14px 16px;
-  border-bottom: 1px solid var(--border);
+ul.feed li {
+  padding: 0.875rem 1rem;
+  border-bottom: 1px solid var(--hairline);
 }
 
-ul.feedback li:last-child {
+ul.feed li:last-child {
   border-bottom: none;
 }
 
-ul.feedback p {
-  margin: 8px 0 0;
+ul.feed p {
+  margin: 0.5rem 0 0;
   white-space: pre-wrap;
-  line-height: 1.5;
+  line-height: 1.6;
+  color: var(--ink-2);
 }
 
-ul.feedback .meta {
+ul.feed .meta {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: 0.625rem;
   align-items: center;
-  font-size: 12px;
-  color: var(--faint);
-}
-
-.tag {
-  font-weight: 600;
-  padding: 2px 8px;
-  border-radius: 999px;
-  background: var(--surfaceMuted, var(--border));
+  font-size: 0.75rem;
   color: var(--muted);
-}
-
-.tag-bug {
-  background: #ff7b7222;
-  color: var(--negative);
-}
-.tag-idea {
-  background: #34d39922;
-  color: var(--positive);
-}
-.tag-deletion {
-  background: #9b83ff22;
-  color: var(--brand);
 }
 
 .gone {
   font-style: italic;
+}
+
+/* ═══ login ══════════════════════════════════════════════════════════════ */
+
+.login-page {
+  min-height: 100vh;
+  min-width: 0;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+  background: var(--bg);
+}
+
+.login-card {
+  width: 22rem;
+  padding: 2rem;
+  background: var(--surface);
+  border: 1px solid var(--hairline);
+  border-radius: var(--r-card);
+  box-shadow: var(--shadow-pop);
+}
+
+.login-card h1 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin: 0.75rem 0 0.25rem;
+}
+
+.login-card form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.login-card input {
+  height: 2.5rem;
+}
+
+.login-card .btn {
+  padding: 0.6875rem 1rem;
+}
+
+.login-mark {
+  display: inline-flex;
+  color: var(--accent-strong);
+}
+
+.login-mark svg {
+  width: 32px;
+  height: 32px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+/* The login page is the one screen that must work anywhere — it is what you
+   reach for on a phone when you cannot get to a desk. */
+body:has(.login-page) {
+  min-width: 0;
+}
+
+@media (max-width: 24rem) {
+  .login-card {
+    width: 100%;
+    padding: 1.5rem;
+  }
 }

--- a/apps/admin/src/app/layout.tsx
+++ b/apps/admin/src/app/layout.tsx
@@ -9,6 +9,14 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
+/**
+ * There is no `viewport` export and no breakpoints below 1024px, on purpose.
+ * This is a desktop tool: `body { min-width: 1024px }` means a narrow screen
+ * gets the real layout and has to pan, which is at least honest, rather than a
+ * reflowed one that pretends to work. The login page opts back out of that
+ * floor (`body:has(.login-page)` in `globals.css`), because signing in from a
+ * phone to check the console is up is a real thing to do.
+ */
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">

--- a/apps/admin/src/app/loading.tsx
+++ b/apps/admin/src/app/loading.tsx
@@ -1,0 +1,16 @@
+import { PageSkeleton } from '@/components/ui';
+
+/**
+ * The root loading state, which every route inherits unless it declares its
+ * own.
+ *
+ * Every page in this console is `force-dynamic` and every one of them opens
+ * with six parallel round trips to a database in another region, so the gap
+ * between clicking a rail item and seeing anything is real and was, until now,
+ * entirely blank — the previous page just sat there. This is the Suspense
+ * fallback that replaces that: shaped like the page behind it, so the layout
+ * does not jump when the numbers land.
+ */
+export default function Loading() {
+  return <PageSkeleton />;
+}

--- a/apps/admin/src/app/login/page.tsx
+++ b/apps/admin/src/app/login/page.tsx
@@ -1,6 +1,7 @@
 import { cookies, headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 
+import { Icon } from '@/components/icons';
 import { checkPassword, issueToken } from '@/lib/session';
 import { clientAddress, recordLoginAttempt } from '@/lib/loginThrottle';
 import { assertSameOrigin, RequestRejected } from '@/lib/csrf';
@@ -57,25 +58,42 @@ export default async function Login({
   }
 
   return (
-    <main className="login">
-      <h1>Waves admin</h1>
-      <p className="faint">Private console. Contains personal data.</p>
-      <form action={signIn}>
-        <input
-          type="password"
-          name="password"
-          placeholder="Password"
-          aria-label="Password"
-          autoFocus
-          autoComplete="current-password"
-        />
-        <button type="submit">Sign in</button>
-        {error === 'locked' ? (
-          <p className="error">Too many attempts. Wait a few minutes and try again.</p>
-        ) : error ? (
-          <p className="error">That did not work.</p>
-        ) : null}
-      </form>
+    <main className="login-page">
+      <div className="login-card">
+        <span className="login-mark">{Icon.cube}</span>
+        <h1>Waves admin</h1>
+        <p className="muted small">Private console. Contains personal data.</p>
+
+        <form action={signIn}>
+          <label className="field">
+            <span>Password</span>
+            <input
+              type="password"
+              name="password"
+              autoFocus
+              autoComplete="current-password"
+              required
+              // The message is deliberately the same whatever went wrong, so
+              // the field points at it rather than describing the failure.
+              aria-describedby={error ? 'login-error' : undefined}
+              aria-invalid={error ? true : undefined}
+            />
+          </label>
+          <button type="submit" className="btn">
+            Sign in
+          </button>
+          {error ? (
+            <p id="login-error" className="banner banner-danger" role="alert">
+              {Icon.alert}
+              <span>
+                {error === 'locked'
+                  ? 'Too many attempts. Wait a few minutes and try again.'
+                  : 'That did not work.'}
+              </span>
+            </p>
+          ) : null}
+        </form>
+      </div>
     </main>
   );
 }

--- a/apps/admin/src/app/not-found.tsx
+++ b/apps/admin/src/app/not-found.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link';
+
+import { Card, Empty, PageHeader } from '@/components/ui';
+
+/**
+ * A mistyped path. Kept inside the shell — the rail is the fastest way out of
+ * here, and dropping somebody onto a bare page with no navigation is a worse
+ * answer than the wrong URL was.
+ */
+export default function NotFound() {
+  return (
+    <main className="page">
+      <PageHeader eyebrow="Admin" title="No such page" />
+      <Card bare>
+        <Empty title="Nothing at that address">
+          Nothing in this console answers on that path. Everything it does have is in the rail on
+          the left, or start again from the <Link href="/">dashboard</Link>.
+        </Empty>
+      </Card>
+    </main>
+  );
+}

--- a/apps/admin/src/app/pack-requests/page.tsx
+++ b/apps/admin/src/app/pack-requests/page.tsx
@@ -1,9 +1,10 @@
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 
-import { decidePackRequest, packRequests } from '@/lib/data';
-import { guardMutation } from '@/lib/csrf';
 import { CsrfField } from '@/components/CsrfField';
+import { Badge, Card, Empty, Lede, Outcome, PageHeader, TableScroll } from '@/components/ui';
+import { guardMutation } from '@/lib/csrf';
+import { decidePackRequest, packRequests } from '@/lib/data';
 
 export const dynamic = 'force-dynamic';
 
@@ -11,13 +12,14 @@ export const dynamic = 'force-dynamic';
  * What people have asked for.
  *
  * The other half of "we author them, others ask": there is no submission flow
- * and nothing anybody writes here reaches another user — a request is a sentence
- * in a queue. Which makes this the cheapest possible way to find out what the
- * shelf is missing, and the only one that carries no moderation burden at all.
+ * and nothing anybody writes here reaches another user — a request is a
+ * sentence in a queue. Which makes this the cheapest possible way to find out
+ * what the shelf is missing, and the only one that carries no moderation
+ * burden at all.
  *
  * No requester is shown. Knowing *who* asked adds nothing to deciding whether
- * the pack is worth making, and this console deliberately keeps what it can see
- * about people to what it needs (see `data.ts`).
+ * the pack is worth making, and this console deliberately keeps what it can
+ * see about people to what it needs (see `data.ts`).
  */
 export default async function PackRequests({
   searchParams,
@@ -48,71 +50,107 @@ export default async function PackRequests({
   }
 
   return (
-    <main>
-      <header className="top">
-        <h1>Pack requests</h1>{' '}
-      </header>
+    <main className="page">
+      <PageHeader
+        eyebrow="Marketplace"
+        title="Pack requests"
+        actions={<span className="small muted">{open.length} waiting</span>}
+      />
+      <Outcome error={error} done={saved ? 'Saved.' : undefined} />
 
-      {error ? <p className="error">{error}</p> : null}
-      {saved ? <p className="faint">Saved.</p> : null}
-
-      <p className="note" style={{ padding: 0 }}>
+      <Lede>
         What people told us the app has no words for. Mark one <strong>done</strong> once a pack
         covering it is published, or <strong>declined</strong> if it is not something we will make.
         Nobody is notified either way.
-      </p>
+      </Lede>
 
-      {open.length === 0 ? (
-        <p className="note">Nothing waiting.</p>
-      ) : (
-        <div className="scroll">
-          <table>
-            <thead>
-              <tr>
-                <th>Asked for</th>
-                <th>When</th>
-                <th />
-              </tr>
-            </thead>
-            <tbody>
-              {open.map((row) => (
-                <tr key={row.id}>
-                  <td>{row.body}</td>
-                  <td className="faint">{new Date(row.created_at).toLocaleDateString()}</td>
-                  <td>
-                    <form action={decide} style={{ display: 'flex', gap: 8 }}>
-                      <CsrfField />
-                      <input type="hidden" name="id" value={row.id} />
-                      <button type="submit" name="status" value="done">
-                        Done
-                      </button>
-                      <button type="submit" name="status" value="declined">
-                        Decline
-                      </button>
-                    </form>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-
-      {decided.length > 0 ? (
-        <>
-          <h2>Decided</h2>
-          <div className="scroll">
+      <Card bare>
+        {open.length === 0 ? (
+          <Empty title="Nothing waiting">Every request has been decided.</Empty>
+        ) : (
+          <TableScroll>
             <table>
+              <caption className="sr-only">Open pack requests</caption>
+              <thead>
+                <tr>
+                  <th scope="col">Asked for</th>
+                  <th scope="col">When</th>
+                  <th scope="col">
+                    <span className="sr-only">Decision</span>
+                  </th>
+                </tr>
+              </thead>
               <tbody>
-                {decided.slice(0, 50).map((row) => (
+                {open.map((row) => (
                   <tr key={row.id}>
-                    <td>{row.body}</td>
-                    <td className="faint">{row.status}</td>
+                    <td className="wrap">{row.body}</td>
+                    <td className="muted">
+                      <time dateTime={row.created_at}>
+                        {new Date(row.created_at).toLocaleDateString('en-IN', {
+                          day: 'numeric',
+                          month: 'short',
+                          year: 'numeric',
+                        })}
+                      </time>
+                    </td>
+                    <td>
+                      <form action={decide} className="row-actions">
+                        <CsrfField />
+                        <input type="hidden" name="id" value={row.id} />
+                        <button
+                          type="submit"
+                          name="status"
+                          value="done"
+                          className="btn btn-sm"
+                          aria-label={`Mark "${row.body}" done`}
+                        >
+                          Done
+                        </button>
+                        <button
+                          type="submit"
+                          name="status"
+                          value="declined"
+                          className="btn btn-danger btn-sm"
+                          aria-label={`Decline "${row.body}"`}
+                        >
+                          Decline
+                        </button>
+                      </form>
+                    </td>
                   </tr>
                 ))}
               </tbody>
             </table>
-          </div>
+          </TableScroll>
+        )}
+      </Card>
+
+      {decided.length > 0 ? (
+        <>
+          <h2 className="section">Decided</h2>
+          <Card bare>
+            <TableScroll>
+              <table>
+                <caption className="sr-only">Requests already decided</caption>
+                <thead>
+                  <tr>
+                    <th scope="col">Asked for</th>
+                    <th scope="col">Decision</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {decided.slice(0, 50).map((row) => (
+                    <tr key={row.id}>
+                      <td className="wrap">{row.body}</td>
+                      <td>
+                        <Badge tone={row.status === 'done' ? 'ok' : 'neutral'}>{row.status}</Badge>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </TableScroll>
+          </Card>
         </>
       ) : null}
     </main>

--- a/apps/admin/src/app/packs/page.tsx
+++ b/apps/admin/src/app/packs/page.tsx
@@ -1,20 +1,38 @@
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 
-import { packs, savePack, setPackStatus } from '@/lib/data';
-import { guardMutation } from '@/lib/csrf';
 import { CsrfField } from '@/components/CsrfField';
+import { Icon } from '@/components/icons';
+import {
+  Badge,
+  Card,
+  Empty,
+  Field,
+  Lede,
+  Outcome,
+  PageHeader,
+  TableScroll,
+  type Tone,
+} from '@/components/ui';
+import { guardMutation } from '@/lib/csrf';
+import { packs, savePack, setPackStatus } from '@/lib/data';
 
 export const dynamic = 'force-dynamic';
+
+const STATUS_TONE: Record<string, Tone> = {
+  published: 'ok',
+  draft: 'warn',
+  unlisted: 'neutral',
+};
 
 /**
  * The shelf, from behind.
  *
  * A pack is a set of categories or income sources somebody can install — data,
- * never code, so there is nothing here to sandbox. What there is instead is one
- * gate: `savePack` runs `parsePack`, the same function the app runs on what it
- * fetches, so a pack that a phone would silently drop cannot be saved at all.
- * The refusal arrives while the person who wrote it is still looking at it.
+ * never code, so there is nothing here to sandbox. What there is instead is
+ * one gate: `savePack` runs `parsePack`, the same function the app runs on what
+ * it fetches, so a pack that a phone would silently drop cannot be saved at
+ * all. The refusal arrives while the person who wrote it is still looking at it.
  *
  * The entries are edited as JSON rather than through a row-by-row form. That is
  * a deliberate trade for a staff tool used by a handful of people: a form would
@@ -29,6 +47,7 @@ export default async function Packs({
 }) {
   const { error, saved } = await searchParams;
   const all = await packs();
+  const live = all.filter((pack) => pack.status === 'published').length;
 
   async function save(formData: FormData) {
     'use server';
@@ -74,126 +93,146 @@ export default async function Packs({
   }
 
   return (
-    <main>
-      <header className="top">
-        <h1>Packs</h1>{' '}
-      </header>
+    <main className="page">
+      <PageHeader
+        eyebrow="Marketplace"
+        title="Packs"
+        actions={
+          <span className="small muted">
+            {live} published of {all.length}
+          </span>
+        }
+      />
+      <Outcome error={error} done={saved ? 'Saved.' : undefined} />
 
-      {error ? <p className="error">{error}</p> : null}
-      {saved ? <p className="faint">Saved.</p> : null}
-
-      <p className="note" style={{ padding: 0 }}>
+      <Lede>
         Sets of categories and income sources people can add to their own list. Only a{' '}
         <strong>published</strong> pack is visible in the app at all — a draft is ours alone, and
         unlisting one stops it spreading without touching anybody who already installed it. Their
         categories are their own by then.
-      </p>
+      </Lede>
 
-      {all.length === 0 ? (
-        <p className="note">
-          None yet. If you expected some, the <code>20260906120000_category_packs</code> migration
-          may not be deployed to this project.
-        </p>
-      ) : (
-        <div className="scroll">
-          <table>
-            <thead>
-              <tr>
-                <th>Pack</th>
-                <th>Entries</th>
-                <th>Installs</th>
-                <th>Status</th>
-                <th />
-              </tr>
-            </thead>
-            <tbody>
-              {all.map((pack) => {
-                const entries = Array.isArray(pack.entries) ? pack.entries.length : 0;
-                return (
-                  <tr key={pack.id}>
-                    <td>
-                      <strong>{pack.title}</strong>
-                      <br />
-                      <span className="faint">{pack.slug}</span>
-                    </td>
-                    <td>{entries}</td>
-                    <td>{pack.install_count}</td>
-                    <td>{pack.status}</td>
-                    <td>
-                      <form action={publish}>
-                        <CsrfField />
-                        <input type="hidden" name="id" value={pack.id} />
-                        <input
-                          type="hidden"
-                          name="status"
-                          value={pack.status === 'published' ? 'unlisted' : 'published'}
-                        />
-                        <button type="submit">
-                          {pack.status === 'published' ? 'Unlist' : 'Publish'}
-                        </button>
-                      </form>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-      )}
+      <Card bare>
+        {all.length === 0 ? (
+          <Empty title="No packs yet" migration="20260906120000_category_packs">
+            Nothing on the shelf.
+          </Empty>
+        ) : (
+          <TableScroll>
+            <table>
+              <caption className="sr-only">Published and draft packs</caption>
+              <thead>
+                <tr>
+                  <th scope="col">Pack</th>
+                  <th scope="col" className="n">
+                    Entries
+                  </th>
+                  <th scope="col" className="n">
+                    Installs
+                  </th>
+                  <th scope="col">Status</th>
+                  <th scope="col">
+                    <span className="sr-only">Actions</span>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {all.map((pack) => {
+                  const entries = Array.isArray(pack.entries) ? pack.entries.length : 0;
+                  const publishing = pack.status !== 'published';
+                  return (
+                    <tr key={pack.id}>
+                      <th scope="row">
+                        <span className="row-title">{pack.title}</span>
+                        <span className="row-sub">{pack.slug}</span>
+                      </th>
+                      <td className="n">{entries}</td>
+                      <td className="n">{pack.install_count}</td>
+                      <td>
+                        <Badge tone={STATUS_TONE[pack.status] ?? 'neutral'}>{pack.status}</Badge>
+                      </td>
+                      <td>
+                        <form action={publish} className="row-actions">
+                          <CsrfField />
+                          <input type="hidden" name="id" value={pack.id} />
+                          <input
+                            type="hidden"
+                            name="status"
+                            value={publishing ? 'published' : 'unlisted'}
+                          />
+                          <button
+                            type="submit"
+                            className={publishing ? 'btn btn-sm' : 'btn btn-quiet btn-sm'}
+                            aria-label={`${publishing ? 'Publish' : 'Unlist'} ${pack.title}`}
+                          >
+                            {publishing ? 'Publish' : 'Unlist'}
+                          </button>
+                        </form>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </TableScroll>
+        )}
+      </Card>
 
-      <h2>Add or edit a pack</h2>
-      <form action={save} className="flag">
-        <CsrfField />
-        <label>
-          Id <span className="faint">(blank to create)</span>
-          <input name="id" placeholder="" />
-        </label>
-        <label>
-          Slug
-          <input
-            name="slug"
-            required
-            placeholder="india-everyday"
-            pattern="[a-z0-9]+(-[a-z0-9]+)*"
-          />
-        </label>
-        <label>
-          Title
-          <input name="title" required placeholder="India · everyday" maxLength={60} />
-        </label>
-        <label>
-          Summary
-          <input name="summary" required maxLength={200} />
-        </label>
-        <label>
-          Status
-          <select name="status" defaultValue="draft">
-            <option value="draft">draft</option>
-            <option value="published">published</option>
-            <option value="unlisted">unlisted</option>
-          </select>
-        </label>
-        <label>
-          Entries
-          <textarea
-            name="entries"
-            required
-            rows={10}
-            defaultValue={
-              '[\n  {"key":"kirana","label":"Kirana","icon":"storefront-outline","tint":"mint","axis":"expense"}\n]'
-            }
-          />
-        </label>
-        <button type="submit">Save pack</button>
-      </form>
-
-      <p className="note">
-        Each entry needs a <code>key</code> (lowercase, unique in the pack), a <code>label</code> of
-        40 characters or fewer, an <code>icon</code> from the curated Ionicons set, a{' '}
-        <code>tint</code> of lilac / pink / mint / peach / sky / coral, and an <code>axis</code> of{' '}
-        <code>expense</code> or <code>income</code>. Anything else is refused here rather than
-        rendering as a blank box on somebody&rsquo;s phone.
-      </p>
+      <h2 className="section">Add or edit a pack</h2>
+      <Card
+        bare
+        note={
+          <>
+            Each entry needs a <code>key</code> (lowercase, unique in the pack), a{' '}
+            <code>label</code> of 40 characters or fewer, an <code>icon</code> from the curated
+            Ionicons set, a <code>tint</code> of lilac / pink / mint / peach / sky / coral, and an{' '}
+            <code>axis</code> of <code>expense</code> or <code>income</code>. Anything else is
+            refused here rather than rendering as a blank box on somebody&rsquo;s phone.
+          </>
+        }
+      >
+        <form action={save} className="form card-body">
+          <CsrfField />
+          <Field label="Id" hint="blank to create">
+            <input name="id" />
+          </Field>
+          <Field label="Slug">
+            <input
+              name="slug"
+              required
+              placeholder="india-everyday"
+              pattern="[a-z0-9]+(-[a-z0-9]+)*"
+            />
+          </Field>
+          <Field label="Title">
+            <input name="title" required placeholder="India · everyday" maxLength={60} />
+          </Field>
+          <Field label="Status">
+            <select name="status" defaultValue="draft">
+              <option value="draft">draft</option>
+              <option value="published">published</option>
+              <option value="unlisted">unlisted</option>
+            </select>
+          </Field>
+          <Field label="Summary" full>
+            <input name="summary" required maxLength={200} />
+          </Field>
+          <Field label="Entries" hint="JSON, validated with the app's own parser" full>
+            <textarea
+              name="entries"
+              required
+              rows={10}
+              defaultValue={
+                '[\n  {"key":"kirana","label":"Kirana","icon":"storefront-outline","tint":"mint","axis":"expense"}\n]'
+              }
+            />
+          </Field>
+          <button type="submit" className="btn">
+            {Icon.save}
+            <span>Save pack</span>
+          </button>
+        </form>
+      </Card>
     </main>
   );
 }

--- a/apps/admin/src/app/page.tsx
+++ b/apps/admin/src/app/page.tsx
@@ -1,9 +1,10 @@
 import { format, money, type CurrencyCode } from '@waves/core';
-import type { ReactNode } from 'react';
 
 import { Bars } from '@/components/Bars';
 import { AreaTrend } from '@/components/charts/AreaTrend';
 import { DonutChart } from '@/components/charts/DonutChart';
+import { Icon } from '@/components/icons';
+import { Card, Empty, PageHeader, Stat, TableScroll } from '@/components/ui';
 import { aiCost, daily, geo, logins, money as moneyRows, overview } from '@/lib/data';
 
 export const dynamic = 'force-dynamic';
@@ -32,13 +33,13 @@ export default async function Dashboard() {
 
   if (!head) {
     return (
-      <main>
-        <h1>Waves admin</h1>
-        <p className="note">
-          The analytics functions returned nothing. That usually means the
-          <code> 20260808190000_admin_analytics </code> migration has not been deployed to this
-          project yet.
-        </p>
+      <main className="page">
+        <PageHeader eyebrow="Overview" title="Dashboard" />
+        <Card>
+          <Empty title="No analytics to read" migration="20260808190000_admin_analytics">
+            The analytics functions returned nothing at all.
+          </Empty>
+        </Card>
       </main>
     );
   }
@@ -61,297 +62,289 @@ export default async function Dashboard() {
     .sort((a, b) => b.value - a.value);
 
   return (
-    <main>
-      <header className="top">
-        <h1>Dashboard</h1>
-        <p className="faint">
-          {new Date().toLocaleString('en-IN', { timeZone: 'Asia/Kolkata' })} IST
-        </p>
-      </header>
-
-      <section className="hero">
-        <div>
-          <div className="who">Waves, at a glance</div>
-          <div className="big">{num(head.active_profiles_30d)}</div>
-          <div className="lead">people active in the last 30 days</div>
-        </div>
-        <div style={{ textAlign: 'right' }}>
-          <div className="big">{num(head.active_profiles_7d)}</div>
-          <div className="lead">active in the last 7 days</div>
-        </div>
-      </section>
-
-      <div className="stats">
-        <Stat
-          tint="purple"
-          icon={ICON.people}
-          label="People"
-          value={num(head.profiles_total)}
-          chip={`+${num(head.profiles_new_7d)} in 7d`}
-          dir={Number(head.profiles_new_7d) > 0 ? 'up' : 'flat'}
-        />
-        <Stat
-          tint="blue"
-          icon={ICON.group}
-          label="Groups"
-          value={num(head.groups_total)}
-          chip={`${num(head.groups_active_30d)} active`}
-          dir="flat"
-        />
-        <Stat
-          tint="green"
-          icon={ICON.receipt}
-          label="Expenses"
-          value={num(head.expenses_total)}
-          chip={`+${num(head.expenses_new_30d)} in 30d`}
-          dir={Number(head.expenses_new_30d) > 0 ? 'up' : 'flat'}
-        />
-        <Stat
-          tint="amber"
-          icon={ICON.check}
-          label="Settlements"
-          value={num(head.settlements_total)}
-          chip={`${num(head.settlements_confirmed)} confirmed`}
-          dir="flat"
-        />
-        <Stat
-          tint="blue"
-          icon={ICON.pulse}
-          label="Active 30d"
-          value={num(head.active_profiles_30d)}
-          chip={`${num(head.active_profiles_7d)} in 7d`}
-          dir="flat"
-        />
-        <Stat
-          tint="red"
-          icon={ICON.trash}
-          label="Deleted expenses"
-          value={num(head.expenses_deleted)}
-          chip="soft-deleted"
-          dir="flat"
-        />
-      </div>
-
-      <div className="grid-2" style={{ marginTop: 18 }}>
-        <div className="card">
-          <div className="card-head">
-            <h3>Expenses by currency</h3>
-          </div>
-          <p className="card-sub">Live expenses, counted — never summed across currencies.</p>
-          {currencySlices.length === 0 ? (
-            <p className="note">No expenses yet.</p>
-          ) : (
-            <div className="echart">
-              <DonutChart slices={currencySlices} centerLabel="expenses" />
-            </div>
-          )}
-        </div>
-
-        <div className="card">
-          <AreaTrend days={trend} />
-          <p className="card-sub" style={{ paddingTop: 0 }}>
-            Active means the ledger recorded something. Opening the app is not written down, so it
-            is not counted here.
-          </p>
-        </div>
-      </div>
-
-      <h2>Where they are</h2>
-      <section className="scroll">
-        <table>
-          <thead>
-            <tr>
-              <th>Country</th>
-              <th>People</th>
-              <th>Groups</th>
-              <th>Expenses</th>
-            </tr>
-          </thead>
-          <tbody>
-            {countries.map((row) => (
-              <tr key={row.country_code ?? 'unknown'}>
-                <td>{row.country_code ?? <span className="muted">Not set</span>}</td>
-                <td>{num(row.profile_count)}</td>
-                <td>{num(row.group_count)}</td>
-                <td>{num(row.expense_count)}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-        <p className="note">
-          This is the device locale the app read at signup, and for groups it is where the group
-          settles. It is not IP geolocation: a phone set to en-GB in Bengaluru counts as GB.
-        </p>
-      </section>
-
-      <h2>Volume</h2>
-      <section className="scroll">
-        <table>
-          <thead>
-            <tr>
-              <th>Currency</th>
-              <th>Expenses</th>
-              <th>Value</th>
-              <th>Settled</th>
-              <th>Settled value</th>
-            </tr>
-          </thead>
-          <tbody>
-            {currencies.map((row) => (
-              <tr key={row.currency}>
-                <td>{row.currency}</td>
-                <td>{num(row.expense_count)}</td>
-                <td>{amount(row.expense_minor, row.currency)}</td>
-                <td>{num(row.settlement_count)}</td>
-                <td>{amount(row.settlement_minor, row.currency)}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-        <p className="note">
-          Never summed across currencies and never converted — the same rule the product follows.
-          Live expenses at their current version only, so an edited expense counts once.
-        </p>
-      </section>
-
-      <h2>AI receipt cost, 30 days</h2>
-      <section className="scroll">
-        {ai.length === 0 ? (
-          <p className="note">No scans in this window.</p>
-        ) : (
-          <table>
-            <thead>
-              <tr>
-                <th>Day</th>
-                <th>Currency</th>
-                <th>Scans</th>
-                <th>In</th>
-                <th>Out</th>
-                <th>Cost</th>
-              </tr>
-            </thead>
-            <tbody>
-              {ai.map((row) => (
-                <tr key={`${row.day}-${row.currency}`}>
-                  <td>{row.day}</td>
-                  <td>{row.currency}</td>
-                  <td>{num(row.events)}</td>
-                  <td>{num(row.input_tokens)}</td>
-                  <td>{num(row.output_tokens)}</td>
-                  <td>{amount(row.cost_minor, row.currency)}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
-      </section>
-
-      <h2>Sign-ins, 30 days</h2>
-      <section>
-        {signIns.unavailable ? (
-          // Said plainly, and not as an empty chart. This is the only panel
-          // reading outside `public`, so it is the only one whose failure means
-          // "the grant is missing" rather than "nobody did anything".
-          <p className="note">
-            Sign-in history could not be read: <code>{signIns.unavailable}</code>. Everything else
-            on this page is unaffected.
-          </p>
-        ) : signIns.rows.length === 0 ? (
-          <p className="note">
-            Nothing to show. Supabase prunes its auth audit log, so an empty result here means the
-            retention window has passed — not that nobody signed in.
-          </p>
-        ) : (
+    <main className="page">
+      <PageHeader
+        eyebrow="Overview"
+        title="Dashboard"
+        actions={
           <>
+            <span className="small muted">
+              {new Date().toLocaleString('en-IN', { timeZone: 'Asia/Kolkata' })} IST
+            </span>
+            {/* A plain anchor, not `next/link`: these are route handlers that
+                stream a file with a Content-Disposition. A client-side
+                navigation to one starts no download. */}
+            {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+            <a className="btn btn-outline" href="/export/daily">
+              {Icon.download}
+              <span>Daily CSV</span>
+            </a>
+          </>
+        }
+      />
+
+      <section aria-labelledby="figures-head">
+        <h2 className="section" id="figures-head">
+          Where things stand
+        </h2>
+        <div className="cols-3">
+          <Stat
+            label="People"
+            value={num(head.profiles_total)}
+            sub={`+${num(head.profiles_new_7d)} in the last 7 days`}
+            dir={Number(head.profiles_new_7d) > 0 ? 'up' : 'flat'}
+            icon={Icon.users}
+          />
+          <Stat
+            label="Groups"
+            value={num(head.groups_total)}
+            sub={`${num(head.groups_active_30d)} active in 30 days`}
+            icon={Icon.layers}
+          />
+          <Stat
+            label="Expenses"
+            value={num(head.expenses_total)}
+            sub={`+${num(head.expenses_new_30d)} in the last 30 days`}
+            dir={Number(head.expenses_new_30d) > 0 ? 'up' : 'flat'}
+            icon={Icon.receipt}
+          />
+          <Stat
+            label="Settlements"
+            value={num(head.settlements_total)}
+            sub={`${num(head.settlements_confirmed)} confirmed`}
+            icon={Icon.check}
+          />
+          <Stat
+            label="Active, 30 days"
+            value={num(head.active_profiles_30d)}
+            sub={`${num(head.active_profiles_7d)} of them in the last 7`}
+            icon={Icon.activity}
+          />
+          <Stat
+            label="Deleted expenses"
+            value={num(head.expenses_deleted)}
+            sub="soft-deleted, still on the ledger"
+            icon={Icon.trash}
+          />
+        </div>
+      </section>
+
+      <h2 className="section">Movement</h2>
+      <div className="cols-chart">
+        <Card
+          title="Expenses by currency"
+          eyebrow="Split"
+          note="Live expenses, counted — never summed across currencies."
+          bare
+        >
+          {currencySlices.length === 0 ? (
+            <Empty title="No expenses yet">
+              Nothing has been added to a ledger on this project.
+            </Empty>
+          ) : (
+            <DonutChart slices={currencySlices} centerLabel="expenses" />
+          )}
+        </Card>
+
+        <Card
+          note="Active means the ledger recorded something. Opening the app is not written down, so it is not counted here."
+          bare
+        >
+          <AreaTrend days={trend} />
+        </Card>
+      </div>
+
+      <h2 className="section">Where they are</h2>
+      <Card
+        bare
+        note="This is the device locale the app read at signup, and for groups it is where the group settles. It is not IP geolocation: a phone set to en-GB in Bengaluru counts as GB."
+      >
+        {countries.length === 0 ? (
+          <Empty title="No countries recorded">Nobody has signed up on this project yet.</Empty>
+        ) : (
+          <TableScroll>
+            <table>
+              <caption className="sr-only">People, groups and expenses per country</caption>
+              <thead>
+                <tr>
+                  <th scope="col">Country</th>
+                  <th scope="col" className="n">
+                    People
+                  </th>
+                  <th scope="col" className="n">
+                    Groups
+                  </th>
+                  <th scope="col" className="n">
+                    Expenses
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {countries.map((row) => (
+                  <tr key={row.country_code ?? 'unknown'}>
+                    <th scope="row" style={{ fontWeight: 600 }}>
+                      {row.country_code ?? <span className="muted">Not set</span>}
+                    </th>
+                    <td className="n">{num(row.profile_count)}</td>
+                    <td className="n">{num(row.group_count)}</td>
+                    <td className="n">{num(row.expense_count)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </TableScroll>
+        )}
+      </Card>
+
+      <h2 className="section">Volume</h2>
+      <Card
+        bare
+        note="Never summed across currencies and never converted — the same rule the product follows. Live expenses at their current version only, so an edited expense counts once."
+      >
+        {currencies.length === 0 ? (
+          <Empty title="No volume yet">No expense has been recorded in any currency.</Empty>
+        ) : (
+          <TableScroll>
+            <table>
+              <caption className="sr-only">Expense and settlement volume per currency</caption>
+              <thead>
+                <tr>
+                  <th scope="col">Currency</th>
+                  <th scope="col" className="n">
+                    Expenses
+                  </th>
+                  <th scope="col" className="n">
+                    Value
+                  </th>
+                  <th scope="col" className="n">
+                    Settled
+                  </th>
+                  <th scope="col" className="n">
+                    Settled value
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {currencies.map((row) => (
+                  <tr key={row.currency}>
+                    <th scope="row" style={{ fontWeight: 600 }}>
+                      {row.currency}
+                    </th>
+                    <td className="n">{num(row.expense_count)}</td>
+                    <td className="n">{amount(row.expense_minor, row.currency)}</td>
+                    <td className="n">{num(row.settlement_count)}</td>
+                    <td className="n">{amount(row.settlement_minor, row.currency)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </TableScroll>
+        )}
+      </Card>
+
+      <h2 className="section">Cost and sign-ins</h2>
+      <div className="cols-2">
+        <Card title="AI receipt cost" eyebrow="Last 30 days" bare>
+          {ai.length === 0 ? (
+            <Empty title="No scans in this window">
+              Nobody has run a receipt through the pipeline in 30 days.
+            </Empty>
+          ) : (
+            <TableScroll>
+              <table>
+                <caption className="sr-only">Receipt pipeline cost per day and currency</caption>
+                <thead>
+                  <tr>
+                    <th scope="col">Day</th>
+                    <th scope="col">Currency</th>
+                    <th scope="col" className="n">
+                      Scans
+                    </th>
+                    <th scope="col" className="n">
+                      In
+                    </th>
+                    <th scope="col" className="n">
+                      Out
+                    </th>
+                    <th scope="col" className="n">
+                      Cost
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {ai.map((row) => (
+                    <tr key={`${row.day}-${row.currency}`}>
+                      <td>{row.day}</td>
+                      <td>{row.currency}</td>
+                      <td className="n">{num(row.events)}</td>
+                      <td className="n">{num(row.input_tokens)}</td>
+                      <td className="n">{num(row.output_tokens)}</td>
+                      <td className="n">{amount(row.cost_minor, row.currency)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </TableScroll>
+          )}
+        </Card>
+
+        <Card
+          title="Sign-ins"
+          eyebrow="Last 30 days"
+          bare
+          note={
+            signIns.unavailable || signIns.rows.length === 0
+              ? undefined
+              : `${num(signInTotal)} sign-ins in the retained window.`
+          }
+        >
+          {signIns.unavailable ? (
+            // Said plainly, and not as an empty chart. This is the only panel
+            // reading outside `public`, so it is the only one whose failure
+            // means "the grant is missing" rather than "nobody did anything".
+            <Empty title="Sign-in history could not be read">
+              <code>{signIns.unavailable}</code>. Everything else on this page is unaffected.
+            </Empty>
+          ) : signIns.rows.length === 0 ? (
+            <Empty title="Nothing in the window">
+              Supabase prunes its auth audit log, so an empty result here means the retention window
+              has passed — not that nobody signed in.
+            </Empty>
+          ) : (
             <Bars
               label="Sign-ins per day"
               rows={[...signIns.rows]
                 .reverse()
                 .map((row) => ({ day: row.day, value: Number(row.sign_ins) }))}
             />
-            <p className="note">{num(signInTotal)} sign-ins in the retained window.</p>
-          </>
-        )}
-      </section>
+          )}
+        </Card>
+      </div>
 
-      <h2>Reports</h2>
-      <section>
-        {/* Plain anchors on purpose. These are route handlers that stream a
-            file with a Content-Disposition, not pages: `next/link` would
-            client-side navigate to them and the download would never start. */}
+      <h2 className="section">Reports</h2>
+      <Card>
+        {/* Plain anchors on purpose — see the note on the header button. */}
         {/* eslint-disable @next/next/no-html-link-for-pages */}
-        <p className="note">
-          <a href="/export/daily">daily.csv</a> · <a href="/export/geo">geo.csv</a> ·{' '}
-          <a href="/export/money">money.csv</a> · <a href="/export/ai">ai-cost.csv</a>
-        </p>
+        <div className="row">
+          <a className="btn btn-quiet" href="/export/daily">
+            {Icon.download}
+            <span>daily.csv</span>
+          </a>
+          <a className="btn btn-quiet" href="/export/geo">
+            {Icon.download}
+            <span>geo.csv</span>
+          </a>
+          <a className="btn btn-quiet" href="/export/money">
+            {Icon.download}
+            <span>money.csv</span>
+          </a>
+          <a className="btn btn-quiet" href="/export/ai">
+            {Icon.download}
+            <span>ai-cost.csv</span>
+          </a>
+        </div>
         {/* eslint-enable @next/next/no-html-link-for-pages */}
-      </section>
+      </Card>
     </main>
   );
 }
-
-function Stat({
-  tint,
-  icon,
-  label,
-  value,
-  chip,
-  dir,
-}: {
-  tint: 'blue' | 'green' | 'amber' | 'red' | 'purple';
-  icon: ReactNode;
-  label: string;
-  value: string;
-  chip: string;
-  dir: 'up' | 'down' | 'flat';
-}) {
-  return (
-    <div className="stat">
-      <div className={`ico tint-${tint}`}>{icon}</div>
-      <span className="label">{label}</span>
-      <div className="figure">
-        <span className="value">{value}</span>
-        <span className={`chip ${dir}`}>{chip}</span>
-      </div>
-    </div>
-  );
-}
-
-/** Stroke icons for the stat cards, matched to the sidebar's set. */
-const ICON = {
-  people: (
-    <svg viewBox="0 0 24 24" aria-hidden fill="none" stroke="currentColor">
-      <circle cx="9" cy="8" r="3.2" />
-      <path d="M3.5 20a5.5 5.5 0 0 1 11 0" />
-      <path d="M16 5.2a3.2 3.2 0 0 1 0 5.6M17.5 14.4A5.5 5.5 0 0 1 20.5 19" />
-    </svg>
-  ),
-  group: (
-    <svg viewBox="0 0 24 24" aria-hidden fill="none" stroke="currentColor">
-      <circle cx="12" cy="12" r="8" />
-      <path d="M12 4v16M4 12h16" />
-    </svg>
-  ),
-  receipt: (
-    <svg viewBox="0 0 24 24" aria-hidden fill="none" stroke="currentColor">
-      <path d="M6 3h12v18l-3-2-3 2-3-2-3 2V3z" />
-      <path d="M9 8h6M9 12h6" />
-    </svg>
-  ),
-  check: (
-    <svg viewBox="0 0 24 24" aria-hidden fill="none" stroke="currentColor">
-      <circle cx="12" cy="12" r="8.5" />
-      <path d="M8.5 12.5l2.5 2.5 4.5-5" />
-    </svg>
-  ),
-  pulse: (
-    <svg viewBox="0 0 24 24" aria-hidden fill="none" stroke="currentColor">
-      <path d="M3 12h4l2.5-6 4 12 2.5-6H21" />
-    </svg>
-  ),
-  trash: (
-    <svg viewBox="0 0 24 24" aria-hidden fill="none" stroke="currentColor">
-      <path d="M4 7h16M9 7V5h6v2M6 7l1 13h10l1-13" />
-    </svg>
-  ),
-} as const;

--- a/apps/admin/src/app/promotions/page.tsx
+++ b/apps/admin/src/app/promotions/page.tsx
@@ -1,9 +1,11 @@
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 
-import { createPromoCode, grantPromo, promoCodes } from '@/lib/data';
-import { guardMutation } from '@/lib/csrf';
 import { CsrfField } from '@/components/CsrfField';
+import { Icon } from '@/components/icons';
+import { Card, Empty, Field, Lede, Outcome, PageHeader, TableScroll } from '@/components/ui';
+import { guardMutation } from '@/lib/csrf';
+import { createPromoCode, grantPromo, promoCodes } from '@/lib/data';
 
 export const dynamic = 'force-dynamic';
 
@@ -60,108 +62,111 @@ export default async function Promotions({
   }
 
   return (
-    <main>
-      <header className="top">
-        <h1>Promotions</h1>{' '}
-      </header>
+    <main className="page">
+      <PageHeader eyebrow="Growth" title="Promotions" />
+      <Outcome error={error} done={done} />
 
-      {error ? <p className="error">{error}</p> : null}
-      {done ? <p className="faint">{done}</p> : null}
-
-      <p className="note" style={{ padding: 0 }}>
+      <Lede>
         A promotion is an ordinary <code>subscriptions</code> row with{' '}
         <code>store = &lsquo;promo&rsquo;</code>. Every screen that already asks what plan somebody
         is on gets the right answer with no change — there is no second source of truth for who has
         paid.
-      </p>
+      </Lede>
 
-      <h2>Comp an account</h2>
-      <section>
-        <form action={grant} className="flag">
-          <CsrfField />
-          <label>
-            <span>Profile id</span>
-            <input type="text" name="profile" placeholder="uuid" required size={38} />
-          </label>
-          <label>
-            <span>Days</span>
-            <input type="number" name="days" min={1} max={3650} defaultValue={30} />
-          </label>
-          <button type="submit">Grant Plus</button>
-        </form>
-        <p className="note">
-          Keyed on the account and the day, so pressing this twice in one conversation is the same
-          grant rather than two months.
-        </p>
-      </section>
+      <div className="cols-2">
+        <Card
+          title="Comp an account"
+          eyebrow="One person"
+          bare
+          note="Keyed on the account and the day, so pressing this twice in one conversation is the same grant rather than two months."
+        >
+          <form action={grant} className="form card-body">
+            <CsrfField />
+            <Field label="Profile id" hint="uuid" full>
+              <input type="text" name="profile" placeholder="uuid" required />
+            </Field>
+            <Field label="Days">
+              <input type="number" name="days" min={1} max={3650} defaultValue={30} />
+            </Field>
+            <button type="submit" className="btn">
+              {Icon.plus}
+              <span>Grant Plus</span>
+            </button>
+          </form>
+        </Card>
 
-      <h2>Codes</h2>
-      <section className="scroll">
+        <Card
+          title="New code"
+          eyebrow="Many people"
+          bare
+          note="Uppercase letters and digits only — these get read aloud and typed by hand. Redeeming is one code per account, enforced by the same unique key the app stores use to stop a replayed store webhook granting a purchase twice."
+        >
+          <form action={create} className="form card-body">
+            <CsrfField />
+            <Field label="Code">
+              <input type="text" name="code" placeholder="DIWALI25" required size={14} />
+            </Field>
+            <Field label="Days granted">
+              <input type="number" name="days" min={1} max={3650} defaultValue={30} />
+            </Field>
+            <Field label="Max redemptions">
+              <input type="number" name="max" min={1} defaultValue={100} />
+            </Field>
+            <Field label="Note" full>
+              <input type="text" name="note" placeholder="Diwali campaign" />
+            </Field>
+            <button type="submit" className="btn">
+              {Icon.plus}
+              <span>Create code</span>
+            </button>
+          </form>
+        </Card>
+      </div>
+
+      <h2 className="section">Codes</h2>
+      <Card bare>
         {codes.length === 0 ? (
-          <p className="note">
-            None yet. If you expected some, the <code>20260808210000_promotions</code> migration may
-            not be deployed to this project.
-          </p>
+          <Empty title="No codes yet" migration="20260808210000_promotions">
+            Nothing in <code>promo_codes</code>.
+          </Empty>
         ) : (
-          <table>
-            <thead>
-              <tr>
-                <th>Code</th>
-                <th>Grants</th>
-                <th>Used</th>
-                <th>Of</th>
-                <th>Expires</th>
-                <th>Note</th>
-              </tr>
-            </thead>
-            <tbody>
-              {codes.map((row) => (
-                <tr key={row.code}>
-                  <td>
-                    <code>{row.code}</code>
-                  </td>
-                  <td>{num(row.days)} days</td>
-                  <td>{num(row.redeemed_count)}</td>
-                  <td>{num(row.max_redemptions)}</td>
-                  <td>{day(row.expires_at)}</td>
-                  <td style={{ textAlign: 'left' }}>
-                    {row.note || <span className="muted">—</span>}
-                  </td>
+          <TableScroll>
+            <table>
+              <caption className="sr-only">Promotional codes and their redemptions</caption>
+              <thead>
+                <tr>
+                  <th scope="col">Code</th>
+                  <th scope="col" className="n">
+                    Grants
+                  </th>
+                  <th scope="col" className="n">
+                    Used
+                  </th>
+                  <th scope="col" className="n">
+                    Of
+                  </th>
+                  <th scope="col">Expires</th>
+                  <th scope="col">Note</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {codes.map((row) => (
+                  <tr key={row.code}>
+                    <th scope="row">
+                      <code>{row.code}</code>
+                    </th>
+                    <td className="n">{num(row.days)} days</td>
+                    <td className="n">{num(row.redeemed_count)}</td>
+                    <td className="n">{num(row.max_redemptions)}</td>
+                    <td>{day(row.expires_at)}</td>
+                    <td className="wrap">{row.note || <span className="muted">—</span>}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </TableScroll>
         )}
-      </section>
-
-      <h2>New code</h2>
-      <section>
-        <form action={create} className="flag">
-          <CsrfField />
-          <label>
-            <span>Code</span>
-            <input type="text" name="code" placeholder="DIWALI25" required />
-          </label>
-          <label>
-            <span>Days granted</span>
-            <input type="number" name="days" min={1} max={3650} defaultValue={30} />
-          </label>
-          <label>
-            <span>Max redemptions</span>
-            <input type="number" name="max" min={1} defaultValue={100} />
-          </label>
-          <label>
-            <span>Note</span>
-            <input type="text" name="note" placeholder="Diwali campaign" />
-          </label>
-          <button type="submit">Create code</button>
-        </form>
-        <p className="note">
-          Uppercase letters and digits only — these get read aloud and typed by hand. Redeeming is
-          one code per account, enforced by the same unique key the app stores use to stop a
-          replayed store webhook granting a purchase twice.
-        </p>
-      </section>
+      </Card>
     </main>
   );
 }

--- a/apps/admin/src/app/rate-limits/page.tsx
+++ b/apps/admin/src/app/rate-limits/page.tsx
@@ -1,24 +1,47 @@
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 
+import { CsrfField } from '@/components/CsrfField';
+import { Icon } from '@/components/icons';
+import {
+  Badge,
+  Banner,
+  Card,
+  Check,
+  Empty,
+  Field,
+  Lede,
+  Outcome,
+  PageHeader,
+  TableScroll,
+} from '@/components/ui';
+import { guardMutation } from '@/lib/csrf';
 import {
   rateLimitEnabled,
   rateLimitRules,
   saveRateLimitRule,
   setRateLimitEnabled,
-  type RateLimitRuleRow,
 } from '@/lib/data';
-import { guardMutation } from '@/lib/csrf';
-import { CsrfField } from '@/components/CsrfField';
 
 export const dynamic = 'force-dynamic';
 
 /** Seconds rendered as the unit an operator thinks in. */
-function window(seconds: number): string {
+function windowLabel(seconds: number): string {
   if (seconds % 3600 === 0) return `${seconds / 3600}h`;
   if (seconds % 60 === 0) return `${seconds / 60}m`;
   return `${seconds}s`;
 }
+
+/** The buckets the code actually consults. Anything else here is inert. */
+const KNOWN = [
+  'sync',
+  'expense-write',
+  'export-data',
+  'fx-rate',
+  'invite-mint',
+  'invite-accept',
+  'receipt-parse',
+];
 
 export default async function RateLimits({
   searchParams,
@@ -62,117 +85,162 @@ export default async function RateLimits({
   }
 
   return (
-    <main>
-      <header className="top">
-        <h1>Rate limits</h1>{' '}
-      </header>
+    <main className="page">
+      <PageHeader
+        eyebrow="Configuration"
+        title="Rate limits"
+        actions={
+          enabled ? <Badge tone="ok">Limiting on</Badge> : <Badge tone="warn">All off</Badge>
+        }
+      />
+      <Outcome error={error} done={saved ? 'Saved.' : undefined} />
 
-      {error ? <p className="error">{error}</p> : null}
-      {saved ? <p className="faint">Saved.</p> : null}
-
-      <p className="note" style={{ padding: 0 }}>
-        The app&rsquo;s own abuse limiter, not Supabase&rsquo;s auth limiter (that one lives in the
-        Supabase dashboard under Authentication &rsquo; Rate limits). Each bucket allows so many
+      <Lede>
+        The app&rsquo;s own abuse limiter, not Supabase&rsquo;s auth limiter — that one lives in the
+        Supabase dashboard under Authentication &rsaquo; Rate limits. Each bucket allows so many
         calls per window; a call over the line comes back <code>429 RATE_LIMITED</code>. A bucket
         with no row here uses the default compiled into <code>_shared/rateLimit.ts</code>. The
         counting fails open — if the database cannot be reached the call is allowed — so this is
         abuse control, never the paywall.
-      </p>
+      </Lede>
 
-      <h2>Master switch</h2>
-      <section>
-        <form action={toggleMaster} className="flag">
-          <CsrfField />
-          <label className="inline">
-            <input type="checkbox" name="enabled" defaultChecked={enabled} />
-            <span>Rate limiting enabled</span>
-          </label>
-          <p className="note">
-            Off exempts every bucket at once — the escape hatch for letting a support engineer
-            replay a stuck queue. Nothing is counted while it is off, so turning it back on starts
-            each bucket from a clean window.
-          </p>
-          <button type="submit">Save</button>
-        </form>
-      </section>
-
-      <h2>Buckets</h2>
       {!enabled ? (
-        <p className="note">The master switch is off, so these limits are not being applied.</p>
-      ) : null}
-      {rules.length === 0 ? (
-        <section style={{ marginTop: 12 }}>
-          <p className="note">
-            No bucket rows. If you expected some, the
-            <code> 20260809040000_rate_limit_controls </code> migration may not be deployed to this
-            project — the app is still limited by the code defaults until it is.
-          </p>
-        </section>
+        <Banner tone="danger">
+          The master switch is off. Every bucket below is being ignored, whatever it says.
+        </Banner>
       ) : null}
 
-      {rules.map((rule: RateLimitRuleRow) => (
-        <section key={rule.bucket}>
-          <h3 style={{ margin: '0 0 8px' }}>
-            <code>{rule.bucket}</code>{' '}
-            <span className="faint">
-              — {rule.max_calls} / {window(rule.window_seconds)}
-              {rule.enabled ? '' : ' · off'}
-            </span>
-          </h3>
-          <form action={saveRule} className="flag">
-            <CsrfField />
-            <input type="hidden" name="bucket" value={rule.bucket} />
-            <label className="inline">
-              <input type="checkbox" name="enabled" defaultChecked={rule.enabled} />
-              <span>Enabled</span>
-            </label>
-            <label>
-              <span>Max calls</span>
-              <input type="number" name="max_calls" min={0} defaultValue={rule.max_calls} />
-            </label>
-            <label>
-              <span>Window (seconds)</span>
-              <input
-                type="number"
-                name="window_seconds"
-                min={1}
-                defaultValue={rule.window_seconds}
-              />
-            </label>
-            <button type="submit">Save</button>
-          </form>
-        </section>
-      ))}
-
-      <h2>Add a bucket</h2>
-      <section>
-        <form action={saveRule} className="flag">
+      <Card
+        title="Master switch"
+        eyebrow="All buckets at once"
+        bare
+        note="Off exempts every bucket at once — the escape hatch for letting a support engineer replay a stuck queue. Nothing is counted while it is off, so turning it back on starts each bucket from a clean window."
+      >
+        <form action={toggleMaster} className="form card-body">
           <CsrfField />
-          <label>
-            <span>Bucket</span>
-            <input type="text" name="bucket" placeholder="expense-write" required />
-          </label>
-          <label className="inline">
-            <input type="checkbox" name="enabled" defaultChecked />
-            <span>Enabled</span>
-          </label>
-          <label>
-            <span>Max calls</span>
-            <input type="number" name="max_calls" min={0} defaultValue={60} />
-          </label>
-          <label>
-            <span>Window (seconds)</span>
-            <input type="number" name="window_seconds" min={1} defaultValue={60} />
-          </label>
-          <button type="submit">Add</button>
+          <Check name="enabled" label="Rate limiting enabled" defaultChecked={enabled} plain />
+          <button type="submit" className="btn">
+            {Icon.save}
+            <span>Save</span>
+          </button>
         </form>
-        <p className="note">
-          Only a bucket the code actually calls will ever be consulted — adding a name here does not
-          create a limiter, it overrides one. The names in use today are <code>sync</code>,{' '}
-          <code>expense-write</code>, <code>export-data</code>, <code>fx-rate</code>,{' '}
-          <code>invite-mint</code>, <code>invite-accept</code> and <code>receipt-parse</code>.
-        </p>
-      </section>
+      </Card>
+
+      <h2 className="section">Buckets</h2>
+      {rules.length === 0 ? (
+        <Card bare>
+          <Empty title="No bucket rows" migration="20260809040000_rate_limit_controls">
+            The app is still limited by the code defaults until this table has rows.
+          </Empty>
+        </Card>
+      ) : (
+        <Card bare>
+          <TableScroll>
+            <table>
+              <caption className="sr-only">Rate limit rules per bucket</caption>
+              <thead>
+                <tr>
+                  <th scope="col">Bucket</th>
+                  <th scope="col">Now</th>
+                  <th scope="col">Rule</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rules.map((rule) => (
+                  <tr key={rule.bucket}>
+                    <th scope="row">
+                      <code>{rule.bucket}</code>
+                      {KNOWN.includes(rule.bucket) ? null : (
+                        <span className="row-sub">no code calls this bucket</span>
+                      )}
+                    </th>
+                    <td>
+                      {rule.enabled ? (
+                        <Badge tone="ok">
+                          {rule.max_calls} / {windowLabel(rule.window_seconds)}
+                        </Badge>
+                      ) : (
+                        <Badge>Off</Badge>
+                      )}
+                    </td>
+                    <td>
+                      <form action={saveRule} className="row" style={{ flexWrap: 'nowrap' }}>
+                        <CsrfField />
+                        <input type="hidden" name="bucket" value={rule.bucket} />
+                        <input
+                          type="number"
+                          name="max_calls"
+                          min={0}
+                          defaultValue={rule.max_calls}
+                          aria-label={`Max calls for ${rule.bucket}`}
+                        />
+                        <span className="muted small">per</span>
+                        <input
+                          type="number"
+                          name="window_seconds"
+                          min={1}
+                          defaultValue={rule.window_seconds}
+                          aria-label={`Window in seconds for ${rule.bucket}`}
+                        />
+                        <span className="muted small">s</span>
+                        <label className="check plain">
+                          <input
+                            type="checkbox"
+                            name="enabled"
+                            defaultChecked={rule.enabled}
+                            aria-label={`${rule.bucket} enabled`}
+                          />
+                          <span aria-hidden>on</span>
+                        </label>
+                        <button type="submit" className="btn btn-sm">
+                          {Icon.save}
+                          <span>Save</span>
+                        </button>
+                      </form>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </TableScroll>
+        </Card>
+      )}
+
+      <h2 className="section">Add a bucket</h2>
+      <Card
+        bare
+        note={
+          <>
+            Only a bucket the code actually calls will ever be consulted — adding a name here does
+            not create a limiter, it overrides one. The names in use today are{' '}
+            {KNOWN.map((bucket, index) => (
+              <span key={bucket}>
+                {index > 0 ? (index === KNOWN.length - 1 ? ' and ' : ', ') : ''}
+                <code>{bucket}</code>
+              </span>
+            ))}
+            .
+          </>
+        }
+      >
+        <form action={saveRule} className="form card-body">
+          <CsrfField />
+          <Field label="Bucket">
+            <input type="text" name="bucket" placeholder="expense-write" required />
+          </Field>
+          <Field label="Max calls">
+            <input type="number" name="max_calls" min={0} defaultValue={60} />
+          </Field>
+          <Field label="Window" hint="seconds">
+            <input type="number" name="window_seconds" min={1} defaultValue={60} />
+          </Field>
+          <Check name="enabled" label="Enabled" defaultChecked />
+          <button type="submit" className="btn">
+            {Icon.plus}
+            <span>Add</span>
+          </button>
+        </form>
+      </Card>
     </main>
   );
 }

--- a/apps/admin/src/app/releases/page.tsx
+++ b/apps/admin/src/app/releases/page.tsx
@@ -1,0 +1,181 @@
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+
+import { CsrfField } from '@/components/CsrfField';
+import { Icon } from '@/components/icons';
+import { Badge, Card, Empty, Field, Lede, Outcome, PageHeader } from '@/components/ui';
+import { guardMutation } from '@/lib/csrf';
+import { appReleases, saveAppRelease, type AppReleaseRow } from '@/lib/data';
+
+export const dynamic = 'force-dynamic';
+
+const STORE: Record<string, string> = { ios: 'App Store', android: 'Google Play' };
+
+/**
+ * The version policy, per store.
+ *
+ * This is the single sharpest lever in the database and it had no screen at
+ * all: raising a minimum version meant a SQL console, which is not a thing
+ * anybody wants to be doing at the moment they need it — the moment they need
+ * it is a bad build in the wild.
+ *
+ * The screen is deliberately blunt about what the minimum does. It is not a
+ * recommendation and it is not a nag: the app checks it before sign-in, so
+ * every install below it is locked out of the product until the store has the
+ * newer build. Hence the warning banner when a minimum is already at the
+ * latest — that is the state where a single mistaken publish strands
+ * everybody — and hence the refusal, in the data layer and again in the
+ * database, of a minimum above the latest.
+ */
+export default async function Releases({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string; saved?: string }>;
+}) {
+  const { error, saved } = await searchParams;
+  const rows = await appReleases();
+
+  async function save(formData: FormData) {
+    'use server';
+
+    let failure: string | null = null;
+    try {
+      await guardMutation(formData);
+      await saveAppRelease({
+        platform: String(formData.get('platform') ?? ''),
+        latestVersion: String(formData.get('latest') ?? ''),
+        minimumVersion: String(formData.get('minimum') ?? ''),
+        storeUrl: String(formData.get('store_url') ?? ''),
+        message: String(formData.get('message') ?? ''),
+      });
+    } catch (caught) {
+      failure = caught instanceof Error ? caught.message : String(caught);
+    }
+
+    if (failure) redirect(`/releases?error=${encodeURIComponent(failure)}`);
+    revalidatePath('/releases');
+    redirect('/releases?saved=1');
+  }
+
+  return (
+    <main className="page">
+      <PageHeader eyebrow="Configuration" title="Releases" />
+      <Outcome error={error} done={saved ? 'Saved.' : undefined} />
+
+      <Lede>
+        What each store is running and what the app will refuse to run below.{' '}
+        <strong>Minimum is a lockout, not a nudge</strong> — it is checked before anybody signs in,
+        so every install under it is out of the product until that store has the newer build.
+        Latest, by contrast, is only what the app compares against to say &ldquo;there is an
+        update&rdquo;. Both take effect on the next launch; there is nothing to deploy.
+      </Lede>
+
+      {rows.length === 0 ? (
+        <Card bare>
+          <Empty title="No release policy" migration="20260904000000_waves_baseline">
+            Nothing in <code>app_releases</code>. The app treats a missing row as &ldquo;no
+            minimum&rdquo;, so nobody is locked out — but nobody is told about updates either.
+          </Empty>
+        </Card>
+      ) : (
+        <div className="cols-2">
+          {rows.map((row) => (
+            <ReleaseCard key={row.platform} row={row} save={save} />
+          ))}
+        </div>
+      )}
+    </main>
+  );
+}
+
+function ReleaseCard({
+  row,
+  save,
+}: {
+  row: AppReleaseRow;
+  save: (formData: FormData) => Promise<void>;
+}) {
+  const gated = row.minimum_version === row.latest_version;
+
+  return (
+    <Card
+      title={STORE[row.platform] ?? row.platform}
+      eyebrow={row.platform}
+      actions={
+        gated ? (
+          <Badge tone="warn">Forced upgrade</Badge>
+        ) : (
+          <Badge tone="ok">Older builds allowed</Badge>
+        )
+      }
+      note={
+        <>
+          Last changed{' '}
+          {new Date(row.updated_at).toLocaleString('en-IN', {
+            dateStyle: 'medium',
+            timeStyle: 'short',
+          })}
+          .{' '}
+          {gated
+            ? `Everybody below ${row.latest_version} is locked out right now.`
+            : `Builds from ${row.minimum_version} up are allowed in.`}
+        </>
+      }
+    >
+      <form action={save} className="form">
+        <CsrfField />
+        <input type="hidden" name="platform" value={row.platform} />
+
+        <Field label="Latest" hint="what the store has">
+          <input
+            type="text"
+            name="latest"
+            defaultValue={row.latest_version}
+            pattern="[0-9]+(\.[0-9]+){0,3}"
+            required
+            size={10}
+            aria-label={`Latest ${row.platform} version`}
+          />
+        </Field>
+
+        <Field label="Minimum" hint="below this, locked out">
+          <input
+            type="text"
+            name="minimum"
+            defaultValue={row.minimum_version}
+            pattern="[0-9]+(\.[0-9]+){0,3}"
+            required
+            size={10}
+            aria-label={`Minimum allowed ${row.platform} version`}
+          />
+        </Field>
+
+        <Field label="Store link" full>
+          <input
+            type="url"
+            name="store_url"
+            defaultValue={row.store_url}
+            required
+            aria-label={`${row.platform} store link`}
+          />
+        </Field>
+
+        <Field label="Upgrade message" hint="blank for the app's own wording" full>
+          <input
+            type="text"
+            name="message"
+            defaultValue={row.message ?? ''}
+            maxLength={300}
+            placeholder="Update to keep syncing."
+            aria-label={`Upgrade message shown on ${row.platform}`}
+          />
+        </Field>
+
+        <button type="submit" className="btn">
+          {Icon.save}
+          <span>Save {row.platform}</span>
+        </button>
+      </form>
+    </Card>
+  );
+}

--- a/apps/admin/src/app/services/page.tsx
+++ b/apps/admin/src/app/services/page.tsx
@@ -5,28 +5,30 @@ import { CsrfField } from '@/components/CsrfField';
 import { Icon } from '@/components/icons';
 import { Card, Empty, Lede, Outcome, PageHeader, TableScroll } from '@/components/ui';
 import { guardMutation } from '@/lib/csrf';
-import { appConfig, saveAppConfig } from '@/lib/data';
+import { saveServiceConfig, serviceConfig } from '@/lib/data';
 
 export const dynamic = 'force-dynamic';
 
 /**
- * The numeric knobs, whichever ones exist.
+ * The string knobs — `service_config`, the sibling of `app_config` that holds
+ * settings whose value is a word rather than a number.
  *
- * Nothing here names a key. `appConfig()` selects the whole table and this
- * renders a row per result, so a knob added by a migration — the receipt cap,
- * the storage cap, the device caps, and `person_lookup_daily_cap` when the
- * person-lookup branch lands — turns up on this page with no change to the
- * console at all. The one thing the console cannot do is *create* a knob: the
- * save is an UPDATE, because a key that no code reads is a number with no
- * effect, and the migration that reads it is the right place to define it.
+ * Today that is which cloud provider and model the voice pipeline calls. It
+ * was editable only by hand in a SQL console, which meant switching speech
+ * providers during an outage was a database session rather than a text field.
+ *
+ * Deliberately generic, exactly like `/config`: no key appears in this file.
+ * A migration that adds a setting gets a row here for free, and the row's own
+ * `description` column is the help text — so the thing that knows what a
+ * setting means is the migration that introduced it, not this page.
  */
-export default async function Config({
+export default async function Services({
   searchParams,
 }: {
   searchParams: Promise<{ error?: string; saved?: string }>;
 }) {
   const { error, saved } = await searchParams;
-  const rows = await appConfig();
+  const rows = await serviceConfig();
 
   async function save(formData: FormData) {
     'use server';
@@ -34,54 +36,50 @@ export default async function Config({
     let failure: string | null = null;
     try {
       await guardMutation(formData);
-      const rawValue = String(formData.get('value') ?? '').trim();
-      if (rawValue === '') {
-        throw new Error('A limit is a whole number, zero or more.');
-      }
-      await saveAppConfig({
+      await saveServiceConfig({
         key: String(formData.get('key') ?? '').trim(),
-        value: Number(rawValue),
+        value: String(formData.get('value') ?? ''),
       });
     } catch (caught) {
       failure = caught instanceof Error ? caught.message : String(caught);
     }
 
-    if (failure) redirect(`/config?error=${encodeURIComponent(failure)}`);
-    revalidatePath('/config');
-    redirect('/config?saved=1');
+    if (failure) redirect(`/services?error=${encodeURIComponent(failure)}`);
+    revalidatePath('/services');
+    redirect('/services?saved=1');
   }
 
   return (
     <main className="page">
-      <PageHeader eyebrow="Configuration" title="Limits" />
+      <PageHeader eyebrow="Configuration" title="Services" />
       <Outcome error={error} done={saved ? 'Saved.' : undefined} />
 
       <Lede>
-        Numeric knobs the app reads at runtime. They live in the database so they can change without
-        a deploy, and the database enforces them, so lowering one is real rather than cosmetic. This
-        list is whatever <code>app_config</code> holds — a knob a migration adds appears here on its
-        own, and a knob no migration created cannot be invented here.
+        Which outside services the backend calls, and with which model. Read by the edge functions
+        at call time, so a change takes effect on the next request rather than the next deploy —
+        which is the point: switching speech providers during somebody else&rsquo;s outage should
+        not need a release. An empty value means &ldquo;the provider&rsquo;s own default&rdquo;.
+        Credentials are <strong>not</strong> here and never will be; those are Supabase function
+        secrets, and this console cannot read them.
       </Lede>
 
       {rows.length === 0 ? (
         <Card bare>
-          <Empty title="No knobs yet" migration="20260818160000_receipt_cap">
-            Nothing in <code>app_config</code> to turn.
+          <Empty title="No service settings" migration="20260904000000_waves_baseline">
+            Nothing in <code>service_config</code> to set.
           </Empty>
         </Card>
       ) : (
         <Card bare>
           <TableScroll>
             <table>
-              <caption className="sr-only">Runtime numeric limits</caption>
+              <caption className="sr-only">Backend service settings</caption>
               <thead>
                 <tr>
-                  <th scope="col">Knob</th>
+                  <th scope="col">Setting</th>
                   <th scope="col">What it does</th>
                   <th scope="col">Changed</th>
-                  <th scope="col" className="n">
-                    Value
-                  </th>
+                  <th scope="col">Value</th>
                 </tr>
               </thead>
               <tbody>
@@ -101,21 +99,18 @@ export default async function Config({
                       })}
                     </td>
                     <td>
-                      <form action={save} className="row" style={{ justifyContent: 'flex-end' }}>
+                      <form action={save} className="row" style={{ flexWrap: 'nowrap' }}>
                         <CsrfField />
                         <input type="hidden" name="key" value={row.key} />
-                        {/* The column header already says "Value"; a visible
-                            label per row would be that word ten times down
-                            the page. The name each input actually needs is
-                            the knob's, and that is what a screen reader gets. */}
+                        {/* The column heading is the visible label; a screen
+                            reader needs to know *which* setting this box is. */}
                         <input
-                          type="number"
-                          className="wide"
+                          type="text"
                           name="value"
-                          min={0}
-                          step={1}
-                          defaultValue={row.value}
-                          required
+                          defaultValue={row.value ?? ''}
+                          maxLength={200}
+                          size={22}
+                          placeholder="(provider default)"
                           aria-label={`Value for ${row.key}`}
                         />
                         <button type="submit" className="btn btn-sm">

--- a/apps/admin/src/app/users/page.tsx
+++ b/apps/admin/src/app/users/page.tsx
@@ -1,9 +1,21 @@
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 
-import { confirmUserEmail, listUsers, upgradeUser, type AdminUserListRow } from '@/lib/data';
-import { assertSameOrigin, guardMutation } from '@/lib/csrf';
 import { CsrfField } from '@/components/CsrfField';
+import { Icon } from '@/components/icons';
+import {
+  Badge,
+  Card,
+  Empty,
+  Field,
+  Lede,
+  Outcome,
+  PageHeader,
+  TableScroll,
+  type Tone,
+} from '@/components/ui';
+import { assertSameOrigin, guardMutation } from '@/lib/csrf';
+import { confirmUserEmail, listUsers, upgradeUser, type AdminUserListRow } from '@/lib/data';
 
 export const dynamic = 'force-dynamic';
 
@@ -18,10 +30,10 @@ function when(iso: string | null): string {
   });
 }
 
-function kind(u: AdminUserListRow): { label: string; cls: string } {
-  if (u.is_anonymous) return { label: 'guest', cls: 'tag' };
-  if (u.is_plus) return { label: 'plus', cls: 'tag tag-deletion' };
-  return { label: 'free', cls: 'tag tag-idea' };
+function kind(u: AdminUserListRow): { label: string; tone: Tone } {
+  if (u.is_anonymous) return { label: 'guest', tone: 'neutral' };
+  if (u.is_plus) return { label: 'plus', tone: 'accent' };
+  return { label: 'free', tone: 'ok' };
 }
 
 /** Carry the current filter + page through an action's redirect. */
@@ -53,6 +65,7 @@ export default async function Users({
 
   const { total, rows } = await listUsers({ limit: PAGE, offset, namePrefix: name, country });
   const back = backTo(name, country, offset);
+  const filtered = Boolean(name || country);
 
   async function filter(formData: FormData) {
     'use server';
@@ -109,152 +122,191 @@ export default async function Users({
   const to = Math.min(offset + PAGE, total);
 
   return (
-    <main>
-      <header className="top">
-        <h1>Users</h1>
-        <p className="faint">{total.toLocaleString('en-IN')} signups</p>
-      </header>
+    <main className="page">
+      <PageHeader
+        eyebrow="People"
+        title="Users"
+        actions={<span className="small muted">{total.toLocaleString('en-IN')} signups</span>}
+      />
+      <Outcome error={sp.error} done={sp.done} />
 
-      {sp.error ? <p className="error">{sp.error}</p> : null}
-      {sp.done ? <p className="faint">{sp.done}</p> : null}
+      <Lede>
+        Sorted newest first. Type, devices and app version come from the account, its subscription
+        and the devices it has registered — the device columns fill in once the device-session
+        feature is live on this project.
+      </Lede>
 
-      <section>
-        <form action={filter} className="flag">
-          <label>
-            <span>Name or email starts with</span>
+      <Card bare>
+        <form action={filter} className="form card-body" role="search">
+          <Field label="Name or email" hint="starts with">
             <input type="text" name="name" defaultValue={name} placeholder="asha" />
-          </label>
-          <label>
-            <span>Country</span>
+          </Field>
+          <Field label="Country" hint="two letters">
             <input
               type="text"
               name="country"
               defaultValue={country}
               placeholder="IN"
               maxLength={2}
+              size={4}
             />
-          </label>
-          <button type="submit">Filter</button>
-          {name || country ? (
-            <a className="faint" href="/users" style={{ alignSelf: 'center' }}>
+          </Field>
+          <button type="submit" className="btn">
+            {Icon.search}
+            <span>Filter</span>
+          </button>
+          {filtered ? (
+            <a className="btn btn-quiet" href="/users">
               Clear
             </a>
           ) : null}
         </form>
-        <p className="note">
-          Sorted newest first. Type, devices and app version come from the account, its subscription
-          and the devices it has registered — device columns fill in once the device-session feature
-          is live on this project.
-        </p>
-      </section>
+      </Card>
 
-      <section className="scroll" style={{ marginTop: 12 }}>
-        {rows.length === 0 ? (
-          <p className="note">No signups match this filter.</p>
-        ) : (
-          <table>
-            <thead>
-              <tr>
-                <th>User</th>
-                <th>Type</th>
-                <th>Country</th>
-                <th>Devices</th>
-                <th>App</th>
-                <th>Joined</th>
-                <th>Last seen</th>
-                <th>Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map((u) => {
-                const k = kind(u);
-                return (
-                  <tr key={u.id}>
-                    <td style={{ textAlign: 'left', maxWidth: 260 }}>
-                      <div style={{ fontWeight: 600 }}>{u.display_name ?? '—'}</div>
-                      <div className="faint" style={{ fontSize: 12 }}>
-                        {u.email ?? u.phone ?? '(no contact)'}
-                        {u.email && !u.email_confirmed ? ' · unconfirmed' : ''}
-                      </div>
-                    </td>
-                    <td>
-                      <span className={k.cls}>{k.label}</span>
-                    </td>
-                    <td>{u.country_code ?? <span className="muted">—</span>}</td>
-                    <td>
-                      {u.device_count > 0 ? u.device_count : <span className="muted">0</span>}
-                    </td>
-                    <td>
-                      {u.app_version ? (
-                        <span>
-                          {u.app_version}
-                          {u.platform ? <span className="faint"> · {u.platform}</span> : null}
-                        </span>
-                      ) : (
-                        <span className="muted">—</span>
-                      )}
-                    </td>
-                    <td>{when(u.created_at)}</td>
-                    <td>{when(u.last_sign_in_at)}</td>
-                    <td>
-                      <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
-                        {u.email_confirmed || !u.email ? null : (
-                          <form action={confirm}>
-                            <CsrfField />
-                            <input type="hidden" name="id" value={u.id} />
-                            <input type="hidden" name="back" value={back} />
-                            <button type="submit" title="Confirm this email by hand">
-                              Confirm
-                            </button>
-                          </form>
-                        )}
-                        <form
-                          action={upgrade}
-                          style={{ display: 'flex', gap: 4, alignItems: 'center' }}
-                        >
-                          <CsrfField />
-                          <input type="hidden" name="id" value={u.id} />
-                          <input type="hidden" name="back" value={back} />
-                          <input
-                            type="number"
-                            name="days"
-                            min={1}
-                            max={3650}
-                            defaultValue={365}
-                            aria-label="Days"
-                            style={{ width: 64 }}
-                          />
-                          <button type="submit" title="Comp a paid grant">
-                            Upgrade
-                          </button>
-                        </form>
-                      </div>
-                    </td>
+      <div className="stack-gap" style={{ marginTop: '1rem' }}>
+        <Card bare>
+          {rows.length === 0 ? (
+            <Empty title={filtered ? 'Nothing matches that filter' : 'No signups yet'}>
+              {filtered
+                ? 'Try a shorter prefix, or clear the filter to see everybody.'
+                : 'Nobody has created an account on this project.'}
+            </Empty>
+          ) : (
+            <TableScroll>
+              <table>
+                <caption className="sr-only">
+                  Signups {from}–{to} of {total}
+                </caption>
+                <thead>
+                  <tr>
+                    <th scope="col">User</th>
+                    <th scope="col">Type</th>
+                    <th scope="col">Country</th>
+                    <th scope="col" className="n">
+                      Devices
+                    </th>
+                    <th scope="col">App</th>
+                    <th scope="col">Joined</th>
+                    <th scope="col">Last seen</th>
+                    <th scope="col">
+                      <span className="sr-only">Actions</span>
+                    </th>
                   </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        )}
-      </section>
+                </thead>
+                <tbody>
+                  {rows.map((u) => {
+                    const k = kind(u);
+                    return (
+                      <tr key={u.id}>
+                        <th scope="row" style={{ maxWidth: '17rem' }}>
+                          <span className="row-title">{u.display_name ?? '—'}</span>
+                          <span className="row-sub">
+                            {u.email ?? u.phone ?? '(no contact)'}
+                            {u.email && !u.email_confirmed ? ' · unconfirmed' : ''}
+                          </span>
+                        </th>
+                        <td>
+                          <Badge tone={k.tone}>{k.label}</Badge>
+                        </td>
+                        <td>{u.country_code ?? <span className="muted">—</span>}</td>
+                        <td className="n">
+                          {u.device_count > 0 ? u.device_count : <span className="muted">0</span>}
+                        </td>
+                        <td>
+                          {u.app_version ? (
+                            <>
+                              {u.app_version}
+                              {u.platform ? <span className="row-sub">{u.platform}</span> : null}
+                            </>
+                          ) : (
+                            <span className="muted">—</span>
+                          )}
+                        </td>
+                        <td>{when(u.created_at)}</td>
+                        <td>{when(u.last_sign_in_at)}</td>
+                        <td>
+                          <div className="row-actions">
+                            {u.email_confirmed || !u.email ? null : (
+                              <form action={confirm}>
+                                <CsrfField />
+                                <input type="hidden" name="id" value={u.id} />
+                                <input type="hidden" name="back" value={back} />
+                                <button
+                                  type="submit"
+                                  className="btn btn-quiet btn-sm"
+                                  title="Confirm this email by hand"
+                                >
+                                  Confirm
+                                </button>
+                              </form>
+                            )}
+                            <form action={upgrade} className="row" style={{ gap: '0.25rem' }}>
+                              <CsrfField />
+                              <input type="hidden" name="id" value={u.id} />
+                              <input type="hidden" name="back" value={back} />
+                              <input
+                                type="number"
+                                name="days"
+                                min={1}
+                                max={3650}
+                                defaultValue={365}
+                                aria-label={`Days of Plus to grant ${u.display_name ?? u.id}`}
+                                style={{ width: '4.5rem' }}
+                              />
+                              <button
+                                type="submit"
+                                className="btn btn-outline btn-sm"
+                                title="Comp a paid grant"
+                              >
+                                Upgrade
+                              </button>
+                            </form>
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </TableScroll>
+          )}
+        </Card>
+      </div>
 
-      <div className="row" style={{ justifyContent: 'space-between', marginTop: 14 }}>
-        <span className="faint">
+      {/* A real nav landmark: this is the only pagination in the console and
+          it is worth being able to jump to. */}
+      <nav className="row spread" style={{ marginTop: '1rem' }} aria-label="Pages of signups">
+        <span className="small muted">
           {from}–{to} of {total.toLocaleString('en-IN')}
         </span>
-        <span className="row" style={{ gap: 8 }}>
+        <span className="row" style={{ gap: '0.5rem' }}>
           {offset > 0 ? (
-            <a href={backTo(name, country, Math.max(0, offset - PAGE))}>← Previous</a>
+            <a
+              className="btn btn-quiet btn-sm"
+              href={backTo(name, country, Math.max(0, offset - PAGE))}
+            >
+              {Icon.arrowLeft}
+              <span>Previous</span>
+            </a>
           ) : (
-            <span className="muted">← Previous</span>
+            <span className="btn btn-quiet btn-sm" aria-disabled="true">
+              {Icon.arrowLeft}
+              <span>Previous</span>
+            </span>
           )}
           {offset + PAGE < total ? (
-            <a href={backTo(name, country, offset + PAGE)}>Next →</a>
+            <a className="btn btn-quiet btn-sm" href={backTo(name, country, offset + PAGE)}>
+              <span>Next</span>
+              {Icon.arrowRight}
+            </a>
           ) : (
-            <span className="muted">Next →</span>
+            <span className="btn btn-quiet btn-sm" aria-disabled="true">
+              <span>Next</span>
+              {Icon.arrowRight}
+            </span>
           )}
         </span>
-      </div>
+      </nav>
     </main>
   );
 }

--- a/apps/admin/src/app/voice-attempts/page.tsx
+++ b/apps/admin/src/app/voice-attempts/page.tsx
@@ -1,3 +1,4 @@
+import { Badge, Card, Empty, Lede, PageHeader, Tile } from '@/components/ui';
 import { voiceAttempts } from '@/lib/data';
 
 export const dynamic = 'force-dynamic';
@@ -5,72 +6,66 @@ export const dynamic = 'force-dynamic';
 /**
  * What the mic heard and the parser could not turn into an expense.
  *
- * The device reports only misses (item_count 0), silently and with the person's
- * analytics consent, so this is the raw material for improving voice quick-add:
- * the actual sentences that failed, newest first. Mirrors the feedback page —
- * same data layer, same console-only read.
+ * The device reports only misses (item_count 0), silently and with the
+ * person's analytics consent, so this is the raw material for improving voice
+ * quick-add: the actual sentences that failed, newest first.
  */
 export default async function VoiceAttemptsPage() {
   const rows = await voiceAttempts(200);
   const withModel = rows.filter((row) => row.used_model).length;
 
   return (
-    <main>
-      <header className="top">
-        <h1>Voice attempts</h1>{' '}
-      </header>
+    <main className="page">
+      <PageHeader
+        eyebrow="Signals"
+        title="Voice attempts"
+        actions={<span className="small muted">newest {rows.length}</span>}
+      />
 
-      <div className="tiles">
-        <div className="tile">
-          <span className="label">Unparsed</span>
-          <div className="value">{rows.length}</div>
-        </div>
-        <div className="tile">
-          <span className="label">Model tier</span>
-          <div className="value">{withModel}</div>
-        </div>
-        <div className="tile">
-          <span className="label">On-device</span>
-          <div className="value">{rows.length - withModel}</div>
-        </div>
+      <Lede>
+        These are raw speech transcripts, so they can name people, amounts and places. They are read
+        here and nowhere else. The profile id is kept, unlike feedback, so a confusing miss can be
+        traced back to the person who spoke it and the parser tuned against real usage.
+      </Lede>
+
+      <div className="cols-3">
+        <Tile label="Unparsed" value={rows.length} sub="dictations the parser could not use" />
+        <Tile label="Model tier" value={withModel} />
+        <Tile label="On-device" value={rows.length - withModel} />
       </div>
 
-      <h2>Newest first</h2>
-      <section>
+      <h2 className="section">Newest first</h2>
+      <Card bare>
         {rows.length === 0 ? (
-          <p className="note">
-            Nothing yet. Attempts arrive only when a dictation fails to parse and the person has
-            turned analytics on; if you expected some, the{' '}
-            <code>20260828000000_voice_attempts</code> migration may not be deployed to this
-            project.
-          </p>
+          <Empty title="Nothing yet" migration="20260828000000_voice_attempts">
+            Attempts arrive only when a dictation fails to parse and the person has turned analytics
+            on.
+          </Empty>
         ) : (
-          <ul className="feedback">
+          <ul className="feed">
             {rows.map((row) => (
               <li key={row.id}>
                 <div className="meta">
-                  <span className={`tag tag-${row.used_model ? 'idea' : 'general'}`}>
+                  <Badge tone={row.used_model ? 'accent' : 'neutral'}>
                     {row.used_model ? 'model' : 'on-device'}
-                  </span>
-                  <span>{new Date(row.created_at).toLocaleString('en-IN')}</span>
+                  </Badge>
+                  <time dateTime={row.created_at}>
+                    {new Date(row.created_at).toLocaleString('en-IN', {
+                      dateStyle: 'medium',
+                      timeStyle: 'short',
+                    })}
+                  </time>
                   {row.locale ? <span>{row.locale}</span> : null}
                   {row.platform ? <span>{row.platform}</span> : null}
                   {row.app_version ? <span>v{row.app_version}</span> : null}
-                  {row.profile_id ? <span>{row.profile_id}</span> : null}
+                  {row.profile_id ? <code>{row.profile_id}</code> : null}
                 </div>
                 <p>{row.transcript}</p>
               </li>
             ))}
           </ul>
         )}
-      </section>
-
-      <p className="note" style={{ padding: '14px 0 0' }}>
-        These are raw speech transcripts, so they can name people, amounts and places. They are read
-        here and nowhere else — no client can select them. The profile id is kept, unlike feedback,
-        so a confusing miss can be traced to the person who spoke it and the parser tuned against
-        real usage.
-      </p>
+      </Card>
     </main>
   );
 }

--- a/apps/admin/src/components/Shell.tsx
+++ b/apps/admin/src/components/Shell.tsx
@@ -1,55 +1,89 @@
 'use client';
 
-import { usePathname } from 'next/navigation';
-import type { ReactNode } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import { useState, type FormEvent, type ReactNode } from 'react';
 
-import { Sidebar } from './Sidebar';
+import { Icon } from './icons';
+import { locate, Sidebar } from './Sidebar';
 
 /**
  * The chrome around every page except the login screen.
  *
- * A Client Component so it can read the path: it both hides itself on `/login`
- * (which has no business behind a signed-in shell) and names the current
- * section in the top bar. The pages it wraps stay Server Components — they are
- * passed in as `children`, rendered on the server, and slotted into the light
- * content column without joining this file's client bundle.
+ * A Client Component for three reasons, all of which need the current path or
+ * local state: it hides itself on `/login`, it names the section in the top
+ * bar, and it owns the rail's collapsed/expanded flag. The pages it wraps stay
+ * Server Components — they arrive as `children`, already rendered, and never
+ * join this file's client bundle.
+ *
+ * The collapse state deliberately lives here rather than in `localStorage`.
+ * This component sits in the root layout, so App Router keeps it mounted
+ * across navigations and the choice survives every link in the console; what
+ * it does not survive is a reload, and a persisted value read in an effect
+ * would mean the rail visibly snaps shut after paint on every cold load. One
+ * of those is a better trade than the other for a console one person opens.
  */
-
-const TITLES: Record<string, string> = {
-  '/': 'Dashboard',
-  '/users': 'Users',
-  '/promotions': 'Promotions',
-  '/campaigns': 'Campaigns',
-  '/flags': 'Experiments',
-  '/config': 'Limits',
-  '/rate-limits': 'Rate limits',
-  '/feedback': 'Feedback',
-  '/voice-attempts': 'Voice attempts',
-};
-
-function titleFor(path: string): string {
-  if (TITLES[path]) return TITLES[path];
-  const hit = Object.entries(TITLES).find(([href]) => href !== '/' && path.startsWith(href));
-  return hit?.[1] ?? 'Admin';
-}
-
 export function Shell({ children }: { children: ReactNode }) {
   const path = usePathname();
+  const router = useRouter();
+  const [collapsed, setCollapsed] = useState(false);
 
   // The login page renders its own centred card and must not gain a rail.
   if (path === '/login') return <>{children}</>;
 
+  const here = locate(path);
+
+  function search(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const form = new FormData(event.currentTarget);
+    const query = String(form.get('q') ?? '').trim();
+    // The reference has a search pill and it searches nothing. The one index
+    // this console can actually search is the user directory, so that is where
+    // it goes rather than pretending to be global.
+    router.push(query ? `/users?name=${encodeURIComponent(query)}` : '/users');
+  }
+
   return (
-    <div className="shell">
+    <div className="wrapper" data-collapsed={collapsed ? 'true' : 'false'}>
+      {/* Six sections of rail stand between the top of the document and the
+          page, on every page. This is the way past them. */}
+      <a className="skip-link" href="#content">
+        Skip to content
+      </a>
       <Sidebar />
-      <div className="content">
+
+      <div className="main">
         <div className="topbar">
-          <div className="crumb">
-            Admin <span aria-hidden>›</span> <b>{titleFor(path)}</b>
-          </div>
-          <span className="pill">Aggregates only · service role</span>
+          <button
+            type="button"
+            className="icon-button"
+            onClick={() => setCollapsed((open) => !open)}
+            aria-expanded={!collapsed}
+            aria-controls="console-rail"
+            aria-label={collapsed ? 'Expand the section rail' : 'Collapse the section rail'}
+          >
+            {Icon.menu}
+          </button>
+
+          {/* Not a `<nav aria-label="Breadcrumb">`: there is no trail to walk
+              back up, only a statement of where you are. */}
+          <p className="crumb">
+            {here.section} <span aria-hidden>›</span> <b>{here.label}</b>
+          </p>
+
+          <span className="topbar-spacer" />
+
+          <form className="searchbox" onSubmit={search} role="search">
+            <label htmlFor="console-search" className="sr-only">
+              Search people by name or email
+            </label>
+            <input id="console-search" type="search" name="q" placeholder="Search people…" />
+            {Icon.search}
+          </form>
         </div>
-        {children}
+
+        <div id="content" className="content-slot" tabIndex={-1}>
+          {children}
+        </div>
       </div>
     </div>
   );

--- a/apps/admin/src/components/Sidebar.tsx
+++ b/apps/admin/src/components/Sidebar.tsx
@@ -4,144 +4,136 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import type { ReactNode } from 'react';
 
+import { Icon } from './icons';
+
 /**
- * The dark rail. A Client Component only because the active link is decided
- * from the current path (`usePathname`) rather than threaded through every page
- * as a `here` prop — which is what the old row-of-links `Nav` did, and what let
- * a page forget to say where it was.
+ * The rail.
+ *
+ * Light rather than the dark slab it used to be, because the reference's
+ * hierarchy comes from the 4px accent bar and a colour change on the label —
+ * not from a wall of contrast down the left of the screen. A dark rail beside
+ * a light page is a second theme to keep in step; this is one.
+ *
+ * A Client Component only because the active row is decided from the current
+ * path. The pages it sits beside stay Server Components.
  */
 
-type Item = { href: string; label: string; icon: ReactNode };
-type Section = { heading: string; items: Item[] };
+export type NavItem = { href: string; label: string; icon: ReactNode };
+export type NavSection = { heading: string; items: NavItem[] };
 
-// Stroke icons inline, for the same reason the charts were hand-drawn before a
-// library was allowed in: an icon set is a dependency that renders a few paths.
-const I = {
-  overview: (
-    <svg viewBox="0 0 24 24" aria-hidden>
-      <rect x="3" y="3" width="7" height="9" rx="1.5" />
-      <rect x="14" y="3" width="7" height="5" rx="1.5" />
-      <rect x="14" y="12" width="7" height="9" rx="1.5" />
-      <rect x="3" y="16" width="7" height="5" rx="1.5" />
-    </svg>
-  ),
-  users: (
-    <svg viewBox="0 0 24 24" aria-hidden>
-      <circle cx="9" cy="8" r="3.2" />
-      <path d="M3.5 20a5.5 5.5 0 0 1 11 0" />
-      <path d="M16 5.2a3.2 3.2 0 0 1 0 5.6" />
-      <path d="M17.5 14.4A5.5 5.5 0 0 1 20.5 19" />
-    </svg>
-  ),
-  flags: (
-    <svg viewBox="0 0 24 24" aria-hidden>
-      <path d="M9 3v7l-3.5 6.5A2 2 0 0 0 7.3 20h9.4a2 2 0 0 0 1.8-3L15 10V3" />
-      <path d="M7.5 3h9" />
-    </svg>
-  ),
-  gauge: (
-    <svg viewBox="0 0 24 24" aria-hidden>
-      <path d="M4 15a8 8 0 0 1 16 0" />
-      <path d="M12 15l4-3.5" />
-      <circle cx="12" cy="15" r="1.3" fill="currentColor" stroke="none" />
-    </svg>
-  ),
-  tag: (
-    <svg viewBox="0 0 24 24" aria-hidden>
-      <path d="M4 4h7l9 9-7 7-9-9V4z" />
-      <circle cx="8.5" cy="8.5" r="1.4" />
-    </svg>
-  ),
-  megaphone: (
-    <svg viewBox="0 0 24 24" aria-hidden>
-      <path d="M4 9v6h4l9 5V4L8 9H4z" />
-      <path d="M19 9a3.5 3.5 0 0 1 0 6" />
-    </svg>
-  ),
-  chat: (
-    <svg viewBox="0 0 24 24" aria-hidden>
-      <path d="M4 5h16v11H9l-5 4V5z" />
-    </svg>
-  ),
-  globe: (
-    <svg viewBox="0 0 24 24" aria-hidden>
-      <circle cx="12" cy="12" r="9" />
-      <path d="M3 12h18" />
-      <path d="M12 3a14 14 0 0 1 0 18a14 14 0 0 1 0-18z" />
-    </svg>
-  ),
-  mic: (
-    <svg viewBox="0 0 24 24" aria-hidden>
-      <rect x="9" y="3" width="6" height="11" rx="3" />
-      <path d="M5 11a7 7 0 0 0 14 0" />
-      <path d="M12 18v3" />
-    </svg>
-  ),
-};
-
-const SECTIONS: Section[] = [
-  { heading: 'Overview', items: [{ href: '/', label: 'Dashboard', icon: I.overview }] },
-  { heading: 'People', items: [{ href: '/users', label: 'Users', icon: I.users }] },
+export const NAV: NavSection[] = [
+  {
+    heading: 'Overview',
+    items: [{ href: '/', label: 'Dashboard', icon: Icon.grid }],
+  },
+  {
+    heading: 'People',
+    items: [{ href: '/users', label: 'Users', icon: Icon.users }],
+  },
   {
     heading: 'Growth',
     items: [
-      { href: '/promotions', label: 'Promotions', icon: I.tag },
-      { href: '/campaigns', label: 'Campaigns', icon: I.megaphone },
+      { href: '/promotions', label: 'Promotions', icon: Icon.tag },
+      { href: '/campaigns', label: 'Campaigns', icon: Icon.send },
     ],
   },
   {
-    heading: 'Config',
+    heading: 'Configuration',
     items: [
-      { href: '/flags', label: 'Experiments', icon: I.flags },
-      { href: '/config', label: 'Limits', icon: I.gauge },
-      { href: '/countries', label: 'Countries', icon: I.globe },
-      { href: '/rate-limits', label: 'Rate limits', icon: I.gauge },
+      { href: '/flags', label: 'Experiments', icon: Icon.flag },
+      { href: '/config', label: 'Limits', icon: Icon.sliders },
+      { href: '/services', label: 'Services', icon: Icon.server },
+      { href: '/releases', label: 'Releases', icon: Icon.smartphone },
+      { href: '/countries', label: 'Countries', icon: Icon.globe },
+      { href: '/rate-limits', label: 'Rate limits', icon: Icon.gauge },
     ],
   },
   {
     heading: 'Marketplace',
     items: [
-      { href: '/packs', label: 'Packs', icon: I.tag },
-      { href: '/pack-requests', label: 'Pack requests', icon: I.chat },
+      { href: '/packs', label: 'Packs', icon: Icon.grid3 },
+      { href: '/pack-requests', label: 'Pack requests', icon: Icon.inbox },
     ],
   },
   {
-    heading: 'Voice',
+    heading: 'Signals',
     items: [
-      { href: '/feedback', label: 'Feedback', icon: I.chat },
-      { href: '/voice-attempts', label: 'Voice attempts', icon: I.mic },
+      { href: '/feedback', label: 'Feedback', icon: Icon.message },
+      { href: '/voice-attempts', label: 'Voice attempts', icon: Icon.mic },
+      { href: '/agent-writes', label: 'Agent writes', icon: Icon.robot },
     ],
   },
 ];
+
+/** `/` matches only itself; everything else matches its own subtree. */
+export function isCurrent(href: string, path: string): boolean {
+  return href === '/' ? path === '/' : path === href || path.startsWith(`${href}/`);
+}
+
+/** The section + page a path sits in, for the topbar crumb and the title. */
+export function locate(path: string): { section: string; label: string } {
+  for (const section of NAV) {
+    for (const item of section.items) {
+      if (isCurrent(item.href, path)) return { section: section.heading, label: item.label };
+    }
+  }
+  // A path the rail does not know — a typo, or the 404. Naming the product
+  // rather than repeating "Admin" twice down the crumb.
+  return { section: 'Waves', label: 'Admin' };
+}
+
+const slug = (heading: string) => heading.toLowerCase().replace(/[^a-z]+/g, '-');
 
 export function Sidebar() {
   const path = usePathname();
 
   return (
-    <nav className="sidebar" aria-label="Sections">
-      <div className="brand">
-        <span className="mark">B</span>
+    <nav className="rail" id="console-rail" aria-label="Console sections">
+      <Link href="/" className="rail-logo">
+        {Icon.cube}
         <span>Waves</span>
-      </div>
-      {SECTIONS.map((section) => (
+      </Link>
+
+      {NAV.map((section) => (
         <div key={section.heading}>
-          <div className="side-group">{section.heading}</div>
-          {section.items.map((item) => {
-            const active = item.href === '/' ? path === '/' : path.startsWith(item.href);
-            return (
-              <Link
-                key={item.href}
-                href={item.href}
-                className="side-link"
-                aria-current={active ? 'page' : undefined}
-              >
-                {item.icon}
-                <span>{item.label}</span>
-              </Link>
-            );
-          })}
+          {/* Labelled rather than headed. A real `<h2>` here would put six of
+              them ahead of the page's own `<h1>` in the document, which reads
+              to a screen reader as a broken outline; `aria-labelledby` gives
+              the list its name without inventing that order. */}
+          <div className="rail-section" id={`rail-${slug(section.heading)}`}>
+            <span>{section.heading}</span>
+          </div>
+          <ul
+            aria-labelledby={`rail-${slug(section.heading)}`}
+            style={{ listStyle: 'none', margin: 0, padding: 0 }}
+          >
+            {section.items.map((item) => {
+              const active = isCurrent(item.href, path);
+              return (
+                <li key={item.href}>
+                  <Link
+                    href={item.href}
+                    className="rail-item"
+                    aria-current={active ? 'page' : undefined}
+                    // Collapsed, the label is invisible but the link is not —
+                    // without this the accessible name goes with the pixels.
+                    title={item.label}
+                  >
+                    {item.icon}
+                    <span className="title">{item.label}</span>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
         </div>
       ))}
+
+      <p className="rail-foot">
+        Aggregates only.
+        <br />
+        Service role · read at a desk.
+      </p>
     </nav>
   );
 }

--- a/apps/admin/src/components/charts/AreaTrend.tsx
+++ b/apps/admin/src/components/charts/AreaTrend.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState } from 'react';
 
 import { ReactEChartsCore } from './echarts-core';
 import { PALETTE } from './palette';
+import { useChartInk } from './useChartInk';
 
 export interface TrendDay {
   day: string;
@@ -20,8 +21,8 @@ enum Metric {
 }
 
 const SERIES: Record<Metric, { label: string; color: string }> = {
-  [Metric.NewProfiles]: { label: 'New people', color: PALETTE.purple },
-  [Metric.NewExpenses]: { label: 'Expenses', color: PALETTE.blue },
+  [Metric.NewProfiles]: { label: 'People', color: PALETTE.blue },
+  [Metric.NewExpenses]: { label: 'Expenses', color: PALETTE.purple },
   [Metric.Active]: { label: 'Active', color: PALETTE.green },
 };
 
@@ -35,28 +36,32 @@ const ORDER: Metric[] = [Metric.NewProfiles, Metric.NewExpenses, Metric.Active];
  */
 export function AreaTrend({ days }: { days: TrendDay[] }) {
   const [metric, setMetric] = useState<Metric>(Metric.NewProfiles);
+  const ink = useChartInk();
   const active = SERIES[metric];
   const summary = describeTrend(days, metric, active.label);
 
   const option = useMemo<EChartsOption>(
     () => ({
-      grid: { left: 8, right: 12, top: 16, bottom: 4, containLabel: true },
+      grid: { left: 4, right: 12, top: 12, bottom: 0, containLabel: true },
       tooltip: {
         trigger: 'axis',
-        axisPointer: { type: 'line', lineStyle: { color: '#c9c7dd' } },
+        backgroundColor: ink.tooltipBg,
+        borderColor: ink.tooltipBorder,
+        textStyle: { color: ink.ink, fontSize: 12 },
+        axisPointer: { type: 'line', lineStyle: { color: ink.line } },
       },
       xAxis: {
         type: 'category',
         boundaryGap: false,
         data: days.map((d) => d.day.slice(5)), // MM-DD; the year is the same 30 days
-        axisLine: { lineStyle: { color: '#e6e5ef' } },
+        axisLine: { lineStyle: { color: ink.line } },
         axisTick: { show: false },
-        axisLabel: { color: '#9997ac', fontSize: 11, interval: 4 },
+        axisLabel: { color: ink.label, fontSize: 11, interval: 4 },
       },
       yAxis: {
         type: 'value',
-        splitLine: { lineStyle: { color: '#eeedf5' } },
-        axisLabel: { color: '#9997ac', fontSize: 11 },
+        splitLine: { lineStyle: { color: ink.grid } },
+        axisLabel: { color: ink.label, fontSize: 11 },
       },
       series: [
         {
@@ -65,7 +70,7 @@ export function AreaTrend({ days }: { days: TrendDay[] }) {
           symbol: 'none',
           name: active.label,
           data: days.map((d) => d[metric]),
-          lineStyle: { width: 2.5, color: active.color },
+          lineStyle: { width: 2, color: active.color },
           itemStyle: { color: active.color },
           areaStyle: {
             color: {
@@ -75,22 +80,25 @@ export function AreaTrend({ days }: { days: TrendDay[] }) {
               x2: 0,
               y2: 1,
               colorStops: [
-                { offset: 0, color: `${active.color}55` },
-                { offset: 1, color: `${active.color}05` },
+                { offset: 0, color: `${active.color}45` },
+                { offset: 1, color: `${active.color}00` },
               ],
             },
           },
         },
       ],
     }),
-    [active.color, active.label, days, metric],
+    [active.color, active.label, days, ink, metric],
   );
 
   return (
     <>
       <div className="card-head">
-        <h3>Activity, 30 days</h3>
-        <div className="seg" role="group" aria-label="Which series">
+        <div>
+          <div className="eyebrow">Last 30 days</div>
+          <h3>Activity</h3>
+        </div>
+        <div className="seg" role="group" aria-label="Which series to draw">
           {ORDER.map((key) => (
             <button
               key={key}
@@ -106,7 +114,7 @@ export function AreaTrend({ days }: { days: TrendDay[] }) {
       <figure className="echart" role="img" aria-label={summary}>
         <ReactEChartsCore
           option={option}
-          style={{ height: 240 }}
+          style={{ height: 260 }}
           opts={{ renderer: 'svg' }}
           notMerge
         />

--- a/apps/admin/src/components/charts/DonutChart.tsx
+++ b/apps/admin/src/components/charts/DonutChart.tsx
@@ -5,6 +5,7 @@ import { useMemo } from 'react';
 
 import { ReactEChartsCore } from './echarts-core';
 import { WHEEL } from './palette';
+import { useChartInk } from './useChartInk';
 
 export interface Slice {
   name: string;
@@ -16,8 +17,8 @@ export interface Slice {
  *
  * Client-only because ECharts needs the DOM to size and paint. The Server
  * Component that renders the surrounding card computes the slices and hands
- * them down as a plain, serialisable array — no echarts import crosses onto the
- * server, no data fetching crosses onto the client.
+ * them down as a plain, serialisable array — no echarts import crosses onto
+ * the server, no data fetching crosses onto the client.
  */
 export function DonutChart({
   slices,
@@ -28,6 +29,7 @@ export function DonutChart({
   centerLabel: string;
   unit?: string;
 }) {
+  const ink = useChartInk();
   const total = slices.reduce((sum, s) => sum + s.value, 0);
   const summary = describeSlices(slices, centerLabel, unit);
 
@@ -36,6 +38,9 @@ export function DonutChart({
       color: [...WHEEL],
       tooltip: {
         trigger: 'item',
+        backgroundColor: ink.tooltipBg,
+        borderColor: ink.tooltipBorder,
+        textStyle: { color: ink.ink, fontSize: 12 },
         formatter: (p: unknown) => {
           const point = p as { name: string; value: number; percent: number };
           return `${point.name}<br/><b>${point.value.toLocaleString('en-IN')}</b>${
@@ -50,35 +55,32 @@ export function DonutChart({
         itemWidth: 9,
         itemHeight: 9,
         icon: 'circle',
-        textStyle: { color: '#6a6880', fontSize: 12 },
+        textStyle: { color: ink.label, fontSize: 12 },
       },
       series: [
         {
           type: 'pie',
-          radius: ['58%', '82%'],
+          radius: ['58%', '80%'],
           center: ['34%', '50%'],
           avoidLabelOverlap: false,
-          itemStyle: { borderRadius: 6, borderColor: 'transparent', borderWidth: 2 },
+          itemStyle: { borderRadius: 4, borderColor: ink.tooltipBg, borderWidth: 2 },
           label: {
             show: true,
             position: 'center',
             formatter: () => `{v|${total.toLocaleString('en-IN')}}
 {l|${centerLabel}}`,
             rich: {
-              v: { fontSize: 24, fontWeight: 700, color: '#14131f' },
-              l: { fontSize: 12, color: '#9997ac', padding: [4, 0, 0, 0] },
+              v: { fontSize: 22, fontWeight: 700, color: ink.ink },
+              l: { fontSize: 12, color: ink.label, padding: [4, 0, 0, 0] },
             },
           },
-          emphasis: {
-            label: { show: true },
-            scaleSize: 4,
-          },
+          emphasis: { label: { show: true }, scaleSize: 4 },
           labelLine: { show: false },
           data: slices,
         },
       ],
     }),
-    [centerLabel, slices, total, unit],
+    [centerLabel, ink, slices, total, unit],
   );
 
   return (

--- a/apps/admin/src/components/charts/palette.ts
+++ b/apps/admin/src/components/charts/palette.ts
@@ -1,28 +1,68 @@
 /**
- * The chart palette, in one place.
+ * The chart palette and the ink around it, in one place.
  *
- * ECharts paints to a canvas and cannot read the CSS custom properties the rest
- * of the console uses, so the hues are duplicated here as plain hex. Kept in
- * step with the `--c-*` tokens in `globals.css` by hand — five colours that
- * change roughly never. Importable from Server Components too, so a legend
- * swatch rendered in HTML matches the slice ECharts draws.
+ * ECharts paints into its own tree and cannot read the CSS custom properties
+ * the rest of the console uses, so the hues are duplicated here as plain hex
+ * and kept in step with the `--c-*` tokens in `globals.css` by hand. They are
+ * the reference dashboard's accent ramp: Tailwind blue/emerald/amber/red/
+ * violet at the 500 step.
+ *
+ * The hues are fixed across light and dark on purpose — a series that changed
+ * colour with the OS theme would be recolouring the data. The *chrome* around
+ * them (axis lines, tick labels, the number in the doughnut's hole) is not
+ * data and does have to follow the theme, so it lives in `AXIS` and is picked
+ * by the one client hook below.
  */
+
 export const PALETTE = {
-  blue: '#4e8cf5',
-  green: '#35c28e',
-  amber: '#f5b74e',
-  red: '#f2685f',
-  purple: '#6d5ef8',
+  blue: '#3b82f6',
+  green: '#10b981',
+  amber: '#f59e0b',
+  red: '#ef4444',
+  purple: '#8b5cf6',
 } as const;
 
 /** The order slices and series cycle through when a colour is not named. */
 export const WHEEL = [
-  PALETTE.purple,
   PALETTE.blue,
+  PALETTE.purple,
   PALETTE.green,
   PALETTE.amber,
   PALETTE.red,
-  '#9b83ff',
-  '#f39bd0',
-  '#5fd0c4',
+  '#06b6d4',
+  '#ec4899',
+  '#84cc16',
 ] as const;
+
+export interface ChartInk {
+  /** Axis lines and the doughnut's gaps. */
+  line: string;
+  /** Split lines behind the plot. */
+  grid: string;
+  /** Tick labels and legend text. */
+  label: string;
+  /** The one big number in the middle of a doughnut. */
+  ink: string;
+  /** Tooltip card. */
+  tooltipBg: string;
+  tooltipBorder: string;
+}
+
+export const AXIS: Record<'light' | 'dark', ChartInk> = {
+  light: {
+    line: '#e5e7eb', // gray-200
+    grid: '#f3f4f6', // gray-100
+    label: '#6b7280', // gray-500
+    ink: '#111827', // gray-900
+    tooltipBg: '#ffffff',
+    tooltipBorder: '#e5e7eb',
+  },
+  dark: {
+    line: '#4b5563', // gray-600
+    grid: '#374151', // gray-700
+    label: '#9ca3af', // gray-400
+    ink: '#f9fafb', // gray-50
+    tooltipBg: '#1f2937', // gray-800
+    tooltipBorder: '#4b5563',
+  },
+};

--- a/apps/admin/src/components/charts/useChartInk.ts
+++ b/apps/admin/src/components/charts/useChartInk.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+import { AXIS, type ChartInk } from './palette';
+
+/**
+ * Which theme the charts should draw their *chrome* in.
+ *
+ * The rest of the console gets this for free — `prefers-color-scheme` swaps
+ * the CSS custom properties and every border follows. ECharts cannot: it
+ * writes computed colours into an SVG tree it owns, so an axis label picked
+ * once at render stays that colour when the OS flips at sunset.
+ *
+ * `useSyncExternalStore` rather than `useState` + `useEffect`, because that is
+ * precisely the shape of the problem: the media query is an external store,
+ * this subscribes to it, and the third argument is the answer to give while
+ * rendering on the server, where `matchMedia` does not exist. Doing it the
+ * other way — setting state inside an effect — renders once with the wrong
+ * value and then immediately again, which React 19's lint rule quite rightly
+ * refuses.
+ */
+
+const QUERY = '(prefers-color-scheme: dark)';
+
+function subscribe(onChange: () => void): () => void {
+  const query = window.matchMedia(QUERY);
+  query.addEventListener('change', onChange);
+  return () => query.removeEventListener('change', onChange);
+}
+
+const getSnapshot = () => window.matchMedia(QUERY).matches;
+
+/**
+ * The server has no media query, so it draws the light chrome — and so does
+ * the client's first paint, which is what keeps the two in agreement. A dark
+ * reader gets one frame of light axis labels before the store corrects it;
+ * the alternative is a hydration mismatch on every chart.
+ */
+const getServerSnapshot = () => false;
+
+export function useChartInk(): ChartInk {
+  const dark = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  return dark ? AXIS.dark : AXIS.light;
+}

--- a/apps/admin/src/components/icons.tsx
+++ b/apps/admin/src/components/icons.tsx
@@ -1,0 +1,261 @@
+import type { ReactElement } from 'react';
+
+/**
+ * The icon set, drawn rather than installed.
+ *
+ * The reference dashboard uses Feather through `react-icons`, and Feather's
+ * grammar is what makes its chrome cohere: a 24×24 box, 2px strokes, round
+ * caps and joins, and no fills anywhere. That grammar is worth copying; a
+ * package that ships two thousand glyphs so this console can show eighteen is
+ * not. Every path below is that grammar applied by hand.
+ *
+ * Sizing, colour and stroke width are set in CSS by whatever contains the
+ * icon (`.rail-item > svg`, `.stat > svg`, `.btn svg` …), so an icon looks
+ * right in a button and in a rail without either call site saying so. That is
+ * also why nothing here takes props: an icon that could be recoloured at the
+ * call site is an icon that will be, inconsistently.
+ */
+
+type Icon = ReactElement;
+
+const box = {
+  viewBox: '0 0 24 24',
+  'aria-hidden': true,
+  focusable: false,
+} as const;
+
+export const Icon = {
+  /** Brand mark — the reference's cube, and the app's own "layers" idea. */
+  cube: (
+    <svg {...box}>
+      <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" />
+      <polyline points="3.27 6.96 12 12.01 20.73 6.96" />
+      <line x1="12" y1="22.08" x2="12" y2="12" />
+    </svg>
+  ),
+
+  // ── navigation ─────────────────────────────────────────────────────────
+  grid: (
+    <svg {...box}>
+      <rect x="3" y="3" width="7" height="7" rx="1" />
+      <rect x="14" y="3" width="7" height="7" rx="1" />
+      <rect x="14" y="14" width="7" height="7" rx="1" />
+      <rect x="3" y="14" width="7" height="7" rx="1" />
+    </svg>
+  ),
+  users: (
+    <svg {...box}>
+      <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+      <circle cx="9" cy="7" r="4" />
+      <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
+      <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+    </svg>
+  ),
+  tag: (
+    <svg {...box}>
+      <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z" />
+      <line x1="7" y1="7" x2="7.01" y2="7" />
+    </svg>
+  ),
+  send: (
+    <svg {...box}>
+      <line x1="22" y1="2" x2="11" y2="13" />
+      <polygon points="22 2 15 22 11 13 2 9 22 2" />
+    </svg>
+  ),
+  flag: (
+    <svg {...box}>
+      <path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z" />
+      <line x1="4" y1="22" x2="4" y2="15" />
+    </svg>
+  ),
+  sliders: (
+    <svg {...box}>
+      <line x1="4" y1="21" x2="4" y2="14" />
+      <line x1="4" y1="10" x2="4" y2="3" />
+      <line x1="12" y1="21" x2="12" y2="12" />
+      <line x1="12" y1="8" x2="12" y2="3" />
+      <line x1="20" y1="21" x2="20" y2="16" />
+      <line x1="20" y1="12" x2="20" y2="3" />
+      <line x1="1" y1="14" x2="7" y2="14" />
+      <line x1="9" y1="8" x2="15" y2="8" />
+      <line x1="17" y1="16" x2="23" y2="16" />
+    </svg>
+  ),
+  globe: (
+    <svg {...box}>
+      <circle cx="12" cy="12" r="10" />
+      <line x1="2" y1="12" x2="22" y2="12" />
+      <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+    </svg>
+  ),
+  gauge: (
+    <svg {...box}>
+      <path d="M3 17a9 9 0 1 1 18 0" />
+      <line x1="12" y1="17" x2="17" y2="11" />
+      <circle cx="12" cy="17" r="1.5" />
+    </svg>
+  ),
+  grid3: (
+    <svg {...box}>
+      <rect x="3" y="3" width="18" height="18" rx="2" />
+      <line x1="3" y1="9" x2="21" y2="9" />
+      <line x1="9" y1="21" x2="9" y2="9" />
+    </svg>
+  ),
+  inbox: (
+    <svg {...box}>
+      <polyline points="22 12 16 12 14 15 10 15 8 12 2 12" />
+      <path d="M5.45 5.11L2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z" />
+    </svg>
+  ),
+  message: (
+    <svg {...box}>
+      <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+    </svg>
+  ),
+  mic: (
+    <svg {...box}>
+      <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z" />
+      <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+      <line x1="12" y1="19" x2="12" y2="23" />
+    </svg>
+  ),
+  smartphone: (
+    <svg {...box}>
+      <rect x="5" y="2" width="14" height="20" rx="2" />
+      <line x1="12" y1="18" x2="12.01" y2="18" />
+    </svg>
+  ),
+  server: (
+    <svg {...box}>
+      <rect x="2" y="2" width="20" height="8" rx="2" />
+      <rect x="2" y="14" width="20" height="8" rx="2" />
+      <line x1="6" y1="6" x2="6.01" y2="6" />
+      <line x1="6" y1="18" x2="6.01" y2="18" />
+    </svg>
+  ),
+  robot: (
+    <svg {...box}>
+      <rect x="4" y="8" width="16" height="12" rx="2" />
+      <path d="M12 8V4" />
+      <circle cx="12" cy="3" r="1" />
+      <line x1="9" y1="13" x2="9.01" y2="13" />
+      <line x1="15" y1="13" x2="15.01" y2="13" />
+      <path d="M9.5 17h5" />
+    </svg>
+  ),
+
+  // ── dashboard stat glyphs ──────────────────────────────────────────────
+  layers: (
+    <svg {...box}>
+      <polygon points="12 2 2 7 12 12 22 7 12 2" />
+      <polyline points="2 17 12 22 22 17" />
+      <polyline points="2 12 12 17 22 12" />
+    </svg>
+  ),
+  receipt: (
+    <svg {...box}>
+      <path d="M6 2h12a1 1 0 0 1 1 1v19l-3-2-3 2-3-2-3 2V3a1 1 0 0 1 1-1z" />
+      <line x1="9" y1="8" x2="15" y2="8" />
+      <line x1="9" y1="12" x2="15" y2="12" />
+    </svg>
+  ),
+  check: (
+    <svg {...box}>
+      <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+      <polyline points="22 4 12 14.01 9 11.01" />
+    </svg>
+  ),
+  activity: (
+    <svg {...box}>
+      <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
+    </svg>
+  ),
+  trash: (
+    <svg {...box}>
+      <polyline points="3 6 5 6 21 6" />
+      <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+    </svg>
+  ),
+
+  // ── chrome ─────────────────────────────────────────────────────────────
+  menu: (
+    <svg {...box}>
+      <line x1="3" y1="12" x2="21" y2="12" />
+      <line x1="3" y1="6" x2="21" y2="6" />
+      <line x1="3" y1="18" x2="21" y2="18" />
+    </svg>
+  ),
+  search: (
+    <svg {...box}>
+      <circle cx="11" cy="11" r="8" />
+      <line x1="21" y1="21" x2="16.65" y2="16.65" />
+    </svg>
+  ),
+  download: (
+    <svg {...box}>
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+      <polyline points="7 10 12 15 17 10" />
+      <line x1="12" y1="15" x2="12" y2="3" />
+    </svg>
+  ),
+  plus: (
+    <svg {...box}>
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <line x1="5" y1="12" x2="19" y2="12" />
+    </svg>
+  ),
+  save: (
+    <svg {...box}>
+      <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" />
+      <polyline points="17 21 17 13 7 13 7 21" />
+      <polyline points="7 3 7 8 15 8" />
+    </svg>
+  ),
+  logout: (
+    <svg {...box}>
+      <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+      <polyline points="16 17 21 12 16 7" />
+      <line x1="21" y1="12" x2="9" y2="12" />
+    </svg>
+  ),
+  ok: (
+    <svg {...box}>
+      <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+      <polyline points="22 4 12 14.01 9 11.01" />
+    </svg>
+  ),
+  alert: (
+    <svg {...box}>
+      <circle cx="12" cy="12" r="10" />
+      <line x1="12" y1="8" x2="12" y2="12" />
+      <line x1="12" y1="16" x2="12.01" y2="16" />
+    </svg>
+  ),
+  info: (
+    <svg {...box}>
+      <circle cx="12" cy="12" r="10" />
+      <line x1="12" y1="16" x2="12" y2="12" />
+      <line x1="12" y1="8" x2="12.01" y2="8" />
+    </svg>
+  ),
+  empty: (
+    <svg {...box}>
+      <circle cx="12" cy="12" r="10" />
+      <line x1="8" y1="12" x2="16" y2="12" />
+    </svg>
+  ),
+  arrowLeft: (
+    <svg {...box}>
+      <line x1="19" y1="12" x2="5" y2="12" />
+      <polyline points="12 19 5 12 12 5" />
+    </svg>
+  ),
+  arrowRight: (
+    <svg {...box}>
+      <line x1="5" y1="12" x2="19" y2="12" />
+      <polyline points="12 5 19 12 12 19" />
+    </svg>
+  ),
+} satisfies Record<string, Icon>;

--- a/apps/admin/src/components/ui.tsx
+++ b/apps/admin/src/components/ui.tsx
@@ -1,0 +1,330 @@
+import type { ReactNode } from 'react';
+
+import { Icon } from './icons';
+
+/**
+ * The console's component vocabulary.
+ *
+ * Every screen here was previously hand-assembled out of `<section>` and a
+ * className, which is how the same idea — "a card with a title", "this went
+ * wrong", "there is nothing here yet" — ended up drawn five slightly different
+ * ways. These are the shapes the reference dashboard has, named once.
+ *
+ * All Server Components: none of them holds state, so none of them needs to
+ * cross onto the client and drag a page's data fetching with it.
+ */
+
+/* ── page header ───────────────────────────────────────────────────────── */
+
+/**
+ * The reference's page head: a small uppercase eyebrow naming the section, the
+ * title under it, and any page-level actions pushed to the right.
+ */
+export function PageHeader({
+  eyebrow,
+  title,
+  actions,
+}: {
+  eyebrow: string;
+  title: string;
+  actions?: ReactNode;
+}) {
+  return (
+    <header className="page-head">
+      <div>
+        <div className="eyebrow">{eyebrow}</div>
+        <h1>{title}</h1>
+      </div>
+      {actions ? <div className="actions">{actions}</div> : null}
+    </header>
+  );
+}
+
+/** The standing paragraph of explanation under a page title. */
+export function Lede({ children }: { children: ReactNode }) {
+  return <p className="lede">{children}</p>;
+}
+
+/* ── card ──────────────────────────────────────────────────────────────── */
+
+export function Card({
+  title,
+  eyebrow,
+  actions,
+  note,
+  bare,
+  children,
+}: {
+  title?: string;
+  eyebrow?: string;
+  actions?: ReactNode;
+  /** Small print under the content — the caveat a number needs to be read with. */
+  note?: ReactNode;
+  /** Skip the inner padding, for a card whose whole body is a table. */
+  bare?: boolean;
+  children?: ReactNode;
+}) {
+  return (
+    <section className="card">
+      {title ? (
+        <div className="card-head">
+          <div>
+            {eyebrow ? <div className="eyebrow">{eyebrow}</div> : null}
+            <h3>{title}</h3>
+          </div>
+          {actions ? <div className="actions row">{actions}</div> : null}
+        </div>
+      ) : null}
+      {children ? bare ? children : <div className="card-body">{children}</div> : null}
+      {note ? <p className="card-note">{note}</p> : null}
+    </section>
+  );
+}
+
+/* ── figures ───────────────────────────────────────────────────────────── */
+
+/**
+ * The reference's stat card: label over value, glyph on the right, no shadow.
+ * `sub` carries the comparison — "+12 in 7d" — and `dir` colours it, because a
+ * movement with no direction is just another number.
+ */
+export function Stat({
+  label,
+  value,
+  sub,
+  dir = 'flat',
+  icon,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  dir?: 'up' | 'down' | 'flat';
+  icon: ReactNode;
+}) {
+  return (
+    <div className="stat">
+      <div>
+        <div className="stat-label">{label}</div>
+        <div className="stat-value">{value}</div>
+        {sub ? <div className={`stat-sub ${dir}`}>{sub}</div> : null}
+      </div>
+      {icon}
+    </div>
+  );
+}
+
+/** A quieter figure, for the count row above a list. */
+export function Tile({ label, value, sub }: { label: string; value: ReactNode; sub?: string }) {
+  return (
+    <div className="tile">
+      <span className="tile-label">{label}</span>
+      <div className="tile-value">{value}</div>
+      {sub ? <div className="tile-sub">{sub}</div> : null}
+    </div>
+  );
+}
+
+/* ── badge ─────────────────────────────────────────────────────────────── */
+
+export type Tone = 'neutral' | 'accent' | 'ok' | 'warn' | 'danger';
+
+const TONE_CLASS: Record<Tone, string> = {
+  neutral: '',
+  accent: ' badge-accent',
+  ok: ' badge-ok',
+  warn: ' badge-warn',
+  danger: ' badge-danger',
+};
+
+export function Badge({ tone = 'neutral', children }: { tone?: Tone; children: ReactNode }) {
+  return <span className={`badge${TONE_CLASS[tone]}`}>{children}</span>;
+}
+
+/** A live/off state, which is a light rather than a label. */
+export function Dot({ on, children }: { on: boolean; children: ReactNode }) {
+  return (
+    <span className="row" style={{ gap: 0 }}>
+      <span className={on ? 'dot on' : 'dot off'} aria-hidden />
+      {children}
+    </span>
+  );
+}
+
+/* ── banners ───────────────────────────────────────────────────────────── */
+
+/**
+ * The outcome of the action you just took.
+ *
+ * Every mutation in this console redirects with `?error=` or `?saved=`, so by
+ * the time one of these renders the whole document has been replaced. That is
+ * why the live region is `polite` and not `alert`: the page change is itself
+ * the interruption, and a second one on top of it is noise. `role="status"`
+ * gives a screen reader the sentence without stealing focus from wherever the
+ * operator was heading next.
+ */
+export function Banner({
+  tone,
+  children,
+}: {
+  tone: 'ok' | 'danger' | 'info';
+  children: ReactNode;
+}) {
+  const glyph = tone === 'ok' ? Icon.ok : tone === 'danger' ? Icon.alert : Icon.info;
+  return (
+    <div className={`banner banner-${tone}`} role="status" aria-live="polite">
+      {glyph}
+      <div>{children}</div>
+    </div>
+  );
+}
+
+/** The two query params every mutating page in here redirects with. */
+export function Outcome({ error, done }: { error?: string; done?: string }) {
+  return (
+    <>
+      {error ? <Banner tone="danger">{error}</Banner> : null}
+      {done ? <Banner tone="ok">{done}</Banner> : null}
+    </>
+  );
+}
+
+/* ── empty state ───────────────────────────────────────────────────────── */
+
+/**
+ * Nothing here — and, importantly, *why*.
+ *
+ * This console runs against projects at different migration levels, so "no
+ * rows" and "that table does not exist here yet" look identical from the
+ * outside and mean completely different things. `migration` names the one that
+ * would create the rows, so a first-run state reads as a first-run state
+ * instead of as a broken screen.
+ */
+export function Empty({
+  title,
+  children,
+  migration,
+}: {
+  title: string;
+  children?: ReactNode;
+  migration?: string;
+}) {
+  return (
+    <div className="empty">
+      {Icon.empty}
+      <div className="empty-title">{title}</div>
+      {children ? <p>{children}</p> : null}
+      {migration ? (
+        <p>
+          If you expected some, the <code>{migration}</code> migration may not be deployed to this
+          project.
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+/* ── table ─────────────────────────────────────────────────────────────── */
+
+/**
+ * A table that scrolls inside its own box rather than pushing the page
+ * sideways. Desktop-only does not mean "assume 4K": a fourteen-column table
+ * still overflows a laptop, and the fix is a scroll container, not a smaller
+ * font.
+ */
+export function TableScroll({ children }: { children: ReactNode }) {
+  return <div className="table-scroll">{children}</div>;
+}
+
+/* ── forms ─────────────────────────────────────────────────────────────── */
+
+/**
+ * A labelled control.
+ *
+ * The `<label>` wraps its input, so the association needs no id and cannot
+ * drift — which matters here because most of these forms are generated from
+ * rows and would otherwise need a unique id per row per field.
+ */
+export function Field({
+  label,
+  hint,
+  children,
+  full,
+}: {
+  label: string;
+  hint?: string;
+  children: ReactNode;
+  full?: boolean;
+}) {
+  return (
+    <label className={full ? 'field form-full' : 'field'}>
+      <span>
+        {label}
+        {hint ? <span className="field-hint"> — {hint}</span> : null}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+/** A checkbox with its words beside it rather than above. */
+export function Check({
+  name,
+  label,
+  defaultChecked,
+  plain,
+}: {
+  name: string;
+  label: string;
+  defaultChecked?: boolean;
+  plain?: boolean;
+}) {
+  return (
+    <label className={plain ? 'check plain' : 'check'}>
+      <input type="checkbox" name={name} defaultChecked={defaultChecked} />
+      <span>{label}</span>
+    </label>
+  );
+}
+
+/* ── skeleton ──────────────────────────────────────────────────────────── */
+
+/**
+ * What a route's `loading.tsx` shows while its server component is still
+ * talking to Postgres. Shaped like the page it precedes — a header, a row of
+ * figures, a slab where the table goes — so the layout does not jump when the
+ * data lands.
+ */
+export function PageSkeleton({ figures = 4, rows = 6 }: { figures?: number; rows?: number }) {
+  return (
+    <main className="page" aria-busy="true" aria-live="polite">
+      <span className="sr-only">Loading.</span>
+      <div className="page-head">
+        <div>
+          <div className="skel skel-line" style={{ width: 90, marginBottom: 8 }} />
+          <div className="skel" style={{ width: 220, height: 22 }} />
+        </div>
+      </div>
+      {figures > 0 ? (
+        <div className="autofit" style={{ marginBottom: '1rem' }}>
+          {Array.from({ length: figures }, (_, i) => (
+            <div className="tile" key={i}>
+              <div className="skel skel-line" style={{ width: '55%', marginBottom: 10 }} />
+              <div className="skel" style={{ width: '35%', height: 20 }} />
+            </div>
+          ))}
+        </div>
+      ) : null}
+      <div className="card">
+        <div className="card-body">
+          {Array.from({ length: rows }, (_, i) => (
+            <div
+              className="skel skel-line"
+              key={i}
+              style={{ width: `${92 - (i % 4) * 11}%`, marginBottom: 12 }}
+            />
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/admin/src/lib/data.ts
+++ b/apps/admin/src/lib/data.ts
@@ -958,3 +958,220 @@ export async function decidePackRequest(id: string, status: 'done' | 'declined')
     .eq('id', id);
   if (error) throw new Error(`deciding the request failed: ${error.message}`);
 }
+
+/* ══════════════════════════════════════════════════════════════════════════
+ * Service settings, release policy, and the agent audit.
+ *
+ * The first two are configuration this console owns, so they are read from
+ * their tables the way `app_config` and `country_settings` already are — not
+ * through a `waves_admin_*` function. That exception is narrow and worth
+ * naming: a function is the right shape for an *aggregate over somebody's
+ * data*, because it fixes what the console can see in one reviewable
+ * migration. A row that only ever held a setting the operator typed has
+ * nothing to hide from the operator.
+ *
+ * `agent_writes` is the exception to the exception. It is a log of what an
+ * automated client did on real people's ledgers, so what is selected here is
+ * kept to what answers "which client, doing what, how often, how much" —
+ * `profile_id`, `group_id` and `object_id` are deliberately left out, because
+ * knowing *whose* expense an agent touched is not needed in order to decide
+ * whether to stop trusting the agent.
+ * ═══════════════════════════════════════════════════════════════════════ */
+
+export interface ServiceConfigRow {
+  key: string;
+  value: string | null;
+  description: string;
+  updated_at: string;
+}
+
+/**
+ * The string knobs — which speech provider and model the voice pipeline uses.
+ * Generic in the same way `appConfig` is: the whole table, no key list, so a
+ * setting a migration adds shows up here without a change to this file.
+ */
+export async function serviceConfig(): Promise<ServiceConfigRow[]> {
+  await requireSession();
+  const { data, error } = await client()
+    .from('service_config')
+    .select('key, value, description, updated_at')
+    .order('key');
+  if (error) {
+    if (error.code === TABLE_MISSING) return [];
+    throw new Error(`reading service_config failed: ${error.message}`);
+  }
+  return (data ?? []) as ServiceConfigRow[];
+}
+
+/**
+ * Change one service knob. An UPDATE for the same reason `saveAppConfig` is:
+ * the keys are defined by the code that reads them, and a key nothing reads is
+ * a setting with no effect.
+ *
+ * An empty string is a real value here and means "the provider's own default"
+ * — that is what `voice_stt_model` ships as — so it is stored rather than
+ * refused. The length cap is not a validation of meaning, only a refusal to
+ * put an essay in a settings row.
+ */
+export async function saveServiceConfig(input: { key: string; value: string }): Promise<void> {
+  await requireSession();
+
+  if (!/^[a-z][a-z0-9_]{1,60}$/.test(input.key)) {
+    throw new Error('A key is lowercase letters, digits and underscores, starting with a letter.');
+  }
+  const value = input.value.trim();
+  if (value.length > 200) {
+    throw new Error('A service setting is 200 characters or fewer.');
+  }
+
+  const { error } = await client()
+    .from('service_config')
+    .update({ value, updated_at: new Date().toISOString() })
+    .eq('key', input.key)
+    .select()
+    .single();
+  if (error) {
+    if (error.code === NO_ROWS) throw new Error(`no such service key "${input.key}"`);
+    throw new Error(`saving ${input.key} failed: ${error.message}`);
+  }
+}
+
+export interface AppReleaseRow {
+  platform: string;
+  latest_version: string;
+  minimum_version: string;
+  store_url: string;
+  message: string | null;
+  updated_at: string;
+}
+
+/** The version policy each store is under. One row per platform, by primary key. */
+export async function appReleases(): Promise<AppReleaseRow[]> {
+  await requireSession();
+  const { data, error } = await client()
+    .from('app_releases')
+    .select('platform, latest_version, minimum_version, store_url, message, updated_at')
+    .order('platform');
+  if (error) {
+    if (error.code === TABLE_MISSING) return [];
+    throw new Error(`reading app_releases failed: ${error.message}`);
+  }
+  return (data ?? []) as AppReleaseRow[];
+}
+
+/** The shape both version columns are constrained to, checked here as well. */
+const VERSION = /^[0-9]+(\.[0-9]+){0,3}$/;
+
+/** Dotted version as four numbers, shorter ones padded — `waves_version_key`. */
+function versionKey(version: string): number[] {
+  const parts = version.split('.').map(Number);
+  while (parts.length < 4) parts.push(0);
+  return parts;
+}
+
+function atMost(a: string, b: string): boolean {
+  const left = versionKey(a);
+  const right = versionKey(b);
+  for (let i = 0; i < 4; i += 1) {
+    if (left[i] !== right[i]) return left[i]! < right[i]!;
+  }
+  return true;
+}
+
+/**
+ * Set a platform's version policy.
+ *
+ * `minimum_version` is the sharpest control in the whole database: the app
+ * checks it before anybody signs in, so raising it past a build locks every
+ * install on that build out of the product until the store has the new one.
+ * The database has a CHECK that minimum never exceeds latest; it is repeated
+ * here so the refusal arrives as a sentence beside the field rather than as a
+ * constraint violation.
+ *
+ * An UPDATE, not an upsert: the two platform rows are seeded by the migration
+ * and `app_releases_platform_check` allows no third.
+ */
+export async function saveAppRelease(input: {
+  platform: string;
+  latestVersion: string;
+  minimumVersion: string;
+  storeUrl: string;
+  message: string;
+}): Promise<void> {
+  await requireSession();
+
+  const platform = input.platform.trim();
+  if (platform !== 'ios' && platform !== 'android') {
+    throw new Error('Platform is ios or android.');
+  }
+  const latest = input.latestVersion.trim();
+  const minimum = input.minimumVersion.trim();
+  if (!VERSION.test(latest)) throw new Error(`"${latest}" is not a version like 1.4.2.`);
+  if (!VERSION.test(minimum)) throw new Error(`"${minimum}" is not a version like 1.4.2.`);
+  if (!atMost(minimum, latest)) {
+    throw new Error(
+      `The minimum (${minimum}) cannot be above the latest release (${latest}) — that would lock out everybody, including people already on the newest build.`,
+    );
+  }
+
+  const storeUrl = input.storeUrl.trim();
+  if (!/^https:\/\/\S+$/.test(storeUrl)) {
+    throw new Error('The store link must be an https:// URL.');
+  }
+
+  const message = input.message.trim();
+  if (message.length > 300) {
+    throw new Error('The upgrade message is 300 characters or fewer.');
+  }
+
+  const { error } = await client()
+    .from('app_releases')
+    .update({
+      latest_version: latest,
+      minimum_version: minimum,
+      store_url: storeUrl,
+      // Null rather than an empty string: the app reads absence as "use the
+      // default wording", and an empty string is a message that says nothing.
+      message: message === '' ? null : message,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('platform', platform)
+    .select()
+    .single();
+  if (error) {
+    if (error.code === NO_ROWS) throw new Error(`no release row for "${platform}"`);
+    throw new Error(`saving the ${platform} release failed: ${error.message}`);
+  }
+}
+
+export interface AgentWriteRow {
+  id: string;
+  client_id: string;
+  action: string;
+  amount_minor: string | null;
+  currency: string | null;
+  created_at: string;
+}
+
+/**
+ * What automated clients have written, newest first.
+ *
+ * `agent_writes` was added as the audit half of letting an outside agent post
+ * to somebody's ledger, and until now it had no reader at all: the two caps
+ * that bound it (`agent_expense_cap_minor`, `agent_daily_cap_minor`) are
+ * turnable on the Limits page while the writes they bound were invisible.
+ * This is the reader.
+ */
+export async function agentWrites(limit = 200): Promise<AgentWriteRow[]> {
+  await requireSession();
+  const { data, error } = await client()
+    .from('agent_writes')
+    .select('id, client_id, action, amount_minor, currency, created_at')
+    .order('created_at', { ascending: false })
+    .limit(Math.min(Math.max(1, limit), 500));
+  if (error) {
+    if (error.code === TABLE_MISSING) return [];
+    throw new Error(`reading agent_writes failed: ${error.message}`);
+  }
+  return (data ?? []) as AgentWriteRow[];
+}


### PR DESCRIPTION
The admin console had grown a screen at a time, and it showed: each page had
invented its own card, its own empty state, its own way of saying a save
failed. Twelve screens sharing a stylesheet without sharing a language.

## The design

Rebuilt against the [d-board](https://d-board-omega.vercel.app/) reference
dashboard. Its tokens were read out of the compiled Tailwind stylesheet rather
than eyeballed, and the vocabulary now lives once — in `globals.css` and
`components/ui.tsx` — with every screen assembling it.

| Token     | Value                                                 |
| --------- | ----------------------------------------------------- |
| Neutrals  | Tailwind `gray` — 50 page, white card, 100 hairline   |
| Accent    | Tailwind `blue` — 500 fills, **600 for text**         |
| Radius    | `rounded-lg` cards, `rounded-md` inputs               |
| Rail      | 16rem → 4rem collapsed, 4px accent bar on active      |
| Bars      | 4rem — logo block, section head and topbar agree      |
| Table row | `px-3 py-2`, uppercase `text-xs` head                 |
| Charts    | blue / violet / emerald / amber / red at the 500 step |

Three deliberate departures, all the same direction:

1. The reference ships `*, :focus { outline: none !important }` — a keyboard
   user locked out of a console that is almost entirely keyboard. Replaced with
   a visible focus ring, written as the **first** rule in the file so nothing
   can quietly beat it.
2. `blue-500` is 3.7:1 on white. Fine as a fill, a failure as text — anything
   blue that has to be *read* is `blue-600` (5.2:1).
3. It hides scrollbars. A console full of wide tables cannot afford that.

**Desktop only**, as asked, and now stated rather than implied: `min-width:
1024px`, no breakpoints under it, and the login page opting back out (signing
in from a phone to check the console is up is a real thing to do). That is
about viewport width and nothing else — tables carry `scope` and captions,
every icon-only control has an accessible name, the rail is skippable, headings
are in order, and the whole thing stays keyboard-reachable.

## The gaps

Three operator surfaces the database had and the console did not:

- **Releases** (`app_releases`) — the version policy, per store. This is the
  sharpest lever in the schema: `minimum_version` is checked *before* anybody
  signs in, so raising it past a build locks every install on it out of the
  product. It had no screen, meaning a SQL console at exactly the moment nobody
  wants to be in one. The "minimum cannot exceed latest" rule is repeated in the
  data layer so the refusal arrives as a sentence beside the field rather than
  as a constraint violation.
- **Services** (`service_config`) — `app_config`'s sibling for settings whose
  value is a word: which speech provider and model the voice pipeline calls.
  Switching providers during somebody else's outage should not be a database
  session. Credentials are *not* here and never will be.
- **Agent writes** (`agent_writes`) — the two caps bounding what an automated
  client may post have been turnable on Limits since the day they landed; the
  writes they bound were invisible. An audit trail nobody can read is a log
  file. Read-only, and no account is named: an individual's own trail is theirs
  in the app, and the question only an operator can answer is whether one client
  is misbehaving across many accounts at once.

Both new config screens are **generic** — the whole table, no key list, the
row's own `description` column as its help text. That is also why the existing
Limits page picks up a new knob for free: **`person_lookup_daily_cap` (#718)
will appear there with no change to this app**, provided its migration does the
`INSERT` (writes are `UPDATE`-only by design, so the console cannot invent a
key no code reads).

Also landed: loading skeletons shaped like the page behind them (every route is
`force-dynamic` against a database in another region, and the wait was blank),
an error boundary that shows the failing function's name instead of swallowing
it, a 404 that keeps the rail, a topbar search wired to the user directory
rather than being decoration, and chart chrome that follows the OS theme via
`useSyncExternalStore`.

## Deliberately left

Each of these is an aggregate over real people's data, and the app's rule is
that those go through a `waves_admin_*` function so what the console can see
stays one reviewable list in one migration. **All of them need a migration
first, which is outside this PR's scope** — they are written up in the README so
the next person does not rediscover them: storage accounting, billing
(`subscriptions` / `group_passes`), delivery health (`notifications` retries,
`email_events`, `email_suppressions`), moderation (flagged comments, disputes),
a groups browser, and rate-limit hits.

Job health is left for a different reason: there is **no run-history table
anywhere**, so "when did auto-archive last run" is a question the database
cannot answer. A screen for it would have to invent the data.

## Two bugs found

- **Fixed here:** the Countries header counted disabled rows that were not in
  the dialable list, so it could report a number the ticks underneath disagreed
  with.
- **Not fixed here, and it is a live security bug.**
  `waves_admin_voice_attempts` is granted to `anon` *and* `authenticated` — by
  the baseline, and again by `20260904200000_authenticated_surface_on_hosted`
  after its blanket revoke. It is `SECURITY DEFINER` over a table no client can
  select, and it returns **verbatim speech transcripts and profile ids**, so any
  signed-in account (guests included) can read them today. Separately,
  `app_releases` is granted `SELECT, INSERT, UPDATE` to `authenticated`, which
  means any signed-in user can set a minimum version and brick every install.
  Both are migrations rather than console changes; they deserve their own PR and
  are recorded in the README.

## Gates

`typecheck`, `lint`, `test` (40 passing) and `build` all green. Verified
visually against a production build with a stubbed PostgREST, in both themes.

Not deployed — admin deploys go to the admin Vercel project and that is the
user's call.
