### PR TITLE
The receipt stays on screen after it uploads, and has something to show before it arrives

### DIFF
--- a/apps/mobile/src/components/ExpenseReceipts.tsx
+++ b/apps/mobile/src/components/ExpenseReceipts.tsx
@@ -58,6 +58,7 @@ import { imageUrl, restrictedImageUrl } from '@/lib/storage';
 import { cacheImage, cachedImageUri, evictImage } from '@/lib/storage/imageCache';
 import {
   discardPendingReceipt,
+  dropSettledReceipts,
   enqueueReceipt,
   flushReceiptQueue,
   pendingReceiptUri,
@@ -80,6 +81,31 @@ type GalleryItem =
   | { kind: 'pending'; key: string; entry: PendingReceiptView };
 
 /**
+ * The file an item can be drawn from *right now*, with nothing awaited: a
+ * capture the queue is still carrying is its own local file, and a bill seen
+ * before is on disk under its stable path (ADR-005). Null when only a
+ * short-lived signed URL will do.
+ *
+ * Cheap enough to ask on every render — it is a stat — which is the point:
+ * answering during render rather than from an effect is what stops an image the
+ * device already holds from showing a spinner for a frame first.
+ */
+function localUri(it: GalleryItem): string | null {
+  if (it.kind === 'pending') return pendingReceiptUri(it.entry);
+  const bucket = it.kind === 'legacy' ? 'receipts' : 'expense-attachments';
+  const path = it.kind === 'legacy' ? it.path : it.row.storagePath;
+  return cachedImageUri(bucket, path);
+}
+
+/** The tiny stored stand-in for an item's image, when it has one. */
+function previewOf(it: GalleryItem): string | null {
+  if (it.kind === 'attachment') return it.row.preview;
+  if (it.kind === 'pending') return it.entry.preview ?? null;
+  // The legacy bill predates the column; there is nothing to have kept.
+  return null;
+}
+
+/**
  * Resolve every item to a displayable URL, each through its own backend (the
  * legacy bill is group-readable in the `receipts` bucket; an attachment is
  * signed by subject in the restricted bucket). Keyed by item so a resolved URL
@@ -97,29 +123,16 @@ function useResolvedUrls(
     void (async () => {
       for (const it of items) {
         if (urls[it.key] !== undefined) continue;
-
-        // A still-unsent capture is already a local file — show it straight from
-        // there, no network and no cache round-trip.
-        if (it.kind === 'pending') {
-          if (!active) return;
-          setUrls((prev) => ({ ...prev, [it.key]: pendingReceiptUri(it.entry) }));
-          continue;
-        }
+        // Already answerable from disk, and the render below has been drawing it
+        // since the item appeared. Nothing to mint.
+        if (localUri(it) !== null) continue;
+        if (it.kind === 'pending') continue;
 
         const bucket = it.kind === 'legacy' ? 'receipts' : 'expense-attachments';
         const path = it.kind === 'legacy' ? it.path : it.row.storagePath;
 
-        // A bill seen before is on disk under its stable path — show it straight
-        // away, so an already-opened receipt renders with no network (ADR-005).
-        const cached = cachedImageUri(bucket, path);
-        if (cached) {
-          if (!active) return;
-          setUrls((prev) => ({ ...prev, [it.key]: cached }));
-          continue;
-        }
-
         // Not cached: resolve the short-lived signed URL. Offline this is null
-        // and the tile stays a blank placeholder, exactly as before.
+        // and the tile falls back to its stored preview, or to a blank tile.
         const url =
           it.kind === 'legacy'
             ? await imageUrl('receipts', path)
@@ -139,11 +152,17 @@ function useResolvedUrls(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [expenseId, keys]);
   // `undefined` = still resolving, `null` = resolved to nothing, string = URL.
-  return items.map((it) => urls[it.key]);
+  // A resolved null stands: it means the mint came back empty (offline, or a
+  // refused signature), which the tile reports rather than spinning forever.
+  return items.map((it) => {
+    const resolved = urls[it.key];
+    return resolved !== undefined ? resolved : (localUri(it) ?? undefined);
+  });
 }
 
 function Thumb({
   url,
+  preview,
   resolved,
   isPrivate,
   status,
@@ -151,6 +170,12 @@ function Thumb({
   label,
 }: {
   url: string | null;
+  /**
+   * The tiny stored stand-in, drawn under the real image and cross-faded out
+   * when it arrives. Decoration only — it lives inside the same `Image`, so a
+   * screen reader is never told there are two pictures here.
+   */
+  preview: string | null;
   resolved: boolean;
   isPrivate: boolean;
   /**
@@ -177,8 +202,18 @@ function Thumb({
         backgroundColor: theme.color.surfaceMuted,
       }}
     >
-      {url ? (
-        <Image source={{ uri: url }} style={{ width: '100%', height: '100%' }} contentFit="cover" />
+      {url || preview ? (
+        <Image
+          source={url ? { uri: url } : null}
+          // Held under the real image until it decodes, so the tile is never a
+          // grey hole: on a cold view this is the bill's colours a whole network
+          // round trip before the bill itself.
+          placeholder={preview ? { uri: preview } : undefined}
+          placeholderContentFit="cover"
+          style={{ width: '100%', height: '100%' }}
+          contentFit="cover"
+          transition={180}
+        />
       ) : (
         <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
           {resolved ? (
@@ -202,7 +237,7 @@ function Thumb({
           <Ionicons name="lock-closed" size={12} color={theme.color.text} />
         </View>
       ) : null}
-      {status ? (
+      {status && status !== 'sent' ? (
         // A soft scrim over the image, with the state drawn on top of it: a
         // spinner while the bytes are in the air, a cloud glyph while they wait
         // for a connection, and a filled red disc when the send failed. The
@@ -386,25 +421,45 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [status]);
 
+    // The handover, completed.
+    //
+    // A capture the queue has finished uploading stays in it, still drawing the
+    // picture, precisely until the row it became arrives from the sync — that is
+    // what stopped the strip going blank for the length of a pull. This is the
+    // other half: once both exist, the entry is a duplicate of the row and goes.
+    useEffect(() => {
+      const landed = pending
+        .filter((entry) => entry.status === 'sent')
+        .filter((entry) => attachments.data.some((row) => row.id === entry.attachmentId))
+        .map((entry) => entry.attachmentId);
+      if (landed.length > 0) void dropSettledReceipts(landed);
+    }, [pending, attachments.data]);
+
     const items = useMemo<GalleryItem[]>(() => {
       const list: GalleryItem[] = [];
       if (legacyReceiptPath) {
         list.push({ kind: 'legacy', key: 'legacy', path: legacyReceiptPath, visibility: 'group' });
+      }
+      // Captures the queue is still carrying come first, newest first — the same
+      // order the attachment rows below are in, and the same place the row will
+      // occupy when it arrives. They used to be appended after them, so the tile
+      // somebody had just taken jumped from the end of the strip to the front the
+      // moment the sync caught up.
+      //
+      // A parked capture is shown only until its real row lands: once the upload
+      // has been pulled into the mirror the entry shares that row's id, so it is
+      // dropped here to avoid two tiles for one receipt.
+      const uploaded = new Set(attachments.data.map((row) => row.id));
+      for (const entry of [...pending].reverse()) {
+        if (!uploaded.has(entry.attachmentId)) {
+          list.push({ kind: 'pending', key: `pending-${entry.attachmentId}`, entry });
+        }
       }
       for (const row of attachments.data) {
         // Just deleted, and the mirror has not caught up yet. Hiding it here
         // rather than waiting is what makes the tap feel like it did something.
         if (removedIds.includes(row.id)) continue;
         list.push({ kind: 'attachment', key: row.id, row });
-      }
-      // Show a parked capture only until its real row lands — once the upload has
-      // been pulled into the mirror, the entry shares that row's id, so drop it
-      // here to avoid a duplicate tile for the same receipt.
-      const uploaded = new Set(attachments.data.map((row) => row.id));
-      for (const entry of pending) {
-        if (!uploaded.has(entry.attachmentId)) {
-          list.push({ kind: 'pending', key: `pending-${entry.attachmentId}`, entry });
-        }
       }
       return list;
     }, [legacyReceiptPath, attachments.data, pending, removedIds]);
@@ -427,6 +482,7 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
       () =>
         items.map((it, i) => ({
           url: urls[i] ?? null,
+          preview: previewOf(it),
           annotations: it.kind === 'attachment' ? (it.row.annotations ?? undefined) : undefined,
         })),
       [items, urls],
@@ -463,6 +519,7 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
             visibility,
             sourceUri: file.uri,
             contentType: file.mimeType,
+            preview: file.preview,
           });
         } catch {
           // The bytes never reached the disk (a full device, a revoked path), so
@@ -531,7 +588,25 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
           onPress: () => {
             setViewerIndex(null);
             const onError = () => Alert.alert(t.imageAudit.couldNotRemove);
-            if (it.kind === 'pending') {
+            if (it.kind === 'pending' && it.entry.sentAt) {
+              // Settled: the server already has this one, it is only still in the
+              // queue because its row has not come back down the sync. Removing
+              // it is therefore a real removal — dropping the local entry alone
+              // would leave the attachment on the server with nothing showing it.
+              const attachmentId = it.entry.attachmentId;
+              const storagePath = it.entry.storagePath;
+              removeAttachment.mutate(
+                { attachmentId, storagePath },
+                {
+                  onError,
+                  onSuccess: () => {
+                    evictImage('expense-attachments', storagePath);
+                    void dropSettledReceipts([attachmentId]);
+                    refreshCap();
+                  },
+                },
+              );
+            } else if (it.kind === 'pending') {
               // Not uploaded yet: just drop the parked capture and its local bytes.
               void discardPendingReceipt(it.entry.attachmentId);
             } else if (it.kind === 'legacy') {
@@ -575,7 +650,11 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
     // What the strip as a whole is doing, for the line under it. Sending wins
     // over failed, and failed over waiting: the line reports the most active
     // thing happening, and the per-tile badges say which capture is which.
-    const unsent = items.flatMap((it) => (it.kind === 'pending' ? [it.entry] : []));
+    // Only the ones still owed to the server: a settled entry is sitting here
+    // waiting for its row, and reporting it as unsent would be a lie.
+    const unsent = items.flatMap((it) =>
+      it.kind === 'pending' && it.entry.status !== 'sent' ? [it.entry] : [],
+    );
     const failedIds = unsent
       .filter((entry) => entry.status === 'failed')
       .map((entry) => entry.attachmentId);
@@ -596,6 +675,11 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
         : state === 'failed'
           ? t.receipts.notSent
           : t.receipts.waitingToSend;
+
+    /** A settled capture is an ordinary receipt as far as the strip is concerned
+     *  — no badge, no scrim, nothing to say about it. */
+    const badgeStatus = (it: GalleryItem): PendingReceiptStatus | undefined =>
+      it.kind === 'pending' && it.entry.status !== 'sent' ? it.entry.status : undefined;
 
     // A capture that did not go up: say what that means and offer the two things
     // worth doing about it. Removing here does not go through `removeAt`'s
@@ -731,6 +815,7 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
             {preparing !== null ? (
               <Thumb
                 url={preparing}
+                preview={null}
                 resolved
                 isPrivate={false}
                 status="uploading"
@@ -743,14 +828,17 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
               <Thumb
                 key={it.key}
                 url={urls[index] ?? null}
+                preview={previewOf(it)}
                 resolved={urls[index] !== undefined}
                 isPrivate={isPrivate(it)}
-                status={it.kind === 'pending' ? it.entry.status : undefined}
+                status={badgeStatus(it)}
                 label={[
                   isPrivate(it)
                     ? `${t.receipts.title} — ${t.receipts.privateTag}`
                     : t.receipts.title,
-                  it.kind === 'pending' ? statusWord(it.entry.status) : null,
+                  it.kind === 'pending' && it.entry.status !== 'sent'
+                    ? statusWord(it.entry.status)
+                    : null,
                 ]
                   .filter(Boolean)
                   .join(' — ')}

--- a/apps/mobile/src/components/ExpenseReceipts.tsx
+++ b/apps/mobile/src/components/ExpenseReceipts.tsx
@@ -63,7 +63,9 @@ import {
   flushReceiptQueue,
   pendingReceiptUri,
   retryPendingReceipts,
+  settledPast,
   usePendingReceipts,
+  SETTLED_MAX_AGE_MS,
   type FlushResult,
   type PendingReceiptStatus,
   type PendingReceiptView,
@@ -427,12 +429,20 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
     // picture, precisely until the row it became arrives from the sync — that is
     // what stopped the strip going blank for the length of a pull. This is the
     // other half: once both exist, the entry is a duplicate of the row and goes.
+    //
+    // The queue's own sweep for the row that never comes runs when something
+    // reads or flushes it, and a gallery left open on screen does neither — so
+    // an entry past its welcome is let go from here too.
     useEffect(() => {
-      const landed = pending
+      const done = pending
         .filter((entry) => entry.status === 'sent')
-        .filter((entry) => attachments.data.some((row) => row.id === entry.attachmentId))
+        .filter(
+          (entry) =>
+            attachments.data.some((row) => row.id === entry.attachmentId) ||
+            settledPast(entry, SETTLED_MAX_AGE_MS),
+        )
         .map((entry) => entry.attachmentId);
-      if (landed.length > 0) void dropSettledReceipts(landed);
+      if (done.length > 0) void dropSettledReceipts(done);
     }, [pending, attachments.data]);
 
     const items = useMemo<GalleryItem[]>(() => {
@@ -451,6 +461,10 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
       // dropped here to avoid two tiles for one receipt.
       const uploaded = new Set(attachments.data.map((row) => row.id));
       for (const entry of [...pending].reverse()) {
+        // Never draw what the sweep would already have removed: an upload whose
+        // row has not arrived in an hour is no longer news, and the effect above
+        // is letting go of it.
+        if (settledPast(entry, SETTLED_MAX_AGE_MS)) continue;
         if (!uploaded.has(entry.attachmentId)) {
           list.push({ kind: 'pending', key: `pending-${entry.attachmentId}`, entry });
         }

--- a/apps/mobile/src/components/ZoomableGallery.tsx
+++ b/apps/mobile/src/components/ZoomableGallery.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from 'react';
+import { Image } from 'expo-image';
 import { FlatList, useWindowDimensions, View, type ListRenderItemInfo } from 'react-native';
 
 import { ZoomableImage } from '@/components/ZoomableImage';
@@ -7,6 +8,12 @@ import type { Annotations } from '@/lib/annotations';
 /** One gallery page: its resolved URL (null while resolving) and any markup. */
 export interface GalleryPage {
   url: string | null;
+  /**
+   * A tiny stored stand-in for the image, shown while the real bytes are being
+   * signed for and fetched. Decoration; null for a receipt kept before there
+   * was such a thing.
+   */
+  preview?: string | null;
   annotations?: Annotations;
 }
 
@@ -44,8 +51,20 @@ export function ZoomableGallery({
       {item.url ? (
         <ZoomableImage
           uri={item.url}
+          preview={item.preview}
           onZoomChange={(next) => setZoomState({ url: item.url, zoomed: next })}
           annotations={item.annotations}
+        />
+      ) : item.preview ? (
+        // Nothing to zoom yet — the URL is still being minted — but a blurred
+        // wash of the bill beats a black screen, and it is the same picture the
+        // real image will fade in over.
+        <Image
+          source={null}
+          placeholder={{ uri: item.preview }}
+          placeholderContentFit="contain"
+          style={{ width, height: '100%' }}
+          contentFit="contain"
         />
       ) : null}
     </View>

--- a/apps/mobile/src/components/ZoomableImage.tsx
+++ b/apps/mobile/src/components/ZoomableImage.tsx
@@ -28,10 +28,19 @@ const AnimatedImage = Animated.createAnimatedComponent(Image);
  */
 export function ZoomableImage({
   uri,
+  preview,
   onZoomChange,
   annotations,
 }: {
   uri: string;
+  /**
+   * A tiny stored stand-in, drawn inside the same `Image` until the real bytes
+   * decode and then cross-faded out. It is the difference between a black
+   * screen and the bill's shape while a signed URL is fetched over a slow
+   * connection — and being the placeholder of one image rather than a second
+   * image, nothing announces it twice.
+   */
+  preview?: string | null;
   /** Fires when the image crosses between fit (1×) and zoomed (>1×). A pager uses
    *  it to stop swiping between pages while a page is zoomed in. */
   onZoomChange?: (zoomed: boolean) => void;
@@ -210,6 +219,8 @@ export function ZoomableImage({
         <Animated.View style={{ flex: 1, justifyContent: 'center' }} collapsable={false}>
           <AnimatedImage
             source={{ uri }}
+            placeholder={preview ? { uri: preview } : undefined}
+            placeholderContentFit="contain"
             style={[{ width, height: boxHeight }, animatedStyle]}
             contentFit="contain"
             transition={150}
@@ -228,6 +239,8 @@ export function ZoomableImage({
         <Animated.View style={[{ width: rect.w, height: rect.h }, animatedStyle]}>
           <Image
             source={{ uri }}
+            placeholder={preview ? { uri: preview } : undefined}
+            placeholderContentFit="contain"
             style={{ width: rect.w, height: rect.h }}
             contentFit="contain"
             transition={150}

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -1987,6 +1987,12 @@ export interface ExpenseAttachmentRow {
   uploaderMemberId: string;
   /** Parsed pen/text markup over the image, or null when unmarked. */
   annotations: Annotations | null;
+  /**
+   * A tiny `data:` URI of the image, stored on the row so this device can draw
+   * something the instant the row is read — before the signed URL exists, let
+   * alone the bytes. Null for anything kept before the column existed.
+   */
+  preview: string | null;
   createdAt: string | null;
 }
 
@@ -2005,6 +2011,7 @@ export function useExpenseAttachments(expenseId: string): LocalRead<ExpenseAttac
         visibility: row.visibility === 'parties' ? 'parties' : 'group',
         uploaderMemberId: row.uploader_member_id,
         annotations: row.annotations == null ? null : parseAnnotations(row.annotations),
+        preview: row.preview ?? null,
         createdAt: row.created_at,
       })),
     [mirror, expenseId],
@@ -2073,6 +2080,9 @@ export function useReplaceExpenseAttachmentImage(groupId: string, expenseId: str
         const { error } = await backend.rpc('waves_replace_expense_attachment_image', {
           p_attachment_id: input.attachmentId,
           p_new_path: path,
+          // New pixels, so a new stand-in: keeping the old one would flash the
+          // previous framing every time this image loaded cold.
+          p_preview: input.picked.preview ?? null,
         });
         if (error) throw new Error(error.message);
         committed = null;

--- a/apps/mobile/src/lib/image.ts
+++ b/apps/mobile/src/lib/image.ts
@@ -578,8 +578,13 @@ export async function prepareReceipt(
   return {
     uri: asset.uri,
     mimeType: asset.mimeType ?? 'image/jpeg',
-    // No manipulator ran, so there is nothing to make a thumbnail with either.
-    preview: null,
+    // Still worth asking. This branch is reached either because there is no
+    // manipulator — in which case this returns null for free, without touching
+    // the file — or because the source did not report its dimensions, which is
+    // not the same as their being unknowable: the picker can omit them for a
+    // file `Image.getSize` reads perfectly well. It cannot throw, and a null is
+    // exactly the "no preview" this used to hard-code.
+    preview: await previewDataUri(asset.uri),
   };
 }
 

--- a/apps/mobile/src/lib/image.ts
+++ b/apps/mobile/src/lib/image.ts
@@ -73,6 +73,11 @@ export interface PickedImage {
   mimeType: string;
   /** Local URI, so the choice is visible before it has been uploaded. */
   uri: string;
+  /**
+   * A ~32px `data:` URI of the same picture — see {@link previewDataUri}. Null
+   * where the manipulator could not produce one; the caller then stores none.
+   */
+  preview?: string | null;
 }
 
 /** Longest edge, in pixels, after downscaling. */
@@ -184,6 +189,58 @@ async function shrinkWithBytes(
   if (!result) return null;
   if (result.base64 === null) throw new Error('Could not read that image.');
   return { base64: result.base64, uri: result.uri, mimeType: result.mimeType };
+}
+
+/**
+ * Longest edge of the stand-in thumbnail kept beside a receipt.
+ *
+ * Thirty-two pixels is not a small picture of the bill; it is the bill's
+ * colours and its rough shape, which is all a placeholder is for. It also has
+ * to stay inside the 4 KB the column allows, and that ceiling — not the looks —
+ * is what fixes the number: at 32px a JPEG lands near a kilobyte, at 64 it is
+ * three or four and the thing has stopped being cheaper than the request it
+ * covers for.
+ */
+export const PREVIEW_MAX_EDGE = 32;
+
+/** The DB drops anything longer, so there is no point sending it. */
+const PREVIEW_MAX_CHARS = 4096;
+
+/**
+ * A tiny stand-in for an image, as a `data:` URI, to draw while the real bytes
+ * are still being signed for and fetched (the LQIP pattern).
+ *
+ * Deliberately JPEG rather than the WebP the full image prefers: at this size
+ * the two are within a few hundred bytes of each other, and WebP encoding is
+ * the one step that is known to throw on some iOS versions. A placeholder that
+ * fails to encode is worth less than a slightly larger one that never does.
+ *
+ * Returns null on any failure — no manipulator, an unreadable file, a string
+ * that came out too long. Every caller treats that as "this receipt has no
+ * preview", which is what every receipt stored before this existed has.
+ */
+export async function previewDataUri(
+  uri: string,
+  size?: { width: number; height: number },
+): Promise<string | null> {
+  const module = await loadManipulator();
+  if (!module) return null;
+  try {
+    const source = size && size.width > 0 && size.height > 0 ? size : await imageSize(uri);
+    if (!source || source.width <= 0 || source.height <= 0) return null;
+    const context = module.ImageManipulator.manipulate(uri);
+    context.resize(
+      source.width >= source.height ? { width: PREVIEW_MAX_EDGE } : { height: PREVIEW_MAX_EDGE },
+    );
+    const saved = await (
+      await context.renderAsync()
+    ).saveAsync({ base64: true, compress: 0.5, format: module.SaveFormat.JPEG });
+    if (!saved.base64) return null;
+    const data = `data:image/jpeg;base64,${saved.base64}`;
+    return data.length <= PREVIEW_MAX_CHARS ? data : null;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -495,7 +552,7 @@ export async function captureReceiptAsset(): Promise<PickedAsset | null> {
  */
 export async function prepareReceipt(
   asset: PickedAsset,
-): Promise<{ uri: string; mimeType: string }> {
+): Promise<{ uri: string; mimeType: string; preview: string | null }> {
   const shrunk =
     asset.width > 0 && asset.height > 0
       ? await shrink({
@@ -507,10 +564,23 @@ export async function prepareReceipt(
           base64: false,
         })
       : null;
-  if (shrunk) return { uri: shrunk.uri, mimeType: shrunk.mimeType };
+  // The placeholder is cut from the resized file, not the original: same
+  // picture, a fraction of the pixels to decode a second time.
+  if (shrunk) {
+    return {
+      uri: shrunk.uri,
+      mimeType: shrunk.mimeType,
+      preview: await previewDataUri(shrunk.uri),
+    };
+  }
   // Untouched bytes, so they keep whatever they already were. JPEG is the guess
   // of last resort, for a source that reported nothing.
-  return { uri: asset.uri, mimeType: asset.mimeType ?? 'image/jpeg' };
+  return {
+    uri: asset.uri,
+    mimeType: asset.mimeType ?? 'image/jpeg',
+    // No manipulator ran, so there is nothing to make a thumbnail with either.
+    preview: null,
+  };
 }
 
 /**
@@ -543,7 +613,17 @@ export async function transformReceipt(
   if (webp) {
     try {
       const saved = await (await render()).saveAsync({ base64: true, compress: 0.9, format: webp });
-      if (saved.base64) return { base64: saved.base64, uri: saved.uri, mimeType: 'image/webp' };
+      if (saved.base64) {
+        return {
+          base64: saved.base64,
+          uri: saved.uri,
+          mimeType: 'image/webp',
+          // These are new pixels — a rotation, a crop — so the old placeholder
+          // would flash the previous framing. Cut a fresh one from what was
+          // actually saved.
+          preview: await previewDataUri(saved.uri),
+        };
+      }
     } catch {
       // iOS without a WebP encoder — fall through to JPEG.
     }
@@ -557,7 +637,12 @@ export async function transformReceipt(
     format: module.SaveFormat.JPEG,
   });
   if (!saved.base64) throw new Error('Could not read that image.');
-  return { base64: saved.base64, uri: saved.uri, mimeType: 'image/jpeg' };
+  return {
+    base64: saved.base64,
+    uri: saved.uri,
+    mimeType: 'image/jpeg',
+    preview: await previewDataUri(saved.uri),
+  };
 }
 
 function imageSize(uri: string): Promise<{ width: number; height: number } | null> {

--- a/apps/mobile/src/lib/receiptQueue.ts
+++ b/apps/mobile/src/lib/receiptQueue.ts
@@ -272,6 +272,36 @@ async function writeQueue(queue: readonly PendingReceipt[]): Promise<void> {
   publish(queue);
 }
 
+/**
+ * One queue at a time.
+ *
+ * Every mutation here is read-modify-write over a single AsyncStorage key, and
+ * both halves are asynchronous. Two that overlap both read the same index and
+ * the second write silently discards the first one's change — which for the
+ * pair that actually collides is a lost receipt: somebody taps add, the resize
+ * runs for a second, and while it does a flush or the gallery's own handover
+ * writes back a queue that never saw the new entry. Its bytes are then sitting
+ * under the pending dir with nothing pointing at them, and the next orphan
+ * sweep deletes the photograph.
+ *
+ * So each mutation takes a turn. The chain is per-module, not per-key, because
+ * there is one key; the failure handlers keep it alive, since a single
+ * rejection propagated down the chain would wedge every write after it. Nothing
+ * inside a turn takes another one — uploads and the flush's network work
+ * deliberately sit outside, so a slow send never blocks somebody adding a
+ * receipt.
+ */
+let queueTurn: Promise<void> = Promise.resolve();
+
+function inTurn<T>(run: () => Promise<T>): Promise<T> {
+  const result = queueTurn.then(run);
+  queueTurn = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
+}
+
 function cleanupOrphanFiles(queue: readonly PendingReceipt[]): void {
   try {
     const dir = new Directory(Paths.document, PENDING_DIR);
@@ -336,21 +366,39 @@ export async function isOnline(): Promise<boolean> {
  * receipt that may since have been removed from another device.
  */
 async function reapSettled(queue: readonly PendingReceipt[]): Promise<PendingReceipt[]> {
-  const now = Date.now();
-  const kept = queue.filter((entry) => {
-    if (!entry.sentAt) return true;
-    const at = Date.parse(entry.sentAt);
-    return !Number.isNaN(at) && now - at < SETTLED_TTL_MS;
-  });
+  const kept = queue.filter((entry) => !settledPast(entry, SETTLED_TTL_MS));
   if (kept.length === queue.length) return [...queue];
   await writeQueue(kept);
   return kept;
 }
 
+/**
+ * Whether a capture finished uploading longer ago than `age`.
+ *
+ * Exported because the sweep below only runs when something reads or flushes
+ * the queue, and a gallery left open does neither — so the gallery applies the
+ * same rule to what it draws (see `ExpenseReceipts`). One definition, asked in
+ * two places, rather than two that can drift.
+ */
+export function settledPast(entry: Pick<PendingReceipt, 'sentAt'>, age: number): boolean {
+  if (!entry.sentAt) return false;
+  const at = Date.parse(entry.sentAt);
+  return Number.isNaN(at) || Date.now() - at >= age;
+}
+
+/** How long a settled capture may be drawn while its row is still on its way. */
+export const SETTLED_MAX_AGE_MS = SETTLED_TTL_MS;
+
 /** Every pending capture, or those for one expense, oldest first. */
 export async function listPendingReceipts(expenseId?: string): Promise<PendingReceipt[]> {
-  const queue = await reapSettled(await readQueue());
-  cleanupOrphanFiles(queue);
+  const queue = await inTurn(async () => {
+    const kept = await reapSettled(await readQueue());
+    // Inside the turn: an enqueue writes its bytes and its entry in one, so a
+    // sweep that runs between those two would delete a receipt somebody just
+    // added.
+    cleanupOrphanFiles(kept);
+    return kept;
+  });
   return expenseId ? queue.filter((entry) => entry.expenseId === expenseId) : queue;
 }
 
@@ -366,46 +414,50 @@ export async function listPendingReceipts(expenseId?: string): Promise<PendingRe
 export async function dropSettledReceipts(attachmentIds: readonly string[]): Promise<void> {
   if (attachmentIds.length === 0) return;
   const wanted = new Set(attachmentIds);
-  const queue = await readQueue();
-  const kept = queue.filter((entry) => !(entry.sentAt && wanted.has(entry.attachmentId)));
-  if (kept.length === queue.length) return;
-  // The bytes normally moved into the view cache when the upload landed; delete
-  // whatever is left over for the case where that write failed.
-  for (const entry of queue) {
-    if (kept.includes(entry)) continue;
-    try {
-      const file = pendingFile(entry);
-      if (file.exists) file.delete();
-    } catch {
-      // Best-effort; a lingering file is reclaimed with the app's document dir.
+  await inTurn(async () => {
+    const queue = await readQueue();
+    const kept = queue.filter((entry) => !(entry.sentAt && wanted.has(entry.attachmentId)));
+    if (kept.length === queue.length) return;
+    // The bytes normally moved into the view cache when the upload landed; delete
+    // whatever is left over for the case where that write failed.
+    for (const entry of queue) {
+      if (kept.includes(entry)) continue;
+      try {
+        const file = pendingFile(entry);
+        if (file.exists) file.delete();
+      } catch {
+        // Best-effort; a lingering file is reclaimed with the app's document dir.
+      }
     }
-  }
-  await writeQueue(kept);
+    await writeQueue(kept);
+  });
 }
 
 /** Sign-out/privacy cleanup: drop the queue index and every pending capture byte file. */
 export async function clearReceiptQueue(): Promise<void> {
-  const queue = await readQueue();
-  for (const entry of queue) {
-    try {
-      const file = pendingFile(entry);
-      if (file.exists) file.delete();
-    } catch {
-      // Best-effort cleanup; keep deleting the rest.
+  await inTurn(async () => {
+    const queue = await readQueue();
+    for (const entry of queue) {
+      try {
+        const file = pendingFile(entry);
+        if (file.exists) file.delete();
+      } catch {
+        // Best-effort cleanup; keep deleting the rest.
+      }
     }
-  }
 
-  try {
-    const dir = new Directory(Paths.document, PENDING_DIR);
-    if (dir.exists) dir.delete();
-  } catch {
-    // Some file-system implementations cannot delete non-empty dirs; queued files
-    // above were already attempted, and the index removal below is the source of truth.
-  }
+    try {
+      const dir = new Directory(Paths.document, PENDING_DIR);
+      if (dir.exists) dir.delete();
+    } catch {
+      // Some file-system implementations cannot delete non-empty dirs; queued files
+      // above were already attempted, and the index removal below is the source of truth.
+    }
 
-  await AsyncStorage.removeItem(QUEUE_KEY);
-  uploading.clear();
-  publish([]);
+    await AsyncStorage.removeItem(QUEUE_KEY);
+    uploading.clear();
+    publish([]);
+  });
 }
 
 /**
@@ -453,36 +505,45 @@ export async function enqueueReceipt(input: {
     sentAt: null,
   };
 
-  const dir = new Directory(Paths.document, PENDING_DIR);
-  if (!dir.exists) dir.create({ intermediates: true });
-  if (input.sourceUri) {
-    // Copied, not moved: the source is the manipulator's own output in the cache
-    // directory, and the caller may still be showing it as the tile's image.
-    await new File(input.sourceUri).copy(pendingFile(entry));
-  } else if (input.base64) {
-    pendingFile(entry).write(new Uint8Array(decode(input.base64)));
-  } else {
+  if (!input.sourceUri && !input.base64) {
     throw new Error('enqueueReceipt needs either sourceUri or base64.');
   }
 
-  const queue = await readQueue();
-  await writeQueue([...queue, entry]);
+  // The bytes and the entry that names them go down together, in one turn.
+  // Split across turns, the file exists for a moment with nothing in the index
+  // pointing at it — and the orphan sweep in `listPendingReceipts` is entitled
+  // to delete exactly that.
+  await inTurn(async () => {
+    const dir = new Directory(Paths.document, PENDING_DIR);
+    if (!dir.exists) dir.create({ intermediates: true });
+    if (input.sourceUri) {
+      // Copied, not moved: the source is the manipulator's own output in the cache
+      // directory, and the caller may still be showing it as the tile's image.
+      await new File(input.sourceUri).copy(pendingFile(entry));
+    } else if (input.base64) {
+      pendingFile(entry).write(new Uint8Array(decode(input.base64)));
+    }
+    const queue = await readQueue();
+    await writeQueue([...queue, entry]);
+  });
   return entry;
 }
 
 /** Drop a pending capture the user chose not to keep, deleting its bytes too. */
 export async function discardPendingReceipt(attachmentId: string): Promise<void> {
-  const queue = await readQueue();
-  const entry = queue.find((item) => item.attachmentId === attachmentId);
-  if (entry) {
-    try {
-      const file = pendingFile(entry);
-      if (file.exists) file.delete();
-    } catch {
-      // Already gone — nothing to clean up.
+  await inTurn(async () => {
+    const queue = await readQueue();
+    const entry = queue.find((item) => item.attachmentId === attachmentId);
+    if (entry) {
+      try {
+        const file = pendingFile(entry);
+        if (file.exists) file.delete();
+      } catch {
+        // Already gone — nothing to clean up.
+      }
     }
-  }
-  await writeQueue(queue.filter((item) => item.attachmentId !== attachmentId));
+    await writeQueue(queue.filter((item) => item.attachmentId !== attachmentId));
+  });
 }
 
 /**
@@ -503,14 +564,18 @@ export async function discardPendingReceipt(attachmentId: string): Promise<void>
 export async function retryPendingReceipts(attachmentIds: readonly string[]): Promise<FlushResult> {
   if (attachmentIds.length === 0) return EMPTY_FLUSH;
   const wanted = new Set(attachmentIds);
-  const queue = await readQueue();
-  await writeQueue(
-    queue.map((entry) =>
-      wanted.has(entry.attachmentId)
-        ? { ...entry, lastError: null, permanent: false, nextAttemptAt: null }
-        : entry,
-    ),
-  );
+  await inTurn(async () => {
+    const queue = await readQueue();
+    await writeQueue(
+      queue.map((entry) =>
+        wanted.has(entry.attachmentId)
+          ? { ...entry, lastError: null, permanent: false, nextAttemptAt: null }
+          : entry,
+      ),
+    );
+  });
+  // Outside the turn: the flush below takes turns of its own, and holding one
+  // across it would deadlock.
   return flushReceiptQueue();
 }
 
@@ -574,7 +639,7 @@ export function flushReceiptQueue(): Promise<FlushResult> {
 }
 
 async function runFlush(): Promise<FlushResult> {
-  const queue = await reapSettled(await readQueue());
+  const queue = await inTurn(async () => reapSettled(await readQueue()));
   if (queue.length === 0) return EMPTY_FLUSH;
 
   // Only entries that are actually due: a permanent refusal waits for somebody
@@ -725,12 +790,14 @@ async function runFlush(): Promise<FlushResult> {
   // uploads above, and writing only what this run touched would silently drop it
   // (its bytes then orphaned under PENDING_DIR). Rebuilding from the current
   // queue keeps those, keeps the untouched entries, and preserves the order.
-  const current = await readQueue();
-  const next = current.flatMap((entry) => {
-    if (!updates.has(entry.attachmentId)) return [entry];
-    const replacement = updates.get(entry.attachmentId);
-    return replacement ? [replacement] : [];
+  await inTurn(async () => {
+    const current = await readQueue();
+    const next = current.flatMap((entry) => {
+      if (!updates.has(entry.attachmentId)) return [entry];
+      const replacement = updates.get(entry.attachmentId);
+      return replacement ? [replacement] : [];
+    });
+    await writeQueue(next);
   });
-  await writeQueue(next);
   return { uploadedExpenseIds: [...uploaded], hadPermanentFailure, capReached };
 }

--- a/apps/mobile/src/lib/receiptQueue.ts
+++ b/apps/mobile/src/lib/receiptQueue.ts
@@ -41,7 +41,7 @@ import * as Network from 'expo-network';
 
 import { backend } from '@/lib/backend';
 import { putImage, removeRestrictedImage } from '@/lib/storage';
-import { cacheImageBytes } from '@/lib/storage/imageCache';
+import { cacheImageBytes, cachedImageUri } from '@/lib/storage/imageCache';
 import { endTransfer, setTransferProgress, startTransfer } from '@/lib/transferProgress';
 
 /** The transfer id the receipt-upload flush reports under (one bar for the batch). */
@@ -64,6 +64,24 @@ const PENDING_DIR = 'pending-receipts';
  */
 const RETRY_BACKOFF_MS = [30_000, 2 * 60_000, 10 * 60_000, 30 * 60_000] as const;
 
+/**
+ * How long a capture that has already been uploaded stays in the queue waiting
+ * for its own row to come back down the sync.
+ *
+ * It is kept because dropping it the instant the upload lands is what made the
+ * gallery blink: the tile drawn from the local file disappeared, and the row
+ * that replaces it does not exist on this device until a pull brings it, which
+ * is a network round trip later. So the entry survives its own success, still
+ * drawing the same picture, and the gallery drops it when the real row arrives
+ * (see `dropSettledReceipts`).
+ *
+ * This ceiling is only the backstop for the pull that never comes — a sync that
+ * keeps failing, an app closed before it finished. An hour is far longer than
+ * any pull and short enough that a receipt deleted elsewhere cannot haunt the
+ * strip for a day.
+ */
+const SETTLED_TTL_MS = 60 * 60 * 1000;
+
 function backoffFor(attempts: number): number {
   const index = Math.min(Math.max(attempts, 1), RETRY_BACKOFF_MS.length) - 1;
   return RETRY_BACKOFF_MS[index] ?? RETRY_BACKOFF_MS[RETRY_BACKOFF_MS.length - 1] ?? 0;
@@ -81,6 +99,12 @@ export interface PendingReceipt {
   contentType: string;
   /** Basename of the bytes file under {@link PENDING_DIR} (dir resolved at read time). */
   fileName: string;
+  /**
+   * A tiny `data:` URI of the same image, stored on the row so every other
+   * device has something to draw while the real bytes are fetched. Null where
+   * the manipulator could not make one.
+   */
+  preview?: string | null;
   createdAt: string;
   attempts: number;
   /** The last failure's raw message. Kept for diagnosis; never shown to anybody. */
@@ -95,6 +119,13 @@ export interface PendingReceipt {
   permanent?: boolean;
   /** Earliest time a background flush may try again; see {@link RETRY_BACKOFF_MS}. */
   nextAttemptAt?: string | null;
+  /**
+   * When the bytes and the row both landed on the server. Set, this entry is
+   * finished work kept only so the gallery has something to draw until the real
+   * attachment row arrives — see {@link SETTLED_TTL_MS}. No flush touches it
+   * again.
+   */
+  sentAt?: string | null;
 }
 
 /**
@@ -105,7 +136,7 @@ export interface PendingReceipt {
  * back as `queued`, because that is the truth — the bytes are on disk and
  * nothing is in the air until a flush picks them up again.
  */
-export type PendingReceiptStatus = 'queued' | 'uploading' | 'failed';
+export type PendingReceiptStatus = 'queued' | 'uploading' | 'failed' | 'sent';
 
 /** A pending capture as a view renders it: the stored row plus its live state. */
 export interface PendingReceiptView extends PendingReceipt {
@@ -139,6 +170,9 @@ let snapshot: readonly PendingReceiptView[] = [];
 let hydrated = false;
 
 function statusOf(entry: PendingReceipt): PendingReceiptStatus {
+  // Sent wins over everything: this one is done, and nothing about it is still
+  // in the air or worth reporting as a problem.
+  if (entry.sentAt) return 'sent';
   if (uploading.has(entry.attachmentId)) return 'uploading';
   return entry.lastError ? 'failed' : 'queued';
 }
@@ -164,7 +198,8 @@ function sameQueue(a: readonly PendingReceipt[], b: readonly PendingReceipt[]): 
       entry.attempts === other.attempts &&
       entry.lastError === other.lastError &&
       Boolean(entry.permanent) === Boolean(other.permanent) &&
-      (entry.nextAttemptAt ?? null) === (other.nextAttemptAt ?? null)
+      (entry.nextAttemptAt ?? null) === (other.nextAttemptAt ?? null) &&
+      (entry.sentAt ?? null) === (other.sentAt ?? null)
     );
   });
 }
@@ -262,8 +297,22 @@ function pendingFile(entry: Pick<PendingReceipt, 'fileName'>): File {
   return new File(Paths.document, PENDING_DIR, entry.fileName);
 }
 
-/** The `file://` a gallery renders for a still-unsent capture. */
-export function pendingReceiptUri(entry: Pick<PendingReceipt, 'fileName'>): string {
+/**
+ * The local file a gallery renders for a capture the queue is still carrying.
+ *
+ * A settled one resolves to the view cache instead, under the very key its real
+ * row will resolve to — so when the row finally arrives and the tile switches
+ * from this entry to that row, it is the same file and nothing redraws.
+ */
+export function pendingReceiptUri(
+  entry: Pick<PendingReceipt, 'fileName' | 'storagePath' | 'sentAt'>,
+): string {
+  if (entry.sentAt) {
+    const cached = cachedImageUri('expense-attachments', entry.storagePath);
+    // Falling through means the cache write failed, and in that case the flush
+    // deliberately kept the pending file.
+    if (cached) return cached;
+  }
   return pendingFile(entry).uri;
 }
 
@@ -277,11 +326,61 @@ export async function isOnline(): Promise<boolean> {
   }
 }
 
+/**
+ * Forget settled captures nobody came back for.
+ *
+ * The gallery normally drops one the moment the real row lands beside it, but
+ * that only happens on a screen somebody is looking at. This is the sweep for
+ * the rest: a capture uploaded an hour ago whose row never arrived here is not
+ * information any more, and leaving it would keep a tile on screen for a
+ * receipt that may since have been removed from another device.
+ */
+async function reapSettled(queue: readonly PendingReceipt[]): Promise<PendingReceipt[]> {
+  const now = Date.now();
+  const kept = queue.filter((entry) => {
+    if (!entry.sentAt) return true;
+    const at = Date.parse(entry.sentAt);
+    return !Number.isNaN(at) && now - at < SETTLED_TTL_MS;
+  });
+  if (kept.length === queue.length) return [...queue];
+  await writeQueue(kept);
+  return kept;
+}
+
 /** Every pending capture, or those for one expense, oldest first. */
 export async function listPendingReceipts(expenseId?: string): Promise<PendingReceipt[]> {
-  const queue = await readQueue();
+  const queue = await reapSettled(await readQueue());
   cleanupOrphanFiles(queue);
   return expenseId ? queue.filter((entry) => entry.expenseId === expenseId) : queue;
+}
+
+/**
+ * Let go of captures whose real attachment row has arrived.
+ *
+ * Called by the gallery the moment the mirror shows the row: from then on the
+ * row is the thing on screen, the bytes are already in the view cache under its
+ * key, and this entry is a duplicate of it. Distinct from
+ * {@link discardPendingReceipt}, which is somebody deciding not to keep a
+ * photograph — this is the handover completing.
+ */
+export async function dropSettledReceipts(attachmentIds: readonly string[]): Promise<void> {
+  if (attachmentIds.length === 0) return;
+  const wanted = new Set(attachmentIds);
+  const queue = await readQueue();
+  const kept = queue.filter((entry) => !(entry.sentAt && wanted.has(entry.attachmentId)));
+  if (kept.length === queue.length) return;
+  // The bytes normally moved into the view cache when the upload landed; delete
+  // whatever is left over for the case where that write failed.
+  for (const entry of queue) {
+    if (kept.includes(entry)) continue;
+    try {
+      const file = pendingFile(entry);
+      if (file.exists) file.delete();
+    } catch {
+      // Best-effort; a lingering file is reclaimed with the app's document dir.
+    }
+  }
+  await writeQueue(kept);
 }
 
 /** Sign-out/privacy cleanup: drop the queue index and every pending capture byte file. */
@@ -322,6 +421,8 @@ export async function enqueueReceipt(input: {
   expenseId: string;
   groupId: string;
   visibility: 'group' | 'parties';
+  /** A tiny `data:` URI to store beside the receipt as a loading placeholder. */
+  preview?: string | null;
   /**
    * A file on this device to take over. Preferred: the image has already been
    * written once by the resize, so copying it costs a file copy, where `base64`
@@ -343,11 +444,13 @@ export async function enqueueReceipt(input: {
     storagePath: `${input.expenseId}/${randomUUID()}.${ext}`,
     contentType: input.contentType,
     fileName: `${attachmentId}.${ext}`,
+    preview: input.preview ?? null,
     createdAt: new Date().toISOString(),
     attempts: 0,
     lastError: null,
     permanent: false,
     nextAttemptAt: null,
+    sentAt: null,
   };
 
   const dir = new Directory(Paths.document, PENDING_DIR);
@@ -448,8 +551,10 @@ const EMPTY_FLUSH: FlushResult = {
  * isolation so one stuck capture never blocks the rest.
  *
  * On success the bytes move into the view cache (so the receipt stays offline-
- * readable) and the entry and its file are dropped. A transient failure keeps
- * the entry with a backoff, to be tried again on the next event; a permanent one
+ * readable) and the entry is marked sent — kept, not dropped, so the gallery has
+ * something to draw for the length of the sync pull that brings the real row
+ * down. A transient failure keeps the entry with a backoff, to be tried again on
+ * the next event; a permanent one
  * (cap, not a party) keeps it too, marked so no background run retries it —
  * either way the tile stays in the gallery saying what happened, and the bytes
  * stay on disk, until the person retries it or removes it.
@@ -469,7 +574,7 @@ export function flushReceiptQueue(): Promise<FlushResult> {
 }
 
 async function runFlush(): Promise<FlushResult> {
-  const queue = await readQueue();
+  const queue = await reapSettled(await readQueue());
   if (queue.length === 0) return EMPTY_FLUSH;
 
   // Only entries that are actually due: a permanent refusal waits for somebody
@@ -477,6 +582,8 @@ async function runFlush(): Promise<FlushResult> {
   // the queue and on screen — being skipped here is not the same as being gone.
   const now = Date.now();
   const due = queue.filter((entry) => {
+    // Already up. It is only still here so the gallery has something to draw.
+    if (entry.sentAt) return false;
     if (entry.permanent) return false;
     if (!entry.nextAttemptAt) return true;
     const at = Date.parse(entry.nextAttemptAt);
@@ -538,19 +645,38 @@ async function runFlush(): Promise<FlushResult> {
           p_storage_path: entry.storagePath,
           p_visibility: entry.visibility,
           p_attachment_id: entry.attachmentId,
+          p_preview: entry.preview ?? null,
         });
         if (error) throw new Error(error.message);
         objectStored = false;
 
-        // Uploaded and recorded. Keep it viewable offline by moving the bytes into
-        // the view cache, then delete the pending file.
-        cacheImageBytes('expense-attachments', entry.storagePath, new Uint8Array(decode(base64)));
-        try {
-          file.delete();
-        } catch {
-          // Best-effort; a lingering file is reclaimed with the app's document dir.
+        // Uploaded and recorded. The bytes move into the view cache under the
+        // key the real row resolves to, which keeps the receipt readable offline
+        // and — because the settled tile below reads that same file — makes the
+        // handover to the row a no-op rather than a second load.
+        const cached = cacheImageBytes(
+          'expense-attachments',
+          entry.storagePath,
+          new Uint8Array(decode(base64)),
+        );
+        if (cached) {
+          try {
+            file.delete();
+          } catch {
+            // Best-effort; a lingering file is reclaimed with the app's document dir.
+          }
         }
-        updates.set(entry.attachmentId, null);
+        // Kept, not dropped. Deleting the entry here is what used to empty the
+        // gallery for the length of a sync pull: the tile drawn from this file
+        // vanished and the row that replaces it had not arrived yet. It stays,
+        // drawing the same picture, until the row does — see SETTLED_TTL_MS.
+        updates.set(entry.attachmentId, {
+          ...entry,
+          sentAt: new Date().toISOString(),
+          lastError: null,
+          permanent: false,
+          nextAttemptAt: null,
+        });
         uploaded.add(entry.expenseId);
       } catch (caught) {
         // The bytes went up but the row did not: take the object back out, or it

--- a/apps/mobile/test/receiptQueue.test.ts
+++ b/apps/mobile/test/receiptQueue.test.ts
@@ -568,6 +568,65 @@ describe('a capture parked while a flush is running', () => {
   });
 });
 
+describe('two things touching the queue at once', () => {
+  it('does not lose a receipt added while another operation is writing the index', async () => {
+    // The collision that matters: somebody taps add (the resize runs for a
+    // second, so the enqueue lands late) while the gallery lets go of a capture
+    // whose row has just arrived. Both read the same index; whoever writes last
+    // used to decide, and when that was the drop, the new receipt was gone from
+    // the index with its bytes orphaned under the pending dir — where the next
+    // orphan sweep deletes them.
+    parkOnDisk();
+    await listPendingReceipts();
+    await flushReceiptQueue();
+
+    const [drop, added] = await Promise.all([
+      dropSettledReceipts(['a1']),
+      enqueueReceipt({
+        expenseId: 'e2',
+        groupId: 'g1',
+        visibility: 'group',
+        base64: Buffer.from([9]).toString('base64'),
+        contentType: 'image/jpeg',
+      }),
+      // `drop` is void; `added` is the entry.
+    ]);
+    void drop;
+
+    expect((await storedQueue()).map((entry) => entry.attachmentId)).toEqual([added.attachmentId]);
+    expect(fs.files.has(pendingPath(added.fileName))).toBe(true);
+    // And the sweep that runs on the next read leaves it alone.
+    await listPendingReceipts();
+    expect(fs.files.has(pendingPath(added.fileName))).toBe(true);
+  });
+
+  it('does not sweep away the bytes of a receipt being added', async () => {
+    // The orphan sweep reads the index and deletes every pending file missing
+    // from it. An enqueue writes bytes and index together for exactly this
+    // reason — split apart, a listing in between would delete the photograph.
+    const [, added] = await Promise.all([
+      listPendingReceipts(),
+      enqueueReceipt({
+        expenseId: 'e1',
+        groupId: 'g1',
+        visibility: 'group',
+        base64: Buffer.from([5]).toString('base64'),
+        contentType: 'image/jpeg',
+      }),
+    ]);
+
+    expect(fs.files.has(pendingPath(added.fileName))).toBe(true);
+    expect((await storedQueue()).map((entry) => entry.attachmentId)).toEqual([added.attachmentId]);
+  });
+
+  it('lets go of a settled capture whose row never came, on the next read', async () => {
+    parkOnDisk({ sentAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString() });
+
+    expect(await listPendingReceipts()).toEqual([]);
+    expect(await storedQueue()).toEqual([]);
+  });
+});
+
 describe('receipt queue local privacy cleanup', () => {
   it('removes the queue index and pending receipt files on sign-out cleanup', async () => {
     const entries = [

--- a/apps/mobile/test/receiptQueue.test.ts
+++ b/apps/mobile/test/receiptQueue.test.ts
@@ -352,6 +352,21 @@ describe('the handover from the queue to the real row', () => {
     expect(world.rpc).not.toHaveBeenCalled();
   });
 
+  it('does not re-send a settled capture even if retry is asked for', async () => {
+    parkOnDisk();
+    await listPendingReceipts();
+    await flushReceiptQueue();
+    world.put.mockClear();
+    world.rpc.mockClear();
+
+    const result = await retryPendingReceipts(['a1']);
+
+    expect(result.uploadedExpenseIds).toEqual([]);
+    expect(world.put).not.toHaveBeenCalled();
+    expect(world.rpc).not.toHaveBeenCalled();
+    expect(getPendingReceiptsSnapshot()[0]?.status).toBe('sent');
+  });
+
   it('lets go once the gallery has seen the row', async () => {
     parkOnDisk();
     await listPendingReceipts();

--- a/apps/mobile/test/receiptQueue.test.ts
+++ b/apps/mobile/test/receiptQueue.test.ts
@@ -28,6 +28,8 @@ const world = vi.hoisted(() => ({
     error: null as { message: string } | null,
   })),
   cached: [] as { bucket: string; path: string }[],
+  /** Whether a cache write succeeds. False stands in for a full/unwritable cache. */
+  cacheWrites: true,
   /** Objects taken back out of the bucket, in order — see the orphan test. */
   removed: [] as { bucket: string; subjectId: string; path: string }[],
   remove: vi.fn(async (bucket: string, subjectId: string, path: string) => {
@@ -122,10 +124,18 @@ vi.mock('@/lib/storage', () => ({
   removeRestrictedImage: (bucket: string, subjectId: string, path: string) =>
     world.remove(bucket, subjectId, path),
 }));
+const cacheUri = (bucket: string, path: string) => `cache-root/${bucket}/${path}`;
 vi.mock('@/lib/storage/imageCache', () => ({
   cacheImageBytes: vi.fn((bucket: string, path: string) => {
+    if (!world.cacheWrites) return null;
     world.cached.push({ bucket, path });
+    return `cache-root/${bucket}/${path}`;
   }),
+  cachedImageUri: vi.fn((bucket: string, path: string) =>
+    world.cached.some((item) => item.bucket === bucket && item.path === path)
+      ? `cache-root/${bucket}/${path}`
+      : null,
+  ),
 }));
 vi.mock('@/lib/transferProgress', () => ({
   endTransfer: vi.fn(),
@@ -136,6 +146,7 @@ vi.mock('@/lib/transferProgress', () => ({
 const {
   clearReceiptQueue,
   discardPendingReceipt,
+  dropSettledReceipts,
   enqueueReceipt,
   flushReceiptQueue,
   getPendingReceiptsSnapshot,
@@ -186,6 +197,7 @@ beforeEach(() => {
   ids.n = 0;
   world.online = true;
   world.cached = [];
+  world.cacheWrites = true;
   world.removed = [];
   world.remove.mockReset();
   world.remove.mockImplementation(async (bucket: string, subjectId: string, path: string) => {
@@ -258,12 +270,16 @@ describe('resuming an interrupted upload', () => {
       p_storage_path: 'e1/a1.jpg',
       p_visibility: 'group',
       p_attachment_id: 'a1',
+      p_preview: null,
     });
     expect(result.uploadedExpenseIds).toEqual(['e1']);
     // Sent, so the bytes move into the view cache and out of the pending dir.
     expect(world.cached).toEqual([{ bucket: 'expense-attachments', path: 'e1/a1.jpg' }]);
     expect(fs.files.has(pendingPath('a1.jpg'))).toBe(false);
-    expect(await storedQueue()).toEqual([]);
+    // The entry itself stays, marked sent — it is what the gallery draws until
+    // the real row arrives, and dropping it here is what used to blank the strip.
+    expect((await storedQueue()).map((entry) => entry.attachmentId)).toEqual(['a1']);
+    expect(fresh.getPendingReceiptsSnapshot()[0]?.status).toBe('sent');
   });
 
   it('says a capture is sending while it is in the air', async () => {
@@ -304,6 +320,86 @@ describe('resuming an interrupted upload', () => {
 
     expect(world.put).not.toHaveBeenCalled();
     expect(await storedQueue()).toHaveLength(1);
+  });
+});
+
+describe('the handover from the queue to the real row', () => {
+  it('keeps drawing the same picture while the row is still on its way down', async () => {
+    parkOnDisk();
+    await listPendingReceipts();
+    await flushReceiptQueue();
+
+    // The whole point: after a successful upload there is still something for
+    // the gallery to draw. Dropping the entry here left the strip empty for the
+    // length of a sync pull — the blank the person actually complained about.
+    const [entry] = getPendingReceiptsSnapshot();
+    expect(entry?.status).toBe('sent');
+    // And it resolves to the very file the real row will resolve to, so the
+    // swap when the row lands redraws nothing.
+    expect(entry && pendingReceiptUri(entry)).toBe(cacheUri('expense-attachments', 'e1/a1.jpg'));
+  });
+
+  it('never sends a settled capture a second time', async () => {
+    parkOnDisk();
+    await listPendingReceipts();
+    await flushReceiptQueue();
+    world.put.mockClear();
+    world.rpc.mockClear();
+
+    await flushReceiptQueue();
+
+    expect(world.put).not.toHaveBeenCalled();
+    expect(world.rpc).not.toHaveBeenCalled();
+  });
+
+  it('lets go once the gallery has seen the row', async () => {
+    parkOnDisk();
+    await listPendingReceipts();
+    await flushReceiptQueue();
+
+    await dropSettledReceipts(['a1']);
+
+    expect(getPendingReceiptsSnapshot()).toEqual([]);
+    expect(await storedQueue()).toEqual([]);
+  });
+
+  it('forgets a settled capture whose row never came', async () => {
+    // Uploaded a day ago on a device that has not managed a pull since. The
+    // gallery would otherwise show a tile for a receipt that may since have
+    // been removed from somewhere else.
+    parkOnDisk({ sentAt: new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString() });
+
+    expect(await listPendingReceipts()).toEqual([]);
+  });
+
+  it('keeps the local bytes when the cache write failed, so there is still something to draw', async () => {
+    world.cacheWrites = false;
+    parkOnDisk();
+    await listPendingReceipts();
+    await flushReceiptQueue();
+
+    const [entry] = getPendingReceiptsSnapshot();
+    expect(entry?.status).toBe('sent');
+    expect(fs.files.has(pendingPath('a1.jpg'))).toBe(true);
+    expect(entry && pendingReceiptUri(entry)).toBe(pendingPath('a1.jpg'));
+  });
+
+  it('carries the stored placeholder up with the receipt', async () => {
+    await enqueueReceipt({
+      expenseId: 'e1',
+      groupId: 'g1',
+      visibility: 'group',
+      base64: Buffer.from([1]).toString('base64'),
+      contentType: 'image/jpeg',
+      preview: 'data:image/jpeg;base64,AAAA',
+    });
+
+    await flushReceiptQueue();
+
+    expect(world.rpc).toHaveBeenCalledWith(
+      'waves_attach_expense_attachment',
+      expect.objectContaining({ p_preview: 'data:image/jpeg;base64,AAAA' }),
+    );
   });
 });
 
@@ -414,7 +510,9 @@ describe('a capture that does not go up', () => {
 
     expect(result.uploadedExpenseIds).toEqual(['e1']);
     expect(world.put).toHaveBeenCalledTimes(2);
-    expect(await storedQueue()).toEqual([]);
+    // Up, and now waiting for its row rather than for another attempt.
+    expect(await storedQueue()).toMatchObject([{ attachmentId: 'a1', lastError: null }]);
+    expect(getPendingReceiptsSnapshot()[0]?.status).toBe('sent');
   });
 
   it('drops an entry whose bytes are gone rather than retrying forever', async () => {
@@ -446,8 +544,10 @@ describe('a capture parked while a flush is running', () => {
     await flushReceiptQueue();
 
     const queue = await storedQueue();
-    expect(queue).toHaveLength(1);
-    expect(queue[0]).toMatchObject({ expenseId: 'e2' });
+    // The one that went up is still here, settled and waiting for its row; the
+    // latecomer is here too, untouched and still to be sent.
+    expect(queue.map((entry) => entry.expenseId)).toEqual(['e1', 'e2']);
+    expect(queue[1]).toMatchObject({ expenseId: 'e2', sentAt: null });
     // Its bytes are still under the pending dir — not orphaned by the write-back.
     expect(fs.files.has(pendingPath(latecomerFile))).toBe(true);
   });

--- a/packages/core/src/sync/mirror.ts
+++ b/packages/core/src/sync/mirror.ts
@@ -1188,6 +1188,14 @@ export interface MirrorExpenseAttachment extends MirrorRow {
   readonly uploader_member_id: string;
   /** Non-destructive pen/text markup (jsonb), or null. Shape parsed at the UI. */
   readonly annotations: unknown;
+  /**
+   * A tiny blurred stand-in for the image, as a `data:` URI — enough to draw
+   * something the instant this row is read, while the real bytes are still
+   * being signed for and fetched. Optional rather than nullable: a mirror
+   * pulled before the column existed has no such key at all, and every receipt
+   * stored before it has null.
+   */
+  readonly preview?: string | null;
   readonly created_at: string | null;
   readonly deleted_at: string | null;
 }

--- a/packages/db/prisma/migrations/20260908160000_receipt_preview_placeholder/migration.sql
+++ b/packages/db/prisma/migrations/20260908160000_receipt_preview_placeholder/migration.sql
@@ -1,0 +1,229 @@
+-- Something to look at while the bill is still being fetched.
+--
+-- A receipt's bytes live behind a short-lived signed URL in a private bucket,
+-- so the first sight of one on a device that has not cached it is a network
+-- round trip: mint the URL, then download a picture sized for OCR. Until both
+-- finish the tile is an empty grey square — and the row describing the receipt
+-- arrived from the mirror long before, so the app knows a picture is coming and
+-- has nothing to say about it.
+--
+-- This is the standard answer: a thumbnail small enough to travel inside the row
+-- itself. The client encodes the receipt down to roughly 32 pixels on its long
+-- edge and stores it here as a `data:` URI — a kilobyte or so, which is cheaper
+-- than the request that would fetch it separately, and therefore only worth
+-- keeping at a size where that stays true. Upscaled to tile or full-screen it is
+-- a soft wash of the real image's colours, drawn the instant the row is read and
+-- cross-faded out when the real bytes land.
+--
+-- It is decoration, and the column treats it as such: the writers below drop
+-- anything that is not a small image data URI rather than refuse the upload. A
+-- receipt with no preview is exactly what every receipt already stored has, and
+-- it renders the way it renders today.
+
+ALTER TABLE public.expense_attachments
+  ADD COLUMN preview text;
+
+COMMENT ON COLUMN public.expense_attachments.preview IS
+  'A tiny blurred stand-in for the image, as a data: URI, drawn while the real bytes load. Decoration — null is normal.';
+
+-- The ceiling is the point of the thing: a preview that is not far smaller than
+-- the request it saves has stopped being a preview. 4 KB is generous for a
+-- 32px JPEG (they land near 1 KB) and small enough that a row carrying one is
+-- still a row.
+ALTER TABLE public.expense_attachments
+  ADD CONSTRAINT expense_attachments_preview_small
+  CHECK (preview IS NULL OR length(preview) <= 4096);
+
+-- What counts as a preview, in one place.
+--
+-- Both writers below take the string from a client, and a client is not a
+-- reason to trust it: a caller could put a novel in this field, or a `javascript:`
+-- URI, and every device in the group would render whatever the row said. So the
+-- shape is checked here — a small, self-contained image data URI and nothing
+-- else — and anything failing the check becomes NULL rather than an error.
+-- IMMUTABLE and STRICT-ish so it costs nothing to call on every write.
+CREATE FUNCTION public.waves_clean_image_preview(p_preview text) RETURNS text
+    LANGUAGE sql IMMUTABLE
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+  SELECT CASE
+    WHEN p_preview IS NULL THEN NULL
+    WHEN length(p_preview) > 4096 THEN NULL
+    WHEN p_preview ~ '^data:image/(jpeg|png|webp);base64,[A-Za-z0-9+/=]+$' THEN p_preview
+    ELSE NULL
+  END;
+$$;
+
+COMMENT ON FUNCTION public.waves_clean_image_preview(text) IS
+  'Accept a small image data URI as a loading placeholder, or NULL. Never raises — a bad preview is dropped, not a reason to fail a write.';
+
+-- Only the two definer writers below call this, and they run as their owner, so
+-- nobody signed in ever needs to reach it directly.
+REVOKE ALL ON FUNCTION public.waves_clean_image_preview(p_preview text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.waves_clean_image_preview(p_preview text) TO service_role;
+
+-- ─────────────────────────────────────────────────────────── the two writers ──
+--
+-- Both are dropped and recreated rather than overloaded. A second signature
+-- differing only by a defaulted trailing argument makes every existing
+-- four-argument call ambiguous, and PostgREST resolves by name — so the app
+-- would start getting "could not choose the best candidate function" for the
+-- calls it has always made. One signature, with the new argument defaulted, is
+-- both unambiguous and backwards compatible: a client built before this ships
+-- omits it and stores no preview.
+
+DROP FUNCTION IF EXISTS public.waves_attach_expense_attachment(uuid, text, text, uuid);
+
+CREATE FUNCTION public.waves_attach_expense_attachment(p_expense_id uuid, p_storage_path text, p_visibility text DEFAULT 'group'::text, p_attachment_id uuid DEFAULT NULL::uuid, p_preview text DEFAULT NULL::text) RETURNS uuid
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+DECLARE
+  v_group_id uuid;
+  v_member   uuid;
+  v_id       uuid;
+  v_preview  text;
+BEGIN
+  IF coalesce(btrim(p_storage_path), '') = '' THEN
+    RAISE EXCEPTION 'INVALID_PATH: an attachment needs a stored image'
+      USING ERRCODE = 'check_violation';
+  END IF;
+  IF p_visibility NOT IN ('group', 'parties') THEN
+    RAISE EXCEPTION 'INVALID_VISIBILITY: group or parties' USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- The key MUST be scoped to this expense: `<expenseId>/…` (see the proof RPC).
+  IF p_storage_path NOT LIKE p_expense_id::text || '/%' THEN
+    RAISE EXCEPTION 'INVALID_PATH: the key must be scoped to its expense'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- A malformed or oversized preview is dropped, not refused. It is a loading
+  -- placeholder; failing somebody's upload over one would trade a real receipt
+  -- for a cosmetic detail.
+  v_preview := public.waves_clean_image_preview(p_preview);
+
+  -- Authorise before resolving the client id (an existence oracle otherwise).
+  SELECT group_id INTO v_group_id FROM public.expenses WHERE id = p_expense_id;
+  IF v_group_id IS NULL THEN
+    RAISE EXCEPTION 'NOT_FOUND: no such expense' USING ERRCODE = 'no_data_found';
+  END IF;
+
+  IF NOT public.waves_is_expense_party(p_expense_id) THEN
+    RAISE EXCEPTION 'NOT_A_PARTY: only a payer or the author may attach to this expense'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Replay bound to the subject: same id + same expense returns the existing row
+  -- (and, because it returns here, never emits a second audit line and is never
+  -- re-counted against the cap).
+  IF p_attachment_id IS NOT NULL THEN
+    SELECT id INTO v_id
+    FROM public.expense_attachments
+    WHERE id = p_attachment_id AND expense_id = p_expense_id;
+    IF v_id IS NOT NULL THEN
+      RETURN v_id;
+    END IF;
+  END IF;
+
+  -- The bytes must really exist: a committed object at this key, in the
+  -- attachments bucket. Blocks a phantom / never-uploaded / pending-only path
+  -- from being recorded as an attachment. Checked for a genuinely new row only.
+  PERFORM public.waves_require_committed_object('expense-attachments', btrim(p_storage_path));
+
+  -- Serialize the count-then-insert against other attaches to THIS expense: a
+  -- transaction-scoped advisory lock keyed on the expense id. Without it two
+  -- concurrent adds could both read a live count below the cap and both insert,
+  -- landing one over (the same race the ghost-merge path guards). Only other
+  -- attach calls take this key, so it never blocks unrelated writers, and it is
+  -- released at commit. Taken before the count so a paid group pays only a
+  -- trivial, uncontended lock and nothing else.
+  PERFORM pg_advisory_xact_lock(hashtextextended(p_expense_id::text, 0));
+
+  -- The per-expense ceiling, enforced at the one insert path. A paid group is
+  -- exempt; only live (non-deleted) attachments count, so removing one frees a
+  -- slot.
+  IF NOT public.waves_group_is_paid(v_group_id)
+     AND (SELECT count(*) FROM public.expense_attachments
+           WHERE expense_id = p_expense_id AND deleted_at IS NULL)
+         >= public.waves_attachment_cap()
+  THEN
+    RAISE EXCEPTION 'ATTACHMENT_CAP'
+      USING ERRCODE = 'check_violation',
+            HINT = 'This expense has reached its free receipt limit; upgrade to add more.';
+  END IF;
+
+  v_member := public.waves_my_member_id(v_group_id);
+
+  INSERT INTO public.expense_attachments
+    (id, expense_id, group_id, uploader_member_id, storage_path, visibility, preview)
+  VALUES
+    (COALESCE(p_attachment_id, gen_random_uuid()), p_expense_id, v_group_id, v_member,
+     btrim(p_storage_path), p_visibility, v_preview)
+  RETURNING id INTO v_id;
+
+  INSERT INTO public.expense_image_events
+    (id, group_id, expense_id, actor_member_id, kind, action, visibility)
+  VALUES
+    (gen_random_uuid(), v_group_id, p_expense_id, v_member, 'attachment', 'added', p_visibility);
+
+  RETURN v_id;
+END
+$$;
+
+-- The dropped signature took its grants with it; put back the ones the baseline
+-- and the authenticated-surface migration gave the four-argument form.
+REVOKE ALL ON FUNCTION public.waves_attach_expense_attachment(p_expense_id uuid, p_storage_path text, p_visibility text, p_attachment_id uuid, p_preview text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.waves_attach_expense_attachment(p_expense_id uuid, p_storage_path text, p_visibility text, p_attachment_id uuid, p_preview text) TO authenticated, service_role;
+
+DROP FUNCTION IF EXISTS public.waves_replace_expense_attachment_image(uuid, text);
+
+CREATE FUNCTION public.waves_replace_expense_attachment_image(p_attachment_id uuid, p_new_path text, p_preview text DEFAULT NULL::text) RETURNS void
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+DECLARE
+  v_expense_id uuid;
+BEGIN
+  IF coalesce(btrim(p_new_path), '') = '' THEN
+    RAISE EXCEPTION 'INVALID_PATH: a replacement needs a stored image'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  SELECT expense_id INTO v_expense_id
+  FROM public.expense_attachments
+  WHERE id = p_attachment_id AND deleted_at IS NULL;
+  IF v_expense_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  -- The new key MUST stay scoped to this expense, exactly like the attach RPC.
+  IF p_new_path NOT LIKE v_expense_id::text || '/%' THEN
+    RAISE EXCEPTION 'INVALID_PATH: the key must be scoped to its expense'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  IF NOT public.waves_is_expense_party(v_expense_id) THEN
+    RAISE EXCEPTION 'NOT_A_PARTY: only a party may adjust this image'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- The replacement bytes must really exist: a committed object at the new key.
+  -- Without this the row could be repointed at a never-uploaded path, and the
+  -- markup would be cleared, leaving the attachment pointing at nothing.
+  PERFORM public.waves_require_committed_object('expense-attachments', btrim(p_new_path));
+
+  -- The preview is overwritten, not merged: these are different pixels — a
+  -- rotation or a crop — and the old thumbnail would flash the previous framing
+  -- before the new image resolved. A caller that sends none leaves the row with
+  -- no preview, which is honest.
+  UPDATE public.expense_attachments
+     SET storage_path = btrim(p_new_path),
+         annotations  = NULL,
+         preview      = public.waves_clean_image_preview(p_preview)
+   WHERE id = p_attachment_id AND deleted_at IS NULL;
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.waves_replace_expense_attachment_image(p_attachment_id uuid, p_new_path text, p_preview text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.waves_replace_expense_attachment_image(p_attachment_id uuid, p_new_path text, p_preview text) TO authenticated, service_role;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1574,6 +1574,13 @@ model ExpenseAttachment {
   /// image coordinates so it renders at any size. Null when the image is not
   /// marked up. Edited by a party through an RPC; the bytes are never touched.
   annotations      Json?
+  /// A ~32px blurred stand-in for the image, as a `data:` URI, so a device that
+  /// has never fetched these bytes still has something to draw the moment the
+  /// row arrives. Small enough to be cheaper than the request it covers for
+  /// (capped at 4 KB by a check constraint) and written only through the attach
+  /// / replace RPCs, which drop anything that is not a small image data URI.
+  /// Null is ordinary — every receipt stored before this existed has none.
+  preview          String?
   createdAt        DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt        DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
   updatedSeq       BigInt    @default(0) @map("updated_seq")

--- a/packages/db/test/receipt-preview.test.ts
+++ b/packages/db/test/receipt-preview.test.ts
@@ -1,0 +1,169 @@
+/**
+ * The loading placeholder a receipt carries with it.
+ *
+ * A receipt's bytes are behind a signed URL, so a device that has never fetched
+ * them has nothing to draw until a round trip finishes. The row carries a ~32px
+ * `data:` URI so it has something. That string comes from a client, so what the
+ * database will accept is the whole security question here — and the answer has
+ * to be "drop it", never "fail the upload": this is decoration, and refusing
+ * somebody's receipt over a thumbnail would be a bad trade.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { addEqualSplitExpense, connect, seedCommittedObject, seedGroup } from './helpers';
+
+let client: Client;
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client.end();
+});
+
+async function as<T>(profileId: string, run: () => Promise<T>): Promise<T> {
+  await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+    JSON.stringify({ sub: profileId, role: 'authenticated' }),
+  ]);
+  await client.query(`SET ROLE authenticated`);
+  try {
+    return await run();
+  } finally {
+    await client.query('RESET ROLE');
+  }
+}
+
+let g: { groupId: string; profileIds: string[]; memberIds: string[] };
+let expenseId: string;
+
+beforeAll(async () => {
+  g = await seedGroup(client, { memberCount: 3, name: 'Preview' });
+  ({ expenseId } = await addEqualSplitExpense(client, {
+    groupId: g.groupId,
+    payers: { [g.memberIds[0] as string]: 3000n },
+    participants: g.memberIds,
+    amount: 3000n,
+  }));
+});
+
+beforeEach(async () => {
+  await client.query(`DELETE FROM expense_attachments WHERE group_id = $1`, [g.groupId]);
+});
+
+const P = (i: number) => g.profileIds[i] as string;
+
+/** A real, if very small, JPEG data URI — the shape the app produces. */
+const GOOD = 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAA==';
+
+async function attach(preview: string | null, path?: string): Promise<string> {
+  const key = path ?? `${expenseId}/${randomUUID()}.webp`;
+  await seedCommittedObject(client, {
+    bucket: 'expense-attachments',
+    path: key,
+    ownerProfileId: P(0),
+  });
+  const id = randomUUID();
+  await as(P(0), () =>
+    client.query(`SELECT waves_attach_expense_attachment($1, $2, 'group', $3, $4)`, [
+      expenseId,
+      key,
+      id,
+      preview,
+    ]),
+  );
+  return id;
+}
+
+const previewOf = (id: string) =>
+  client
+    .query<{ preview: string | null }>(`SELECT preview FROM expense_attachments WHERE id = $1`, [
+      id,
+    ])
+    .then((r) => r.rows[0]?.preview ?? null);
+
+describe('a receipt preview', () => {
+  it('is kept when it is a small image data URI', async () => {
+    expect(await previewOf(await attach(GOOD))).toBe(GOOD);
+  });
+
+  it('is simply absent when the client sends none', async () => {
+    expect(await previewOf(await attach(null))).toBeNull();
+  });
+
+  it('still attaches for a client that predates the argument', async () => {
+    // The four-argument call every shipped build makes. It must keep working,
+    // which is why the new argument is defaulted rather than a second overload.
+    const key = `${expenseId}/${randomUUID()}.webp`;
+    await seedCommittedObject(client, {
+      bucket: 'expense-attachments',
+      path: key,
+      ownerProfileId: P(0),
+    });
+    const id = randomUUID();
+    await as(P(0), () =>
+      client.query(`SELECT waves_attach_expense_attachment($1, $2, 'group', $3)`, [
+        expenseId,
+        key,
+        id,
+      ]),
+    );
+    expect(await previewOf(id)).toBeNull();
+  });
+
+  it('drops anything that is not one, rather than refusing the receipt', async () => {
+    // A URI scheme that executes, a remote reference that phones home, and a
+    // string far too large to be a placeholder. None of these is a reason to
+    // lose somebody's bill — each is a reason to store no placeholder.
+    for (const bad of [
+      'javascript:alert(1)',
+      'https://example.test/tracker.gif',
+      'data:text/html;base64,PHNjcmlwdD4=',
+      `data:image/jpeg;base64,${'A'.repeat(5000)}`,
+    ]) {
+      // One at a time: the free per-expense receipt ceiling is smaller than
+      // this list, and the cap is not what is under test here.
+      await client.query(`DELETE FROM expense_attachments WHERE group_id = $1`, [g.groupId]);
+      expect(await previewOf(await attach(bad))).toBeNull();
+    }
+  });
+
+  it('is replaced along with the pixels when the image is adjusted', async () => {
+    const id = await attach(GOOD);
+    const newPath = `${expenseId}/${randomUUID()}.webp`;
+    await seedCommittedObject(client, {
+      bucket: 'expense-attachments',
+      path: newPath,
+      ownerProfileId: P(0),
+    });
+    const next = 'data:image/webp;base64,UklGRhoAAABXRUJQ';
+    await as(P(0), () =>
+      client.query(`SELECT waves_replace_expense_attachment_image($1, $2, $3)`, [
+        id,
+        newPath,
+        next,
+      ]),
+    );
+    // Not merged: a crop or a rotation makes the old thumbnail wrong, so the
+    // new one stands alone — and a caller sending none leaves the row bare.
+    expect(await previewOf(id)).toBe(next);
+  });
+
+  it('is cleared, not kept, when an adjust sends none', async () => {
+    const id = await attach(GOOD);
+    const newPath = `${expenseId}/${randomUUID()}.webp`;
+    await seedCommittedObject(client, {
+      bucket: 'expense-attachments',
+      path: newPath,
+      ownerProfileId: P(0),
+    });
+    await as(P(0), () =>
+      client.query(`SELECT waves_replace_expense_attachment_image($1, $2)`, [id, newPath]),
+    );
+    expect(await previewOf(id)).toBeNull();
+  });
+});


### PR DESCRIPTION
The report: *"it loads and gets uploaded, and there is a blank screen, there's nothing. It goes back to nothing, and then after some time, the image comes back, maybe downloading again."* Two separate problems, both fixed here.

## 1. The blank is a real bug

`runFlush` deleted the queue entry and its bytes the instant the attach RPC returned (`apps/mobile/src/lib/receiptQueue.ts:547` before this change). The attachment row that replaces it does not exist on this device until a sync pull brings it down — a network round trip later — so for that whole window the gallery had **neither** a pending entry nor a row, and the strip went empty. The row then arrived under a new key and `useResolvedUrls` started from `undefined`, so the picture reappeared as if it had been fetched. The de-dupe in `ExpenseReceipts` written for exactly this handover could never fire, because the thing it was handing over *from* was deleted first.

- A successful upload now marks the entry `sentAt` and **keeps** it, still drawing the same picture. The gallery drops it when the row it became lands beside it (`dropSettledReceipts`); an hour-long TTL sweeps the case where the pull never comes.
- The settled entry resolves to the **view cache under the key the real row resolves to**, so the swap from entry to row is the same file — nothing reloads, nothing crossfades.
- Cached/local images now resolve **during render** rather than from an effect, so an image already on disk never shows a spinner for a frame first.
- Parked captures sort **with** the attachment rows (newest first) instead of after them, so a new tile no longer jumps from the end of the strip to the front when the sync catches up.
- Removing a settled capture goes through the real removal RPC — it is on the server, and dropping the local entry alone would have orphaned it.

## 2. A low-quality placeholder, on both screens

A ~32px JPEG of the receipt now travels inside the row as a `data:` URI (under a kilobyte — cheaper than the request it covers for), drawn under the real image and cross-faded out when it decodes. Both the edit screen and the view-expense screen share `ExpenseReceipts`, so both get it, on the thumbnail strip and in the full-screen viewer.

Built on `expo-image`'s own `placeholder` + `transition` and `expo-image-manipulator`, both already dependencies — **no new native module**, so this still ships over OTA once the migration is deployed. The placeholder is the same `Image`'s placeholder, not a second image, so a screen reader is never told there are two pictures. Tiles are fixed-size and the viewer is full-screen, so nothing reflows.

No new user-visible strings, so no i18n changes.

## Deploy-gated

`20260908160000_receipt_preview_placeholder` adds `expense_attachments.preview`, a 4 KB check constraint, a `waves_clean_image_preview` validator, and recreates `waves_attach_expense_attachment` / `waves_replace_expense_attachment_image` with a defaulted `p_preview`. Dropped-and-recreated rather than overloaded: a second signature differing only by a trailing default makes every existing four-argument call ambiguous through PostgREST. Old clients omit the argument and store no preview.

`pnpm db:migrate` is the whole deploy — the `sync` edge function selects `expense_attachments` as `*`, so the new column reaches devices with no edge change, and neither `api-client` nor `apps/web` carries attachments. Until the migration lands, previews are simply never stored and every screen behaves as it does today; the blank-flash fix is client-side and independent of it.

## Verified

- `packages/db`: full suite, 766 tests, against a database rebuilt from every migration in order (including this one, and the anon-surface guard that counts reachable definer functions). New `test/receipt-preview.test.ts` covers the kept/dropped/oversized/`javascript:` cases, replace-overwrites-preview, and that a four-argument client still attaches.
- `apps/mobile`: 977 tests, including six new ones on the handover — the entry survives its own success, resolves to the cache file, is never re-sent, is let go when the row lands, is reaped when it never does, and keeps its local bytes when the cache write fails.
- `packages/core`: 922 tests. `tsc --noEmit` clean on mobile and core; `expo lint` clean; `prettier --check` clean.

**Not verified without a device:** the actual look of the crossfade and of a 32px placeholder upscaled to a 96pt tile and to full screen, the real timing of the pending→settled→row handover on a phone, and that `expo-image-manipulator` produces a preview under 4 KB from a real camera photo on both platforms (it falls back to no preview if not).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added blurred image previews that appear while receipt images load.
  * Receipt uploads now remain visible locally until synchronization completes.
  * Pending receipts are prioritized and sorted newest first.
  * Users can remove receipts that have already synced with the server.

* **Bug Fixes**
  * Improved receipt loading by using local images and cached previews when available.
  * Prevented duplicate or stale queued receipts from remaining after synchronization.
  * Preserved local receipt images even if caching fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->