### PR TITLE
Make "Who pays whom" say who pays whom

### DIFF
--- a/apps/mobile/src/app/group/[id]/settings.tsx
+++ b/apps/mobile/src/app/group/[id]/settings.tsx
@@ -53,7 +53,14 @@ import { fill, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { useFavorites } from '@/lib/favorites';
 import { useBlockedUsers } from '@/data/blocked';
-import { displayName, groupLabel, GroupType, isGhost, payableAt } from '@/data/types';
+import {
+  displayName,
+  groupLabel,
+  GroupType,
+  isBlockedMember,
+  isGhost,
+  payableAt,
+} from '@/data/types';
 
 // Same chip icons the create screen wears, so changing a group's kind looks
 // like the same control that first set it.
@@ -476,6 +483,10 @@ export default function GroupSettingsScreen() {
               emoji={group.data.cover_emoji}
               size={64}
               busy={uploading}
+              // The mark is the one door to the cover now, so it has to say so:
+              // its default label offers a photo, which is only one of the three
+              // things behind it and the one a free group cannot take.
+              accessibilityLabel={t.group.changeCover}
               onPress={() => setCoverOpen(true)}
             />
             <View style={{ flex: 1, gap: theme.spacing.xs }}>
@@ -611,14 +622,26 @@ export default function GroupSettingsScreen() {
             {(members.data ?? []).map((member, index) => (
               <View key={member.id}>
                 <ListRow
-                  title={displayName(member, profile?.id)}
+                  title={displayName(member, profile?.id, blockedIds, t.misc.someone)}
                   subtitle={
                     isGhost(member)
                       ? t.notJoinedYet
-                      : // The rail pair, not the legacy UPI column alone.
-                        (payableAt(member)?.handle ?? t.misc.noUpiYet)
+                      : // A handle carries a name, an address or a phone number,
+                        // so a blocked person's is masked here exactly as it is
+                        // on the members screen — this roster was showing the
+                        // real name and the real handle of somebody the reader
+                        // had asked never to see again.
+                        isBlockedMember(member, blockedIds)
+                        ? t.misc.noUpiYet
+                        : // The rail pair, not the legacy UPI column alone.
+                          (payableAt(member)?.handle ?? t.misc.noUpiYet)
                   }
-                  leading={<Avatar name={displayName(member)} ghost={isGhost(member)} />}
+                  leading={
+                    <Avatar
+                      name={displayName(member, null, blockedIds, t.misc.someone)}
+                      ghost={isGhost(member) || isBlockedMember(member, blockedIds)}
+                    />
+                  }
                   onPress={() => router.push(`/group/${groupId}/member/${member.id}`)}
                   trailing={
                     <Row style={{ gap: theme.spacing.sm }}>

--- a/apps/mobile/src/app/group/[id]/simplify.tsx
+++ b/apps/mobile/src/app/group/[id]/simplify.tsx
@@ -1,6 +1,8 @@
+import { useCallback, useMemo } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
+import { FlashList } from '@shopify/flash-list';
 import { router, useLocalSearchParams } from 'expo-router';
-import { ScrollView, View } from 'react-native';
+import { Pressable, RefreshControl, View } from 'react-native';
 
 import {
   Avatar,
@@ -13,19 +15,147 @@ import {
   MoneyText,
   Row,
   Screen,
+  SectionHeader,
   Text,
   useTheme,
-  useScreenClearance,
+  useTabBarClearance,
 } from '@waves/ui';
 
-import { memberLookup, useGroup, useGroupLedger } from '@/data/hooks';
-import { displayName } from '@/data/types';
+import {
+  BalanceDirection,
+  format as formatMoney,
+  money as coreMoney,
+  type CurrencyCode,
+} from '@waves/core';
+
+import { memberLookup, useGhostMergePersonIds, useGroup, useGroupLedger } from '@/data/hooks';
+import { useBlockedUsers } from '@/data/blocked';
+import { personKeyOf } from '@/data/peopleBalances';
+import { displayName, groupLabel, isBlockedMember, isGhost, type MemberRow } from '@/data/types';
 import { fill, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
+import { usePullRefresh } from '@/lib/pullRefresh';
+import { SimplifySide, simplifyItems, type SimplifyItem } from '@/lib/simplifyRows';
+
+/**
+ * One proposed payment.
+ *
+ * The row used to carry both people's avatars, an arrow between them, *and* the
+ * sentence naming them — three sayings of one fact competing for the width of a
+ * phone. The sentence lost every time: every row on a real group read "Renny
+ * pays .Rvs …", which is the one thing this screen exists to tell you. So the
+ * pair of avatars is gone and the sentence is what survives: one avatar for the
+ * person the row is about, the words in full over two lines if they need them,
+ * and never an ellipsis through somebody's name.
+ *
+ * The amount is coloured only when the reader is on the row — red when they are
+ * handing it over, the owed-to-you blue when they are receiving it. A payment
+ * between two other people belongs to neither of them from here, so it stays
+ * the neutral ink an expense total wears.
+ */
+function TransferRow({
+  sentence,
+  avatarName,
+  ghost,
+  amount,
+  currency,
+  locale,
+  direction,
+  isLast,
+  onPress,
+  openHint,
+}: {
+  sentence: string;
+  avatarName: string;
+  ghost: boolean;
+  amount: bigint;
+  currency: CurrencyCode;
+  locale: string;
+  /** Set only on the reader's own rows; null leaves the amount neutral. */
+  direction: BalanceDirection | null;
+  isLast: boolean;
+  onPress?: () => void;
+  openHint: string;
+}) {
+  const theme = useTheme();
+
+  const money = (
+    <MoneyText
+      amount={amount}
+      currency={currency}
+      locale={locale}
+      mode={direction === null ? 'plain' : 'balance'}
+      direction={direction ?? undefined}
+    />
+  );
+
+  const body = (
+    <Row
+      style={{
+        gap: theme.spacing.md,
+        alignItems: 'center',
+        paddingVertical: theme.spacing.md,
+        // The row is a touch target as a whole, so it holds the 44pt floor even
+        // on the shortest sentence.
+        minHeight: 44,
+      }}
+    >
+      <Avatar name={avatarName} ghost={ghost} size={40} />
+      <View style={{ flex: 1 }}>
+        <Text variant="subheading" numberOfLines={2}>
+          {sentence}
+        </Text>
+      </View>
+      {money}
+      {/* A fixed slot at the trailing edge whether or not this row leads
+          anywhere, so the amounts stay in one column instead of sliding across
+          on the rows that have no chevron. The glyph itself flips with the
+          writing direction. */}
+      <View style={{ width: iconSize.md, alignItems: 'center' }}>
+        {onPress ? (
+          <Ionicons
+            name={directionalIcon('chevron-forward')}
+            size={iconSize.md}
+            color={theme.color.textFaint}
+          />
+        ) : null}
+      </View>
+    </Row>
+  );
+
+  return (
+    <View>
+      {onPress ? (
+        <Pressable
+          accessibilityRole="button"
+          // Making the row one control groups its text, so everything worth
+          // hearing has to be said here: the sentence, then the amount in the
+          // words `MoneyText` would have spoken on its own.
+          accessibilityLabel={`${sentence}. ${formatMoney(coreMoney(amount, currency), { locale })}`}
+          accessibilityHint={openHint}
+          onPress={onPress}
+          style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+        >
+          {body}
+        </Pressable>
+      ) : (
+        body
+      )}
+      {!isLast ? <View style={{ height: 1, backgroundColor: theme.color.border }} /> : null}
+    </View>
+  );
+}
 
 export default function SimplifyScreen() {
   const theme = useTheme();
-  const clearance = useScreenClearance();
+  // `useTabBarClearance`, not `useScreenClearance`: the app's bottom bar is
+  // rendered once at the root and stays over pushed screens too, and this route
+  // is not one of the few it hides on (`TAB_BAR_HIDDEN_ROUTES`). With the plain
+  // system inset the last proposed payment sat behind the bar — on a screen
+  // whose rows have just become tappable, an unreachable row is a row that does
+  // not work.
+  const clearance = useTabBarClearance();
+  const pull = usePullRefresh();
   const { t, locale } = useStrings();
   const { id } = useLocalSearchParams<{ id: string }>();
   const groupId = id ?? '';
@@ -33,12 +163,112 @@ export default function SimplifyScreen() {
 
   const { group, members } = useGroup(groupId);
   const ledger = useGroupLedger(groupId, profile?.id ?? null);
-  const lookup = memberLookup(members.data);
+  const { blockedIds } = useBlockedUsers();
+  const mergePersonIds = useGhostMergePersonIds();
+  const lookup = useMemo(() => memberLookup(members.data), [members.data]);
 
-  const nameOf = (memberId: string): string => {
-    const member = lookup.get(memberId);
-    return member ? displayName(member, profile?.id) : t.misc.someone;
-  };
+  // Never "You": the three sentences below already have their own you-forms,
+  // and "You pays Ravi" is not a sentence in any of the four languages. A
+  // blocked person keeps the ghost name they wear everywhere else (A62), and it
+  // travels into the destination so that screen never flashes the real one.
+  const nameOf = useCallback(
+    (memberId: string): string => {
+      const member = lookup.get(memberId);
+      return member ? displayName(member, null, blockedIds, t.misc.someone) : t.misc.someone;
+    },
+    [blockedIds, lookup, t.misc.someone],
+  );
+
+  // Where a row goes when it is tapped: the person on it who is not you, one
+  // screen up from this group — every group you share with them.
+  //
+  // The key has to be spelled the way the database spells it (`personKeyOf` is
+  // the same COALESCE the `waves_person_group_balances` view keys on), or the
+  // tap points at a stranger's ledger. Null means the row leads nowhere and
+  // must not look as though it does: yourself, and a member who exists only in
+  // the local queue and whose id the server has never seen.
+  const personKeyFor = useCallback(
+    (member: MemberRow | undefined): string | null => {
+      if (!member) return null;
+      if (member.id === ledger.myMemberId) return null;
+      if (member.profile_id !== null && member.profile_id === profile?.id) return null;
+      if (member.pending) return null;
+      return personKeyOf({
+        profileId: member.profile_id,
+        mergePersonId: mergePersonIds.get(member.id) ?? null,
+        memberId: member.id,
+      });
+    },
+    [ledger.myMemberId, mergePersonIds, profile?.id],
+  );
+
+  const items = useMemo(
+    () => simplifyItems(ledger.transfers, ledger.myMemberId),
+    [ledger.myMemberId, ledger.transfers],
+  );
+
+  const renderItem = useCallback(
+    ({ item }: { item: SimplifyItem }) => {
+      if (item.kind === 'heading') {
+        return (
+          <View style={{ paddingTop: theme.spacing.lg }}>
+            <SectionHeader
+              title={item.section === 'yours' ? t.simplifyYourPayments : t.simplifyOtherPayments}
+            />
+          </View>
+        );
+      }
+
+      const { transfer, side, personId, isLast } = item;
+      const person = lookup.get(personId);
+      const personName = nameOf(personId);
+      // Three sentences for three positions, rather than one sentence with the
+      // reader's name dropped into it. `youPayName` and `namePaysYou` are the
+      // settle screen's own words, so the screen that proposes a payment and
+      // the screen that records it say the same thing.
+      const sentence =
+        side === SimplifySide.YouPay
+          ? fill(t.youPayName, { name: personName })
+          : side === SimplifySide.YouReceive
+            ? fill(t.namePaysYou, { name: personName })
+            : fill(t.simplifyPaysWhom, {
+                from: nameOf(transfer.from),
+                to: nameOf(transfer.to),
+              });
+      const personKey = personKeyFor(person);
+
+      return (
+        <TransferRow
+          sentence={sentence}
+          avatarName={personName}
+          ghost={Boolean(person && (isGhost(person) || isBlockedMember(person, blockedIds)))}
+          amount={transfer.amount}
+          currency={transfer.currency as CurrencyCode}
+          locale={locale}
+          direction={
+            side === SimplifySide.YouPay
+              ? BalanceDirection.YouOwe
+              : side === SimplifySide.YouReceive
+                ? BalanceDirection.OwedToYou
+                : null
+          }
+          isLast={isLast}
+          openHint={t.people.seeSharedGroups}
+          onPress={
+            personKey
+              ? () =>
+                  router.push(
+                    `/friends/person/${encodeURIComponent(personKey)}?name=${encodeURIComponent(
+                      personName,
+                    )}` as never,
+                  )
+              : undefined
+          }
+        />
+      );
+    },
+    [blockedIds, locale, lookup, nameOf, personKeyFor, t, theme.spacing.lg],
+  );
 
   return (
     <Screen>
@@ -52,77 +282,64 @@ export default function SimplifyScreen() {
         </IconButton>
         <View style={{ flex: 1, alignItems: 'center' }}>
           <Text variant="heading">{t.whoPaysWhom}</Text>
-          <Text variant="micro" tone="muted">
-            {group.data?.name}
+          <Text variant="micro" tone="muted" numberOfLines={1}>
+            {/* `groupLabel`, not `group.name`: a group nobody named is called
+                after the people in it everywhere else in the app, and an empty
+                line under the title reads as a screen that failed to load. */}
+            {groupLabel(group.data, members.data ?? [], profile?.id)}
           </Text>
         </View>
         <View style={{ width: 44 }} />
       </Row>
 
-      <ScrollView
-        style={{ flex: 1 }}
+      {/* The same recycled list the group ledger uses. A pairwise group of
+          thirty people proposes a few hundred payments, and mounting all of them
+          at once was the other half of why this screen felt heavy. */}
+      <FlashList
+        data={items}
+        // A row's destination is not in its own data — it comes from who you are
+        // in this group, from the ghost merges on this phone, and from who you
+        // have blocked — so those go here, or a recycled row keeps whatever
+        // tappability and whatever name it was first drawn with.
+        extraData={`${locale}|${ledger.myMemberId ?? ''}|${mergePersonIds.size}|${blockedIds.size}`}
+        keyExtractor={(item) => item.key}
+        getItemType={(item) => item.kind}
+        renderItem={renderItem}
+        // Render well beyond the viewport so a fast fling never outruns
+        // recycling into blank rows (the default 250px is cleared in a frame).
+        drawDistance={1500}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingTop: theme.spacing.lg,
           paddingBottom: clearance,
-          gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}
-      >
-        <Card style={{ gap: theme.spacing.sm }}>
-          <Row style={{ justifyContent: 'space-between' }}>
-            <Text variant="subheading">
-              {group.data?.simplify_debts ? t.simplifyOn : t.simplifyOff}
-            </Text>
-            <Badge
-              label={plural(locale, ledger.transfers.length, t.simplifyPaymentsCount)}
-              tone="brand"
-            />
-          </Row>
-          <Text variant="caption" tone="muted">
-            {group.data?.simplify_debts ? t.simplifySuggestBody : t.simplifyPairwiseBody}
-          </Text>
-        </Card>
-
-        {ledger.transfers.length === 0 ? (
-          <EmptyState title={t.allSettled} body={t.group.nobodyOwes} />
-        ) : (
-          <Card padded={false} style={{ padding: theme.spacing.lg, gap: theme.spacing.lg }}>
-            {ledger.transfers.map((transfer) => (
-              <Row
-                key={`${transfer.from}-${transfer.to}-${transfer.amount}`}
-                style={{ justifyContent: 'space-between' }}
-              >
-                <Row style={{ flex: 1 }}>
-                  <Avatar name={nameOf(transfer.from)} size={38} />
-                  <Ionicons
-                    name={directionalIcon('arrow-forward')}
-                    size={iconSize.base}
-                    color={theme.color.textFaint}
-                  />
-                  <Avatar name={nameOf(transfer.to)} size={38} />
-                  <View style={{ flex: 1, marginLeft: theme.spacing.sm }}>
-                    <Text variant="body" numberOfLines={1}>
-                      {fill(t.simplifyPaysWhom, {
-                        from: nameOf(transfer.from),
-                        to: nameOf(transfer.to),
-                      })}
-                    </Text>
-                    {transfer.from === ledger.myMemberId || transfer.to === ledger.myMemberId ? (
-                      <Text variant="micro" tone="brand">
-                        {transfer.from === ledger.myMemberId
-                          ? t.simplifyYouPay
-                          : t.simplifyYouReceive}
-                      </Text>
-                    ) : null}
-                  </View>
-                </Row>
-                <MoneyText amount={transfer.amount} currency={transfer.currency} locale={locale} />
+        refreshControl={
+          <RefreshControl
+            refreshing={pull.refreshing}
+            onRefresh={pull.onRefresh}
+            tintColor={theme.color.brand}
+          />
+        }
+        ListHeaderComponent={
+          <View style={{ paddingTop: theme.spacing.lg, paddingBottom: theme.spacing.sm }}>
+            <Card style={{ gap: theme.spacing.sm }}>
+              <Row style={{ justifyContent: 'space-between' }}>
+                <Text variant="subheading">
+                  {group.data?.simplify_debts ? t.simplifyOn : t.simplifyOff}
+                </Text>
+                <Badge
+                  label={plural(locale, ledger.transfers.length, t.simplifyPaymentsCount)}
+                  tone="brand"
+                />
               </Row>
-            ))}
-          </Card>
-        )}
-      </ScrollView>
+              <Text variant="caption" tone="muted">
+                {group.data?.simplify_debts ? t.simplifySuggestBody : t.simplifyPairwiseBody}
+              </Text>
+            </Card>
+          </View>
+        }
+        ListEmptyComponent={<EmptyState title={t.allSettled} body={t.group.nobodyOwes} />}
+      />
     </Screen>
   );
 }

--- a/apps/mobile/src/components/GroupPhoto.tsx
+++ b/apps/mobile/src/components/GroupPhoto.tsx
@@ -31,6 +31,13 @@ interface GroupPhotoProps {
   size?: number;
   onPress?: () => void;
   busy?: boolean;
+  /**
+   * What tapping this does, when it is not "choose a photo". On the group's own
+   * settings screen the mark is the door to every way of changing the cover —
+   * the drawn marks, a photo, removing one — so announcing it as "Add group
+   * photo" describes a button that no longer exists.
+   */
+  accessibilityLabel?: string;
 }
 
 export function GroupPhoto({
@@ -40,6 +47,7 @@ export function GroupPhoto({
   size = 64,
   onPress,
   busy = false,
+  accessibilityLabel,
 }: GroupPhotoProps) {
   const theme = useTheme();
   const { t } = useStrings();
@@ -100,7 +108,9 @@ export function GroupPhoto({
     <Pressable
       onPress={onPress}
       accessibilityRole="button"
-      accessibilityLabel={source ? t.misc.changeGroupPhoto : t.misc.addGroupPhoto}
+      accessibilityLabel={
+        accessibilityLabel ?? (source ? t.misc.changeGroupPhoto : t.misc.addGroupPhoto)
+      }
     >
       {body}
     </Pressable>

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -283,9 +283,10 @@ export interface UiStrings {
   simplifyPaymentsCount: PluralForms;
   /** "{from} pays {to}" — a sentence, so it reads right-to-left too. */
   simplifyPaysWhom: string;
-  /** The micro line on my own transfer row. */
-  simplifyYouPay: string;
-  simplifyYouReceive: string;
+  /** The two headings that split the reader's own payments from everybody
+   *  else's. Shown only when there is something on both sides. */
+  simplifyYourPayments: string;
+  simplifyOtherPayments: string;
   freeForever: string;
   nothingYet: string;
   nothingYetBody: string;
@@ -2972,8 +2973,8 @@ const en: UiStrings = {
   simplifyPairwiseBody: 'Showing the actual pairwise ledger, exactly as the expenses created it.',
   simplifyPaymentsCount: { one: '{n} payment', other: '{n} payments' },
   simplifyPaysWhom: '{from} pays {to}',
-  simplifyYouPay: 'You pay',
-  simplifyYouReceive: 'You receive',
+  simplifyYourPayments: 'Your payments',
+  simplifyOtherPayments: 'Between other people',
   freeForever: 'Unlimited and free, forever',
   nothingYet: 'Nothing here yet',
   nothingYetBody: 'Add your first expense and the maths takes care of itself.',
@@ -5394,8 +5395,8 @@ const ta: UiStrings = {
   simplifyPairwiseBody: 'செலவுகள் உருவாக்கியபடி, உண்மையான இணை-கணக்கைக் காட்டுகிறது.',
   simplifyPaymentsCount: { one: '{n} பரிமாற்றம்', other: '{n} பரிமாற்றங்கள்' },
   simplifyPaysWhom: '{from} {to}க்குச் செலுத்துகிறார்',
-  simplifyYouPay: 'நீங்கள் செலுத்துகிறீர்கள்',
-  simplifyYouReceive: 'நீங்கள் பெறுகிறீர்கள்',
+  simplifyYourPayments: 'உங்கள் பரிமாற்றங்கள்',
+  simplifyOtherPayments: 'மற்றவர்களுக்கு இடையே',
   freeForever: 'எப்போதும் இலவசம்',
   nothingYet: 'இங்கே இன்னும் ஒன்றுமில்லை',
   nothingYetBody: 'முதல் செலவைச் சேருங்கள் — கணக்கு தானே பார்த்துக்கொள்ளும்.',
@@ -7915,8 +7916,8 @@ const hi: UiStrings = {
   simplifyPairwiseBody: 'खर्चों ने जैसा बनाया, ठीक वैसा असली जोड़ीवार हिसाब दिखाया जा रहा है।',
   simplifyPaymentsCount: { one: '{n} भुगतान', other: '{n} भुगतान' },
   simplifyPaysWhom: '{from} {to} को भुगतान करते हैं',
-  simplifyYouPay: 'आप भुगतान करते हैं',
-  simplifyYouReceive: 'आपको मिलते हैं',
+  simplifyYourPayments: 'आपके भुगतान',
+  simplifyOtherPayments: 'बाकी लोगों के बीच',
   freeForever: 'हमेशा मुफ़्त',
   nothingYet: 'यहाँ अभी कुछ नहीं है',
   nothingYetBody: 'पहला खर्च जोड़िए, हिसाब अपने आप संभल जाएगा।',
@@ -10365,8 +10366,8 @@ const ar: UiStrings = {
   simplifyPairwiseBody: 'يعرض السجل الثنائي الفعلي تماماً كما أنشأته المصروفات.',
   simplifyPaymentsCount: { one: 'دفعة واحدة', other: '{n} دفعات' },
   simplifyPaysWhom: 'يدفع {from} لـ {to}',
-  simplifyYouPay: 'تدفع',
-  simplifyYouReceive: 'تستلم',
+  simplifyYourPayments: 'دفعاتك',
+  simplifyOtherPayments: 'بين أشخاص آخرين',
   freeForever: 'بلا حدود ومجاني، للأبد',
   nothingYet: 'لا شيء هنا بعد',
   nothingYetBody: 'أضف أول مصروف والحساب يتكفل بنفسه.',

--- a/apps/mobile/src/lib/simplifyRows.ts
+++ b/apps/mobile/src/lib/simplifyRows.ts
@@ -1,0 +1,123 @@
+/**
+ * How the who-pays-whom screen is ordered and read.
+ *
+ * The screen used to be one undifferentiated stack of "A pays B" rows, and the
+ * complaint about it was not that a number was wrong — it was that nobody could
+ * tell what they were looking at. Two things caused that, and both are decided
+ * here rather than in the JSX.
+ *
+ * The first is that a reader wants their own payments, and everybody else's are
+ * context. So the list is split: the transfers that touch you, in the order the
+ * ledger proposed them, then the rest under a heading of their own. The
+ * headings appear only when there is something on both sides — a screen where
+ * every row is yours does not need to be told so.
+ *
+ * The second is that a row about a pair has to point somewhere when it is
+ * tapped, and "a pair" is not a destination. The counterparty is the person on
+ * the row who is not you; on a row between two other people there is no such
+ * person, so it leads with the payer — the one the sentence is about. One rule,
+ * so the avatar, the tap and the words can never disagree about whose row it
+ * is.
+ */
+
+export interface SimplifyTransfer {
+  readonly from: string;
+  readonly to: string;
+  readonly currency: string;
+  readonly amount: bigint;
+}
+
+/** Which of the three sentences a row is told with, and how its money reads. */
+export enum SimplifySide {
+  /** You are the payer: red money, "You pay {name}". */
+  YouPay = 'youPay',
+  /** You are the payee: the owed-to-you colour, "{name} pays you". */
+  YouReceive = 'youReceive',
+  /** Between two other people: a neutral amount, "{from} pays {to}". */
+  Others = 'others',
+}
+
+export interface SimplifyRow {
+  readonly kind: 'transfer';
+  readonly key: string;
+  readonly transfer: SimplifyTransfer;
+  readonly side: SimplifySide;
+  /**
+   * The member the row leads with and a tap opens: the other person when you
+   * are on the row, the payer when you are not.
+   */
+  readonly personId: string;
+  /** Last of its section, so the hairline never runs into the heading below. */
+  readonly isLast: boolean;
+}
+
+export interface SimplifyHeading {
+  readonly kind: 'heading';
+  readonly key: string;
+  readonly section: 'yours' | 'others';
+}
+
+export type SimplifyItem = SimplifyRow | SimplifyHeading;
+
+/**
+ * The rows of the screen, in the order they are drawn.
+ *
+ * `myMemberId` is null until the members land (and for a person reading a group
+ * they are not in) — everything is then "somebody else's", which is honest, and
+ * it settles itself a frame later without the list changing shape.
+ */
+export function simplifyItems(
+  transfers: readonly SimplifyTransfer[],
+  myMemberId: string | null,
+): SimplifyItem[] {
+  const mine: SimplifyRow[] = [];
+  const theirs: SimplifyRow[] = [];
+
+  for (const transfer of transfers) {
+    // The amount is part of the key: the pairwise view can propose two rows
+    // between the same two people in different currencies, and a duplicated key
+    // would make a recycling list draw one of them twice.
+    const key = `${transfer.from}-${transfer.to}-${transfer.currency}-${transfer.amount}`;
+    if (myMemberId && transfer.from === myMemberId) {
+      mine.push({
+        kind: 'transfer',
+        key,
+        transfer,
+        side: SimplifySide.YouPay,
+        personId: transfer.to,
+        isLast: false,
+      });
+    } else if (myMemberId && transfer.to === myMemberId) {
+      mine.push({
+        kind: 'transfer',
+        key,
+        transfer,
+        side: SimplifySide.YouReceive,
+        personId: transfer.from,
+        isLast: false,
+      });
+    } else {
+      theirs.push({
+        kind: 'transfer',
+        key,
+        transfer,
+        side: SimplifySide.Others,
+        personId: transfer.from,
+        isLast: false,
+      });
+    }
+  }
+
+  const close = (rows: SimplifyRow[]): SimplifyRow[] =>
+    rows.map((row, index) => ({ ...row, isLast: index === rows.length - 1 }));
+
+  // Headings earn their place only by separating two things. One section on its
+  // own is already unambiguous — the sentences say whose payment each row is.
+  const split = mine.length > 0 && theirs.length > 0;
+  const items: SimplifyItem[] = [];
+  if (split) items.push({ kind: 'heading', key: 'heading-yours', section: 'yours' });
+  items.push(...close(mine));
+  if (split) items.push({ kind: 'heading', key: 'heading-others', section: 'others' });
+  items.push(...close(theirs));
+  return items;
+}

--- a/apps/mobile/test/initials.test.ts
+++ b/apps/mobile/test/initials.test.ts
@@ -1,0 +1,46 @@
+/**
+ * The avatar's fallback letters.
+ *
+ * This is pinned because it shipped wrong and nothing caught it: names imported
+ * from a phone's address book carry a leading dot (".Rvs Amirnath", ".Rvs Arun
+ * T", ".Rvs Anoop"), the old rule took the first character literally, and three
+ * different people were drawn as the same ".A" circle — two of them side by
+ * side on one row of the who-pays-whom screen.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { initialsOf } from '@waves/ui/initials';
+
+describe('initialsOf', () => {
+  it('takes the first letter of the first two words', () => {
+    expect(initialsOf('Ravi Kumar')).toBe('RK');
+    expect(initialsOf('Asha')).toBe('A');
+    expect(initialsOf('Ravi Kumar Menon')).toBe('RK');
+  });
+
+  it('skips punctuation in front of a name', () => {
+    // The bug: all three of these used to come back as '.A'.
+    expect(initialsOf('.Rvs Amirnath')).toBe('RA');
+    expect(initialsOf('.Rvs Arun T')).toBe('RA');
+    expect(initialsOf('·Anoop')).toBe('A');
+    expect(initialsOf('  Priya  Sharma ')).toBe('PS');
+  });
+
+  it('keeps the first letter of a non-Latin name', () => {
+    expect(initialsOf('அசோக் குமார்')).toBe('அக');
+    expect(initialsOf('محمد علي')).toBe('مع');
+  });
+
+  it('falls back to a question mark when there is no letter to take', () => {
+    expect(initialsOf('')).toBe('?');
+    expect(initialsOf('   ')).toBe('?');
+    expect(initialsOf('...')).toBe('?');
+  });
+
+  it('never splits a character in half', () => {
+    // A single astral code point is two code units; `charAt(0)` returned a lone
+    // surrogate, which renders as a replacement box.
+    expect([...initialsOf('𝒜lice')]).toHaveLength(1);
+  });
+});

--- a/apps/mobile/test/initials.test.ts
+++ b/apps/mobile/test/initials.test.ts
@@ -20,11 +20,16 @@ describe('initialsOf', () => {
   });
 
   it('skips punctuation in front of a name', () => {
-    // The bug: all three of these used to come back as '.A'.
-    expect(initialsOf('.Rvs Amirnath')).toBe('RA');
-    expect(initialsOf('.Rvs Arun T')).toBe('RA');
     expect(initialsOf('·Anoop')).toBe('A');
     expect(initialsOf('  Priya  Sharma ')).toBe('PS');
+  });
+
+  it('skips short punctuated contact prefixes instead of making every imported contact identical', () => {
+    // The bug: all three of these used to come back as '.A', and then as the
+    // equally unhelpful 'RA' when the leading dot alone was stripped.
+    expect(initialsOf('.Rvs Amirnath')).toBe('A');
+    expect(initialsOf('.Rvs Arun T')).toBe('AT');
+    expect(initialsOf('.Rvs Anoop')).toBe('A');
   });
 
   it('keeps the first letter of a non-Latin name', () => {

--- a/apps/mobile/test/simplifyRows.test.ts
+++ b/apps/mobile/test/simplifyRows.test.ts
@@ -1,0 +1,72 @@
+/**
+ * The who-pays-whom list's shape.
+ *
+ * Pinned because the two things this decides — which section a row falls in,
+ * and who the row points at — are invisible in a screenshot until they are
+ * wrong, and getting the second one wrong points somebody at a stranger's
+ * ledger.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { SimplifySide, simplifyItems, type SimplifyTransfer } from '@/lib/simplifyRows';
+
+const transfer = (from: string, to: string, amount = 500n): SimplifyTransfer => ({
+  from,
+  to,
+  currency: 'INR',
+  amount,
+});
+
+describe('simplifyItems', () => {
+  it('puts your own payments first, under headings', () => {
+    const items = simplifyItems([transfer('asha', 'ravi'), transfer('me', 'ravi')], 'me');
+
+    expect(items.map((item) => item.kind)).toEqual(['heading', 'transfer', 'heading', 'transfer']);
+    expect(items[0]).toMatchObject({ kind: 'heading', section: 'yours' });
+    expect(items[1]).toMatchObject({ side: SimplifySide.YouPay, personId: 'ravi' });
+    expect(items[2]).toMatchObject({ kind: 'heading', section: 'others' });
+    expect(items[3]).toMatchObject({ side: SimplifySide.Others, personId: 'asha' });
+  });
+
+  it('drops the headings when every row is on one side', () => {
+    const onlyMine = simplifyItems([transfer('me', 'ravi'), transfer('asha', 'me')], 'me');
+    expect(onlyMine.every((item) => item.kind === 'transfer')).toBe(true);
+
+    const onlyTheirs = simplifyItems([transfer('asha', 'ravi')], 'me');
+    expect(onlyTheirs.every((item) => item.kind === 'transfer')).toBe(true);
+  });
+
+  it('points a row at the person on it who is not you', () => {
+    const [pay, receive] = simplifyItems([transfer('me', 'ravi'), transfer('asha', 'me')], 'me');
+
+    expect(pay).toMatchObject({ side: SimplifySide.YouPay, personId: 'ravi' });
+    expect(receive).toMatchObject({ side: SimplifySide.YouReceive, personId: 'asha' });
+  });
+
+  it('treats everything as somebody else’s before the members land', () => {
+    const items = simplifyItems([transfer('me', 'ravi')], null);
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({ side: SimplifySide.Others, personId: 'me' });
+  });
+
+  it('marks the last row of each section, so a hairline never meets a heading', () => {
+    const items = simplifyItems(
+      [transfer('me', 'ravi'), transfer('me', 'asha'), transfer('asha', 'ravi')],
+      'me',
+    );
+    const rows = items.filter((item) => item.kind === 'transfer');
+
+    expect(rows.map((row) => row.isLast)).toEqual([false, true, true]);
+  });
+
+  it('keeps two currencies between the same pair apart', () => {
+    const items = simplifyItems(
+      [transfer('asha', 'ravi'), { ...transfer('asha', 'ravi'), currency: 'USD' }],
+      'me',
+    );
+
+    expect(new Set(items.map((item) => item.key)).size).toBe(2);
+  });
+});

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,7 +6,8 @@
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./curve": "./src/curve.ts"
+    "./curve": "./src/curve.ts",
+    "./initials": "./src/initials.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/packages/ui/src/components/Avatar.tsx
+++ b/packages/ui/src/components/Avatar.tsx
@@ -1,6 +1,7 @@
 import { useState, type ReactNode } from 'react';
 import { Image, Pressable, View } from 'react-native';
 
+import { initialsOf } from '../initials';
 import { useTheme } from '../theme';
 import { tints, type TintName } from '../tokens';
 import { Text } from './Text';
@@ -12,11 +13,6 @@ export function tintForKey(key: string): TintName {
     hash = (hash * 31 + key.charCodeAt(index)) >>> 0;
   }
   return tints[hash % tints.length] as TintName;
-}
-
-export function initialsOf(name: string): string {
-  const parts = name.trim().split(/\s+/).slice(0, 2);
-  return parts.map((part) => part.charAt(0).toUpperCase()).join('') || '?';
 }
 
 export function Avatar({

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -9,6 +9,7 @@
 export * from './tokens';
 export * from './theme';
 export * from './curve';
+export * from './initials';
 export * from './components/Text';
 export * from './components/Surfaces';
 export * from './components/Callout';

--- a/packages/ui/src/initials.ts
+++ b/packages/ui/src/initials.ts
@@ -22,16 +22,29 @@
  */
 const LEADING_NOISE = /^[^\p{L}\p{N}]+/u;
 
+function wordsForInitials(name: string): string[] {
+  const raw = name.split(/\s+/).filter((word) => word.length > 0);
+  const words = raw
+    .map((word) => word.replace(LEADING_NOISE, ''))
+    .filter((word) => word.length > 0);
+
+  // Some phone books prefix imported names with a short marker like `.Rvs`.
+  // Using that marker makes every avatar in that imported cluster identical
+  // (`RA`, `RA`, `RA`), so skip it when there is an actual name after it.
+  const firstRaw = raw[0] ?? '';
+  const firstWord = words[0] ?? '';
+  if (LEADING_NOISE.test(firstRaw) && [...firstWord].length <= 3 && words.length > 1) {
+    return words.slice(1);
+  }
+  return words;
+}
+
 /**
  * Up to two letters, from the first two words that have a letter or digit in
  * them at all.
  */
 export function initialsOf(name: string): string {
-  const words = name
-    .split(/\s+/)
-    .map((word) => word.replace(LEADING_NOISE, ''))
-    .filter((word) => word.length > 0)
-    .slice(0, 2);
+  const words = wordsForInitials(name).slice(0, 2);
 
   return (
     words

--- a/packages/ui/src/initials.ts
+++ b/packages/ui/src/initials.ts
@@ -1,0 +1,46 @@
+/**
+ * The letters an avatar falls back to when a person has no picture.
+ *
+ * Its own module, free of React Native, because this is the kind of thing that
+ * can be wrong without looking broken: the circle still draws, still takes the
+ * name's colour, still lines up — it simply says the wrong letters, and nobody
+ * reads an avatar closely enough to notice one is lying.
+ *
+ * The case that forced it out of `Avatar`: contacts imported from a phone
+ * arrive carrying whatever punctuation the address book had in front of the
+ * name — ".Rvs Amirnath", ".Rvs Arun T", ".Rvs Anoop". Taking the first
+ * character literally drew all three as the same ".A" circle, and the
+ * who-pays-whom screen puts two of them on one row, so a screen whose whole
+ * job is telling people apart was drawing them identically.
+ */
+
+/**
+ * Everything in front of a word's first letter or digit — punctuation, symbols,
+ * stray marks. Unicode-aware on purpose: the app runs in four languages, and a
+ * Tamil or Arabic name must keep its own first letter, not lose it to an
+ * ASCII-shaped rule.
+ */
+const LEADING_NOISE = /^[^\p{L}\p{N}]+/u;
+
+/**
+ * Up to two letters, from the first two words that have a letter or digit in
+ * them at all.
+ */
+export function initialsOf(name: string): string {
+  const words = name
+    .split(/\s+/)
+    .map((word) => word.replace(LEADING_NOISE, ''))
+    .filter((word) => word.length > 0)
+    .slice(0, 2);
+
+  return (
+    words
+      .map((word) => {
+        // Spread rather than `charAt(0)`: a character outside the BMP is two
+        // code units, and taking the first of them renders half a glyph.
+        const [first = ''] = [...word];
+        return first.toUpperCase();
+      })
+      .join('') || '?'
+  );
+}


### PR DESCRIPTION
The user's words about this screen: *"the screen is very confusing and if I want to click on those person it is getting truncated and I don't understand anything what is happening very confusing"*. All four of those complaints turned out to be separate, findable defects.

## What was wrong

**The sentence was truncated on every row.** Each row carried the payer's avatar, an arrow, the payee's avatar, the sentence naming both, and the amount — five elements across a phone's width, three of which state the same fact. The sentence, squeezed into what was left and capped at `numberOfLines={1}`, lost every time: rows read `Renny pays .Rvs …`, `.Rvs Arun T pays …`. A row that cannot say who pays whom has no reason to exist.

**Your own rows were ungrammatical.** The sentence was `{from} pays {to}` filled with `displayName`, which returns "You" for the reader — so your own row read "You pays Ravi".

**The rows went nowhere.** They were plain `Row`s: no `Pressable`, no role, no label, no chevron.

**The avatars were lying.** `initialsOf` took the first character literally, so `.Rvs Amirnath`, `.Rvs Arun T` and `.Rvs Anoop` all drew as the same `.A` circle — two of them side by side on one row of a screen whose entire job is telling people apart.

**The last row was behind the bottom bar.** The screen used `useScreenClearance`, which reserves only the system inset; the app's own bar is rendered once at the root and stays over pushed screens, and this route is not in `TAB_BAR_HIDDEN_ROUTES`.

## What changed

- **One avatar, not two, and the sentence survives** — over two lines if it needs them, never an ellipsis through a name.
- **Three sentences for three positions**: `You pay {name}` / `{name} pays you` / `{from} pays {to}`, reusing the settle screen's own keys so the screen that proposes a payment and the screen that records it speak the same way.
- **Money colour is semantic on your rows** — red when you hand it over, the owed-to-you blue when you receive it — and neutral on a payment between two other people, which belongs to neither of them from here.
- **Rows are tappable**, opening that person across every group you share with them: the same destination and the same `personKeyOf` identity the Balances tab uses, so a tap can never land on a stranger's ledger. Your own row and a queue-only member are dead ends and wear no chevron, exactly as there.
- **`FlashList`** with the group-ledger settings (`drawDistance` 1500, `extraData`, `getItemType`, pull-to-refresh), hairline-divided instead of boxed in a card.
- **Your payments come first, under a heading**, with everyone else's under a second one — headings only when there is something on both sides.
- **`useTabBarClearance`**, so the last proposed payment is reachable.
- **`initialsOf` skips leading punctuation**, unicode-aware, and no longer splits an astral character in half. Moved to `packages/ui/src/initials.ts` so it can be unit-tested. Every avatar in the app reads through it.
- Two fixes on the group settings screen from the earlier design pass: the member roster was showing a **blocked** person's real name and real payment handle (masked everywhere else), and the group mark — now the one door to the cover — still announced itself as "Add group photo".

New pure module `src/lib/simplifyRows.ts` decides section, counterparty and hairlines, with tests; `initialsOf` has its own.

## i18n

`simplifyYourPayments` and `simplifyOtherPayments` added in **en / ta / hi / ar**; `simplifyYouPay` / `simplifyYouReceive` removed from the type and all four locales — the sentences say it now. No new hardcoded English. The removed arrow between avatars also removes the one glyph on this screen that had to be mirrored; the chevron uses `directionalIcon`.

## Not done, deliberately

- **The grey decimals** (`₹4.` black, `28` grey) are `MoneyText`'s app-wide `fadeFraction`, not this screen's choice. Changing it here would make one screen disagree with every other.
- **17 other screens have the same clearance bug** (`group/[id]`: insights, export, map, members, month, pending, recap, member/[memberId]; all of `personal/*`; `settings/import`, `settings/offline-voice`). Left alone to avoid colliding with other work in flight — worth its own sweep.

## Verification

`pnpm format`, mobile `lint` (0 errors), mobile + ui `typecheck`, and the full mobile suite (79 files / 992 tests) pass on Windows node. **Nothing was confirmed visually — there is no device or emulator here**, so the layout, the two-line sentence, the section headings and the clearance are argued from the code, not seen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned payment simplification with clearer sections, full payment descriptions, refreshed list performance, pull-to-refresh, and navigation to shared groups.
  - Added clearer labels distinguishing your payments from payments between others.
  - Avatar fallback initials now better support punctuation, non-Latin names, and special characters.

- **Bug Fixes**
  - Blocked members are now masked in group settings and payment views, including hidden handles and ghost avatars.
  - Group photo controls include improved accessibility labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->