### PR TITLE
fix(db): make the version kill switch read-only for signed-in clients

### DIFF
--- a/packages/db/prisma/migrations/20260908140000_revoke_app_releases_writes/migration.sql
+++ b/packages/db/prisma/migrations/20260908140000_revoke_app_releases_writes/migration.sql
@@ -1,0 +1,45 @@
+-- The kill switch, and who is allowed to touch it.
+--
+-- `app_releases` holds `minimum_version` per platform: the app reads it before
+-- its own sign-in screen and refuses to run when it is below that number. It is
+-- the one row in this database that can stop every install of Waves at once.
+--
+-- `authenticated` holds SELECT, INSERT and UPDATE on it — from the baseline
+-- (`20260904000000` :12545) and re-granted by `20260904160000` :61. Only SELECT
+-- was ever intended; the table's own comment says so in as many words: "Public
+-- read, service-role write."
+--
+-- **This is not currently exploitable, and the migration should not be read as
+-- fixing a live hole.** Checked by trying it as `authenticated` rather than by
+-- reading the grants:
+--
+--   * `UPDATE app_releases SET minimum_version = '99.0.0'` — succeeds and
+--     changes **zero rows**. RLS is on and the only policy is
+--     `FOR SELECT ... USING (true)`; with no UPDATE policy no row is visible to
+--     update, so the statement is a silent no-op rather than an error.
+--   * `INSERT` — refused outright: "new row violates row-level security policy".
+--
+-- So RLS is doing the work, and the grant is redundant. It is revoked because
+-- redundant is not the same as harmless: an UPDATE or ALL policy added later for
+-- some good reason would turn this into a denial of service against the entire
+-- product, delivered by any signed-in account — a guest included — and the
+-- person adding that policy would have no reason to look for a leftover grant.
+-- The blast radius is the whole install base, which is a poor thing to leave
+-- resting on one policy nobody is thinking about.
+--
+-- This is the same shape as `20260908120000_revoke_admin_voice_attempts_grant`,
+-- and the same root cause: `20260904160000_anon_surface_on_hosted` re-granted
+-- the schema by replaying a local build, faithfully reproducing a grant the
+-- baseline should never have carried.
+--
+-- Nothing breaks. Writes come from the admin console over the service-role key
+-- (`apps/admin/src/lib/data.ts`), and the pre-sign-in version gate only reads —
+-- `anon` and `authenticated` keep SELECT.
+
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.app_releases FROM authenticated;
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.app_releases FROM anon;
+
+-- Restated rather than assumed: the version gate has to answer before there is
+-- a session, so both roles keep read.
+GRANT SELECT ON TABLE public.app_releases TO anon, authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.app_releases TO service_role;

--- a/packages/db/test/admin-surface.test.ts
+++ b/packages/db/test/admin-surface.test.ts
@@ -96,3 +96,49 @@ describe('the admin console surface', () => {
     expect(rows[0]?.select_policies).toBe('0');
   });
 });
+
+/**
+ * The three tables that answer before there is a session — the version gate the
+ * app reads before its own sign-in screen, the country denylist on the phone
+ * sign-in screen, and public feature configuration. They are public *read*;
+ * every write is service-role.
+ *
+ * `app_releases` is the one that matters most: `minimum_version` is the single
+ * row in this database that can stop every install of Waves at once. It carried
+ * INSERT and UPDATE grants for `authenticated` from the baseline until
+ * `20260908140000`, which RLS happened to neutralise — an UPDATE matched zero
+ * rows because the only policy is `FOR SELECT`. Redundant is not harmless: an
+ * UPDATE policy added later for a good reason would have turned a leftover
+ * grant into a product-wide denial of service by any signed-in account.
+ */
+describe('the pre-sign-in config surface', () => {
+  it('is read-only for anon and authenticated', async () => {
+    const { rows } = await client.query<{
+      table_name: string;
+      grantee: string;
+      privilege: string;
+    }>(`
+      SELECT t.table_name, r.rolname AS grantee, p.privilege
+        FROM (VALUES ('app_releases'), ('country_settings'), ('feature_flags')) AS t(table_name)
+        CROSS JOIN (VALUES ('anon'), ('authenticated')) AS roles(rolname)
+        CROSS JOIN (VALUES ('INSERT'), ('UPDATE'), ('DELETE'), ('TRUNCATE')) AS p(privilege)
+        JOIN pg_roles r ON r.rolname = roles.rolname
+       WHERE has_table_privilege(r.rolname, 'public.' || t.table_name, p.privilege)
+       ORDER BY t.table_name, r.rolname, p.privilege
+    `);
+
+    expect(rows.map((row) => `${row.table_name} -> ${row.grantee} ${row.privilege}`)).toEqual([]);
+  });
+
+  it('still lets a signed-out client read the version gate', async () => {
+    // The other half of the same property: revoking the writes must not take
+    // the read with it, or the app cannot check its own minimum version before
+    // sign-in and every launch fails closed.
+    const { rows } = await client.query<{ anon_read: boolean; auth_read: boolean }>(`
+      SELECT has_table_privilege('anon', 'public.app_releases', 'SELECT') AS anon_read,
+             has_table_privilege('authenticated', 'public.app_releases', 'SELECT') AS auth_read
+    `);
+    expect(rows[0]?.anon_read).toBe(true);
+    expect(rows[0]?.auth_read).toBe(true);
+  });
+});

--- a/packages/db/test/appReleases.test.ts
+++ b/packages/db/test/appReleases.test.ts
@@ -64,12 +64,24 @@ describe('app_releases', () => {
     ]);
 
     await asRole('authenticated', { sub: profileId, role: 'authenticated' }, async () => {
-      // No policy for UPDATE means no rows are visible to update: Postgres
-      // reports success having changed nothing rather than refusing.
-      const updated = await client.query(
-        `UPDATE app_releases SET minimum_version = '99.0.0' WHERE platform = 'android'`,
-      );
-      expect(updated.rowCount).toBe(0);
+      // Both statements are refused at the grant, since `20260908140000` took
+      // INSERT and UPDATE away from `authenticated`.
+      //
+      // This assertion used to be weaker, and the way it was weak is the reason
+      // that migration exists. It asserted `rowCount === 0` on the UPDATE —
+      // Postgres reporting success having changed nothing, because the only
+      // policy on the table is `FOR SELECT` and so no row was visible to
+      // update. That is a real barrier, but it is a *single* barrier, and the
+      // grant sitting behind it meant an UPDATE policy added later for some
+      // unrelated reason would have silently handed every signed-in account the
+      // ability to set `minimum_version` and lock every install out of Waves.
+      // The refusal is now the grant's, and the policy is the second line
+      // rather than the only one.
+      await expect(
+        client.query(
+          `UPDATE app_releases SET minimum_version = '99.0.0' WHERE platform = 'android'`,
+        ),
+      ).rejects.toThrow(/permission denied/i);
 
       await expect(
         client.query(
@@ -77,7 +89,7 @@ describe('app_releases', () => {
            VALUES ('android', '99.0.0', '99.0.0', 'https://evil.example')
            ON CONFLICT (platform) DO UPDATE SET minimum_version = '99.0.0'`,
         ),
-      ).rejects.toThrow(/row-level security|policy/i);
+      ).rejects.toThrow(/permission denied/i);
     });
 
     const after = await client.query(


### PR DESCRIPTION
## The lever

`app_releases.minimum_version` is the single row in this database that can stop **every install of Waves at once** — the app reads it before its own sign-in screen and refuses to run below that version. `authenticated` held `SELECT, INSERT, UPDATE` on it (baseline `:12545`, re-granted by `20260904160000` `:61`).

The table's own comment says what was meant: *"Public read, service-role write."*

## Not exploitable — checked, not assumed

An audit reported this as live: any signed-in user locking everyone out of the product. I tried it as `authenticated` rather than reading the grant table:

| Attempt | Result |
|---|---|
| `UPDATE app_releases SET minimum_version = '99.0.0'` | Succeeds, **zero rows changed** |
| `INSERT` a new platform row | `new row violates row-level security policy` |

RLS is on and the only policy is `FOR SELECT ... USING (true)`. With no UPDATE policy, no row is visible to update — so the statement is a silent no-op, not an error. Rows were unchanged afterwards.

So the grant is redundant, and this PR is not a vulnerability fix.

## Why revoke it anyway

Redundant is not harmless. An `UPDATE` or `ALL` policy added later for a perfectly good reason turns the leftover grant into a **denial of service against the entire install base**, delivered by any signed-in account — a guest included. Whoever adds that policy has no reason to go hunting for a grant nobody mentions.

The blast radius is every user of the product. That is too wide to leave resting on one policy nobody is thinking about.

## Same root cause as #719

`20260904160000_anon_surface_on_hosted` re-granted the schema by replaying a local build, faithfully reproducing a grant the baseline should never have carried. That is now the second instance found. A replay copies mistakes as carefully as it copies intent.

## The test

Extends `admin-surface.test.ts` (added in #719) with the **property**, not the instance:

1. No `INSERT`, `UPDATE`, `DELETE` or `TRUNCATE` for `anon` or `authenticated` on any of the three pre-sign-in config tables — `app_releases`, `country_settings`, `feature_flags`.
2. Its converse: both roles **keep** `SELECT` on `app_releases`. Revoking the read would be the more damaging mistake — every launch would fail closed at the version gate — so the test pins both directions.

**Verified to fail before the revoke:**

```
+   "app_releases -> authenticated INSERT",
+   "app_releases -> authenticated UPDATE",
```

40/40 across `admin-surface`, `anon-surface` and `definer-boundary` after.

## Deploy

Migration pending on prod. No app code, nothing to OTA. Writes continue to come from the admin console over the service-role key.
