### PR TITLE
The bottom edge gets its clearance from one place

### DIFF
--- a/apps/mobile/src/app/capture.tsx
+++ b/apps/mobile/src/app/capture.tsx
@@ -29,6 +29,7 @@ import {
   Row,
   Screen,
   Text,
+  useScreenClearance,
   useTheme,
 } from '@waves/ui';
 
@@ -174,6 +175,9 @@ const consumedScans = new Set<string>();
 export default function CaptureScreen() {
   const theme = useTheme();
   const insets = useSafeAreaInsets();
+  // What the pinned Save bar leaves beneath itself for the system navigation
+  // bar, from the helper every scrolling screen uses for the same question.
+  const clearance = useScreenClearance(theme.spacing.md);
   const { t, locale } = useStrings();
   const createCapture = useCreateCapture();
   const updateCapture = useUpdateCapture();
@@ -490,7 +494,7 @@ export default function CaptureScreen() {
   // renders with the shot, on cancel it navigates back.
   if (awaitingScan) {
     return (
-      <Screen edges={['top', 'bottom']}>
+      <Screen edges={['top']}>
         <View
           style={{
             flex: 1,
@@ -509,7 +513,7 @@ export default function CaptureScreen() {
   }
 
   return (
-    <Screen edges={['top', 'bottom']}>
+    <Screen edges={['top']}>
       <View style={{ paddingHorizontal: theme.spacing.xl }}>
         <ExpenseHeader title={isEditing ? t.captures.editTitle : t.captures.newTitle} />
       </View>
@@ -716,6 +720,12 @@ export default function CaptureScreen() {
         style={{
           paddingHorizontal: theme.spacing.xl,
           paddingTop: theme.spacing.md,
+          // The bar carries the navigation-bar inset itself rather than letting
+          // the Screen hold it off the bottom edge: its fill and hairline reach
+          // the edge, Save keeps a breath under it, and the picker sheets — which
+          // are absolutely positioned inside this same tree — can finally reach
+          // the bottom of the screen instead of stopping at the Screen's padding.
+          paddingBottom: clearance,
           gap: theme.spacing.sm,
           borderTopWidth: 1,
           borderTopColor: theme.color.border,

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -56,6 +56,7 @@ import {
   Row,
   Screen,
   Text,
+  useScreenClearance,
   useTheme,
 } from '@waves/ui';
 
@@ -126,6 +127,20 @@ const EMPTY_LOCKS: ReadonlySet<MemberId> = new Set();
  * rather than one row of faces.
  */
 const PAYER_TILE_WIDTH = 60;
+
+/**
+ * The press area around this form's small text links — "Split by item", "Paid
+ * by several", "Split evenly".
+ *
+ * They are drawn in `micro`, which is 15 points of line: a symmetric slop of 8
+ * left them a ~31pt target, well under the 44 both platforms ask for, and
+ * they sit on crowded rows where a miss lands on something else. The vertical
+ * slop is the half that matters, so it is the half that grows; widening the
+ * sides as well would only steal presses from the control next to them. Slop
+ * rather than padding because these links share a line with a heading — padding
+ * would push the heading's baseline around.
+ */
+const LINK_HIT_SLOP = { top: 15, bottom: 15, left: 8, right: 8 } as const;
 
 /** Who paid what, in minor units. */
 type PayerMap = ReadonlyMap<MemberId, bigint>;
@@ -326,6 +341,10 @@ function parseLocationParam(value: string | undefined): ExpenseLocation | null {
 
 export default function AddExpenseScreen() {
   const theme = useTheme();
+  // The room the pinned action bar leaves under Save for the system navigation
+  // bar. Read here rather than in the bar's style so the whole screen agrees on
+  // one number, and so the hook is not buried in a `return`.
+  const clearance = useScreenClearance(theme.spacing.md);
   const { t, locale } = useStrings();
   // The capture params are the inbox handoff (A34): assigning a capture opens
   // this form prefilled and carries the capture id so a successful save can
@@ -1110,7 +1129,7 @@ export default function AddExpenseScreen() {
     // only the form body waits on the mirror read (a few ms at launch). A bare
     // full-screen spinner used to leave a headerless blank while it loaded.
     return (
-      <Screen edges={['bottom']}>
+      <Screen edges={[]}>
         <StatusBar style="light" />
         {/* The same hero the loaded form opens on, so the panel does not repaint
             from a white bar to a purple one once the mirror read lands. */}
@@ -1531,7 +1550,19 @@ export default function AddExpenseScreen() {
         : plural(locale, participants.length, t.memberCount);
 
   return (
-    <Screen edges={['bottom']}>
+    // No safe-area edges: this screen reserves neither end itself. The hero pads
+    // the status bar into its own gradient at the top, and the action bar pads
+    // the navigation bar into its own fill at the bottom, so both surfaces run
+    // to the screen edge instead of floating on a strip of page colour — the
+    // grammar the app's bottom bar already uses.
+    //
+    // It also settles where a picker sheet lands. `SheetOverlay` is drawn in
+    // this tree, absolutely positioned to the bottom, and an absolute child is
+    // laid out inside its parent's padding: with a bottom inset on the Screen
+    // the sheet stopped short of the screen edge, its scrim left the navigation
+    // bar unwashed, and the sheet then reserved the same inset a second time
+    // under its own last row.
+    <Screen edges={[]}>
       {/* The hero runs dark under the status bar, so its icons must be light —
           the same override the expense screen this form mirrors makes. */}
       <StatusBar style="light" />
@@ -1756,7 +1787,7 @@ export default function AddExpenseScreen() {
                   accessibilityRole="button"
                   accessibilityLabel={t.expense.splitByItem}
                   onPress={() => router.replace(`/group/${groupId}/itemize`)}
-                  hitSlop={8}
+                  hitSlop={LINK_HIT_SLOP}
                   style={{ flexShrink: 0 }}
                 >
                   <Text
@@ -1863,7 +1894,7 @@ export default function AddExpenseScreen() {
                     accessibilityRole="button"
                     accessibilityLabel={t.expense.splitPaidEvenly}
                     onPress={splitPaidEvenly}
-                    hitSlop={8}
+                    hitSlop={LINK_HIT_SLOP}
                   >
                     <Text variant="micro" tone="brand" style={{ fontWeight: '700' }}>
                       {t.expense.splitPaidEvenly}
@@ -1878,7 +1909,7 @@ export default function AddExpenseScreen() {
                   accessibilityState={{ checked: manyPayers }}
                   accessibilityLabel={manyPayers ? t.expense.paidByOne : t.expense.paidBySeveral}
                   onPress={() => setManyPayers(!manyPayers)}
-                  hitSlop={8}
+                  hitSlop={LINK_HIT_SLOP}
                 >
                   <Text variant="micro" tone="brand" style={{ fontWeight: '700' }}>
                     {manyPayers ? t.expense.paidByOne : t.expense.paidBySeveral}
@@ -2210,7 +2241,14 @@ export default function AddExpenseScreen() {
           style={{
             paddingHorizontal: theme.spacing.xl,
             paddingTop: theme.spacing.md,
-            paddingBottom: theme.spacing.md,
+            // The bar is the last thing on the screen, so it is the one that
+            // owes the navigation bar its room — and it pays it as padding, not
+            // as a gap: the fill and the hairline run all the way to the bottom
+            // edge behind the gesture pill or the three buttons, and Save sits a
+            // clear breath above them. A bare `spacing.md` left the button
+            // pressed against the system bar on any phone whose bar is drawn
+            // over the app.
+            paddingBottom: clearance,
             gap: theme.spacing.sm,
             borderTopWidth: 1,
             borderTopColor: theme.color.border,

--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -25,7 +25,6 @@ import {
   SegmentedTabs,
   Text,
   useTheme,
-  useScreenClearance,
 } from '@waves/ui';
 
 import { format, money } from '@waves/core';
@@ -53,6 +52,7 @@ import { plural, useStrings, type UiStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { expenseReceiptPath, expenseReceiptUrl } from '@/data/api';
 import { coordLabel, mapsUrl } from '@/lib/location';
+import { useBottomClearance } from '@/lib/clearance';
 
 function splitLabels(t: UiStrings): Record<string, string> {
   return {
@@ -126,7 +126,7 @@ function DetailLine({
 export default function ExpenseDetailScreen() {
   const theme = useTheme();
   const insets = useSafeAreaInsets();
-  const clearance = useScreenClearance();
+  const clearance = useBottomClearance();
   const { t, locale } = useStrings();
   const { id, expenseId } = useLocalSearchParams<{ id: string; expenseId: string }>();
   const groupId = id ?? '';

--- a/apps/mobile/src/app/group/[id]/export.tsx
+++ b/apps/mobile/src/app/group/[id]/export.tsx
@@ -17,7 +17,6 @@ import {
   Row,
   Screen,
   Text,
-  useScreenClearance,
   useTheme,
 } from '@waves/ui';
 
@@ -35,6 +34,7 @@ import { friendlyError } from '@/lib/errors';
 import { printAvailable, printHtmlToFile } from '@/lib/print';
 import { useAuth } from '@/lib/auth';
 import { useStrings } from '@/i18n';
+import { useBottomClearance } from '@/lib/clearance';
 
 /** The correct OOXML spreadsheet MIME type + Apple UTI for an .xlsx. */
 const XLSX_MIME = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
@@ -68,7 +68,7 @@ function slugify(name: string): string {
  */
 export default function GroupExportScreen() {
   const theme = useTheme();
-  const clearance = useScreenClearance();
+  const clearance = useBottomClearance();
   const { t, locale } = useStrings();
   const { id } = useLocalSearchParams<{ id: string }>();
   const groupId = id ?? '';

--- a/apps/mobile/src/app/group/[id]/insights.tsx
+++ b/apps/mobile/src/app/group/[id]/insights.tsx
@@ -41,7 +41,6 @@ import {
   type BarDatum,
   type ColumnDatum,
   useTheme,
-  useScreenClearance,
 } from '@waves/ui';
 
 import { CategoryBadge } from '@/components/Category';
@@ -51,6 +50,7 @@ import { computeSpendingRows } from '@/data/spending';
 import { useGroup } from '@/data/hooks';
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
+import { useBottomClearance } from '@/lib/clearance';
 
 enum Scope {
   Group = 'group',
@@ -62,7 +62,7 @@ const MONTHS_SHOWN = 6;
 
 export default function InsightsScreen() {
   const theme = useTheme();
-  const clearance = useScreenClearance();
+  const clearance = useBottomClearance();
   const { t, locale } = useStrings();
   const { id } = useLocalSearchParams<{ id: string }>();
   const groupId = id ?? '';

--- a/apps/mobile/src/app/group/[id]/map.tsx
+++ b/apps/mobile/src/app/group/[id]/map.tsx
@@ -32,7 +32,6 @@ import {
   Row,
   Screen,
   Text,
-  useScreenClearance,
   useTheme,
 } from '@waves/ui';
 
@@ -40,6 +39,7 @@ import { useGroup } from '@/data/hooks';
 import { coordLabel, mapsUrl } from '@/lib/location';
 import { InsightsSkeleton } from '@/components/Skeletons';
 import { useStrings } from '@/i18n';
+import { useBottomClearance } from '@/lib/clearance';
 
 interface Place {
   readonly id: string;
@@ -51,7 +51,7 @@ interface Place {
 
 export default function PlacesScreen() {
   const theme = useTheme();
-  const clearance = useScreenClearance();
+  const clearance = useBottomClearance();
   const { t, locale } = useStrings();
   const { id } = useLocalSearchParams<{ id: string }>();
   const groupId = id ?? '';

--- a/apps/mobile/src/app/group/[id]/member/[memberId].tsx
+++ b/apps/mobile/src/app/group/[id]/member/[memberId].tsx
@@ -21,7 +21,6 @@ import {
   Text,
   TintCard,
   useTheme,
-  useScreenClearance,
 } from '@waves/ui';
 
 import { useGroup, useGroupLedger, useSetMemberRole, useUpdateMember } from '@/data/hooks';
@@ -31,10 +30,11 @@ import { useBlockedUsers } from '@/data/blocked';
 import { displayName, groupLabel, isBlockedMember, isGhost } from '@/data/types';
 import { fill, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
+import { useBottomClearance } from '@/lib/clearance';
 
 export default function MemberScreen() {
   const theme = useTheme();
-  const clearance = useScreenClearance();
+  const clearance = useBottomClearance();
   const { t, locale } = useStrings();
   const { id, memberId } = useLocalSearchParams<{ id: string; memberId: string }>();
   const groupId = id ?? '';

--- a/apps/mobile/src/app/group/[id]/members.tsx
+++ b/apps/mobile/src/app/group/[id]/members.tsx
@@ -18,7 +18,6 @@ import {
   Screen,
   Text,
   useTheme,
-  useScreenClearance,
 } from '@waves/ui';
 
 import { type PickedContact } from '@/components/ContactPicker';
@@ -36,10 +35,11 @@ import { useAuth } from '@/lib/auth';
 import { requestContacts } from '@/lib/contactPickerBridge';
 import { friendlyError } from '@/lib/errors';
 import { isPhoneCountryError } from '@/lib/phone';
+import { useBottomClearance } from '@/lib/clearance';
 
 export default function MembersScreen() {
   const theme = useTheme();
-  const clearance = useScreenClearance();
+  const clearance = useBottomClearance();
   const { t, locale } = useStrings();
   const { id } = useLocalSearchParams<{ id: string }>();
   const groupId = id ?? '';

--- a/apps/mobile/src/app/group/[id]/month.tsx
+++ b/apps/mobile/src/app/group/[id]/month.tsx
@@ -32,7 +32,6 @@ import {
   TintCard,
   tintForKey,
   useTheme,
-  useScreenClearance,
 } from '@waves/ui';
 
 import { CategoryBadge } from '@/components/Category';
@@ -42,6 +41,7 @@ import { displayName, groupLabel, type ExpenseRow } from '@/data/types';
 import { fill, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { paidBy } from '@/lib/payerLines';
+import { useBottomClearance } from '@/lib/clearance';
 
 /** One row of the flattened month: the header tile, a day heading, or a bill. */
 type MonthItem =
@@ -59,7 +59,7 @@ function myShare(shares: { member_id: string; amount: string }[], memberId: stri
 
 export default function SpendingMonthScreen() {
   const theme = useTheme();
-  const clearance = useScreenClearance();
+  const clearance = useBottomClearance();
   const { t, locale } = useStrings();
   const params = useLocalSearchParams<{
     id: string;

--- a/apps/mobile/src/app/group/[id]/pending.tsx
+++ b/apps/mobile/src/app/group/[id]/pending.tsx
@@ -15,7 +15,6 @@ import {
   Screen,
   Text,
   useTheme,
-  useScreenClearance,
 } from '@waves/ui';
 
 import {
@@ -30,6 +29,7 @@ import { useBlockedUsers } from '@/data/blocked';
 import { displayName, isGhost, type SettlementRow } from '@/data/types';
 import { fill, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
+import { useBottomClearance } from '@/lib/clearance';
 
 /**
  * Whole days left before a pending settlement auto-confirms — the 7-day window
@@ -57,7 +57,7 @@ function daysToConfirm(initiatedIso: string, now: number = Date.now()): number {
  */
 export default function PendingConfirmationsScreen() {
   const theme = useTheme();
-  const clearance = useScreenClearance();
+  const clearance = useBottomClearance();
   const { t, locale } = useStrings();
   const { id } = useLocalSearchParams<{ id: string }>();
   const groupId = id ?? '';

--- a/apps/mobile/src/app/group/[id]/recap.tsx
+++ b/apps/mobile/src/app/group/[id]/recap.tsx
@@ -24,7 +24,6 @@ import {
   Row,
   Screen,
   Text,
-  useScreenClearance,
   useTheme,
 } from '@waves/ui';
 
@@ -33,10 +32,11 @@ import { useGroup } from '@/data/hooks';
 import { useAuth } from '@/lib/auth';
 import { InsightsSkeleton } from '@/components/Skeletons';
 import { useStrings, fill } from '@/i18n';
+import { useBottomClearance } from '@/lib/clearance';
 
 export default function RecapScreen() {
   const theme = useTheme();
-  const clearance = useScreenClearance();
+  const clearance = useBottomClearance();
   const { t, locale } = useStrings();
   const { id } = useLocalSearchParams<{ id: string }>();
   const groupId = id ?? '';

--- a/apps/mobile/src/app/personal/budgets.tsx
+++ b/apps/mobile/src/app/personal/budgets.tsx
@@ -30,7 +30,6 @@ import {
   Sheet,
   SegmentedTabs,
   Text,
-  useScreenClearance,
   useTheme,
 } from '@waves/ui';
 
@@ -43,10 +42,11 @@ import {
 } from '@/data/personal';
 import { useDefaultCurrency } from '@/lib/currency';
 import { useStrings } from '@/i18n';
+import { useBottomClearance } from '@/lib/clearance';
 
 export default function BudgetsScreen() {
   const theme = useTheme();
-  const clearance = useScreenClearance();
+  const clearance = useBottomClearance();
   const { t, locale } = useStrings();
   const dc = useDefaultCurrency();
   const { budgets, txns } = usePersonalLedger();

--- a/apps/mobile/src/app/personal/entry.tsx
+++ b/apps/mobile/src/app/personal/entry.tsx
@@ -30,7 +30,6 @@ import {
   Screen,
   SegmentedTabs,
   Text,
-  useScreenClearance,
   useTheme,
 } from '@waves/ui';
 
@@ -46,6 +45,7 @@ import {
 import { useDefaultCurrency } from '@/lib/currency';
 import { useSync } from '@/sync';
 import { useStrings } from '@/i18n';
+import { useBottomClearance } from '@/lib/clearance';
 
 export default function PersonalEntryScreen() {
   const theme = useTheme();
@@ -116,7 +116,7 @@ function EntryForm({
   t: ReturnType<typeof useStrings>['t'];
 }) {
   const theme = useTheme();
-  const clearance = useScreenClearance();
+  const clearance = useBottomClearance();
   const upsert = useUpsertPersonalRecord();
   const remove = useDeletePersonalRecord();
 

--- a/apps/mobile/src/app/personal/loans.tsx
+++ b/apps/mobile/src/app/personal/loans.tsx
@@ -33,7 +33,6 @@ import {
   Sheet,
   SegmentedTabs,
   Text,
-  useScreenClearance,
   useTheme,
 } from '@waves/ui';
 
@@ -46,10 +45,11 @@ import {
 } from '@/data/personal';
 import { useDefaultCurrency } from '@/lib/currency';
 import { useStrings } from '@/i18n';
+import { useBottomClearance } from '@/lib/clearance';
 
 export default function LoansScreen() {
   const theme = useTheme();
-  const clearance = useScreenClearance();
+  const clearance = useBottomClearance();
   const { t, locale } = useStrings();
   const dc = useDefaultCurrency();
   const { loans, txns } = usePersonalLedger();

--- a/apps/mobile/src/app/personal/recurring.tsx
+++ b/apps/mobile/src/app/personal/recurring.tsx
@@ -42,7 +42,6 @@ import {
   SegmentedTabs,
   Text,
   Toggle,
-  useScreenClearance,
   useTheme,
 } from '@waves/ui';
 
@@ -58,6 +57,7 @@ import {
 } from '@/data/personal';
 import { useDefaultCurrency } from '@/lib/currency';
 import { fill, useStrings } from '@/i18n';
+import { useBottomClearance } from '@/lib/clearance';
 
 /** A repeat pattern in words. The open-ended one names its own interval, so
  *  "every 5 months" never reads as the vaguer "every few months". */
@@ -88,7 +88,7 @@ export function frequencyLabel(
 
 export default function RecurringScreen() {
   const theme = useTheme();
-  const clearance = useScreenClearance();
+  const clearance = useBottomClearance();
   const { t, locale } = useStrings();
   const dc = useDefaultCurrency();
   const { recurrings, txns } = usePersonalLedger();

--- a/apps/mobile/src/app/personal/source/[id].tsx
+++ b/apps/mobile/src/app/personal/source/[id].tsx
@@ -46,7 +46,6 @@ import {
   Screen,
   Sheet,
   Text,
-  useScreenClearance,
   useTheme,
 } from '@waves/ui';
 
@@ -59,6 +58,7 @@ import {
   useUpsertPersonalRecord,
 } from '@/data/personal';
 import { fill, useStrings } from '@/i18n';
+import { useBottomClearance } from '@/lib/clearance';
 
 /**
  * How far back the timeline looks: five years of months.
@@ -71,7 +71,7 @@ const LOOKBACK_YEARS = 5;
 
 export default function SourceTimelineScreen() {
   const theme = useTheme();
-  const clearance = useScreenClearance();
+  const clearance = useBottomClearance();
   const { t, locale } = useStrings();
   const { id } = useLocalSearchParams<{ id: string }>();
   const { txns, recurrings } = usePersonalLedger();

--- a/apps/mobile/src/app/personal/transactions.tsx
+++ b/apps/mobile/src/app/personal/transactions.tsx
@@ -17,17 +17,17 @@ import {
   Row,
   Screen,
   Text,
-  useScreenClearance,
   useTheme,
 } from '@waves/ui';
 
 import { CategoryBadge } from '@/components/Category';
 import { usePersonalLedger } from '@/data/personal';
 import { useStrings } from '@/i18n';
+import { useBottomClearance } from '@/lib/clearance';
 
 export default function PersonalTransactionsScreen() {
   const theme = useTheme();
-  const clearance = useScreenClearance();
+  const clearance = useBottomClearance();
   const { t, locale } = useStrings();
   const { txns } = usePersonalLedger();
 

--- a/apps/mobile/src/app/settings/import.tsx
+++ b/apps/mobile/src/app/settings/import.tsx
@@ -51,7 +51,6 @@ import {
   SectionHeader,
   Sheet,
   Text,
-  useTabBarClearance,
   useTheme,
 } from '@waves/ui';
 
@@ -63,6 +62,7 @@ import { useReducedMotion } from '@/lib/reducedMotion';
 import { useGroups } from '@/data/hooks';
 import { displayName, groupLabel, GroupType, type MemberRow } from '@/data/types';
 import { useAuth } from '@/lib/auth';
+import { useBottomClearance } from '@/lib/clearance';
 
 /** What a column in the file has been mapped to. */
 type Mapping = { kind: 'me' } | { kind: 'member'; memberId: string } | { kind: 'ghost' };
@@ -131,9 +131,10 @@ export default function ImportScreen() {
   // The bottom bar shows on this screen (it is a settings page, not a modal), and
   // it is opaque — so the scroll has to clear the *bar*, not just the system
   // inset. `useScreenClearance` only cleared the inset, which left the Import CTA
-  // jammed under the bar. `useTabBarClearance` is the bar-aware room the other
-  // settings screens use; a token more on top gives the footer CTA its breath.
-  const clearance = useTabBarClearance() + theme.spacing.xl;
+  // jammed under the bar. `useBottomClearance` asks the bar itself whether it is
+  // showing here rather than this screen having to know; a token more on top
+  // gives the footer CTA its breath.
+  const clearance = useBottomClearance() + theme.spacing.xl;
   const { t, locale } = useStrings();
   const reduceMotion = useReducedMotion();
   const groups = useGroups();

--- a/apps/mobile/src/app/settings/offline-voice.tsx
+++ b/apps/mobile/src/app/settings/offline-voice.tsx
@@ -75,7 +75,6 @@ import {
   Screen,
   SectionHeader,
   Text,
-  useScreenClearance,
   useTheme,
   type Theme,
 } from '@waves/ui';
@@ -89,6 +88,7 @@ import {
 } from '@/lib/dictation';
 import { useReducedMotion } from '@/lib/reducedMotion';
 import { speechModels } from '@/lib/speechModels';
+import { useBottomClearance } from '@/lib/clearance';
 
 /**
  * How long a download may run before the screen stops claiming to know.
@@ -149,7 +149,7 @@ function localeName(tag: string, locale: string): string | null {
 
 export default function OfflineVoiceScreen() {
   const theme = useTheme();
-  const clearance = useScreenClearance();
+  const clearance = useBottomClearance();
   const reduceMotion = useReducedMotion();
   const { t, locale } = useStrings();
   const [progress, setProgress] = useState<Record<string, RowProgress>>({});

--- a/apps/mobile/src/components/ActivityDateFilter.tsx
+++ b/apps/mobile/src/components/ActivityDateFilter.tsx
@@ -116,7 +116,13 @@ export function ActivityDateFilter({
         <ScrollView
           horizontal
           showsHorizontalScrollIndicator={false}
-          contentContainerStyle={{ gap: theme.spacing.sm }}
+          // A gutter past the last chip, the same one the payment rails and the
+          // payer lane carry: the four ranges do not fit a narrow phone, and a
+          // chip sliced off flush at the card's edge reads as a broken layout
+          // rather than as "there is more this way". `paddingEnd`, not
+          // `paddingRight`, so the gutter follows the row when Arabic reverses
+          // it and the cut lands on the trailing side either way.
+          contentContainerStyle={{ gap: theme.spacing.sm, paddingEnd: theme.spacing.xl }}
         >
           {presets.map((p) => {
             const active = activePreset(p);
@@ -151,12 +157,20 @@ export function ActivityDateFilter({
           })}
         </ScrollView>
 
-        {/* The selected range, read-only — it echoes the calendar taps below. */}
+        {/* The selected range, read-only — it echoes the calendar taps below.
+
+            Both halves shrink and truncate rather than push each other about:
+            the dates are formatted long ("Sat, 12 Sept") in the reader's own
+            language, and a Tamil or Arabic month name at a large font scale can
+            outrun half a phone. Without this the trailing half was shoved past
+            the card's padding and clipped at the screen edge — the leading one
+            keeping its gutter, which is what makes the row look lopsided rather
+            than full. */}
         <Row style={{ justifyContent: 'space-between', alignItems: 'baseline' }}>
-          <Text variant="caption" tone="muted">
+          <Text variant="caption" tone="muted" numberOfLines={1} style={{ flexShrink: 1 }}>
             {t.activityFilter.from} · {showDate(start)}
           </Text>
-          <Text variant="caption" tone="muted">
+          <Text variant="caption" tone="muted" numberOfLines={1} style={{ flexShrink: 1 }}>
             {t.activityFilter.to} · {showDate(end ?? start)}
           </Text>
         </Row>

--- a/apps/mobile/src/components/RangeCalendar.tsx
+++ b/apps/mobile/src/components/RangeCalendar.tsx
@@ -38,7 +38,29 @@ import {
   startOfDay,
 } from '@/lib/calendarGrid';
 
+/**
+ * A day cell's height, and the diameter the day's own circle is drawn at.
+ *
+ * Not its width: the seven columns share the width they are given, so the grid
+ * is exactly as wide as whatever holds it. It used to be a width too, and seven
+ * fixed cells with `Row`'s default 12pt gap between them came to 352 points —
+ * wider than the content box of a sheet on a 360pt phone, which pushed the grid
+ * (and everything else sharing that scroll column, such as the From/To line) off
+ * the right-hand edge. The gap did a second kind of damage: it broke the tinted
+ * span between the two ends into stripes, since a band drawn inside a cell
+ * cannot cross the gap to the next one.
+ */
 const CELL = 40;
+
+/**
+ * How wide the calendar is allowed to get before it stops growing.
+ *
+ * Columns that share the width need a ceiling, or on a tablet seven day circles
+ * drift to the far corners of a very wide row with the tint band stretched
+ * between them. Roughly a large phone's grid: past that the calendar centres
+ * itself in whatever it was given.
+ */
+const MAX_GRID_WIDTH = 7 * 56;
 
 export function RangeCalendar({
   earliest = null,
@@ -124,7 +146,14 @@ export function RangeCalendar({
   const weeks = monthGrid(view, weekStart);
 
   return (
-    <View style={{ gap: theme.spacing.sm }}>
+    <View
+      style={{
+        gap: theme.spacing.sm,
+        width: '100%',
+        maxWidth: MAX_GRID_WIDTH,
+        alignSelf: 'center',
+      }}
+    >
       {/* Month header with ‹ › paging, clamped to the caller's months. */}
       <Row style={{ alignItems: 'center', justifyContent: 'space-between' }}>
         <Pressable
@@ -163,9 +192,9 @@ export function RangeCalendar({
       {/* Weekday initials. The row is a plain `row`, which React Native reverses
           under RTL, so the first weekday lands on the side the reader starts
           from and the columns below line up with it either way. */}
-      <Row>
+      <Row gap={0}>
         {weekdays.map((w, i) => (
-          <View key={i} style={{ width: CELL, alignItems: 'center' }}>
+          <View key={i} style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="micro" tone="faint" style={{ fontWeight: '600' }}>
               {w}
             </Text>
@@ -176,9 +205,9 @@ export function RangeCalendar({
       {/* The day grid. */}
       <View style={{ gap: 2 }}>
         {weeks.map((week, wi) => (
-          <Row key={wi}>
+          <Row key={wi} gap={0}>
             {week.map((d, di) => {
-              if (!d) return <View key={di} style={{ width: CELL, height: CELL }} />;
+              if (!d) return <View key={di} style={{ flex: 1, height: CELL }} />;
               const disabled = !inBounds(d);
               const isFrom = spanLo !== null && sameDay(d, spanLo);
               const isTo = spanHi !== null && sameDay(d, spanHi);
@@ -202,7 +231,12 @@ export function RangeCalendar({
                   disabled={disabled}
                   onPress={() => pick(d)}
                   style={{
-                    width: CELL,
+                    // A seventh of the row rather than a fixed 40: the columns
+                    // divide the width they are given, which is what keeps the
+                    // grid inside its container on a narrow phone and lets the
+                    // tint band run unbroken from one end of a range to the
+                    // other. The circle inside stays its own fixed size.
+                    flex: 1,
                     height: CELL,
                     alignItems: 'center',
                     justifyContent: 'center',

--- a/apps/mobile/src/components/expense/SheetOverlay.tsx
+++ b/apps/mobile/src/components/expense/SheetOverlay.tsx
@@ -20,9 +20,10 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 
-import { directionalIcon, iconSize, Row, Text, useScreenClearance, useTheme } from '@waves/ui';
+import { directionalIcon, iconSize, Row, Text, useTheme } from '@waves/ui';
 
 import { useStrings } from '@/i18n';
+import { useBottomClearance } from '@/lib/clearance';
 
 /**
  * A labelled tap-row: a leading icon, the field name over its value, a chevron.
@@ -173,12 +174,18 @@ export function SheetOverlay({
 }): React.JSX.Element {
   const theme = useTheme();
   const { t } = useStrings();
-  // The foot every screen in this app leaves at the bottom edge, from the one
-  // helper that knows how to work it out. This sheet is drawn in the screen's
-  // own tree rather than in a modal window, so nothing else is going to clear
-  // the navigation bar for it: the last row of the list is the last thing above
-  // the gesture pill or the three buttons.
-  const foot = useScreenClearance(theme.spacing.xl);
+  // The foot this sheet leaves at the bottom edge.
+  //
+  // Route-aware, because this sheet is drawn in the screen's own tree rather
+  // than in a modal window of its own. A modal would be a separate native window
+  // and would cover everything; this is a view inside the page, and the app's
+  // bottom bar is a later sibling at the root — it paints *over* the sheet, scrim
+  // and all. So on any route where the bar is showing (the Activity feed's date
+  // filter, say) the sheet has to clear the bar as well as the system navigation
+  // inset, or its last control ends up behind the bar and cannot be tapped at
+  // all. On a route the bar hides on (add-expense, capture) the plain screen foot
+  // is right, and `useBottomClearance` knows which is which.
+  const foot = useBottomClearance(theme.spacing.xl);
 
   // Drag the handle down to dismiss. translateY only ever goes positive (down);
   // past a short threshold or on a quick flick the sheet closes, otherwise it

--- a/apps/mobile/src/components/expense/SheetOverlay.tsx
+++ b/apps/mobile/src/components/expense/SheetOverlay.tsx
@@ -11,7 +11,6 @@
 import { type ReactNode } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Pressable, ScrollView, View } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   runOnJS,
@@ -21,7 +20,7 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 
-import { directionalIcon, iconSize, Row, Text, useTheme } from '@waves/ui';
+import { directionalIcon, iconSize, Row, Text, useScreenClearance, useTheme } from '@waves/ui';
 
 import { useStrings } from '@/i18n';
 
@@ -174,7 +173,12 @@ export function SheetOverlay({
 }): React.JSX.Element {
   const theme = useTheme();
   const { t } = useStrings();
-  const insets = useSafeAreaInsets();
+  // The foot every screen in this app leaves at the bottom edge, from the one
+  // helper that knows how to work it out. This sheet is drawn in the screen's
+  // own tree rather than in a modal window, so nothing else is going to clear
+  // the navigation bar for it: the last row of the list is the last thing above
+  // the gesture pill or the three buttons.
+  const foot = useScreenClearance(theme.spacing.xl);
 
   // Drag the handle down to dismiss. translateY only ever goes positive (down);
   // past a short threshold or on a quick flick the sheet closes, otherwise it
@@ -233,9 +237,7 @@ export function SheetOverlay({
             borderTopLeftRadius: theme.radius.lg,
             borderTopRightRadius: theme.radius.lg,
             padding: theme.spacing.xl,
-            // Clear the Android gesture/nav bar so the last list row is not
-            // hidden behind it.
-            paddingBottom: theme.spacing.xl + insets.bottom,
+            paddingBottom: foot,
             gap: theme.spacing.md,
             maxHeight: '75%',
           },

--- a/apps/mobile/src/lib/clearance.ts
+++ b/apps/mobile/src/lib/clearance.ts
@@ -1,0 +1,58 @@
+/**
+ * How much room the thing at the bottom of the screen has to leave beneath it.
+ *
+ * The design system offers two answers — `useScreenClearance`, which reserves
+ * the system navigation bar, and `useTabBarClearance`, which reserves that plus
+ * the app's own floating bar — and until now every screen picked one by hand.
+ * Picking by hand is the bug: the bar is rendered once at the *root*, over the
+ * whole navigation stack (`AppTabBar`), so it is on top of a pushed group page
+ * or a personal ledger just as much as it is on top of the four tabs. Being
+ * pushed is not the test, and reading it that way left seventeen screens and a
+ * picker sheet ending their last row underneath the bar.
+ *
+ * There is one test, and it is not a judgement call: `resolveTabBar` already
+ * decides whether the bar is showing on this route, because the bar itself asks
+ * it. This hook asks the same question and hands back the matching number, so a
+ * screen no longer has to know which of the two it is — and a screen added to
+ * (or removed from) `TAB_BAR_HIDDEN_ROUTES` later gets the right foot without
+ * anybody remembering to come back here.
+ *
+ * The rule is not new here, only named: the toast host (`lib/toast.tsx`) works
+ * the same question out inline for the panel it floats, and the import screen
+ * used to reason about it in a comment. Whichever of the two branches lands
+ * second should hand the toast host this hook rather than keep a second copy of
+ * the decision — there is nothing in its version this one does not do.
+ */
+
+import { useSegments } from 'expo-router';
+
+import { useScreenClearance, useTabBarClearance } from '@waves/ui';
+
+import { useAuth } from '@/lib/auth';
+import { resolveTabBar } from '@/lib/tabBar';
+
+/**
+ * The foot for whatever sits last on this screen: the system navigation bar,
+ * plus the app's bottom bar when the bar is drawn over this route.
+ *
+ * `base` is the breath below the last row on a screen the bar does not cover —
+ * pass a larger one for a floating action or a pinned footer. When the bar *is*
+ * covering the route the deeper of the two wins: the bar and its own breath are
+ * normally more than any base a screen asks for, but a screen with a tall pinned
+ * footer must not have its own request quietly dropped.
+ */
+export function useBottomClearance(base?: number): number {
+  const { session } = useAuth();
+  // Typed as a union of fixed-length route tuples, so indexing past the first
+  // element trips the tuple bounds check under the CI tsconfig — the same widen
+  // `AppTabBar` does for the same read.
+  const segments = useSegments() as readonly string[];
+  const { hidden } = resolveTabBar(segments, !session);
+
+  // Both hooks run every render: which of the two numbers is used is a value
+  // decision, never a decision about whether to call a hook.
+  const screen = useScreenClearance(base);
+  const overBar = useTabBarClearance();
+
+  return hidden ? screen : Math.max(screen, overBar);
+}

--- a/apps/mobile/src/lib/toast.tsx
+++ b/apps/mobile/src/lib/toast.tsx
@@ -13,17 +13,16 @@
  * Callout on the screen that owns it, or a sheet.
  *
  * The bar it must clear is not fixed, so the host asks the same rules the bar
- * itself follows (`resolveTabBar`) which of the two clearances applies.
+ * itself follows, through `useBottomClearance`, which of the two clearances
+ * applies.
  */
 
 import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react';
-import { useSegments } from 'expo-router';
 
-import { Toast, useScreenClearance, useTabBarClearance } from '@waves/ui';
+import { Toast } from '@waves/ui';
 
-import { useAuth } from '@/lib/auth';
 import { useReducedMotion } from '@/lib/reducedMotion';
-import { resolveTabBar } from '@/lib/tabBar';
+import { useBottomClearance } from '@/lib/clearance';
 
 interface ToastValue {
   /** Show a line briefly over whatever is on screen. The newest one wins. */
@@ -73,14 +72,13 @@ function ToastHost({
   current: { seq: number; message: string } | null;
   onDone: () => void;
 }) {
-  const segments = useSegments() as readonly string[];
-  const { session } = useAuth();
   const reduceMotion = useReducedMotion();
-  // Both are hooks, so both are asked; which one is right depends on whether the
-  // bottom bar is over this screen — the same question `AppTabBar` asks.
-  const overBar = useTabBarClearance();
-  const overScreen = useScreenClearance();
-  const { hidden } = resolveTabBar(segments, !session);
+  // The toast floats over whatever screen is showing, so it needs the same
+  // answer every screen needs: the system navigation bar, plus the app's bottom
+  // bar wherever that is drawn over the route. `useBottomClearance` is that
+  // question asked once, so a route moving in or out of `TAB_BAR_HIDDEN_ROUTES`
+  // corrects the toast along with everything else.
+  const bottom = useBottomClearance();
 
   return (
     <Toast
@@ -89,7 +87,7 @@ function ToastHost({
       message={current?.message ?? ''}
       visible={current !== null}
       onDone={onDone}
-      bottom={hidden ? overScreen : overBar}
+      bottom={bottom}
       animated={!reduceMotion}
     />
   );

--- a/packages/ui/src/components/Overlay.tsx
+++ b/packages/ui/src/components/Overlay.tsx
@@ -27,9 +27,10 @@ import {
   View,
   type ViewStyle,
 } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { SafeAreaProvider, useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { useTheme } from '../theme';
+import { useScreenClearance } from './PillTabBar';
 
 /** The scrim behind every overlay — a near-black wash, enough to sit the surface
  *  off the screen without dimming it to a blackout. */
@@ -115,6 +116,70 @@ export interface SheetProps {
 }
 
 /**
+ * The card itself, rendered *inside* the modal's own safe-area provider so its
+ * foot is measured against the window it is actually drawn in.
+ *
+ * Split out for exactly that reason: `useScreenClearance` has to run under the
+ * provider below, and a hook cannot be called halfway down a return tree.
+ */
+function SheetCard({
+  handle,
+  padded,
+  style,
+  onLayout,
+  children,
+}: {
+  handle: boolean;
+  padded: boolean;
+  style?: ViewStyle;
+  onLayout: (height: number) => void;
+  children: ReactNode;
+}) {
+  const theme = useTheme();
+  // The same foot every scrolling screen leaves at the bottom edge, from the
+  // same helper: the system navigation bar plus a breath, so the last row of a
+  // sheet clears the gesture pill or the three buttons the way the last row of
+  // a list does. It used to be spelled out here as `spacing.md + insets.bottom`,
+  // which was the same arithmetic in a second place — and a second place is
+  // where the two drift apart.
+  const foot = useScreenClearance(theme.spacing.md);
+
+  return (
+    <Pressable
+      onPress={() => {}}
+      accessibilityViewIsModal
+      onLayout={(event) => onLayout(event.nativeEvent.layout.height)}
+      style={[
+        {
+          backgroundColor: theme.color.surface,
+          borderTopLeftRadius: theme.radius.xxl,
+          borderTopRightRadius: theme.radius.xxl,
+          paddingHorizontal: padded ? theme.spacing.lg : 0,
+          paddingTop: theme.spacing.md,
+          paddingBottom: foot,
+          ...theme.shadow.lifted,
+        },
+        style,
+      ]}
+    >
+      {handle ? (
+        <View
+          style={{
+            alignSelf: 'center',
+            width: 40,
+            height: 4,
+            borderRadius: 2,
+            backgroundColor: theme.color.border,
+            marginBottom: theme.spacing.sm,
+          }}
+        />
+      ) : null}
+      {children}
+    </Pressable>
+  );
+}
+
+/**
  * A bottom sheet: the surface slides up from the bottom edge under a fading
  * scrim, and back down on dismiss. Tapping the scrim closes it; the sheet itself
  * swallows the tap so a press inside never dismisses. Rounded top corners, a
@@ -129,10 +194,9 @@ export function Sheet({
   style,
   closeLabel = 'Close',
 }: SheetProps) {
-  const theme = useTheme();
   const insets = useSafeAreaInsets();
   const reduceMotion = useReduceMotion();
-  const { height: screenHeight } = useWindowDimensions();
+  const { width: screenWidth, height: screenHeight } = useWindowDimensions();
   const { mounted, progress } = useOverlay(visible);
   // The sheet's own height, measured on layout, so it travels exactly its own
   // distance rather than a guess. Until the first measure a screen-height
@@ -152,52 +216,52 @@ export function Sheet({
     <Modal
       transparent
       statusBarTranslucent
+      // A sheet is anchored to the bottom edge, so the *bottom* edge is the one
+      // that has to be its own. Without this the modal gets a window that stops
+      // above the navigation bar: the card's rounded top corners are then drawn
+      // over a surface that ends short of the screen, and the safe-area foot
+      // below the last row is reserved twice — once by the window, once by the
+      // padding. `statusBarTranslucent` has always said this about the top; this
+      // is the same sentence for the other end.
+      navigationBarTranslucent
       visible={mounted}
       animationType="none"
       onRequestClose={onClose}
     >
-      <Animated.View style={{ flex: 1, backgroundColor: SCRIM, opacity: progress }}>
-        <Pressable
-          onPress={onClose}
-          accessibilityRole="button"
-          accessibilityLabel={closeLabel}
-          style={{ flex: 1, justifyContent: 'flex-end' }}
-        >
-          <Animated.View style={{ transform: [{ translateY }] }}>
-            <Pressable
-              onPress={() => {}}
-              accessibilityViewIsModal
-              onLayout={(event) => setHeight(event.nativeEvent.layout.height)}
-              style={[
-                {
-                  backgroundColor: theme.color.surface,
-                  borderTopLeftRadius: theme.radius.xxl,
-                  borderTopRightRadius: theme.radius.xxl,
-                  paddingHorizontal: padded ? theme.spacing.lg : 0,
-                  paddingTop: theme.spacing.md,
-                  paddingBottom: theme.spacing.md + insets.bottom,
-                  ...theme.shadow.lifted,
-                },
-                style,
-              ]}
-            >
-              {handle ? (
-                <View
-                  style={{
-                    alignSelf: 'center',
-                    width: 40,
-                    height: 4,
-                    borderRadius: 2,
-                    backgroundColor: theme.color.border,
-                    marginBottom: theme.spacing.sm,
-                  }}
-                />
-              ) : null}
-              {children}
-            </Pressable>
-          </Animated.View>
-        </Pressable>
-      </Animated.View>
+      {/* A modal is its own native window, and the app's root provider never
+          measures it: the insets read through the context belong to the screen
+          underneath, which is a different window with different bars. Giving the
+          modal its own provider makes the safe area re-measure against the
+          window the sheet is actually drawn in — the same cure `Screen`'s
+          `inModal` applies, and the reason that prop exists.
+
+          Seeded with the app's insets rather than left to measure from nothing:
+          a bare provider renders null until its first layout lands, which would
+          hold the sheet off the screen for a frame while the entrance animation
+          was already running — the sheet would appear halfway up its own travel.
+          The seed is a good guess for one frame; the real measurement replaces
+          it immediately. */}
+      <SafeAreaProvider
+        initialMetrics={{
+          frame: { x: 0, y: 0, width: screenWidth, height: screenHeight },
+          insets,
+        }}
+      >
+        <Animated.View style={{ flex: 1, backgroundColor: SCRIM, opacity: progress }}>
+          <Pressable
+            onPress={onClose}
+            accessibilityRole="button"
+            accessibilityLabel={closeLabel}
+            style={{ flex: 1, justifyContent: 'flex-end' }}
+          >
+            <Animated.View style={{ transform: [{ translateY }] }}>
+              <SheetCard handle={handle} padded={padded} style={style} onLayout={setHeight}>
+                {children}
+              </SheetCard>
+            </Animated.View>
+          </Pressable>
+        </Animated.View>
+      </SafeAreaProvider>
     </Modal>
   );
 }

--- a/packages/ui/src/components/PillTabBar.tsx
+++ b/packages/ui/src/components/PillTabBar.tsx
@@ -102,11 +102,18 @@ export function useTabBarClearance(): number {
  *
  * Not only screens: anything whose last row is the last thing above the system
  * bar asks the same question and must get the same answer — a bottom sheet's
- * foot (`Sheet`, and the expense forms' own `SheetOverlay`), and a pinned action
- * bar that carries the inset itself so its fill reaches the screen edge instead
- * of floating on a strip of page colour. The arithmetic is trivial, which is
- * exactly why it had been written out by hand in three other places; there is
- * one of it now.
+ * foot (`Sheet`), and a pinned action bar that carries the inset itself so its
+ * fill reaches the screen edge instead of floating on a strip of page colour.
+ * The arithmetic is trivial, which is exactly why it had been written out by
+ * hand in three other places; there is one of it now.
+ *
+ * `Sheet` is the interesting case, and the reason it is *this* helper and not
+ * `useTabBarClearance`: a sheet drawn in a `Modal` gets its own native window
+ * above everything the app has drawn, bottom bar included, so the only thing
+ * under it is the system's own bar. A sheet drawn inside the page instead — the
+ * expense forms' `SheetOverlay` — is painted *under* that bar and has to clear
+ * it as well; the app answers that one with `useBottomClearance`, which picks
+ * between these two hooks by asking whether the bar is showing on this route.
  */
 export function useScreenClearance(base: number = spacing.xxxl): number {
   const insets = useSafeAreaInsets();

--- a/packages/ui/src/components/PillTabBar.tsx
+++ b/packages/ui/src/components/PillTabBar.tsx
@@ -99,6 +99,14 @@ export function useTabBarClearance(): number {
  * app draws edge-to-edge — a fixed `paddingBottom` cannot know its height, so
  * the last row ends up under the system UI. Pass a larger `base` on a screen
  * with a floating action or a pinned footer.
+ *
+ * Not only screens: anything whose last row is the last thing above the system
+ * bar asks the same question and must get the same answer — a bottom sheet's
+ * foot (`Sheet`, and the expense forms' own `SheetOverlay`), and a pinned action
+ * bar that carries the inset itself so its fill reaches the screen edge instead
+ * of floating on a strip of page colour. The arithmetic is trivial, which is
+ * exactly why it had been written out by hand in three other places; there is
+ * one of it now.
  */
 export function useScreenClearance(base: number = spacing.xxxl): number {
   const insets = useSafeAreaInsets();


### PR DESCRIPTION
Two bottom bars, three sheets and seventeen screens, all asking the same
question and each answering it by hand. This makes one place answer it.

## 1. The system navigation bar

**`Sheet` (`packages/ui`) measured the wrong window.** It reads
`useSafeAreaInsets()` while rendering inside a React Native `Modal`. A modal is
its own native window, which the app's root `SafeAreaProvider` never measures —
this repo already documents that trap on `Screen`'s `inModal` prop, and that
prop exists to cure it. `Sheet` never got the cure. It also set
`statusBarTranslucent` but not `navigationBarTranslucent`, so its window stopped
above the navigation bar: the card's rounded corners were drawn on a surface
that ended short of the screen, and the foot under the last row was reserved
twice — once by the window, once by the padding. It now carries both the flag
and its own provider (seeded with the app's insets so the first frame is not
blank while the entrance spring is already running).

**`add-expense` and `capture` reserved the inset on the wrong view.** Both
passed `edges={['bottom']}` to `Screen`, so the navigation bar was held off by
*page* padding: a strip of page colour under a pinned action bar whose fill and
hairline should reach the screen edge — the grammar `PillTabBar` already
follows. It also moved the bottom of the world for their picker sheets, which
are absolutely positioned inside that same padded tree and so stopped short of
the edge, scrim and all, then reserved the inset a second time under their last
row. The two screens now reserve nothing; the bars carry the inset themselves.

## 2. The app's own floating bar

The first round of this branch cleared the Activity feed's date sheet as
"already correct". It was not, and the reasoning that cleared it was the same
reasoning that put the bug there: `AppTabBar` renders **once at the root, over
the whole navigation stack**, so being pushed is not the test. `captures.tsx`
already says it in as many words —

> A real Modal, not an absolute overlay: the one bottom bar (`AppTabBar`) is
> rendered at the root over the whole stack, so an in-tree overlay paints
> *under* it and the sheet's lower rows hide behind the nav bar.

— and `SheetOverlay` is an in-tree overlay. On the Activity feed its Apply and
Clear buttons sat behind the bar, unreachable.

`useBottomClearance` (`apps/mobile/src/lib/clearance.ts`) now asks
`resolveTabBar` — the same rule the bar itself follows — and returns the
matching clearance. Nothing chooses by hand any more, and a route added to or
removed from `TAB_BAR_HIDDEN_ROUTES` later corrects its own screens.

**Sixteen screens had chosen wrong**, all of them routes the bar is drawn over:

- `group/[id]/`: `expense/[expenseId]`, `export`, `insights`, `map`,
  `member/[memberId]`, `members`, `month`, `pending`, `recap`
- `personal/`: `budgets`, `entry`, `loans`, `recurring`, `source/[id]`,
  `transactions`
- `settings/offline-voice`

`settings/import` had already reasoned it out by hand and was right; it now says
the same thing through the hook, keeping its deliberate extra breath.
`group/[id]/simplify` is left to #727, which fixes it there.

## 3. Two right-edge defects on the same sheet, one cause

`RangeCalendar` laid its seven day columns out at a fixed 40pt each, inside
`Row`, whose default gap is 12 — a grid **352pt wide**. A sheet's content box on
a 360pt phone is 320. Two consequences, both visible in the report:

- The over-wide grid stretched the vertical scroll column it sits in, so the
  `From · … / To · …` line above it (a `space-between` row) was stretched with
  it and its trailing half pushed past the card's padding, clipped at the screen
  edge while the leading half kept its gutter. In RTL it would mirror.
- The 12pt gaps also broke the tinted range between the two ends into stripes —
  the file's own comment says the band exists so a range reads "as one
  continuous bar rather than a circle, a gap, a bar", which is precisely what
  the gap was making it.

The columns now share the width they are given (`flex: 1`, fixed height, fixed
circle), with a max width so a tablet does not scatter them. The From/To halves
also shrink and truncate, so a long date in Tamil or Arabic cannot re-create the
overflow. The preset chip row is a horizontal scroller, so its cut is real, but
it had no trailing gutter — it now carries the same peek the payment rails and
the payer lane use, as `paddingEnd` so it follows the writing direction.

Also on `add-expense`: the three `micro` text links on the split and payer rows
("Split by item", "Paid by several", "Split evenly") had `hitSlop={8}` around a
15pt line — a ~31pt target on a crowded row. Grown to 44 vertically via slop, so
nothing on those lines moves.

## Reach

- **`Sheet` — 18 call sites.** A modal window covers the tab bar, so these only
  ever needed the system inset; the `packages/ui` fix is the whole of it.
  (home, captures ×2, personal budgets/loans/recurring/source, scan, backup ×3,
  import, packs, cover-emoji ×2, quick-add, sync banner, tag editor.)
- **`SheetOverlay` — 7 render sites.** Only `ActivityDateFilter` is opened on a
  route where the bar shows; the other six (capture ×2, add-expense ×2, the
  category sheet, the payment-method sheet) are on routes in
  `TAB_BAR_HIDDEN_ROUTES`. All seven now get the right answer without knowing
  which they are.
- **17 screens** switched to the route-aware hook.

## Deliberately not changed

- **The 41 screens already on `useTabBarClearance`.** Correct where the bar
  shows. One is arguably not: `settings/privacy` is reachable signed out, where
  the bar hides and it over-reserves 76pt. Over-reserving is benign, and
  sweeping 41 files on a change nobody can see running is not.
- **The bar stays tappable over an open `SheetOverlay`.** It is painted above
  the scrim, so you can navigate away from underneath a modal sheet. The real
  cure is the one `captures.tsx` took — a real `Modal` — but `SheetOverlay`
  carries a drag-to-dismiss gesture that would need a `GestureHandlerRootView`
  inside the modal window, and that is not a change to make blind.
- **`Popup`.** Centred with a 20pt gutter, never reaches either bar.
- **The participant check glyph** on each split row (22pt icon + slop 8 = 38pt):
  a duplicate affordance marked `accessible={false}`; the primary target is the
  whole ~46pt name row.
- **`ExpenseHero`.** Read closely and found no real defect — back chevron 24pt
  with slop 10, currency pill on a 36pt floor plus slop 10, amount field already
  taking the whole run between them.

## Notes for whoever merges

`lib/toast.tsx` on #730 works the same route question out inline for the panel
it floats. Whichever of the two lands second should hand it `useBottomClearance`
rather than keep a second copy of the decision — there is nothing in its version
this hook does not do. #730 and #727 both touch `packages/ui`; this branch
touches `PillTabBar`'s docblock and `Overlay.tsx` only.

## Testing

`pnpm format`, `pnpm lint`, `pnpm typecheck` (mobile + ui) and `pnpm test:app`
(981 tests, 77 files) pass. **Nothing here has been seen running.** No device,
no emulator: every fix is argued from the code, and the two Android-specific
halves (the modal window's bottom edge, and the 352pt grid against a 360pt
phone) are arithmetic and RN's `Modal` contract rather than observation.

No user-visible strings added or changed, so no locale work. The two new
direction-sensitive bits — the chip row's peek gutter and the calendar's shared
columns — use `paddingEnd` and symmetric flex respectively, so both mirror.
