### PR TITLE
fix(m4): settlements that tell the other party, switches that work, one rail pair

### DIFF
--- a/apps/agent-mcp/src/tools.ts
+++ b/apps/agent-mcp/src/tools.ts
@@ -199,7 +199,7 @@ export function buildWavesServer(
       const { data, error } = await supabase
         .from('group_members')
         .select(
-          'id, group_id, profile_id, ghost_name, vpa, role, profile:profiles!profile_id ( display_name, default_vpa )',
+          'id, group_id, profile_id, ghost_name, vpa, payment_rail, payment_handle, role, profile:profiles!profile_id ( display_name, default_vpa, payment_rail, payment_handle )',
         )
         .eq('group_id', groupId)
         .is('left_at', null)
@@ -207,14 +207,37 @@ export function buildWavesServer(
       if (error) return fail(error.message);
       return ok(
         (data ?? []).map((m) => {
-          const profile = m.profile as { display_name?: string; default_vpa?: string } | null;
+          const profile = m.profile as {
+            display_name?: string;
+            default_vpa?: string;
+            payment_rail?: string;
+            payment_handle?: string;
+          } | null;
+          // `payableFor` from `@waves/core`, inlined because this server
+          // deliberately depends on nothing in the workspace. Reading
+          // `vpa ?? default_vpa` alone told an agent that a payee on any rail
+          // but UPI had given no details at all. The pairs are taken whole —
+          // a rail from one source with a handle from another is how a UPI
+          // intent gets built around an Australian phone number.
+          const payable =
+            (m.payment_rail && m.payment_handle
+              ? { rail: m.payment_rail, handle: m.payment_handle }
+              : null) ??
+            (m.vpa ? { rail: 'upi', handle: m.vpa } : null) ??
+            (profile?.payment_rail && profile.payment_handle
+              ? { rail: profile.payment_rail, handle: profile.payment_handle }
+              : null) ??
+            (profile?.default_vpa ? { rail: 'upi', handle: profile.default_vpa } : null);
           return {
             memberId: m.id,
             name: profile?.display_name ?? m.ghost_name ?? 'Unnamed',
             isYou: m.profile_id === meId,
             isGhost: !m.profile_id,
             role: m.role,
-            vpa: m.vpa ?? profile?.default_vpa ?? null,
+            rail: payable?.rail ?? null,
+            handle: payable?.handle ?? null,
+            /** @deprecated Superseded by `handle`; kept while callers move over. */
+            vpa: payable?.handle ?? null,
           };
         }),
       );

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -61,6 +61,7 @@ import {
   displayName,
   isBlockedMember,
   isGhost,
+  payableAt,
   type ActivityActor,
   type ActivityRow,
   type ExpenseRow,
@@ -910,9 +911,14 @@ export default function GroupScreen() {
               {isGhost(member)
                 ? t.notJoinedYet
                 : isBlockedMember(member, blockedIds)
-                  ? // A VPA carries a name or phone — masked for a blocked person.
+                  ? // A payment handle carries a name, an address or a phone
+                    // number — masked for a blocked person.
                     '—'
-                  : (member.vpa ?? member.profile?.default_vpa ?? '—')}
+                  : // `payableAt`, not `member.vpa ?? profile.default_vpa`: the
+                    // rail pair is where a handle lives now, and reading only
+                    // the old column showed a dash to everybody whose handle is
+                    // a Pix key, a PayID or a Venmo name.
+                    (payableAt(member)?.handle ?? '—')}
             </Text>
           </View>
           <Row style={{ gap: theme.spacing.sm, alignItems: 'center' }}>

--- a/apps/mobile/src/app/group/[id]/members.tsx
+++ b/apps/mobile/src/app/group/[id]/members.tsx
@@ -30,7 +30,7 @@ import {
   useMemberClaims,
 } from '@/data/hooks';
 import { useBlockedUsers } from '@/data/blocked';
-import { displayName, groupLabel, isBlockedMember, isGhost, vpaOf } from '@/data/types';
+import { displayName, groupLabel, isBlockedMember, isGhost, payableAt } from '@/data/types';
 import { fill, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { requestContacts } from '@/lib/contactPickerBridge';
@@ -265,9 +265,14 @@ export default function MembersScreen() {
                   isGhost(member)
                     ? t.notJoinedYet
                     : isBlockedMember(member, blockedIds)
-                      ? // A VPA carries a name or phone — masked for a blocked person.
+                      ? // A payment handle carries a name, an address or a
+                        // phone number — masked for a blocked person.
                         t.misc.noUpiYet
-                      : (vpaOf(member) ?? t.misc.noUpiYet)
+                      : // `payableAt`, not the legacy column alone: the rail
+                        // pair is where a handle lives now, and reading only
+                        // `vpa`/`default_vpa` told everybody on Pix, PayID or
+                        // Venmo that they had given nothing.
+                        (payableAt(member)?.handle ?? t.misc.noUpiYet)
                 }
                 leading={
                   <Avatar

--- a/apps/mobile/src/app/group/[id]/settings.tsx
+++ b/apps/mobile/src/app/group/[id]/settings.tsx
@@ -53,7 +53,7 @@ import { fill, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { useFavorites } from '@/lib/favorites';
 import { useBlockedUsers } from '@/data/blocked';
-import { displayName, groupLabel, GroupType, isGhost, vpaOf } from '@/data/types';
+import { displayName, groupLabel, GroupType, isGhost, payableAt } from '@/data/types';
 
 // Same chip icons the create screen wears, so changing a group's kind looks
 // like the same control that first set it.
@@ -612,7 +612,12 @@ export default function GroupSettingsScreen() {
               <View key={member.id}>
                 <ListRow
                   title={displayName(member, profile?.id)}
-                  subtitle={isGhost(member) ? t.notJoinedYet : (vpaOf(member) ?? t.misc.noUpiYet)}
+                  subtitle={
+                    isGhost(member)
+                      ? t.notJoinedYet
+                      : // The rail pair, not the legacy UPI column alone.
+                        (payableAt(member)?.handle ?? t.misc.noUpiYet)
+                  }
                   leading={<Avatar name={displayName(member)} ghost={isGhost(member)} />}
                   onPress={() => router.push(`/group/${groupId}/member/${member.id}`)}
                   trailing={

--- a/apps/mobile/src/app/group/[id]/settle.tsx
+++ b/apps/mobile/src/app/group/[id]/settle.tsx
@@ -72,7 +72,6 @@ export default function SettleScreen() {
   const country = group.data?.country_code ?? null;
   const rails = useMemo(() => railsFor(country), [country]);
   const [rail, setRail] = useState<string | null>(null);
-  const method = rail ?? defaultRailFor(country);
   const myMemberId = ledger.myMemberId;
 
   // Only people on the other side of my ledger can settle with me: if I am owed
@@ -94,6 +93,21 @@ export default function SettleScreen() {
 
   const counterparty: MemberRow | undefined =
     counterparties.find((member) => member.id === selected) ?? counterparties[0];
+
+  /**
+   * The rail this settlement is on.
+   *
+   * Seeded from the payee, not from the group's country. The link is built from
+   * *their* stored rail (`payableAt` below) while `settlements.rail` recorded
+   * whatever the picker said, so the two could disagree: the button read "Pay
+   * via Pix" over a UPI intent, and the row afterwards named a rail nobody
+   * used. One truth, and it is the person being paid — they are the only party
+   * who knows what will actually reach them. The country default is what is
+   * left when they have said nothing at all, and the picker still overrides
+   * both, because cash is always a possibility no profile records.
+   */
+  const payeeRail = counterparty ? (payableAt(counterparty)?.rail ?? null) : null;
+  const method = rail ?? payeeRail ?? defaultRailFor(country);
 
   const theirBalance = counterparty ? (ledger.balances.get(counterparty.id) ?? 0n) : 0n;
   const iPay = ledger.myBalance < 0n && theirBalance > 0n;
@@ -195,17 +209,25 @@ export default function SettleScreen() {
       return;
     }
 
-    const uri = buildPaymentUri(
-      {
-        railId: payable.rail,
-        handle: payable.handle,
-        payeeName: displayName(counterparty),
-        amount,
-        currency,
-        note: `Waves ${group.data?.name ?? ''}`.trim(),
-      },
-      (value, code) => toMajorString({ minor: value, currency: code }),
-    );
+    // Only when the picker is still on the rail this handle belongs to. A
+    // handle is not portable between rails — somebody who overrides the picker
+    // to Wise has not given us a Wise handle, and building a link out of their
+    // UPI id under a Wise label is a tap that cannot work dressed as one that
+    // can. The fallback below is the honest answer in that case.
+    const uri =
+      method !== payable.rail
+        ? null
+        : buildPaymentUri(
+            {
+              railId: payable.rail,
+              handle: payable.handle,
+              payeeName: displayName(counterparty),
+              amount,
+              currency,
+              note: `Waves ${group.data?.name ?? ''}`.trim(),
+            },
+            (value, code) => toMajorString({ minor: value, currency: code }),
+          );
 
     // An 'app' scheme is asked about first: a custom scheme with nothing
     // installed to answer it fails silently, and a tap that looks like it
@@ -226,6 +248,9 @@ export default function SettleScreen() {
     Alert.alert(
       t.misc.settlePayTitle.replace('{name}', displayName(counterparty)),
       t.misc.settlePayBody
+        // `payable.rail`, because the handle underneath belongs to it — naming
+        // the picker's rail here is what let the button say "Pay via Pix" over
+        // an alert reading "UPI".
         .replace('{rail}', railById(payable.rail)?.label ?? t.misc.settleSendTo)
         .replace('{handle}', payable.handle),
       [

--- a/apps/mobile/src/app/settings/notifications.tsx
+++ b/apps/mobile/src/app/settings/notifications.tsx
@@ -65,14 +65,27 @@ function pushRows(t: UiStrings): PrefRow[] {
   ];
 }
 
-/** The weekly digest arrives by email, not push, so it sits in its own section. */
+/**
+ * The email door, which is not the phone's.
+ *
+ * `email` is the master switch — `waves_claim_email_notifications` has read it
+ * since M4 and suppressed every mail when it is false, and until now there was
+ * no screen anywhere that could set it. It leads, because turning it off makes
+ * the row under it moot.
+ */
 function emailRows(t: UiStrings): PrefRow[] {
   return [
+    {
+      key: 'email',
+      title: t.notifications.emailAll,
+      body: t.notifications.emailAllBody,
+      icon: 'mail-outline',
+    },
     {
       key: 'weeklyEmail',
       title: t.notifications.weeklyEmail,
       body: t.notifications.weeklyEmailBody,
-      icon: 'mail-outline',
+      icon: 'newspaper-outline',
     },
   ];
 }

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -11,6 +11,7 @@ import { randomUUID } from 'expo-crypto';
 
 import {
   buildExpenseWriteBody,
+  DEFAULT_NOTIFICATION_PREFS,
   normaliseEmail,
   normalisePhone,
   serialiseSplitParams,
@@ -20,6 +21,7 @@ import {
   type DeviceSession,
   type ExpenseLocation,
   type FxRecord,
+  type NotificationPrefs,
   type ParsedReceipt,
   type PaymentMethod,
   type ReceiptCheck,
@@ -254,7 +256,7 @@ export async function fetchMembersByGroup(): Promise<Map<string, MemberRow[]>> {
     await backend
       .from('group_members')
       .select(
-        'id, group_id, profile_id, ghost_name, role, vpa, left_at, invite_email, invite_phone, profile:profiles!profile_id ( id, display_name, avatar_url, default_vpa )',
+        'id, group_id, profile_id, ghost_name, role, vpa, payment_rail, payment_handle, left_at, invite_email, invite_phone, profile:profiles!profile_id ( id, display_name, avatar_url, default_vpa, payment_rail, payment_handle )',
       )
       .is('left_at', null)
       .order('created_at', { ascending: true }),
@@ -1304,22 +1306,12 @@ export async function importLedger(input: {
 
 // ─────────────────────────────── notification preferences (ADR-010) ──
 
-export interface NotificationPrefs {
-  /** Push only for things that involve me — the default that stops the spam. */
-  involvesMe: boolean;
-  groupActivityDigest: boolean;
-  settlementRequests: boolean;
-  nudges: boolean;
-  weeklyEmail: boolean;
-}
-
-export const DEFAULT_NOTIFICATION_PREFS: NotificationPrefs = {
-  involvesMe: true,
-  groupActivityDigest: true,
-  settlementRequests: true,
-  nudges: true,
-  weeklyEmail: false,
-};
+/**
+ * Re-exported from `@waves/core`, where the shape lives. It used to be declared
+ * here as well, and the two copies had already drifted apart from the SQL that
+ * actually obeys the keys — see the note on the source.
+ */
+export { DEFAULT_NOTIFICATION_PREFS, type NotificationPrefs };
 
 export async function fetchNotificationPrefs(profileId: string): Promise<NotificationPrefs> {
   const { data, error } = await backend

--- a/apps/mobile/src/data/types.ts
+++ b/apps/mobile/src/data/types.ts
@@ -1,4 +1,5 @@
-import type { CategoryMeta, ExpenseLocation, MemberId, SplitParams } from '@waves/core';
+import { payableFor } from '@waves/core';
+import type { CategoryMeta, ExpenseLocation, MemberId, Payable, SplitParams } from '@waves/core';
 
 export enum GroupType {
   Trip = 'trip',
@@ -339,29 +340,15 @@ export function isGhost(member: MemberRow): boolean {
   return member.profile_id === null;
 }
 
-export function vpaOf(member: MemberRow): string | null {
-  return member.vpa ?? member.profile?.default_vpa ?? null;
-}
-
 /**
  * How this person is paid: the rail, and the handle on it.
  *
- * Per-group first, then their profile default — the same precedence `vpaOf`
- * has always used, because one person can be paid over UPI in one group and
- * over Wise in another. The `vpa` columns are the last fallback: everything
- * written before rails existed is a UPI ID, and the person who typed it should
- * not have to type it again.
+ * The precedence lives in `@waves/core` (`payableFor`), because the web settle
+ * screen has to answer the same question off the same columns and used to
+ * answer it differently — reading `vpa ?? default_vpa` alone, so a payee on any
+ * rail but UPI looked like somebody who had given no details. This is the thin
+ * wrapper that types it against the mobile row.
  */
-export function payableAt(member: MemberRow): { rail: string; handle: string } | null {
-  const handle = member.payment_handle ?? member.profile?.payment_handle ?? vpaOf(member) ?? null;
-  if (!handle) return null;
-
-  const rail =
-    member.payment_rail ??
-    member.profile?.payment_rail ??
-    // A handle from before rails existed can only have been a UPI ID.
-    (vpaOf(member) ? 'upi' : null);
-  if (!rail) return null;
-
-  return { rail, handle };
+export function payableAt(member: MemberRow): Payable | null {
+  return payableFor(member);
 }

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1084,6 +1084,8 @@ export interface UiStrings {
     digestBody: string;
     /** The weekly email is not a push notification, so it gets its own section. */
     emailSection: string;
+    emailAll: string;
+    emailAllBody: string;
     weeklyEmail: string;
     weeklyEmailBody: string;
     failDenied: string;
@@ -3563,6 +3565,9 @@ const en: UiStrings = {
     digest: 'Daily group summary',
     digestBody: 'Everything else, batched into one notification a day instead of a stream.',
     emailSection: 'By email',
+    emailAll: 'Email me at all',
+    emailAllBody:
+      'Settlements, reminders and the weekly summary. Security alerts about a new sign-in arrive whatever this says.',
     weeklyEmail: 'Weekly email digest',
     weeklyEmailBody: 'Your net balance and pending confirmations, once a week. Off by default.',
     failDenied: 'Not enabled — you can turn it on in your phone settings later.',
@@ -5953,6 +5958,9 @@ const ta: UiStrings = {
     digest: 'நாள்தோறும் குழுச் சுருக்கம்',
     digestBody: 'மற்ற அனைத்தும், தொடர்ச்சியாக அல்லாமல் நாளுக்கு ஒரு அறிவிப்பாகத் தொகுத்து.',
     emailSection: 'மின்னஞ்சல் வழியாக',
+    emailAll: 'மின்னஞ்சல் அனுப்பவும்',
+    emailAllBody:
+      'தீர்வுகள், நினைவூட்டல்கள், வாராந்திரச் சுருக்கம். புதிய உள்நுழைவு பற்றிய பாதுகாப்பு எச்சரிக்கை இது எதுவாக இருந்தாலும் வரும்.',
     weeklyEmail: 'வாராந்திர மின்னஞ்சல் சுருக்கம்',
     weeklyEmailBody:
       'உங்கள் நிகர பாக்கியும் நிலுவையிலுள்ள உறுதிப்படுத்தல்களும், வாரம் ஒருமுறை. இயல்பாக நிறுத்தத்தில்.',
@@ -8410,6 +8418,9 @@ const hi: UiStrings = {
     digest: 'दैनिक समूह सारांश',
     digestBody: 'बाकी सब कुछ, लगातार की जगह दिन में एक सूचना में इकट्ठा।',
     emailSection: 'ईमेल से',
+    emailAll: 'मुझे ईमेल भेजें',
+    emailAllBody:
+      'हिसाब, याद दिलाने वाले संदेश और साप्ताहिक सारांश। नए साइन-इन की सुरक्षा चेतावनी इससे परे हमेशा आएगी।',
     weeklyEmail: 'साप्ताहिक ईमेल सारांश',
     weeklyEmailBody: 'आपकी कुल बाकी और लंबित पुष्टियाँ, हफ़्ते में एक बार। डिफ़ॉल्ट रूप से बंद।',
     failDenied: 'चालू नहीं हुआ — आप बाद में फ़ोन सेटिंग्स में इसे चालू कर सकते हैं।',
@@ -10845,6 +10856,9 @@ const ar: UiStrings = {
     digest: 'ملخص المجموعة اليومي',
     digestBody: 'كل ما تبقّى، مجمّعًا في إشعار واحد يوميًا بدل تدفق مستمر.',
     emailSection: 'عبر البريد',
+    emailAll: 'راسلني بالبريد',
+    emailAllBody:
+      'التسويات والتذكيرات والملخص الأسبوعي. تنبيه الأمان عند تسجيل دخول جديد يصل مهما كان هذا الإعداد.',
     weeklyEmail: 'ملخص أسبوعي بالبريد',
     weeklyEmailBody: 'صافي باقيك والتأكيدات المعلّقة، مرة كل أسبوع. متوقف افتراضيًا.',
     failDenied: 'لم يُفعَّل — يمكنك تفعيله لاحقًا من إعدادات هاتفك.',

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -16,13 +16,14 @@
  * second answer to the same question.
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import {
   DEFAULT_NOTIFICATION_PREFS,
   type NotificationPrefs,
   type ProfileRow,
 } from '@waves/api-client';
+import { defaultRailFor, railsFor } from '@waves/core';
 
 import { AppFrame } from '@/components/AppFrame';
 import { Section } from '@/components/Shell';
@@ -47,7 +48,23 @@ function Settings() {
   const [currency, setCurrency] = useState('INR');
   const [country, setCountry] = useState('');
   const [handle, setHandle] = useState('');
+  // Saved beside the handle, never left behind it. Web used to write
+  // `payment_handle` alone, and a handle with no rail is not a way to be paid:
+  // `payableFor` refuses to guess UPI over what might be a Pix key, so every
+  // handle set from a browser was invisible to both settle screens.
+  const [rail, setRail] = useState('');
   const [prefs, setPrefs] = useState<NotificationPrefs>(DEFAULT_NOTIFICATION_PREFS);
+  // The rails this country actually uses, plus the universal ones. Never empty:
+  // `railsFor` always ends with bank, cash and other, so an unknown country
+  // still offers something rather than an empty select.
+  const rails = useMemo(() => railsFor(country), [country]);
+  // What is shown when the account has no rail yet, and what is saved if the
+  // person never touches the picker. Recomputed as the country changes, so
+  // typing "BR" lands on Pix rather than on whatever India suggested.
+  const effectiveRail = useMemo(
+    () => rails.find((entry) => entry.id === rail)?.id ?? defaultRailFor(country),
+    [rails, rail, country],
+  );
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
   const [saved, setSaved] = useState(false);
@@ -64,6 +81,8 @@ function Settings() {
     // UPI-shaped field, still read so an account written before the pair
     // existed does not look like it has no handle at all.
     setHandle(row.payment_handle ?? row.default_vpa ?? '');
+    // A row written before rails existed can only have held a UPI id.
+    setRail(row.payment_rail ?? (row.default_vpa ? 'upi' : ''));
     setPrefs({ ...DEFAULT_NOTIFICATION_PREFS, ...(row.notification_prefs ?? {}) });
   }, []);
 
@@ -120,6 +139,9 @@ function Settings() {
     { key: 'groupActivityDigest', label: t.settings.notifyDigest },
     { key: 'settlementRequests', label: t.settings.notifySettlements },
     { key: 'nudges', label: t.settings.notifyNudges },
+    // The master switch on the email door. The SQL has read this key since M4
+    // and neither client could set it.
+    { key: 'email', label: t.settings.notifyEmail },
     { key: 'weeklyEmail', label: t.settings.notifyWeekly },
   ];
 
@@ -178,6 +200,17 @@ function Settings() {
               </label>
 
               <label className="field">
+                <span className="field-label">{t.settings.paymentRail}</span>
+                <select value={effectiveRail} onChange={(event) => setRail(event.target.value)}>
+                  {rails.map((entry) => (
+                    <option key={entry.id} value={entry.id}>
+                      {entry.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="field">
                 <span className="field-label">{t.settings.paymentHandle}</span>
                 <input
                   value={handle}
@@ -198,6 +231,9 @@ function Settings() {
                     default_currency: currency,
                     country_code: country.trim() || null,
                     payment_handle: handle.trim() || null,
+                    // Cleared together: a rail with nobody to pay is noise, and
+                    // a handle with no rail is unusable.
+                    payment_rail: handle.trim() ? effectiveRail : null,
                   })
                 }
               >

--- a/apps/web/src/app/settle/page.tsx
+++ b/apps/web/src/app/settle/page.tsx
@@ -29,6 +29,7 @@ import {
 import {
   buildPaymentUri,
   defaultRailFor,
+  payableFor,
   railById,
   railsFor,
   toMajorString,
@@ -437,7 +438,13 @@ function SettleForm({
 }) {
   const { t, locale } = useStrings();
   const rails = useMemo(() => railsFor(group.country_code), [group.country_code]);
-  const [rail, setRail] = useState<string>(() => defaultRailFor(group.country_code));
+  // What this payee is actually reachable on, and only then the country's
+  // default. Starting from the country meant offering a UPI intent to somebody
+  // whose handle is a PayID, which builds a link no app will answer.
+  const payable = useMemo(() => payableFor(payee), [payee]);
+  const [rail, setRail] = useState<string>(
+    () => payable?.rail ?? defaultRailFor(group.country_code),
+  );
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   // The idempotency key for this settlement attempt. Minted once when the form
@@ -447,7 +454,7 @@ function SettleForm({
   // next settlement is a new one and not a replay of this one.
   const [mutationId, setMutationId] = useState<string>(() => crypto.randomUUID());
 
-  const handle = payee.vpa ?? payee.profile?.default_vpa ?? '';
+  const handle = payable?.handle ?? '';
   const railInfo = railById(rail);
   const needsHandle = railInfo ? railInfo.handle !== 'none' : false;
 

--- a/apps/web/src/i18n.ts
+++ b/apps/web/src/i18n.ts
@@ -397,6 +397,7 @@ export interface WebStrings {
     country: string;
     paymentHandle: string;
     paymentHandleBody: string;
+    paymentRail: string;
     save: string;
     saved: string;
     notifications: string;
@@ -405,6 +406,7 @@ export interface WebStrings {
     notifySettlements: string;
     notifyNudges: string;
     notifyWeekly: string;
+    notifyEmail: string;
     language: string;
     languageBody: string;
     guestTitle: string;
@@ -756,6 +758,7 @@ const en: WebStrings = {
     country: 'Country',
     paymentHandle: 'Payment handle',
     paymentHandleBody: 'Shown to people settling up with you, so they can pay without asking.',
+    paymentRail: 'Paid via',
     save: 'Save',
     saved: 'Saved',
     notifications: 'What we tell you about',
@@ -764,6 +767,7 @@ const en: WebStrings = {
     notifySettlements: 'When somebody pays me, or asks me to confirm',
     notifyNudges: 'Reminders somebody sends me',
     notifyWeekly: 'A weekly email',
+    notifyEmail: 'Email me at all',
     language: 'Language',
     languageBody: 'Follows your browser. Change it there and this page follows.',
     guestTitle: 'You are a guest',
@@ -1123,6 +1127,7 @@ const ta: WebStrings = {
     country: 'நாடு',
     paymentHandle: 'பணம் பெறும் முகவரி',
     paymentHandleBody: 'உங்களுக்குப் பணம் தருபவர்களுக்குக் காட்டப்படும், கேட்காமல் அனுப்ப.',
+    paymentRail: 'எதன் மூலம் பணம்',
     save: 'சேமி',
     saved: 'சேமிக்கப்பட்டது',
     notifications: 'எதைப் பற்றி சொல்ல வேண்டும்',
@@ -1131,6 +1136,7 @@ const ta: WebStrings = {
     notifySettlements: 'யாரோ பணம் தந்தால், அல்லது உறுதிப்படுத்தச் சொன்னால்',
     notifyNudges: 'யாரோ அனுப்பும் நினைவூட்டல்கள்',
     notifyWeekly: 'வாராந்திர மின்னஞ்சல்',
+    notifyEmail: 'மின்னஞ்சல் அனுப்பவும்',
     language: 'மொழி',
     languageBody: 'உலாவியைப் பின்பற்றுகிறது. அங்கே மாற்றினால் இந்தப் பக்கமும் மாறும்.',
     guestTitle: 'நீங்கள் விருந்தினர்',
@@ -1482,6 +1488,7 @@ const hi: WebStrings = {
     country: 'देश',
     paymentHandle: 'भुगतान पता',
     paymentHandleBody: 'आपको भुगतान करने वालों को दिखता है, ताकि पूछना न पड़े.',
+    paymentRail: 'किसके ज़रिए',
     save: 'सहेजें',
     saved: 'सहेजा गया',
     notifications: 'किस बारे में बताएँ',
@@ -1490,6 +1497,7 @@ const hi: WebStrings = {
     notifySettlements: 'जब कोई मुझे भुगतान करे या पुष्टि माँगे',
     notifyNudges: 'किसी की भेजी याद-दिलाहट',
     notifyWeekly: 'साप्ताहिक ईमेल',
+    notifyEmail: 'मुझे ईमेल भेजें',
     language: 'भाषा',
     languageBody: 'ब्राउज़र के अनुसार. वहाँ बदलें, यह पेज भी बदल जाएगा.',
     guestTitle: 'आप अतिथि हैं',
@@ -1891,6 +1899,7 @@ const ar: WebStrings = {
     country: 'الدولة',
     paymentHandle: 'عنوان الدفع',
     paymentHandleBody: 'يظهر لمن يسدد لك، ليدفع دون أن يسأل.',
+    paymentRail: 'يُدفع عبر',
     save: 'حفظ',
     saved: 'تم الحفظ',
     notifications: 'ما الذي نخبرك به',
@@ -1899,6 +1908,7 @@ const ar: WebStrings = {
     notifySettlements: 'حين يدفع لي أحد أو يطلب تأكيدًا',
     notifyNudges: 'التذكيرات التي يرسلها أحدهم',
     notifyWeekly: 'بريد أسبوعي',
+    notifyEmail: 'راسلني بالبريد',
     language: 'اللغة',
     languageBody: 'تتبع المتصفح. غيّرها هناك وتتبعها هذه الصفحة.',
     guestTitle: 'أنت ضيف',

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -62,8 +62,8 @@ const GROUP_ROW_COLUMNS = `
 // both group_members and profiles, so PostgREST sees two group_members↔profiles
 // relationships and an unqualified embed fails ("more than one relationship").
 const MEMBER_ROW_COLUMNS = `
-  id, group_id, profile_id, ghost_name, role, vpa, left_at,
-  profile:profiles!profile_id ( id, display_name, avatar_url, default_vpa )
+  id, group_id, profile_id, ghost_name, role, vpa, payment_rail, payment_handle, left_at,
+  profile:profiles!profile_id ( id, display_name, avatar_url, default_vpa, payment_rail, payment_handle )
 `;
 
 const ACTIVITY_COLUMNS = `

--- a/packages/api-client/src/rows.ts
+++ b/packages/api-client/src/rows.ts
@@ -9,7 +9,7 @@
  * a number.
  */
 
-import type { RailId } from '@waves/core';
+import type { NotificationPrefs, RailId } from '@waves/core';
 
 export enum GroupType {
   Trip = 'trip',
@@ -48,13 +48,19 @@ export interface MemberRow {
   profile_id: string | null;
   ghost_name: string | null;
   role?: 'admin' | 'member';
+  /** The UPI-shaped fields. Superseded by the rail pair; still read as a fallback. */
   vpa?: string | null;
+  /** Which rail this person is paid on here — a `RailId` from `@waves/core`. */
+  payment_rail?: string | null;
+  payment_handle?: string | null;
   left_at: string | null;
   profile?: {
     id: string;
     display_name: string | null;
     avatar_url: string | null;
     default_vpa?: string | null;
+    payment_rail?: string | null;
+    payment_handle?: string | null;
   } | null;
 }
 
@@ -296,23 +302,12 @@ export interface ProfileRow {
   notification_prefs?: NotificationPrefs | null;
 }
 
-/** What somebody agrees to be told about. Stored as JSON on the profile. */
-export interface NotificationPrefs {
-  /** Only things that involve me — the default that stops the noise. */
-  involvesMe: boolean;
-  groupActivityDigest: boolean;
-  settlementRequests: boolean;
-  nudges: boolean;
-  weeklyEmail: boolean;
-}
-
-export const DEFAULT_NOTIFICATION_PREFS: NotificationPrefs = {
-  involvesMe: true,
-  groupActivityDigest: true,
-  settlementRequests: true,
-  nudges: true,
-  weeklyEmail: false,
-};
+/**
+ * Re-exported so a caller holding a `ProfileRow` does not have to know that the
+ * shape lives in `@waves/core`. One definition, three consumers — see the note
+ * on the source for why it moved there.
+ */
+export { DEFAULT_NOTIFICATION_PREFS, type NotificationPrefs } from '@waves/core';
 
 /**
  * One person's balance in one group — the un-collapsed version of what the

--- a/packages/core/src/notifications/copy.ts
+++ b/packages/core/src/notifications/copy.ts
@@ -26,6 +26,15 @@ export enum NotificationKind {
   SettlementInitiated = 'settlement_initiated',
   SettlementConfirmRequest = 'settlement_confirm_request',
   SettlementConfirmed = 'settlement_confirmed',
+  /**
+   * The two ends ADR-007 calls "deliberate mirror images, one per party": the
+   * payer withdrawing a claim while it is still pending, and the payee's answer
+   * to a payment they never received. Both exist so that neither party can
+   * silently erase the other's record — which needs the other party to be told,
+   * or "silently" is exactly what it stays.
+   */
+  SettlementCancelled = 'settlement_cancelled',
+  SettlementDisputed = 'settlement_disputed',
   Nudge = 'nudge',
   GhostClaimed = 'ghost_claimed',
   GroupInviteAccepted = 'group_invite_accepted',
@@ -164,6 +173,14 @@ const en: CopyStrings = {
       title: 'Settled with {actor}',
       body: '{amount} in {group}',
     },
+    [NotificationKind.SettlementCancelled]: {
+      title: '{actor} withdrew a payment',
+      body: '{amount} in {group} is owed again',
+    },
+    [NotificationKind.SettlementDisputed]: {
+      title: '{actor} has not received it',
+      body: '{amount} in {group} — check with them',
+    },
     [NotificationKind.Nudge]: {
       title: 'A gentle nudge from {actor}',
       body: '{amount} pending in {group}',
@@ -267,6 +284,14 @@ const ta: CopyStrings = {
     [NotificationKind.SettlementConfirmed]: {
       title: '{actor} உடன் தீர்ந்தது',
       body: '{amount} ({group})',
+    },
+    [NotificationKind.SettlementCancelled]: {
+      title: '{actor} பணப் பதிவை விலக்கிக் கொண்டார்',
+      body: '{group} இல் {amount} மீண்டும் பாக்கி',
+    },
+    [NotificationKind.SettlementDisputed]: {
+      title: '{actor} அதைப் பெறவில்லை',
+      body: '{group} இல் {amount} — அவரிடம் சரிபாருங்கள்',
     },
     [NotificationKind.Nudge]: {
       title: '{actor} இடமிருந்து ஒரு நினைவூட்டல்',
@@ -372,6 +397,14 @@ const hi: CopyStrings = {
       title: '{actor} के साथ हिसाब बराबर',
       body: '{amount} ({group})',
     },
+    [NotificationKind.SettlementCancelled]: {
+      title: '{actor} ने भुगतान वापस लिया',
+      body: '{group} में {amount} फिर से बाकी है',
+    },
+    [NotificationKind.SettlementDisputed]: {
+      title: '{actor} को यह नहीं मिला',
+      body: '{group} में {amount} — उनसे पुष्टि करें',
+    },
     [NotificationKind.Nudge]: {
       title: '{actor} की ओर से एक याद',
       body: '{group} में {amount} बाकी',
@@ -475,6 +508,14 @@ const ar: CopyStrings = {
     [NotificationKind.SettlementConfirmed]: {
       title: 'تمت التسوية مع {actor}',
       body: '{amount} في {group}',
+    },
+    [NotificationKind.SettlementCancelled]: {
+      title: 'تراجع {actor} عن دفعة',
+      body: 'أصبح {amount} في {group} مستحقًا من جديد',
+    },
+    [NotificationKind.SettlementDisputed]: {
+      title: 'لم يستلمها {actor}',
+      body: '{amount} في {group} — تحقق معهم',
     },
     [NotificationKind.Nudge]: {
       title: 'تذكير لطيف من {actor}',

--- a/packages/core/src/notifications/index.ts
+++ b/packages/core/src/notifications/index.ts
@@ -1,4 +1,5 @@
 export * from './copy';
+export * from './prefs';
 export * from './render';
 export * from './push';
 export * from './email';

--- a/packages/core/src/notifications/prefs.ts
+++ b/packages/core/src/notifications/prefs.ts
@@ -1,0 +1,69 @@
+/**
+ * What somebody agrees to be told about.
+ *
+ * Stored as one JSON blob on `profiles.notification_prefs` rather than as
+ * columns, because the set of things worth being told about changes with the
+ * product and a migration per switch would be a migration per idea (ADR-010,
+ * TDR §7). Per-account, not per-group: granularity that fine was considered and
+ * not built.
+ *
+ * It lives in `@waves/core` because three places were carrying it and they had
+ * already drifted — `apps/mobile/src/data/api.ts` and
+ * `packages/api-client/src/rows.ts` each declared their own copy, and the SQL
+ * that actually obeys these keys read one (`email`) that appeared in neither.
+ * A preference the server enforces and no client can set is a preference
+ * nobody has; the way that happens is three lists nobody diffs.
+ *
+ * **The database is the enforcer, not this file.** The keys here are honoured
+ * in `waves_claim_push_notifications` (via `waves_pref_key_for_kind`),
+ * `waves_claim_email_notifications`, `waves_trip_nudges` and
+ * `waves_enqueue_weekly_digest`. Adding a key here does nothing on its own —
+ * it needs a reader in SQL, or it is another switch wired to a switch.
+ */
+export interface NotificationPrefs {
+  /**
+   * Push for things that involve me: an expense I am in, a balance that moved,
+   * somebody claiming a place in a group I run. The default that stops the
+   * noise.
+   */
+  involvesMe: boolean;
+  /** The batched "what happened in this group" summary. */
+  groupActivityDigest: boolean;
+  /** Somebody says they paid me, or answered a payment I said I made. */
+  settlementRequests: boolean;
+  /** A reminder — sent by a person, or by a trip that is still running. */
+  nudges: boolean;
+  /**
+   * The master switch on the email door.
+   * `waves_claim_email_notifications` has read this key since M4 and suppressed
+   * every mail when it is false; it was in no type and on no screen until the
+   * switch was added, so the one thing it governed was unreachable.
+   *
+   * Two things beat it, both deliberately. A hard suppression — a bounce, a
+   * complaint, an unsubscribe click — wins, because that is the mailbox
+   * refusing rather than the person choosing. And `new_device_login` ignores it
+   * by name: turning off ledger mail does not mean "stop telling me when my
+   * account is opened somewhere".
+   */
+  email: boolean;
+  /** Monday morning's summary of the week. The one switch that starts off. */
+  weeklyEmail: boolean;
+}
+
+/**
+ * What an account that has never touched the screen means.
+ *
+ * Every push switch is on and the email door is open, matching the
+ * `COALESCE(..., TRUE)` the SQL applies to an absent key — so a profile written
+ * before a switch existed reads as on, which is what it has been. `weeklyEmail`
+ * is the exception and starts off: a summary nobody asked for arriving every
+ * Monday is how a sender gets filtered.
+ */
+export const DEFAULT_NOTIFICATION_PREFS: NotificationPrefs = {
+  involvesMe: true,
+  groupActivityDigest: true,
+  settlementRequests: true,
+  nudges: true,
+  email: true,
+  weeklyEmail: false,
+};

--- a/packages/core/src/settlement/rails.ts
+++ b/packages/core/src/settlement/rails.ts
@@ -366,6 +366,82 @@ export function isValidHandle(railId: string, handle: string): boolean {
   }
 }
 
+// ─────────────────────────────────────────── who gets paid, and on what ──
+
+/**
+ * The columns a settlement needs off a member row, whichever client is holding
+ * it. Deliberately snake_case and all-optional: this is the database's spelling,
+ * every caller reads it out of a PostgREST row, and no client should have to
+ * reshape a row to ask a question about it.
+ */
+export interface PayableMember {
+  /** Per-group override, UPI-shaped. Superseded by the rail pair below. */
+  readonly vpa?: string | null;
+  /** Per-group override on the rail pair. */
+  readonly payment_rail?: string | null;
+  readonly payment_handle?: string | null;
+  readonly profile?: {
+    readonly default_vpa?: string | null;
+    readonly payment_rail?: string | null;
+    readonly payment_handle?: string | null;
+  } | null;
+}
+
+export interface Payable {
+  readonly rail: string;
+  readonly handle: string;
+}
+
+/**
+ * How this person is paid: the rail, and the handle on it.
+ *
+ * Per-group first, then their profile default, because one person can be paid
+ * over UPI in one group and over Wise in another. The `vpa` columns are the
+ * last fallback: everything written before rails existed is a UPI ID, and the
+ * person who typed it should not have to type it again.
+ *
+ * Lives here rather than in either client because both were answering it, and
+ * only one of them was answering it correctly — the web settle screen read
+ * `vpa ?? profile.default_vpa` and nothing else, so a payee whose handle is a
+ * Pix key or a PayID had, as far as that screen was concerned, given no details
+ * at all. Two clients reading one pair of columns is one function's job.
+ *
+ * **The rail and the handle are chosen together, from one source.** The obvious
+ * way to write this is two independent `??` chains, one per field, and that way
+ * is wrong in a way nothing would catch: somebody with a per-group `vpa` and a
+ * later profile PayID gets the profile's handle paired with — depending on
+ * which chain resolved first — the group's rail, and the app builds a UPI
+ * intent around an Australian phone number. A rail and a handle are one fact
+ * about how to reach somebody, not two facts that happen to sit beside each
+ * other, so each candidate is taken whole or skipped whole.
+ */
+export function payableFor(member: PayableMember): Payable | null {
+  /**
+   * A rail pair counts only when it has both halves. A `payment_handle` with no
+   * `payment_rail` is not "presumably UPI" — that column holds Pix keys and
+   * Venmo names too, and guessing UPI over an Australian phone number builds an
+   * intent no app will answer. It is skipped, and the fall-through below finds
+   * the legacy column or nobody. (`apps/web` used to write exactly that pair
+   * half-filled; it no longer does.)
+   */
+  const pair = (rail?: string | null, handle?: string | null): Payable | null =>
+    rail && handle ? { rail, handle } : null;
+
+  /** A `vpa` column predates rails, so it can only ever have held a UPI id. */
+  const legacy = (handle?: string | null): Payable | null =>
+    handle ? { rail: RailId.Upi, handle } : null;
+
+  return (
+    // Per-group first, whole: this group's own answer about this person.
+    pair(member.payment_rail, member.payment_handle) ??
+    legacy(member.vpa) ??
+    // Then how they are paid everywhere else.
+    pair(member.profile?.payment_rail, member.profile?.payment_handle) ??
+    legacy(member.profile?.default_vpa) ??
+    null
+  );
+}
+
 /**
  * Where a link leads, and how much to trust it.
  *

--- a/packages/core/test/rails.test.ts
+++ b/packages/core/test/rails.test.ts
@@ -14,6 +14,7 @@ import {
   buildPaymentUri,
   defaultRailFor,
   isValidHandle,
+  payableFor,
   PAYMENT_RAILS,
   railById,
   railsFor,
@@ -274,5 +275,54 @@ describe('the markets Waves is going to next', () => {
         railId,
       ).toBeNull();
     }
+  });
+});
+
+describe('how a person is paid', () => {
+  // The precedence used to live in `apps/mobile/src/data/types.ts` and,
+  // separately and differently, in the web settle page — which read
+  // `vpa ?? default_vpa` and nothing else, so a payee on any rail but UPI
+  // looked to it like somebody who had given no details at all.
+
+  it('prefers the per-group override to the profile default', () => {
+    expect(
+      payableFor({
+        payment_rail: 'pix',
+        payment_handle: 'ravi@example.com',
+        profile: { payment_rail: 'upi', payment_handle: 'ravi@okhdfcbank' },
+      }),
+    ).toEqual({ rail: 'pix', handle: 'ravi@example.com' });
+  });
+
+  it('falls back to the profile when the group says nothing', () => {
+    expect(
+      payableFor({ profile: { payment_rail: 'payid', payment_handle: '+61 400 123 456' } }),
+    ).toEqual({ rail: 'payid', handle: '+61 400 123 456' });
+  });
+
+  it('reads a handle written before rails existed as a UPI id', () => {
+    // Nobody who typed a VPA into the old field should have to type it again.
+    expect(payableFor({ profile: { default_vpa: 'ravi@okhdfcbank' } })).toEqual({
+      rail: 'upi',
+      handle: 'ravi@okhdfcbank',
+    });
+    expect(payableFor({ vpa: 'trip@okaxis' })).toEqual({ rail: 'upi', handle: 'trip@okaxis' });
+  });
+
+  it('lets the rail pair win over the legacy column on the same row', () => {
+    expect(
+      payableFor({
+        vpa: 'old@okhdfcbank',
+        payment_rail: 'venmo',
+        payment_handle: '@ravi-kumar',
+      }),
+    ).toEqual({ rail: 'venmo', handle: '@ravi-kumar' });
+  });
+
+  it('is null for somebody who has given no way to be paid', () => {
+    expect(payableFor({})).toBeNull();
+    expect(payableFor({ profile: null })).toBeNull();
+    // A rail with no handle is not a way to be paid either.
+    expect(payableFor({ payment_rail: 'pix' })).toBeNull();
   });
 });

--- a/packages/db/prisma/migrations/20260908120000_settlement_notices_and_push_prefs/migration.sql
+++ b/packages/db/prisma/migrations/20260908120000_settlement_notices_and_push_prefs/migration.sql
@@ -1,0 +1,501 @@
+-- The two halves of M4 that were built but never joined up.
+--
+-- M4's acceptance criterion (TDR §10) is one sentence: "initiate UPI settle →
+-- payee push with Confirm action → balances update". Every piece of that
+-- sentence exists — the settle screen, the rails, the state machine, the
+-- fan-out, the claim/finish protocol, the templates — except the one in the
+-- middle. Nothing has ever written a `settlement_initiated` or a
+-- `settlement_confirm_request` row. Those two kinds appear in
+-- `waves_claim_email_notifications`'s whitelist, in the copy table in four
+-- languages, and in `TEMPLATE_FOR_KIND`; no function in this database produces
+-- either. The only settlement notice that exists at all is the one the
+-- seven-day job writes when *nobody* answered, which is the branch you reach by
+-- never having been told.
+--
+-- The same gap runs the other way. `waves_settlement_transition` polices
+-- `cancelled` and `disputed` — ADR-007 calls them "deliberate mirror images,
+-- one per party", and the point of them is that "neither party can silently
+-- erase the other's record". Silently is exactly what they do: the payer
+-- cancels and the payee is never told; the payee disputes and the payer is
+-- never told. The transition is guarded and unheard.
+--
+-- And the preferences. `profiles.notification_prefs` carries four push
+-- switches; the notifications screen renders all four with a "we will never
+-- spam you" promise above them. `waves_claim_push_notifications` reads the
+-- column not at all. `nudges` happens to work, because `waves_trip_nudges`
+-- checks it before enqueuing — and only for trip nudges, not for a nudge
+-- somebody sent by hand. `involvesMe`, `settlementRequests` and
+-- `groupActivityDigest` are three switches wired to nothing: turning them off
+-- has never stopped a single push. That is worse than not offering them.
+--
+-- Three changes, then: settlements tell the other party, transitions tell the
+-- other party, and the push claim honours the switches the way the email claim
+-- already honours its one.
+
+-- ───────────────────────────────────────────────── the other party is told ──
+
+-- Who to tell, and what to call everybody. Both notice paths below need the
+-- same five facts (each side's profile, each side's name, the group's name),
+-- and both have to cope with a party who is a ghost — a placeholder with a
+-- `ghost_name` and no profile to notify. Resolving it once keeps the two from
+-- drifting, and keeps `COALESCE(display_name, ghost_name)` written down in one
+-- place rather than three.
+--
+-- STABLE, not VOLATILE: it only reads. SECURITY DEFINER because both callers
+-- are, and because a payer looking up their payee's display name must not
+-- depend on the payer's own RLS view of `profiles`.
+CREATE OR REPLACE FUNCTION public.waves_settlement_parties(p_settlement_id uuid)
+RETURNS TABLE(
+  group_id uuid,
+  group_name text,
+  amount text,
+  currency text,
+  payer_profile uuid,
+  payer_name text,
+  payee_profile uuid,
+  payee_name text
+)
+    LANGUAGE sql STABLE SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+  SELECT s.group_id,
+         g.name,
+         -- Text, not bigint: the payload is JSON and a minor-unit amount that
+         -- goes through a JSON number comes back as a float. `render.ts` parses
+         -- it with BigInt for exactly this reason.
+         s.amount::text,
+         s.currency::text,
+         payer.profile_id,
+         COALESCE(payer_profile.display_name, payer.ghost_name),
+         payee.profile_id,
+         COALESCE(payee_profile.display_name, payee.ghost_name)
+    FROM public.settlements s
+    JOIN public.groups g            ON g.id = s.group_id
+    JOIN public.group_members payer ON payer.id = s.from_member_id
+    JOIN public.group_members payee ON payee.id = s.to_member_id
+    LEFT JOIN public.profiles payer_profile ON payer_profile.id = payer.profile_id
+    LEFT JOIN public.profiles payee_profile ON payee_profile.id = payee.profile_id
+   WHERE s.id = p_settlement_id;
+$$;
+
+REVOKE ALL ON FUNCTION public.waves_settlement_parties(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.waves_settlement_parties(uuid) TO service_role;
+
+-- Recording a settlement now taps the person on the other end.
+--
+-- Unchanged from `20260907140000_agent_writes_and_caps` except for the block
+-- marked below. The whole body is restated because Postgres has no way to
+-- amend a function in place.
+--
+-- Only the payer's recording notifies. When the *payee* records ("they gave me
+-- cash"), the payer is not asked to confirm anything — the money already
+-- reached the person who would be doing the confirming — so a push would be a
+-- buzz with no action behind it. That side stays in the activity feed, which is
+-- where a fact you do not have to answer belongs.
+CREATE OR REPLACE FUNCTION public.waves_record_settlement(p_group_id uuid, p_from_member_id uuid, p_to_member_id uuid, p_amount bigint, p_method text, p_currency character DEFAULT NULL::bpchar, p_note text DEFAULT NULL::text, p_allocations jsonb DEFAULT '[]'::jsonb, p_client_mutation_id uuid DEFAULT NULL::uuid, p_rail text DEFAULT NULL::text) RETURNS uuid
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+DECLARE
+  v_settlement_id uuid;
+  v_currency      char(3);
+  v_actor         uuid;
+  v_allocation    jsonb;
+  v_rail          text := COALESCE(NULLIF(btrim(p_rail), ''), p_method);
+  v_parties       record;
+BEGIN
+  IF NOT public.is_group_member(p_group_id) THEN
+    RAISE EXCEPTION 'NOT_A_MEMBER: you are not in this group'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Resolve the caller's own member id up front: it is both the authorization
+  -- check below and the actor on the activity entry further down.
+  v_actor := public.waves_my_member_id(p_group_id);
+  IF v_actor IS NULL OR v_actor NOT IN (p_from_member_id, p_to_member_id) THEN
+    RAISE EXCEPTION 'NOT_A_PARTY: you can only record a settlement you are part of'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Both parties must be members of THIS group. The FKs only prove the ids are
+  -- real `group_members` rows, not that they belong here — without this a member
+  -- could name a party from another group, and auto-confirm would later write an
+  -- offsetting balance against a member nobody in this group can see, erasing
+  -- their own debt while the per-group sum still totals zero.
+  IF NOT EXISTS (
+        SELECT 1 FROM public.group_members gm
+        WHERE gm.id = p_from_member_id AND gm.group_id = p_group_id
+      )
+     OR NOT EXISTS (
+        SELECT 1 FROM public.group_members gm
+        WHERE gm.id = p_to_member_id AND gm.group_id = p_group_id
+      ) THEN
+    RAISE EXCEPTION 'UNKNOWN_MEMBER: both parties must be members of this group'
+      USING ERRCODE = 'foreign_key_violation';
+  END IF;
+
+  IF p_amount <= 0 THEN
+    RAISE EXCEPTION 'INVALID_AMOUNT: settle a positive amount' USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Replaying the same mutation must not create a second settlement (ADR-005),
+  -- and must not spend an agent's daily ceiling again.
+  IF p_client_mutation_id IS NOT NULL THEN
+    SELECT id INTO v_settlement_id
+    FROM public.settlements WHERE client_mutation_id = p_client_mutation_id;
+    IF v_settlement_id IS NOT NULL THEN
+      RETURN v_settlement_id;
+    END IF;
+  END IF;
+
+  SELECT COALESCE(p_currency, default_currency) INTO v_currency
+  FROM public.groups WHERE id = p_group_id;
+
+  PERFORM public.waves_assert_agent_cap(p_amount);
+
+  INSERT INTO public.settlements
+    (group_id, from_member_id, to_member_id, currency, amount, method, rail, status, note,
+     client_mutation_id)
+  VALUES
+    (p_group_id, p_from_member_id, p_to_member_id, upper(v_currency), p_amount,
+     CASE WHEN p_method IN ('upi', 'cash', 'bank', 'other') THEN p_method ELSE 'other' END
+       ::"SettlementMethod",
+     v_rail, 'initiated', p_note, p_client_mutation_id)
+  RETURNING id INTO v_settlement_id;
+
+  FOR v_allocation IN SELECT * FROM jsonb_array_elements(COALESCE(p_allocations, '[]'::jsonb))
+  LOOP
+    INSERT INTO public.settlement_allocations (settlement_id, expense_id, amount)
+    VALUES (
+      v_settlement_id,
+      (v_allocation ->> 'expenseId')::uuid,
+      (v_allocation ->> 'amount')::bigint
+    )
+    ON CONFLICT (settlement_id, expense_id)
+    DO UPDATE SET amount = public.settlement_allocations.amount + EXCLUDED.amount;
+  END LOOP;
+
+  INSERT INTO public.activity_log (group_id, actor_member_id, verb, object_type, object_id, payload)
+  VALUES (p_group_id, v_actor, 'settled', 'settlement', v_settlement_id,
+          jsonb_build_object('amount', p_amount, 'currency', v_currency,
+                             'method', p_method, 'rail', v_rail));
+
+  PERFORM public.waves_record_agent_write(
+    'settlement.record', p_group_id, v_settlement_id, p_amount, upper(v_currency)
+  );
+
+  -- ── new: the payee is asked to confirm ──────────────────────────────────
+  --
+  -- The dedupe key is the settlement id, so the offline queue replaying this
+  -- mutation cannot buzz somebody twice — and neither can a retry that got as
+  -- far as the INSERT. Deliberately after the writes: a notification that fails
+  -- to be written must not lose the settlement, and `waves_notify` is a plain
+  -- INSERT with `ON CONFLICT DO NOTHING`, so there is nothing here to fail on
+  -- besides the ghost case it already returns NULL for.
+  IF v_actor = p_from_member_id THEN
+    SELECT * INTO v_parties FROM public.waves_settlement_parties(v_settlement_id);
+    PERFORM public.waves_notify(
+      v_parties.payee_profile,
+      p_group_id,
+      'settlement_confirm_request',
+      COALESCE(v_parties.payer_name, 'Someone') || ' says they paid you',
+      'Confirm it so your balance stays right',
+      'waves://group/' || p_group_id::text,
+      jsonb_build_object(
+        'settlementId', v_settlement_id,
+        'amount', v_parties.amount,
+        'currency', v_parties.currency,
+        'role', 'payee',
+        'counterparty', v_parties.payer_name,
+        'group', v_parties.group_name
+      ),
+      'settle_confirm_req:' || v_settlement_id::text
+    );
+  END IF;
+
+  RETURN v_settlement_id;
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.waves_record_settlement(p_group_id uuid, p_from_member_id uuid, p_to_member_id uuid, p_amount bigint, p_method text, p_currency character, p_note text, p_allocations jsonb, p_client_mutation_id uuid, p_rail text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.waves_record_settlement(p_group_id uuid, p_from_member_id uuid, p_to_member_id uuid, p_amount bigint, p_method text, p_currency character, p_note text, p_allocations jsonb, p_client_mutation_id uuid, p_rail text) TO authenticated, service_role;
+
+-- ───────────────────────────────────────────── and so does every transition ──
+
+-- A trigger rather than three RPCs, because there are no three RPCs: the app
+-- confirms, cancels and disputes by UPDATEing `settlements.status` directly
+-- under RLS, and `waves_settlement_transition` is the BEFORE guard that decides
+-- whether the move is legal. Anything that can legally change the status can
+-- reach this, including the offline queue replaying a confirm and an import
+-- confirming a row it named — which is the property that matters, because a
+-- notice attached to one code path is a notice missing from the others.
+--
+-- `auto_confirmed` is deliberately absent. `waves_auto_confirm_settlements`
+-- already writes both sides of that one, with wording ("nobody said otherwise
+-- for a week") that this trigger has no way to reproduce; firing here as well
+-- would be a second buzz saying less.
+--
+-- SECURITY DEFINER: the invoker is `authenticated`, and `waves_notify` is
+-- service-role only. Without it every confirm would fail on a permission error
+-- rather than send a notification.
+CREATE OR REPLACE FUNCTION public.waves_settlement_notify() RETURNS trigger
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+DECLARE
+  v_parties record;
+BEGIN
+  IF NEW.status = OLD.status THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.status NOT IN ('confirmed', 'cancelled', 'disputed') THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT * INTO v_parties FROM public.waves_settlement_parties(NEW.id);
+
+  IF NEW.status = 'confirmed' THEN
+    -- Only the payee can confirm, so the payer is the one who learns something.
+    PERFORM public.waves_notify(
+      v_parties.payer_profile,
+      v_parties.group_id,
+      'settlement_confirmed',
+      'Settled',
+      COALESCE(v_parties.payee_name, 'They') || ' confirmed your payment',
+      'waves://group/' || v_parties.group_id::text,
+      jsonb_build_object(
+        'settlementId', NEW.id,
+        'amount', v_parties.amount,
+        'currency', v_parties.currency,
+        'role', 'payer',
+        'counterparty', v_parties.payee_name,
+        'group', v_parties.group_name
+      ),
+      'settle_confirmed:' || NEW.id::text
+    );
+
+  ELSIF NEW.status = 'cancelled' THEN
+    -- ADR-007: only the payer may cancel, and only while the claim is pending.
+    -- The payee is the party whose pending "did you get it?" just disappeared,
+    -- and a request that vanishes with no word is the thing this prevents.
+    PERFORM public.waves_notify(
+      v_parties.payee_profile,
+      v_parties.group_id,
+      'settlement_cancelled',
+      'A payment claim was withdrawn',
+      COALESCE(v_parties.payer_name, 'Someone') || ' took back what they said they paid',
+      'waves://group/' || v_parties.group_id::text,
+      jsonb_build_object(
+        'settlementId', NEW.id,
+        'amount', v_parties.amount,
+        'currency', v_parties.currency,
+        'role', 'payee',
+        'counterparty', v_parties.payer_name,
+        'group', v_parties.group_name
+      ),
+      'settle_cancelled:' || NEW.id::text
+    );
+
+  ELSE
+    -- Disputed. The payee's answer to a payment they never received, so the
+    -- payer is the one who has to do something about it.
+    PERFORM public.waves_notify(
+      v_parties.payer_profile,
+      v_parties.group_id,
+      'settlement_disputed',
+      'Your payment was not recognised',
+      COALESCE(v_parties.payee_name, 'They') || ' say they did not receive it',
+      'waves://group/' || v_parties.group_id::text,
+      jsonb_build_object(
+        'settlementId', NEW.id,
+        'amount', v_parties.amount,
+        'currency', v_parties.currency,
+        'role', 'payer',
+        'counterparty', v_parties.payee_name,
+        'group', v_parties.group_name
+      ),
+      'settle_disputed:' || NEW.id::text
+    );
+  END IF;
+
+  RETURN NEW;
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.waves_settlement_notify() FROM PUBLIC;
+
+DROP TRIGGER IF EXISTS settlements_transition_notify ON public.settlements;
+
+-- AFTER, not BEFORE: the guard has to have accepted the move first, or a
+-- refused transition would still have sent the mail about it.
+--
+-- Not `AFTER UPDATE OF status`: that fires on whether the *statement* named the
+-- column, which is a property of how somebody happened to write their UPDATE
+-- rather than of whether the status changed. The `NEW.status = OLD.status`
+-- guard inside the function is the real test, and it costs one comparison.
+CREATE TRIGGER settlements_transition_notify
+    AFTER UPDATE ON public.settlements
+    FOR EACH ROW EXECUTE FUNCTION public.waves_settlement_notify();
+
+-- ──────────────────────────────────────── the switches are wired to something ──
+
+-- Which preference governs which kind.
+--
+-- A function rather than a table: it is a constant, it belongs to the same
+-- deploy as the claim that reads it, and a table would be one more thing for
+-- Prisma to know about and for a migration to keep in step. It is separate from
+-- the claim so a test can ask the mapping directly — "does turning off
+-- settlement requests cover a dispute?" is a question with an answer, and the
+-- answer should not require enqueuing a notification to find out.
+--
+-- NULL means "no preference silences this". A kind this function has never
+-- heard of gets NULL too, which is the safe default: something added later
+-- pushes until somebody decides which switch it belongs under, rather than
+-- going quiet for reasons nobody can see.
+--
+-- `new_device_login` is NULL on purpose, for the same reason
+-- `waves_claim_email_notifications` carves it out by name: turning
+-- notifications off means "stop telling me about ledgers", and nobody means it
+-- to include "and stop telling me when my account is opened somewhere".
+CREATE OR REPLACE FUNCTION public.waves_pref_key_for_kind(p_kind text) RETURNS text
+    LANGUAGE sql IMMUTABLE
+    -- Pinned like everything else in this schema, and checked by
+    -- `anon-surface.test.ts`. A pure CASE over a text literal reads nothing, so
+    -- there is no path for a path to matter on — which is exactly the argument
+    -- somebody makes right before the one function without a pin is the one
+    -- that grows a table lookup.
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+  SELECT CASE p_kind
+    WHEN 'expense_added'             THEN 'involvesMe'
+    WHEN 'expense_edited'            THEN 'involvesMe'
+    WHEN 'expense_deleted'           THEN 'involvesMe'
+    WHEN 'you_owe'                   THEN 'involvesMe'
+    WHEN 'expense_disputed'          THEN 'involvesMe'
+    WHEN 'expense_dispute_resolved'  THEN 'involvesMe'
+    WHEN 'ghost_claimed'             THEN 'involvesMe'
+    WHEN 'ghost_claim_requested'     THEN 'involvesMe'
+    WHEN 'ghost_claim_approved'      THEN 'involvesMe'
+    WHEN 'ghost_claim_declined'      THEN 'involvesMe'
+    WHEN 'group_invite_accepted'     THEN 'involvesMe'
+    WHEN 'group_added'               THEN 'involvesMe'
+    WHEN 'settlement_initiated'      THEN 'settlementRequests'
+    WHEN 'settlement_confirm_request' THEN 'settlementRequests'
+    WHEN 'settlement_confirmed'      THEN 'settlementRequests'
+    WHEN 'settlement_cancelled'      THEN 'settlementRequests'
+    WHEN 'settlement_disputed'       THEN 'settlementRequests'
+    WHEN 'nudge'                     THEN 'nudges'
+    WHEN 'trip_nudge_morning'        THEN 'nudges'
+    WHEN 'trip_nudge_evening'        THEN 'nudges'
+    WHEN 'digest_daily'              THEN 'groupActivityDigest'
+    WHEN 'digest_weekly'             THEN 'groupActivityDigest'
+    ELSE NULL
+  END;
+$$;
+
+REVOKE ALL ON FUNCTION public.waves_pref_key_for_kind(text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.waves_pref_key_for_kind(text) TO service_role;
+
+-- The claim, now reading the switches.
+--
+-- Unchanged from the baseline except for the block marked below. `suppressed`
+-- rather than `failed`: this is a decision, not a delivery that went wrong, and
+-- the difference shows up the first time somebody asks why a person got no
+-- push. It is also terminal — `push_next_retry_at` stays NULL — because a
+-- preference does not come back on by itself.
+--
+-- The check is at claim time rather than at `waves_notify` time on purpose: a
+-- notification row is the record that something happened, and the email half
+-- may still want it (an unpushed nudge is precisely the one that gets mailed).
+-- Suppressing the *delivery* leaves that intact; not writing the row would not.
+CREATE OR REPLACE FUNCTION public.waves_claim_push_notifications(p_limit integer DEFAULT 200)
+RETURNS TABLE(id uuid, kind text, title text, body text, deep_link text, payload jsonb, locale text, tokens text[])
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+DECLARE
+  v_ids UUID[];
+BEGIN
+  -- `FOR UPDATE SKIP LOCKED` is what lets two runs overlap harmlessly: the
+  -- second finds the rows locked and moves on rather than sending them
+  -- again. A first try (`push_status IS NULL`) and a retry (`failed`, under
+  -- 3 attempts, backoff elapsed) are the same claim, differing only in which
+  -- half of the WHERE let the row through.
+  WITH picked AS (
+    SELECT n.id
+    FROM public.notifications n
+    WHERE (
+            n.push_status IS NULL
+         OR (n.push_status = 'failed'
+             AND n.push_attempts < 3
+             AND n.push_next_retry_at IS NOT NULL
+             AND n.push_next_retry_at <= now())
+          )
+      -- Anything older than this was missed while the fanout was down, and a
+      -- buzz about a two-day-old reminder is worse than silence.
+      AND n.created_at > now() - interval '2 days'
+    ORDER BY n.created_at
+    LIMIT p_limit
+    FOR UPDATE SKIP LOCKED
+  ),
+  claimed AS (
+    UPDATE public.notifications n
+       SET push_status = 'queued'
+      FROM picked
+     WHERE n.id = picked.id
+    RETURNING n.id
+  )
+  SELECT COALESCE(array_agg(claimed.id), '{}') INTO v_ids FROM claimed;
+
+  -- ── new: the four switches on the notifications screen ──────────────────
+  --
+  -- Absent key means on: `DEFAULT_NOTIFICATION_PREFS` has all four true, and a
+  -- profile written before a switch existed must not be read as having turned
+  -- it off. A kind with no mapping, and a kind mapped to NULL, both fall
+  -- through untouched.
+  UPDATE public.notifications n
+     SET push_status = 'suppressed',
+         push_next_retry_at = NULL
+   WHERE n.id = ANY(v_ids)
+     AND public.waves_pref_key_for_kind(n.kind) IS NOT NULL
+     AND NOT COALESCE(
+           (SELECT (p.notification_prefs ->> public.waves_pref_key_for_kind(n.kind))::boolean
+              FROM public.profiles p WHERE p.id = n.profile_id),
+           TRUE
+         );
+
+  -- A separate statement: Postgres will not apply two updates to the same
+  -- row inside one statement, so folding this into the CTE above would
+  -- silently do nothing.
+  --
+  -- No device is a decision, not a failure — closed out terminally
+  -- (`push_next_retry_at` cleared, not just `push_status`) rather than left
+  -- retryable, or it would sit in the claim's way on every future run.
+  -- `push_attempts` is left alone: a new token showing up later is a
+  -- different signal than time passing, and not this branch's business.
+  UPDATE public.notifications n
+     SET push_status = 'failed',
+         push_next_retry_at = NULL
+   WHERE n.id = ANY(v_ids)
+     AND n.push_status = 'queued'
+     AND NOT EXISTS (
+       SELECT 1 FROM public.push_tokens t
+       WHERE t.profile_id = n.profile_id AND t.revoked_at IS NULL
+     );
+
+  RETURN QUERY
+  SELECT n.id, n.kind, n.title, n.body, n.deep_link, n.payload,
+         COALESCE(p.locale, 'en'),
+         ARRAY_AGG(t.expo_push_token)
+  FROM public.notifications n
+  LEFT JOIN public.profiles p ON p.id = n.profile_id
+  JOIN public.push_tokens t
+    ON t.profile_id = n.profile_id AND t.revoked_at IS NULL
+  WHERE n.id = ANY(v_ids) AND n.push_status = 'queued'
+  GROUP BY n.id, n.kind, n.title, n.body, n.deep_link, n.payload, p.locale;
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.waves_claim_push_notifications(integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.waves_claim_push_notifications(integer) TO service_role;

--- a/packages/db/scripts/apply-one-migration.mjs
+++ b/packages/db/scripts/apply-one-migration.mjs
@@ -1,0 +1,28 @@
+/**
+ * Apply a single migration file to the local test database.
+ *
+ * The suite in `packages/db/test` runs against a Postgres that already has the
+ * schema; this is the one-liner for pushing a migration you are still writing
+ * into it without rebuilding the whole database.
+ *
+ *   node packages/db/scripts/apply-one-migration.mjs packages/db/prisma/migrations/<dir>/migration.sql
+ */
+import { readFileSync } from 'node:fs';
+import pg from 'pg';
+
+const file = process.argv[2];
+if (!file) {
+  console.error('usage: node packages/db/scripts/apply-one-migration.mjs <path to migration.sql>');
+  process.exit(1);
+}
+
+const client = new pg.Client(
+  process.env.TEST_DATABASE_URL ?? 'postgresql://postgres:postgres@localhost:54330/waves',
+);
+await client.connect();
+try {
+  await client.query(readFileSync(file, 'utf8'));
+  console.log('applied', file);
+} finally {
+  await client.end();
+}

--- a/packages/db/test/m4-push-prefs.test.ts
+++ b/packages/db/test/m4-push-prefs.test.ts
@@ -1,0 +1,245 @@
+/**
+ * The four switches on the notifications screen, wired to something at last.
+ *
+ * `profiles.notification_prefs` has carried four push preferences since M4, and
+ * `apps/mobile/src/app/settings/notifications.tsx` renders all four under a
+ * promise that reads "we will never spam you". `waves_claim_push_notifications`
+ * read the column not at all. One of the four worked by accident —
+ * `waves_trip_nudges` checks `nudges` before enqueuing, so trip reminders
+ * stopped, though a nudge somebody sent by hand did not. The other three
+ * silenced nothing whatsoever: turning `involvesMe` off and then being added to
+ * a group still buzzed the phone.
+ *
+ * A switch that does nothing is worse than no switch, so what is pinned here is
+ * that each one covers the kinds it claims to, that a security notice is not
+ * one of the things a person can turn off by accident, and that a preference
+ * somebody has never touched means yes.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { connect } from './helpers.js';
+
+let client: Client;
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client?.end();
+});
+
+/** A profile with a live device, so the claim has somewhere to send to. */
+async function personWithPhone(prefs: Record<string, boolean> | null): Promise<string> {
+  const id = randomUUID();
+  await client.query(
+    `INSERT INTO profiles (id, display_name, country_code, notification_prefs)
+     VALUES ($1, 'Ravi', 'IN', COALESCE($2::jsonb, '{}'::jsonb))`,
+    [id, prefs === null ? null : JSON.stringify(prefs)],
+  );
+  await client.query(
+    `INSERT INTO push_tokens (profile_id, expo_push_token, platform)
+     VALUES ($1, $2, 'android')`,
+    [id, `ExponentPushToken[${randomUUID()}]`],
+  );
+  return id;
+}
+
+async function enqueue(profileId: string, kind: string): Promise<string> {
+  const { rows } = await client.query(
+    `INSERT INTO notifications (profile_id, kind, title, body, dedupe_key)
+     VALUES ($1, $2, 'title', 'body', $3) RETURNING id`,
+    [profileId, kind, `${kind}:${randomUUID()}`],
+  );
+  return String(rows[0].id);
+}
+
+/** Run the claim and report what it decided about one particular row. */
+async function claimAndRead(id: string): Promise<{ claimed: boolean; status: string | null }> {
+  const { rows: claimed } = await client.query(
+    `SELECT id FROM waves_claim_push_notifications(500) WHERE id = $1`,
+    [id],
+  );
+  const { rows: stored } = await client.query(
+    `SELECT push_status::text AS status, push_next_retry_at FROM notifications WHERE id = $1`,
+    [id],
+  );
+  return { claimed: claimed.length === 1, status: stored[0]?.status ?? null };
+}
+
+// `notifications` is swept clean around every case, the same way
+// `device-alert-and-digest.test.ts` does — the two files are the ones that call
+// the claim RPCs, which have no way to be scoped to one test's rows.
+//
+// Before, because the claim is a global sweep with a row limit and a table left
+// full by an earlier file would be the reason a row here goes unclaimed: an
+// answer about the limit dressed up as an answer about preferences. After, so
+// this file hands the next one an empty table rather than its leftovers. Safe
+// on both counts because the suite sets `fileParallelism: false` — no other
+// file is mid-assertion while this one runs.
+beforeEach(async () => {
+  await client.query(`DELETE FROM notifications`);
+});
+
+afterEach(async () => {
+  await client.query(`DELETE FROM notifications`);
+});
+
+describe('the mapping from a kind to the switch that governs it', () => {
+  it('puts every kind under the switch its screen copy promises', async () => {
+    const { rows } = await client.query(
+      `SELECT kind, waves_pref_key_for_kind(kind) AS pref
+         FROM unnest($1::text[]) AS kind`,
+      [
+        [
+          'group_added',
+          'expense_added',
+          'ghost_claim_approved',
+          'settlement_confirm_request',
+          'settlement_confirmed',
+          'settlement_cancelled',
+          'settlement_disputed',
+          'nudge',
+          'trip_nudge_morning',
+          'digest_weekly',
+          'new_device_login',
+          'something_invented_next_year',
+        ],
+      ],
+    );
+    const map = Object.fromEntries(rows.map((r) => [r.kind, r.pref]));
+
+    expect(map.group_added).toBe('involvesMe');
+    expect(map.expense_added).toBe('involvesMe');
+    expect(map.ghost_claim_approved).toBe('involvesMe');
+    expect(map.settlement_confirm_request).toBe('settlementRequests');
+    expect(map.settlement_confirmed).toBe('settlementRequests');
+    // The two ADR-007 calls mirror images belong with the rest of settling up;
+    // somebody who wants to hear about settlements wants to hear about the ones
+    // that came apart most of all.
+    expect(map.settlement_cancelled).toBe('settlementRequests');
+    expect(map.settlement_disputed).toBe('settlementRequests');
+    expect(map.nudge).toBe('nudges');
+    expect(map.trip_nudge_morning).toBe('nudges');
+    expect(map.digest_weekly).toBe('groupActivityDigest');
+
+    // A security notice is not ledger news, and nobody turning off ledger news
+    // means "and stop telling me when my account is opened somewhere".
+    expect(map.new_device_login).toBeNull();
+    // A kind added later pushes until somebody decides where it belongs, rather
+    // than going quiet for a reason nobody can see.
+    expect(map.something_invented_next_year).toBeNull();
+  });
+});
+
+describe('a switch that is off actually silences the push', () => {
+  it('drops a group_added when involvesMe is off', async () => {
+    const person = await personWithPhone({ involvesMe: false });
+    const id = await enqueue(person, 'group_added');
+
+    const result = await claimAndRead(id);
+    expect(result.claimed).toBe(false);
+    // `suppressed`, not `failed`: this is a decision, and the difference is the
+    // whole answer the first time somebody asks why a person got no push.
+    expect(result.status).toBe('suppressed');
+  });
+
+  it('drops a settlement confirm request when settlementRequests is off', async () => {
+    const person = await personWithPhone({ settlementRequests: false });
+    const id = await enqueue(person, 'settlement_confirm_request');
+
+    expect((await claimAndRead(id)).claimed).toBe(false);
+  });
+
+  it('drops a hand-sent nudge when nudges is off, not only the trip reminders', async () => {
+    // `waves_trip_nudges` has always checked this key before enqueuing, which
+    // is why trip reminders looked like they honoured it. `waves_nudge_to_settle`
+    // never did, so the switch was half a switch.
+    const person = await personWithPhone({ nudges: false });
+    const id = await enqueue(person, 'nudge');
+
+    expect((await claimAndRead(id)).claimed).toBe(false);
+  });
+
+  it('drops a digest when groupActivityDigest is off', async () => {
+    const person = await personWithPhone({ groupActivityDigest: false });
+    const id = await enqueue(person, 'digest_weekly');
+
+    expect((await claimAndRead(id)).claimed).toBe(false);
+  });
+
+  it("does not let one switch silence another switch's kinds", async () => {
+    const person = await personWithPhone({ nudges: false });
+    const id = await enqueue(person, 'settlement_confirm_request');
+
+    expect((await claimAndRead(id)).claimed).toBe(true);
+  });
+});
+
+describe('what a switch cannot do', () => {
+  it('never silences a new sign-in, whatever is turned off', async () => {
+    const person = await personWithPhone({
+      involvesMe: false,
+      settlementRequests: false,
+      nudges: false,
+      groupActivityDigest: false,
+    });
+    const id = await enqueue(person, 'new_device_login');
+
+    expect((await claimAndRead(id)).claimed).toBe(true);
+  });
+
+  it('reads an untouched preference as yes', async () => {
+    // A profile written before a switch existed must not be read as having
+    // turned it off. `DEFAULT_NOTIFICATION_PREFS` has all four true.
+    const person = await personWithPhone(null);
+    const id = await enqueue(person, 'group_added');
+
+    expect((await claimAndRead(id)).claimed).toBe(true);
+  });
+
+  it('leaves an on switch alone', async () => {
+    const person = await personWithPhone({ involvesMe: true });
+    const id = await enqueue(person, 'group_added');
+
+    const result = await claimAndRead(id);
+    expect(result.claimed).toBe(true);
+    expect(result.status).toBe('queued');
+  });
+});
+
+describe('a suppressed push is still a notification', () => {
+  it('leaves the email half free to send what the push did not', async () => {
+    // The check is at claim time, not at `waves_notify` time, on purpose: the
+    // row is the record that something happened, and a nudge with no push is
+    // precisely the one the email half exists for (TDR §7.4).
+    const person = await personWithPhone({ nudges: false });
+    const id = await enqueue(person, 'nudge');
+    await claimAndRead(id);
+
+    const { rows } = await client.query(
+      `SELECT push_status::text AS push, email_status FROM notifications WHERE id = $1`,
+      [id],
+    );
+    expect(rows[0].push).toBe('suppressed');
+    expect(rows[0].email_status).toBeNull();
+  });
+
+  it('does not come back on a retry, because a preference does not lapse', async () => {
+    const person = await personWithPhone({ involvesMe: false });
+    const id = await enqueue(person, 'group_added');
+    await claimAndRead(id);
+
+    // The retry branch only picks up `failed` rows with a `push_next_retry_at`.
+    expect((await claimAndRead(id)).claimed).toBe(false);
+    const { rows } = await client.query(
+      `SELECT push_next_retry_at FROM notifications WHERE id = $1`,
+      [id],
+    );
+    expect(rows[0].push_next_retry_at).toBeNull();
+  });
+});

--- a/packages/db/test/m4-settlement-notices.test.ts
+++ b/packages/db/test/m4-settlement-notices.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Telling the other party.
+ *
+ * M4's acceptance criterion (TDR §10) is "initiate UPI settle → payee push with
+ * Confirm action → balances update", and until this migration the middle third
+ * of it did not exist: `waves_record_settlement` wrote a settlement, an
+ * activity row and an agent-audit row, and nothing at all in `notifications`.
+ * The kinds were there — `settlement_confirm_request` is in the email claim's
+ * whitelist, in the copy table in four languages, and in `TEMPLATE_FOR_KIND` —
+ * with no producer anywhere in the database.
+ *
+ * The transitions were the same story from the other end. ADR-007 makes cancel
+ * and dispute "deliberate mirror images, one per party" whose whole purpose is
+ * that "neither party can silently erase the other's record"; both moved the
+ * status and told nobody.
+ *
+ * What is pinned here is who hears about what, and — as much — who does not: a
+ * settlement the payee recorded themselves asks nobody to confirm anything, a
+ * replayed mutation does not buzz twice, and `auto_confirmed` stays the seven-
+ * day job's to announce so a phone does not vibrate twice for one event.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { connect, seedGroup, type SeededGroup } from './helpers.js';
+
+let client: Client;
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client?.end();
+});
+
+/** Run something with the request claims of a signed-in person. */
+async function asUser<T>(profileId: string, run: () => Promise<T>): Promise<T> {
+  // Session-level, not transaction-local: these statements do not run inside a
+  // transaction, and `is_local = true` would discard the claim before the RPC
+  // ever read it.
+  await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+    JSON.stringify({ sub: profileId, role: 'authenticated' }),
+  ]);
+  try {
+    return await run();
+  } finally {
+    await client.query(`SELECT set_config('request.jwt.claims', '', false)`);
+  }
+}
+
+interface Notice {
+  profile_id: string;
+  kind: string;
+  payload: Record<string, unknown>;
+  dedupe_key: string;
+}
+
+/** The one notice this group has, asserted to exist so the reads below are typed. */
+async function onlyNotice(groupId: string): Promise<Notice> {
+  const notices = await noticesFor(groupId);
+  expect(notices).toHaveLength(1);
+  return notices[0] as Notice;
+}
+
+async function noticesFor(groupId: string): Promise<Notice[]> {
+  const { rows } = await client.query(
+    `SELECT profile_id, kind, payload, dedupe_key
+       FROM notifications WHERE group_id = $1 ORDER BY created_at, kind`,
+    [groupId],
+  );
+  return rows as Notice[];
+}
+
+async function record(
+  group: SeededGroup,
+  actorIndex: number,
+  mutationId: string | null = randomUUID(),
+): Promise<string> {
+  return asUser(group.profileIds[actorIndex] ?? '', async () => {
+    const { rows } = await client.query(
+      `SELECT waves_record_settlement($1, $2, $3, 42000, 'upi', 'INR', NULL, '[]'::jsonb, $4, 'upi') AS id`,
+      [group.groupId, group.memberIds[0], group.memberIds[1], mutationId],
+    );
+    return String(rows[0].id);
+  });
+}
+
+describe('recording a settlement asks the payee to confirm', () => {
+  it('notifies the payee, with the facts the copy table interpolates', async () => {
+    const group = await seedGroup(client, { memberCount: 2, name: 'Goa trip' });
+    const settlementId = await record(group, 0);
+
+    const notice = await onlyNotice(group.groupId);
+    expect(notice.kind).toBe('settlement_confirm_request');
+    // The payee — member 1 — is the one asked. The payer already knows.
+    expect(notice.profile_id).toBe(group.profileIds[1]);
+    expect(notice.dedupe_key).toBe(`settle_confirm_req:${settlementId}`);
+
+    // `render.ts` reads exactly these keys and formats the amount from minor
+    // units, so an amount that arrived as a JSON number would come back as a
+    // float and BigInt would throw on it. Text, therefore.
+    expect(notice.payload.amount).toBe('42000');
+    expect(notice.payload.currency).toBe('INR');
+    expect(notice.payload.group).toBe('Goa trip');
+    expect(notice.payload.counterparty).toBeTruthy();
+    expect(notice.payload.settlementId).toBe(settlementId);
+  });
+
+  it('does not ask anybody to confirm a payment the payee recorded', async () => {
+    const group = await seedGroup(client, { memberCount: 2 });
+    // Member 1 is the payee. "They gave me the cash" is not a request for the
+    // payer to confirm anything — the money reached the person who would be
+    // doing the confirming.
+    await record(group, 1);
+
+    expect(await noticesFor(group.groupId)).toHaveLength(0);
+  });
+
+  it('does not buzz twice when the offline queue replays the same mutation', async () => {
+    const group = await seedGroup(client, { memberCount: 2 });
+    const mutationId = randomUUID();
+
+    const first = await record(group, 0, mutationId);
+    const second = await record(group, 0, mutationId);
+
+    // ADR-005: the replay returns the same settlement rather than making a new
+    // one, so there is nothing new to be told about.
+    expect(second).toBe(first);
+    expect(await noticesFor(group.groupId)).toHaveLength(1);
+  });
+
+  it('says nothing to a ghost, who has no account to say it to', async () => {
+    const group = await seedGroup(client, { memberCount: 1, ghostCount: 1 });
+    await asUser(group.profileIds[0] ?? '', async () => {
+      await client.query(
+        `SELECT waves_record_settlement($1, $2, $3, 500, 'cash', 'INR', NULL, '[]'::jsonb, $4, 'cash')`,
+        [group.groupId, group.memberIds[0], group.memberIds[1], randomUUID()],
+      );
+    });
+
+    // `waves_notify` returns NULL for a null profile rather than failing, which
+    // is what keeps settling up with a ghost from erroring.
+    expect(await noticesFor(group.groupId)).toHaveLength(0);
+  });
+});
+
+describe('every transition tells the party that did not make it', () => {
+  async function pending(): Promise<{ group: SeededGroup; settlementId: string }> {
+    const group = await seedGroup(client, { memberCount: 2, name: 'Goa trip' });
+    const settlementId = await record(group, 0);
+    // Clear the confirm request so each case below reads only its own notice.
+    await client.query(`DELETE FROM notifications WHERE group_id = $1`, [group.groupId]);
+    return { group, settlementId };
+  }
+
+  it('tells the payer when the payee confirms', async () => {
+    const { group, settlementId } = await pending();
+    await asUser(group.profileIds[1] ?? '', () =>
+      client.query(`SELECT waves_confirm_settlement($1)`, [settlementId]),
+    );
+
+    const notice = await onlyNotice(group.groupId);
+    expect(notice.kind).toBe('settlement_confirmed');
+    expect(notice.profile_id).toBe(group.profileIds[0]);
+    expect(notice.payload.group).toBe('Goa trip');
+  });
+
+  it('tells the payee when the payer withdraws the claim', async () => {
+    const { group, settlementId } = await pending();
+    await asUser(group.profileIds[0] ?? '', () =>
+      client.query(`SELECT waves_cancel_settlement($1)`, [settlementId]),
+    );
+
+    const notice = await onlyNotice(group.groupId);
+    expect(notice.kind).toBe('settlement_cancelled');
+    // The payee is the one whose pending "did you get it?" just vanished.
+    expect(notice.profile_id).toBe(group.profileIds[1]);
+  });
+
+  it('tells the payer when the payee says it never arrived', async () => {
+    const { group, settlementId } = await pending();
+    await asUser(group.profileIds[1] ?? '', () =>
+      client.query(`SELECT waves_dispute_settlement($1, 'never arrived')`, [settlementId]),
+    );
+
+    const notice = await onlyNotice(group.groupId);
+    expect(notice.kind).toBe('settlement_disputed');
+    expect(notice.profile_id).toBe(group.profileIds[0]);
+  });
+
+  it('leaves auto-confirmation to the job that already announces it', async () => {
+    const group = await seedGroup(client, { memberCount: 2 });
+    const settlementId = randomUUID();
+    await client.query(
+      `INSERT INTO settlements
+         (id, group_id, from_member_id, to_member_id, currency, amount, method, status, initiated_at)
+       VALUES ($1, $2, $3, $4, 'INR', 900, 'upi', 'initiated', now() - interval '8 days')`,
+      [settlementId, group.groupId, group.memberIds[0], group.memberIds[1]],
+    );
+
+    await client.query(`SELECT waves_auto_confirm_settlements()`);
+
+    // Two notices, both the job's own — one per party, with the wording that
+    // says a week went by. The trigger deliberately stays out of it, or there
+    // would be a third saying less.
+    const notices = await noticesFor(group.groupId);
+    expect(notices.map((n) => n.kind)).toEqual(['settlement_confirmed', 'settlement_confirmed']);
+    expect(notices.map((n) => n.dedupe_key).sort()).toEqual([
+      `auto_confirm:${settlementId}:payee`,
+      `auto_confirm:${settlementId}:payer`,
+    ]);
+  });
+
+  it('does not repeat itself when a settlement is written to without moving', async () => {
+    const { group, settlementId } = await pending();
+    await client.query(`UPDATE settlements SET note = 'a note' WHERE id = $1`, [settlementId]);
+
+    expect(await noticesFor(group.groupId)).toHaveLength(0);
+  });
+});

--- a/supabase/functions/_shared/email.ts
+++ b/supabase/functions/_shared/email.ts
@@ -337,24 +337,41 @@ export async function buildFor(row: EmailableRow): Promise<BuiltEmail | null> {
   );
 }
 
-/** The facts a mail can interpolate, taken from the row that was written. */
-function factsOf(payload: Record<string, unknown>): Record<string, string | undefined> {
+/**
+ * The facts a mail or a push can interpolate, taken from the row that was
+ * written.
+ *
+ * One copy, exported, because there were two — identical, in this file and in
+ * `notify-fanout/handler.ts` — and two whitelists that must agree is a bug
+ * waiting for somebody to add a fact to the half they happened to be reading.
+ * A mail and a push say the same sentence out of the same copy table; there was
+ * never a reason for them to disagree about which words it may contain.
+ *
+ * Every placeholder any mailed or pushed kind uses has to be named here: this
+ * is a whitelist, and a fact that is missing from it does not fail — it renders
+ * the placeholder itself, so somebody receives "New sign-in on {device}".
+ * `device` is the sign-in alert's; `name` is the ghost-claim kinds'.
+ */
+export function factsOf(payload: Record<string, unknown>): Record<string, string | undefined> {
   const text = (key: string): string | undefined =>
     typeof payload[key] === 'string' ? (payload[key] as string) : undefined;
   return {
     amount: text('amount'),
     currency: text('currency'),
     counterparty: text('counterparty'),
-    group: text('group'),
+    // `group_name` and `ghost_name` are the same two facts under the names the
+    // member-claim RPCs happen to write them by (`waves_request_member_claim`,
+    // `waves_decide_member_claim`). Without the alias all three ghost-claim
+    // kinds reach a phone reading "You are in {group}" — the copy is
+    // translated, the placeholder is never filled, and the English fallback on
+    // the row is not used because the *kind* is perfectly well known. The
+    // spelling is the producer's; the vocabulary is this function's, and this
+    // is where the two are reconciled.
+    group: text('group') ?? text('group_name'),
     description: text('description'),
     count: text('count'),
-    // Every placeholder any mailed or pushed kind uses has to be named here:
-    // this is a whitelist, and a fact that is missing from it does not fail —
-    // it renders the placeholder itself, so somebody receives
-    // "New sign-in on {device}". `device` is the sign-in alert's; `name` is the
-    // ghost-claim kinds', which push today and could be mailed tomorrow.
     device: text('device'),
-    name: text('name'),
+    name: text('name') ?? text('ghost_name'),
   };
 }
 

--- a/supabase/functions/notify-fanout/handler.test.ts
+++ b/supabase/functions/notify-fanout/handler.test.ts
@@ -17,6 +17,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { handlePushFanout, type NotifyFanoutDeps } from './handler.ts';
 import { factsOf } from '../_shared/email.ts';
+import { COPY, renderNotification } from '../_shared/core.js';
 
 const SERVICE_KEY = 'service-role-key';
 
@@ -105,6 +106,59 @@ describe('factsOf', () => {
   it('carries the sign-in alert device through', () => {
     expect(factsOf({ device: 'Pixel 9 · android' }).device).toBe('Pixel 9 · android');
   });
+
+  /**
+   * The member-claim RPCs write `group_name` and `ghost_name` where the copy
+   * table says `{group}` and `{name}`. Nothing reconciled the two, so all three
+   * ghost-claim kinds reached a phone reading "You are in {group}" — translated
+   * copy with an unfilled placeholder, and the English fallback on the row
+   * unused because the *kind* was perfectly well known.
+   */
+  it('reconciles the names the member-claim RPCs actually write', () => {
+    expect(factsOf({ group_name: 'Goa trip', ghost_name: 'Ravi' })).toMatchObject({
+      group: 'Goa trip',
+      name: 'Ravi',
+    });
+  });
+
+  it('prefers the canonical spelling when a payload carries both', () => {
+    expect(factsOf({ group: 'Goa trip', group_name: 'Something else' }).group).toBe('Goa trip');
+  });
+});
+
+/**
+ * The end-to-end vocabulary check, and the one this file exists for.
+ *
+ * Three lists have to agree for a notification to read as a sentence: what a
+ * producer puts in `payload`, what `factsOf` is willing to carry out of it, and
+ * what the copy table asks for in `{braces}`. Nothing enforced that. A fact
+ * missing from the middle list does not throw — it renders its own placeholder,
+ * so somebody receives "New sign-in on {device}". That has shipped twice.
+ *
+ * So: for every kind, in every language, hand `factsOf` a payload with every
+ * name a producer might use, render it, and insist no brace survives.
+ */
+describe('every kind renders into a sentence, in every language', () => {
+  const everyFact = {
+    amount: '42000',
+    currency: 'INR',
+    counterparty: 'Ravi',
+    group: 'Goa trip',
+    description: 'Dinner',
+    count: '3',
+    device: 'Pixel 9 · android',
+    name: 'Ravi',
+  };
+
+  for (const locale of Object.keys(COPY)) {
+    for (const kind of Object.keys(COPY[locale as keyof typeof COPY].notifications)) {
+      it(`${kind} in ${locale}`, () => {
+        const { title, body } = renderNotification(kind, factsOf(everyFact), locale);
+        expect(title, `${kind}/${locale} title`).not.toMatch(/[{}]/);
+        expect(body, `${kind}/${locale} body`).not.toMatch(/[{}]/);
+      });
+    }
+  }
 });
 
 describe('the machine-to-machine gate', () => {

--- a/supabase/functions/notify-fanout/handler.test.ts
+++ b/supabase/functions/notify-fanout/handler.test.ts
@@ -15,7 +15,8 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { factsOf, handlePushFanout, type NotifyFanoutDeps } from './handler.ts';
+import { handlePushFanout, type NotifyFanoutDeps } from './handler.ts';
+import { factsOf } from '../_shared/email.ts';
 
 const SERVICE_KEY = 'service-role-key';
 

--- a/supabase/functions/notify-fanout/handler.ts
+++ b/supabase/functions/notify-fanout/handler.ts
@@ -32,6 +32,7 @@ import {
 import { errorResponse, HttpError, json, type SupabaseClient } from '../_shared/auth.ts';
 import {
   buildFor,
+  factsOf,
   pause,
   emailSendable,
   sendEmail,
@@ -76,27 +77,6 @@ export interface NotifyFanoutDeps {
   env(name: string): string | undefined;
   fetchImpl: typeof fetch;
   dispatchEmail(service: SupabaseClient): Promise<EmailSummary>;
-}
-
-/** The facts a push can interpolate, taken from the row that was written. */
-export function factsOf(payload: Record<string, unknown>): Record<string, string | undefined> {
-  const text = (key: string): string | undefined =>
-    typeof payload[key] === 'string' ? (payload[key] as string) : undefined;
-  return {
-    amount: text('amount'),
-    currency: text('currency'),
-    counterparty: text('counterparty'),
-    group: text('group'),
-    description: text('description'),
-    count: text('count'),
-    // Every placeholder any mailed or pushed kind uses has to be named here:
-    // this is a whitelist, and a fact that is missing from it does not fail —
-    // it renders the placeholder itself, so somebody receives
-    // "New sign-in on {device}". `device` is the sign-in alert's; `name` is the
-    // ghost-claim kinds', which push today and could be mailed tomorrow.
-    device: text('device'),
-    name: text('name'),
-  };
 }
 
 export async function handlePushFanout(

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -218,7 +218,15 @@ const GROUP_TABLES = [
   // profiles is embedded by the explicit FK column: ghost_merges references
   // both group_members and profiles, so PostgREST otherwise sees two
   // group_members↔profiles relationships and refuses to guess.
-  ['group_members', '*, profile:profiles!profile_id ( id, display_name, avatar_url, default_vpa )'],
+  // The rail pair travels with the member, not only `default_vpa`: the mirror
+  // is what the settle screen reads, and a payee whose handle is a PayID or a
+  // Pix key had no handle at all here — `payableAt` looked for
+  // `payment_handle`, this pull never fetched it, and the screen said the
+  // person had given no details.
+  [
+    'group_members',
+    '*, profile:profiles!profile_id ( id, display_name, avatar_url, default_vpa, payment_rail, payment_handle )',
+  ],
   ['expenses', EXPENSE_SELECT],
   ['settlements', SETTLEMENT_SELECT],
   ['activity_log', '*'],


### PR DESCRIPTION
## What was actually wrong

M4's acceptance criterion (TDR §10) is one sentence — *"initiate UPI settle → payee push with Confirm action → balances update"* — and the middle third of it did not exist.

`waves_record_settlement` wrote a settlement, an activity row and an agent-audit row, and **nothing at all in `notifications`**. The kinds were all there: `settlement_confirm_request` sits in `waves_claim_email_notifications`'s whitelist, in the copy table in four languages, and in `TEMPLATE_FOR_KIND` — with no producer anywhere in the database. The only settlement notice that existed was the one the seven-day job writes when *nobody* answered, which is the branch you reach by never having been told.

The transitions were the same story from the other end. ADR-007 calls cancel and dispute "deliberate mirror images, one per party", and the point of them is that "neither party can silently erase the other's record". Silently is what they did: the payer cancels and the payee is never told; the payee disputes and the payer is never told.

And the preferences. The notifications screen renders four push switches under a promise reading "we will never spam you". `waves_claim_push_notifications` read `notification_prefs` **not at all**. One switch worked by accident and only halfway — `waves_trip_nudges` checks `nudges` before enqueuing, so trip reminders stopped while a nudge somebody sent by hand did not. `involvesMe`, `settlementRequests` and `groupActivityDigest` silenced nothing whatsoever.

## Migration `20260908120000_settlement_notices_and_push_prefs`

- **`waves_record_settlement` asks the payee to confirm**, deduped on the settlement id so an offline replay cannot buzz twice. Only when the *payer* is recording — a payee logging "they gave me cash" is not a request for anybody to confirm anything, and a push with no action behind it is the kind people mute.
- **A trigger on `settlements` tells the party that did not make the move**: confirmed → the payer, cancelled → the payee, disputed → the payer. On the table rather than in the three RPCs, so the offline queue and an import reach it too. `auto_confirmed` is deliberately left to the job that already announces it with wording this trigger cannot reproduce.
- **`waves_pref_key_for_kind`** maps a kind to the switch that governs it, and the push claim suppresses on it. `suppressed` rather than `failed`, and terminally — a preference is a decision, not a delivery that went wrong, and it does not lapse on a retry. `new_device_login` maps to nothing, the same carve-out the email claim already makes by name.

The check is at claim time rather than at `waves_notify` time on purpose: the row is the record that something happened, and the email half may still want it — an unpushed nudge is precisely the one that gets mailed (TDR §7.4).

## Two sources of truth, closed

- **`payableFor` in `@waves/core`** is now the one answer to "how is this person paid". Mobile had it; web had a different and wrong one (`vpa ?? default_vpa` alone, so a payee on any rail but UPI looked like somebody who had given no details); agent-mcp had a third. It resolves the rail and the handle **together** — the two independent `??` chains it replaces could pair one source's rail with another's handle and build a UPI intent around an Australian phone number.
- **The rail pair now survives the wire.** `sync`, `@waves/api-client` and `fetchMembersByGroup` embedded only `default_vpa` on the member's profile, so `payment_handle` was written by the Paying screen and never read by anything downstream. Every member list and both settle screens read the pair now.
- **Web settings writes `payment_rail`** beside `payment_handle` — it had no rail picker at all, so every handle saved from a browser was unusable on both clients. The mobile settle sheet seeds its picker from the payee's stored rail rather than the group's country; the link was already built from the payee, so the button could read "Pay via Pix" over a UPI intent.
- **`NotificationPrefs`** lived in two TypeScript files that had drifted from the SQL. It moves to `@waves/core`. That drift had swallowed a whole switch: `waves_claim_email_notifications` has read an `email` key since M4 and suppressed every mail when false, and neither client could set it. Both can now, in en/ta/hi/ar.
- **`factsOf`** was two identical copies of a whitelist that must agree. One now — and it maps `group_name`/`ghost_name`, the names the member-claim RPCs actually write, so the three ghost-claim kinds stop arriving on a phone as literal "You are in {group}".

## Tests

- `packages/db/test/m4-settlement-notices.test.ts` — who is told, and as much, who is deliberately not: a payee-recorded settlement asks nobody, a replayed mutation does not buzz twice, a ghost is skipped, `auto_confirmed` stays the job's.
- `packages/db/test/m4-push-prefs.test.ts` — each switch covers the kinds it claims, one switch cannot silence another's, a security notice ignores all four, an untouched preference means yes, and a suppressed push leaves the email half free.
- `payableFor` cases in `packages/core/test/rails.test.ts`.

## Gates

`pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm format:check` ✅ · `pnpm test:core` 927 ✅ · `pnpm test:edge` 157 ✅ · mobile 971 ✅ · web 33 ✅ · api-client 12 ✅ · agent-mcp 25 ✅ · `pnpm test:db` 766 ✅ (twice, against a database rebuilt from every migration via `prisma migrate deploy` — the migration applies cleanly to an empty Postgres, and `db:drift` reports no difference) · `check-definer-grants` ✅

## Not deployed

The migration is written and tested, not applied. Push still cannot reach a device and mail still cannot be ingested — both for console reasons listed separately for the repo owner, not code ones.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Payment profiles now support multiple payment rails and handles, including group-specific details and legacy fallback support.
  * Settlement flows select the payee’s available payment method and prevent mismatched payment links.
  * Added email notification preferences, weekly digest controls, and localized settings labels.
  * Added settlement notifications for confirmations, cancellations, and disputes.
* **Bug Fixes**
  * Member lists, balances, settings, and synchronization now display payment details more reliably.
  * Notification preferences correctly suppress selected push alerts while preserving security notices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->