### PR TITLE
Say what signing out takes with it, and let it be kept

### DIFF
--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -22,6 +22,7 @@ import {
 } from '@waves/ui';
 
 import { ProfileAvatar } from '@/components/ProfileAvatar';
+import { SignOutSheet } from '@/components/SignOutSheet';
 import { friendlyError } from '@/lib/errors';
 import { SkeletonList } from '@/components/Skeletons';
 import { removeAvatar, uploadAvatar } from '@/data/api';
@@ -237,6 +238,7 @@ function ProfileForm() {
 
   const [status, setStatus] = useState<string | null>(null);
   const [photoBusy, setPhotoBusy] = useState(false);
+  const [signingOut, setSigningOut] = useState(false);
 
   /**
    * Pick, shrink, upload, then tell the profile where it landed. The upload
@@ -333,17 +335,6 @@ function ProfileForm() {
         : t.account.lockOff;
 
   const signOutHint = isGuest ? t.account.signOutGuestHint : t.account.signOutHint;
-
-  const confirmSignOut = (): void => {
-    Alert.alert(
-      t.lock.signOutQuestion,
-      isGuest ? t.lock.signOutGuestWarning : t.lock.signOutReassure,
-      [
-        { text: t.lock.staySignedIn, style: 'cancel' },
-        { text: t.lock.signOut, style: 'destructive', onPress: () => void signOut() },
-      ],
-    );
-  };
 
   return (
     <Screen>
@@ -587,7 +578,7 @@ function ProfileForm() {
               icon: 'log-out-outline',
               label: t.lock.signOut,
               hint: signOutHint,
-              onPress: confirmSignOut,
+              onPress: () => setSigningOut(true),
               destructive: true,
             },
           ]}
@@ -604,6 +595,22 @@ function ProfileForm() {
           ]}
         />
       </ScrollView>
+
+      {/* Signing out is a confirmation the OS cannot draw: it wipes this
+          device's mirror and the queue with it, so the question has to be able
+          to name what is still unsent and offer to send it or save a copy
+          first. An alert can only ask; this can show. Mounted only while open,
+          because a Modal that starts hidden never presents on Android. */}
+      {signingOut ? (
+        <SignOutSheet
+          visible
+          onClose={() => setSigningOut(false)}
+          onSignOut={() => {
+            setSigningOut(false);
+            void signOut();
+          }}
+        />
+      ) : null}
     </Screen>
   );
 }

--- a/apps/mobile/src/components/SignOutSheet.tsx
+++ b/apps/mobile/src/components/SignOutSheet.tsx
@@ -1,0 +1,371 @@
+/**
+ * The sheet that stands between somebody and signing out.
+ *
+ * Signing out is not a neutral act on this app: the `SyncProvider` wipes the
+ * mirror, the queue, the drafts, the receipt bytes and this account's backup
+ * credentials the moment the session goes, because the next person to hold this
+ * phone must not find the last account's ledger on it. Everything the server
+ * already has comes back on the next sign-in — but a mutation still in the
+ * queue has reached nobody, a refusal is being kept *only* here, an expense
+ * somebody was still typing was never submitted at all, and the backup recovery
+ * key exists in one keystore in the world. A plain "Sign out?" alert over that
+ * is a trapdoor.
+ *
+ * So this says what is about to go, and offers the two ways to keep it, and
+ * then gets out of the way. Nothing here blocks the sign-out: a person handing
+ * back a borrowed phone must be able to leave right now, and a dialog that
+ * holds somebody's account open until an upload succeeds is a worse failure
+ * than a lost draft. The warning is honest and the door stays unlocked.
+ *
+ * The copy button writes a plain JSON snapshot of everything on the device
+ * (`saveDeviceCopy`) — the unsent queue and the drafts included — and hands it
+ * to the share sheet. It never touches the network, because the case it exists
+ * for is a device holding changes that could not be sent. It holds no receipt
+ * photographs, which is why the sheet says so out loud rather than letting the
+ * file quietly not contain them.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { ScrollView, View } from 'react-native';
+
+import { unsentWork, type DeviceDraft } from '@waves/core';
+import { Button, Callout, iconSize, Row, Sheet, Text, useTheme } from '@waves/ui';
+
+import { plural, useStrings } from '@/i18n';
+import { loadRecoveryKey } from '@/lib/backup/recoveryKey';
+import { loadBackupSettings } from '@/lib/backup/settings';
+import { useAuth } from '@/lib/auth';
+import { saveDeviceCopy } from '@/lib/deviceCopy';
+import { friendlyError } from '@/lib/errors';
+import { reportHandled } from '@/lib/observability';
+import {
+  flushReceiptQueue,
+  getPendingReceiptsSnapshot,
+  usePendingReceipts,
+} from '@/lib/receiptQueue';
+import { syncEngine, SyncStatus, useSync } from '@/sync';
+
+/** What the two work buttons are doing, so neither can be pressed twice. */
+type Busy = 'none' | 'sync' | 'copy';
+
+/** One "this is still only here" line: a warning glyph and the count in words. */
+function RiskRow({ icon, label }: { icon: keyof typeof Ionicons.glyphMap; label: string }) {
+  const theme = useTheme();
+  return (
+    <Row style={{ gap: theme.spacing.md, alignItems: 'center' }}>
+      <Ionicons name={icon} size={iconSize.md} color={theme.color.warning} />
+      <Text variant="body" style={{ flex: 1 }}>
+        {label}
+      </Text>
+    </Row>
+  );
+}
+
+/**
+ * The autosaved forms this device is holding, re-read each time the sheet opens.
+ *
+ * Nothing else in the app wants the whole list — a form reads back its own
+ * draft by key and that is that — so there is no context to take this from, and
+ * the store is the only source. Gated on `visible` because this sheet lives
+ * mounted and closed on the Profile tab: an ungated read would touch the disk
+ * for a sheet nobody has opened, every time somebody looks at their profile.
+ */
+function useDeviceDrafts(visible: boolean): readonly DeviceDraft[] {
+  const [drafts, setDrafts] = useState<readonly DeviceDraft[]>([]);
+  useEffect(() => {
+    if (!visible) return;
+    let alive = true;
+    void syncEngine
+      .listDrafts()
+      .then((rows) => {
+        if (alive) setDrafts(rows);
+      })
+      .catch((error: unknown) => reportHandled(error, 'signOut.listDrafts'));
+    return () => {
+      alive = false;
+    };
+  }, [visible]);
+  return drafts;
+}
+
+/**
+ * Whether this device holds a backup recovery key nobody has confirmed writing
+ * down — the one loss that happens even when every last change has synced.
+ *
+ * The two leaf readers rather than `useBackup`: that hook mounts the personal
+ * ledger and asks Google over the network for the linked address, which is a
+ * great deal of machinery to run on the Profile tab for one boolean. `keySeen`
+ * narrows it to the case that is actually a loss: a key that exists only in
+ * this keystore, which sign-out clears (`clearBackupState`). Once somebody has
+ * written it down there is nothing here to warn about — the file on Drive
+ * outlives the app either way.
+ */
+function useUnconfirmedBackupKey(visible: boolean, ownerId: string): boolean {
+  const [atRisk, setAtRisk] = useState(false);
+  useEffect(() => {
+    if (!visible || !ownerId) return;
+    let alive = true;
+    void (async () => {
+      const [key, settings] = await Promise.all([
+        loadRecoveryKey(ownerId),
+        loadBackupSettings(ownerId),
+      ]);
+      if (alive) setAtRisk(key !== null && !settings.keySeen);
+    })().catch((error: unknown) => reportHandled(error, 'signOut.backupKey'));
+    return () => {
+      alive = false;
+    };
+  }, [visible, ownerId]);
+  return atRisk;
+}
+
+export function SignOutSheet({
+  visible,
+  onClose,
+  onSignOut,
+}: {
+  visible: boolean;
+  onClose: () => void;
+  /** Runs the actual sign-out. This sheet never decides *whether* — only informs. */
+  onSignOut: () => void;
+}): React.JSX.Element {
+  const theme = useTheme();
+  const { t, locale } = useStrings();
+  const { session, isGuest } = useAuth();
+  const { mirror, queue, status, flush } = useSync();
+  const receipts = usePendingReceipts();
+
+  const ownerId = session?.user?.id ?? '';
+  const drafts = useDeviceDrafts(visible);
+  const backupKeyAtRisk = useUnconfirmedBackupKey(visible, ownerId);
+  const work = useMemo(() => unsentWork(queue, ownerId), [queue, ownerId]);
+  // A receipt that has been sent stays in the queue a while so its tile keeps
+  // its place; only the ones still owed are at risk.
+  const unsentReceipts = receipts.filter((item) => item.status !== 'sent').length;
+  const atRisk = work.total + unsentReceipts + drafts.length;
+  // What "Sync now" could actually move. Receipts count: they go out through
+  // their own queue, and leaving them out of this gated the button away from a
+  // device whose only unsent thing was a photograph it could have sent.
+  const sendable = work.personal + work.other + unsentReceipts > 0;
+
+  const [busy, setBusy] = useState<Busy>('none');
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState<string | null>(null);
+
+  const offline = status === SyncStatus.Offline || status === SyncStatus.Metered;
+
+  const syncNow = useCallback(async (): Promise<void> => {
+    setBusy('sync');
+    setError(null);
+    try {
+      // The photographs go out through their own queue, and they go first —
+      // the same order `resumeReceiptUploads` uses, and for its reason: each
+      // upload records an attachment row server-side, and the flush below is
+      // what pulls those rows back down. Sending the bytes without that pull
+      // would leave the gallery drawing optimistic tiles for receipts that had
+      // already landed.
+      if (unsentReceipts > 0) await flushReceiptQueue();
+      await flush();
+      // `flush` records a failed round trip on the engine instead of throwing
+      // it, so the catch below never fires for the case this button exists
+      // for — a dead network, a timeout, a server having a bad minute. Asked
+      // nothing afterwards, a sync that sent nothing looked exactly like one
+      // that sent everything, on the one screen where that difference is the
+      // whole point.
+      const after = syncEngine.getState();
+      if (after.status === SyncStatus.Error) {
+        setError(friendlyError(after.lastError, t.signOutSheet.syncFailed, 'signOut.flush'));
+      } else if (getPendingReceiptsSnapshot().some((item) => item.status !== 'sent')) {
+        // A receipt flush is best-effort and never throws: a capture the server
+        // refused, or one whose bytes would not go, simply stays in the queue.
+        // The row above it already says so, but leaving the press itself silent
+        // would read as "sent" — the one thing this sheet must not imply.
+        setError(t.signOutSheet.syncFailed);
+      }
+    } catch (caught) {
+      setError(friendlyError(caught, t.signOutSheet.syncFailed, 'signOut.flush'));
+    } finally {
+      setBusy('none');
+    }
+  }, [flush, unsentReceipts, t]);
+
+  const download = useCallback(async (): Promise<void> => {
+    setBusy('copy');
+    setError(null);
+    setSaved(null);
+    try {
+      const result = await saveDeviceCopy({
+        mirror,
+        queue,
+        drafts,
+        ownerId,
+        dialogTitle: t.signOutSheet.copyShareTitle,
+      });
+      // The temporary is deleted as soon as the share sheet closes, so a
+      // platform with no share sheet ends the run holding nothing — and
+      // "Saved …" over that would be the exact lie this sheet exists to avoid.
+      if (result.shared) {
+        setSaved(`${result.filename} · ${Math.ceil(result.sizeBytes / 1024)} KB`);
+      } else {
+        setError(t.signOutSheet.copyFailed);
+      }
+    } catch (caught) {
+      setError(friendlyError(caught, t.signOutSheet.copyFailed, 'signOut.copy'));
+    } finally {
+      setBusy('none');
+    }
+  }, [mirror, queue, drafts, ownerId, t]);
+
+  return (
+    <Sheet
+      visible={visible}
+      onClose={onClose}
+      closeLabel={t.common.close}
+      style={{ maxHeight: '88%' }}
+    >
+      <View style={{ gap: theme.spacing.lg, flexShrink: 1 }}>
+        <Text variant="heading">{t.lock.signOutQuestion}</Text>
+
+        <ScrollView
+          showsVerticalScrollIndicator={false}
+          style={{ flexShrink: 1 }}
+          contentContainerStyle={{ gap: theme.spacing.md }}
+        >
+          {/* A guest has no way back into the account at all, which outranks
+              everything else on this sheet — so it is said first, and loudest. */}
+          {isGuest ? (
+            <Callout tone="negative" title={t.signOutSheet.guestTitle}>
+              {t.lock.signOutGuestWarning}
+            </Callout>
+          ) : null}
+
+          {/* Deliberately outside the two branches below. The recovery key is
+              not unsent work — it is lost on sign-out whether or not anything
+              is still queued — so it has to be sayable beside the green
+              callout as well as the warning one. That is also why `allSafeBody`
+              is scoped to the ledger: "everything comes back" with this
+              underneath it would be a contradiction on the same screen. */}
+          {backupKeyAtRisk ? (
+            <Callout tone="warning" title={t.signOutSheet.backupKeyTitle}>
+              {t.signOutSheet.backupKeyWarning}
+            </Callout>
+          ) : null}
+
+          {atRisk === 0 ? (
+            <Callout tone="positive" title={t.signOutSheet.allSafeTitle}>
+              {t.signOutSheet.allSafeBody}
+            </Callout>
+          ) : (
+            <>
+              <Callout tone="warning" title={t.signOutSheet.atRiskTitle}>
+                {t.signOutSheet.atRiskBody}
+              </Callout>
+
+              <View style={{ gap: theme.spacing.sm, paddingVertical: theme.spacing.xs }}>
+                {work.other > 0 ? (
+                  <RiskRow
+                    icon="people-outline"
+                    label={plural(locale, work.other, t.signOutSheet.otherUnsent)}
+                  />
+                ) : null}
+                {/* The private ledger gets its own line rather than being folded
+                    into the count above: it lives on the Me tab, it is the one
+                    part of the app nobody else holds a copy of, and somebody who
+                    keeps their money there deserves to be told by name. */}
+                {work.personal > 0 ? (
+                  <RiskRow
+                    icon="wallet-outline"
+                    label={plural(locale, work.personal, t.signOutSheet.personalUnsent)}
+                  />
+                ) : null}
+                {work.refused > 0 ? (
+                  <RiskRow
+                    icon="alert-circle-outline"
+                    label={plural(locale, work.refused, t.signOutSheet.refused)}
+                  />
+                ) : null}
+                {unsentReceipts > 0 ? (
+                  <RiskRow
+                    icon="receipt-outline"
+                    label={plural(locale, unsentReceipts, t.signOutSheet.receiptsUnsent)}
+                  />
+                ) : null}
+                {/* A draft was never submitted, so unlike everything above it
+                    there is no server copy waiting and no queue entry to send —
+                    only the file below can keep it. */}
+                {drafts.length > 0 ? (
+                  <RiskRow
+                    icon="document-text-outline"
+                    label={plural(locale, drafts.length, t.signOutSheet.draftsUnsent)}
+                  />
+                ) : null}
+              </View>
+
+              {/* Offline is why the copy button is not an afterthought: sending
+                  is not on the table, so "sync first" would be advice nobody in
+                  that moment can take. */}
+              {offline ? (
+                <Text variant="caption" tone="muted">
+                  {t.signOutSheet.offlineHint}
+                </Text>
+              ) : null}
+
+              {/* The snapshot is JSON: the records go in, the image bytes do
+                  not. Said here, next to the count of photos still on the
+                  phone, because "download a copy" one line above it otherwise
+                  reads as an offer to keep them. */}
+              {unsentReceipts > 0 ? (
+                <Text variant="caption" tone="muted">
+                  {t.signOutSheet.copyExcludesPhotos}
+                </Text>
+              ) : null}
+            </>
+          )}
+
+          {error ? (
+            <Text variant="caption" style={{ color: theme.color.negative }}>
+              {error}
+            </Text>
+          ) : null}
+          {saved ? (
+            <Text variant="caption" tone="muted">
+              {t.signOutSheet.copySaved.replace('{file}', saved)}
+            </Text>
+          ) : null}
+        </ScrollView>
+
+        {/* The two ways to keep the data, then the two doors. The order is
+            deliberate — safe first, destructive last — but nothing here is
+            gated on anything else: this sheet warns, it does not hold anybody
+            hostage. */}
+        <View style={{ gap: theme.spacing.sm }}>
+          {sendable && !offline ? (
+            <Button
+              label={busy === 'sync' ? t.signOutSheet.syncing : t.signOutSheet.syncNow}
+              variant="primary"
+              fullWidth
+              disabled={busy !== 'none'}
+              onPress={() => void syncNow()}
+            />
+          ) : null}
+          <Button
+            label={busy === 'copy' ? t.signOutSheet.copying : t.signOutSheet.copyNow}
+            variant="secondary"
+            fullWidth
+            disabled={busy !== 'none'}
+            onPress={() => void download()}
+          />
+          <Button
+            label={t.lock.signOut}
+            variant="ghostDanger"
+            fullWidth
+            disabled={busy !== 'none'}
+            onPress={onSignOut}
+          />
+          <Button label={t.lock.staySignedIn} variant="ghost" fullWidth onPress={onClose} />
+        </View>
+      </View>
+    </Sheet>
+  );
+}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -762,6 +762,55 @@ export interface UiStrings {
     /** Native biometric prompt shown on entering the private Me tab. */
     personalPrompt: string;
   };
+  /** The sheet behind Sign out: what leaves the phone with the account, and
+   *  the two things you can do about it before you go. */
+  signOutSheet: {
+    /** Callout title above the guest warning in `lock.signOutGuestWarning`. */
+    guestTitle: string;
+    /** Callout when the queue is empty and every photo has been sent. Scoped to
+     *  the ledger on purpose: the backup-key warning below can appear beside
+     *  it, and a reassurance that claimed *everything* comes back would then
+     *  contradict the line right under it. */
+    allSafeTitle: string;
+    allSafeBody: string;
+    /** Callout when something on this device has not reached the account. */
+    atRiskTitle: string;
+    atRiskBody: string;
+    /** The lines under that callout. `otherUnsent` counts queued changes to
+     *  shared groups, `personalUnsent` the private records on the Personal
+     *  tab, `refused` the ones the server turned down, which will never go on
+     *  their own, `receiptsUnsent` the photos still only on the phone, and
+     *  `draftsUnsent` the forms somebody had started but never submitted —
+     *  those live in the drafts table, which the sign-out wipe deletes. */
+    otherUnsent: PluralForms;
+    personalUnsent: PluralForms;
+    refused: PluralForms;
+    receiptsUnsent: PluralForms;
+    draftsUnsent: PluralForms;
+    /** The backup recovery key, which this device holds and sign-out forgets.
+     *  Not part of the list above: it is lost even when everything has synced,
+     *  so it is shown whether or not anything is unsent. */
+    backupKeyTitle: string;
+    backupKeyWarning: string;
+    /** Shown when nothing can be sent right now — offline, or on a connection
+     *  the sync setting does not allow. */
+    offlineHint: string;
+    syncNow: string;
+    syncing: string;
+    /** Sending finished with something still queued. */
+    syncFailed: string;
+    /** Writes everything on the device to a file and opens the share sheet. */
+    copyNow: string;
+    copying: string;
+    copyFailed: string;
+    /** Said beside the copy button when receipt photos are unsent: the file is
+     *  JSON and does not carry image bytes. */
+    copyExcludesPhotos: string;
+    /** "Saved {file}" — `{file}` is the file name. */
+    copySaved: string;
+    /** Title on the system share sheet. */
+    copyShareTitle: string;
+  };
   /** The devices screen and the free-tier two-device cap. */
   devices: {
     couldNotSignOut: string;
@@ -3364,6 +3413,49 @@ const en: UiStrings = {
       'This guards the screen, not the data — your ledger is protected by row-level security on the server whether the lock is on or not.',
     personalPrompt: 'Unlock your personal ledger',
   },
+  signOutSheet: {
+    guestTitle: 'This account cannot be signed back into',
+    allSafeTitle: 'Everything is safe',
+    allSafeBody:
+      'Every change on this device has reached your account. Sign back in and your ledger comes back.',
+    atRiskTitle: 'Some of this would be lost',
+    atRiskBody:
+      "Signing out erases this device's copy. What is listed below has not reached your account yet, so it goes with it.",
+    otherUnsent: {
+      one: '{n} change to your groups has not been sent',
+      other: '{n} changes to your groups have not been sent',
+    },
+    personalUnsent: {
+      one: '{n} personal record has not been sent',
+      other: '{n} personal records have not been sent',
+    },
+    refused: {
+      one: '{n} change the server would not accept',
+      other: '{n} changes the server would not accept',
+    },
+    receiptsUnsent: {
+      one: '{n} receipt photo is still only on this phone',
+      other: '{n} receipt photos are still only on this phone',
+    },
+    draftsUnsent: {
+      one: '{n} expense you were still typing',
+      other: '{n} expenses you were still typing',
+    },
+    backupKeyTitle: 'Your backup key is only on this device',
+    backupKeyWarning:
+      'Signing out forgets the recovery key for your backup. The file stays on Drive, but nothing can open it again without that key — not even you. Write it down before you go.',
+    offlineHint: 'Nothing can be sent right now. Download a copy before you go.',
+    syncNow: 'Sync now',
+    syncing: 'Sending…',
+    syncFailed: 'Could not send everything. Try again, or download a copy.',
+    copyNow: 'Download a copy',
+    copying: 'Preparing…',
+    copyFailed: 'Could not make the file.',
+    copyExcludesPhotos:
+      'The file holds your records, not the receipt photos. Send those first if you need them kept.',
+    copySaved: 'Saved {file}',
+    copyShareTitle: 'Your Waves data',
+  },
   devices: {
     couldNotSignOut: 'Could not sign out the other devices. Please try again.',
     title: 'Devices',
@@ -5791,6 +5883,50 @@ const ta: UiStrings = {
     footnote:
       'இது திரையைக் காக்கிறது, தரவை அல்ல — பூட்டு இருந்தாலும் இல்லாவிட்டாலும் உங்கள் கணக்கு சர்வரில் வரிசை அளவிலான பாதுகாப்பால் காக்கப்படுகிறது.',
     personalPrompt: 'உங்கள் தனிப்பட்ட கணக்கைத் திறக்கவும்',
+  },
+  signOutSheet: {
+    guestTitle: 'இந்தக் கணக்கில் மீண்டும் உள்நுழைய முடியாது',
+    allSafeTitle: 'எல்லாம் பாதுகாப்பாக உள்ளது',
+    allSafeBody:
+      'இந்தச் சாதனத்தில் செய்த ஒவ்வொரு மாற்றமும் உங்கள் கணக்கை அடைந்துவிட்டது. மீண்டும் உள்நுழைந்தால் உங்கள் கணக்குப் பதிவு திரும்பி வரும்.',
+    atRiskTitle: 'இவற்றில் சில தொலைந்துவிடும்',
+    atRiskBody:
+      'வெளியேறினால் இந்தச் சாதனத்தில் உள்ள நகல் அழிக்கப்படும். கீழே பட்டியலிட்டவை இன்னும் உங்கள் கணக்கை அடையவில்லை, எனவே அவையும் அதனுடன் போய்விடும்.',
+    otherUnsent: {
+      one: 'உங்கள் குழுக்களில் {n} மாற்றம் அனுப்பப்படவில்லை',
+      other: 'உங்கள் குழுக்களில் {n} மாற்றங்கள் அனுப்பப்படவில்லை',
+    },
+    personalUnsent: {
+      one: '{n} தனிப்பட்ட பதிவு அனுப்பப்படவில்லை',
+      other: '{n} தனிப்பட்ட பதிவுகள் அனுப்பப்படவில்லை',
+    },
+    refused: {
+      one: 'சர்வர் ஏற்க மறுத்த {n} மாற்றம்',
+      other: 'சர்வர் ஏற்க மறுத்த {n} மாற்றங்கள்',
+    },
+    receiptsUnsent: {
+      one: '{n} ரசீதுப் படம் இன்னும் இந்தத் தொலைபேசியில் மட்டுமே உள்ளது',
+      other: '{n} ரசீதுப் படங்கள் இன்னும் இந்தத் தொலைபேசியில் மட்டுமே உள்ளன',
+    },
+    draftsUnsent: {
+      one: 'நீங்கள் இன்னும் தட்டச்சு செய்துகொண்டிருந்த {n} செலவு',
+      other: 'நீங்கள் இன்னும் தட்டச்சு செய்துகொண்டிருந்த {n} செலவுகள்',
+    },
+    backupKeyTitle: 'உங்கள் காப்புப்பிரதி விசை இந்தச் சாதனத்தில் மட்டுமே உள்ளது',
+    backupKeyWarning:
+      'வெளியேறினால் உங்கள் காப்புப்பிரதியின் மீட்பு விசை மறக்கப்படும். கோப்பு Drive-இல் இருக்கும், ஆனால் அந்த விசை இல்லாமல் அதை யாராலும் — உங்களாலும் — திறக்க முடியாது. வெளியேறும் முன் அதை எழுதி வைத்துக்கொள்ளுங்கள்.',
+    offlineHint: 'இப்போது எதையும் அனுப்ப முடியாது. வெளியேறும் முன் ஒரு நகலைப் பதிவிறக்கவும்.',
+    syncNow: 'இப்போது ஒத்திசை',
+    syncing: 'அனுப்பப்படுகிறது…',
+    syncFailed:
+      'எல்லாவற்றையும் அனுப்ப முடியவில்லை. மீண்டும் முயற்சிக்கவும், அல்லது ஒரு நகலைப் பதிவிறக்கவும்.',
+    copyNow: 'ஒரு நகலைப் பதிவிறக்கு',
+    copying: 'தயாராகிறது…',
+    copyFailed: 'கோப்பை உருவாக்க முடியவில்லை.',
+    copyExcludesPhotos:
+      'இந்தக் கோப்பில் உங்கள் பதிவுகள் இருக்கும், ரசீதுப் படங்கள் இருக்காது. அவை தேவைப்பட்டால் முதலில் அவற்றை அனுப்பிவிடுங்கள்.',
+    copySaved: '{file} சேமிக்கப்பட்டது',
+    copyShareTitle: 'உங்கள் Waves தரவு',
   },
   devices: {
     couldNotSignOut: 'மற்ற சாதனங்களை வெளியேற்ற முடியவில்லை. மீண்டும் முயற்சிக்கவும்.',
@@ -8312,6 +8448,49 @@ const hi: UiStrings = {
       'यह स्क्रीन की रक्षा करता है, डेटा की नहीं — लॉक चालू हो या बंद, आपका हिसाब सर्वर पर रो-लेवल सुरक्षा से सुरक्षित है।',
     personalPrompt: 'अपना निजी हिसाब अनलॉक करें',
   },
+  signOutSheet: {
+    guestTitle: 'इस खाते में दोबारा साइन इन नहीं किया जा सकता',
+    allSafeTitle: 'सब कुछ सुरक्षित है',
+    allSafeBody:
+      'इस डिवाइस का हर बदलाव आपके खाते तक पहुँच चुका है। दोबारा साइन इन करने पर आपका पूरा हिसाब वापस आ जाएगा।',
+    atRiskTitle: 'इनमें से कुछ खो जाएगा',
+    atRiskBody:
+      'साइन आउट करने पर इस डिवाइस की कॉपी मिट जाती है। नीचे जो दिखाया है वह अभी आपके खाते तक नहीं पहुँचा है, इसलिए वह भी उसी के साथ चला जाएगा।',
+    otherUnsent: {
+      one: 'आपके समूहों में {n} बदलाव नहीं भेजा गया',
+      other: 'आपके समूहों में {n} बदलाव नहीं भेजे गए',
+    },
+    personalUnsent: {
+      one: '{n} निजी प्रविष्टि नहीं भेजी गई',
+      other: '{n} निजी प्रविष्टियाँ नहीं भेजी गईं',
+    },
+    refused: {
+      one: '{n} बदलाव जिसे सर्वर ने स्वीकार नहीं किया',
+      other: '{n} बदलाव जिन्हें सर्वर ने स्वीकार नहीं किया',
+    },
+    receiptsUnsent: {
+      one: '{n} रसीद की फ़ोटो अब भी सिर्फ़ इसी फ़ोन पर है',
+      other: '{n} रसीदों की फ़ोटो अब भी सिर्फ़ इसी फ़ोन पर हैं',
+    },
+    draftsUnsent: {
+      one: '{n} ख़र्च जो आप अब भी लिख रहे थे',
+      other: '{n} ख़र्च जो आप अब भी लिख रहे थे',
+    },
+    backupKeyTitle: 'आपकी बैकअप कुंजी सिर्फ़ इसी डिवाइस पर है',
+    backupKeyWarning:
+      'साइन आउट करने पर आपके बैकअप की रिकवरी कुंजी भूल जाएगी। फ़ाइल Drive पर रहेगी, पर उस कुंजी के बिना उसे कोई नहीं खोल सकता — आप भी नहीं। जाने से पहले उसे लिख लें।',
+    offlineHint: 'अभी कुछ भी नहीं भेजा जा सकता। जाने से पहले एक कॉपी डाउनलोड कर लें।',
+    syncNow: 'अभी सिंक करें',
+    syncing: 'भेजा जा रहा है…',
+    syncFailed: 'सब कुछ भेजा नहीं जा सका। फिर कोशिश करें, या एक कॉपी डाउनलोड कर लें।',
+    copyNow: 'एक कॉपी डाउनलोड करें',
+    copying: 'तैयार हो रही है…',
+    copyFailed: 'फ़ाइल नहीं बनाई जा सकी।',
+    copyExcludesPhotos:
+      'फ़ाइल में आपकी प्रविष्टियाँ होंगी, रसीदों की फ़ोटो नहीं। उन्हें रखना है तो पहले उन्हें भेज दें।',
+    copySaved: '{file} सहेज लिया',
+    copyShareTitle: 'आपका Waves डेटा',
+  },
   devices: {
     couldNotSignOut: 'अन्य डिवाइस साइन आउट नहीं हो सके। कृपया फिर कोशिश करें।',
     title: 'डिवाइस',
@@ -10778,6 +10957,68 @@ const ar: UiStrings = {
     footnote:
       'هذا يحمي الشاشة لا البيانات — دفترك محمي على الخادم بأمان على مستوى الصفوف سواء كان القفل مفعّلًا أم لا.',
     personalPrompt: 'افتح قفل دفترك الشخصي',
+  },
+  signOutSheet: {
+    guestTitle: 'لا يمكن تسجيل الدخول إلى هذا الحساب مرة أخرى',
+    allSafeTitle: 'كل شيء بأمان',
+    allSafeBody: 'كل تغيير على هذا الجهاز وصل إلى حسابك. سجّل الدخول مرة أخرى وسيعود دفترك كما هو.',
+    atRiskTitle: 'بعض هذا سيُفقد',
+    atRiskBody:
+      'تسجيل الخروج يمحو نسخة هذا الجهاز. وما هو مذكور أدناه لم يصل إلى حسابك بعد، فسيذهب معها.',
+    otherUnsent: {
+      zero: 'لا تغييرات غير مُرسَلة في مجموعاتك',
+      one: 'تغيير واحد في مجموعاتك لم يُرسَل',
+      two: 'تغييران في مجموعاتك لم يُرسَلا',
+      few: '{n} تغييرات في مجموعاتك لم تُرسَل',
+      many: '{n} تغييرًا في مجموعاتك لم يُرسَل',
+      other: '{n} تغيير في مجموعاتك لم يُرسَل',
+    },
+    personalUnsent: {
+      zero: 'لا سجلات شخصية غير مُرسَلة',
+      one: 'سجل شخصي واحد لم يُرسَل',
+      two: 'سجلان شخصيان لم يُرسَلا',
+      few: '{n} سجلات شخصية لم تُرسَل',
+      many: '{n} سجلًا شخصيًا لم يُرسَل',
+      other: '{n} سجل شخصي لم يُرسَل',
+    },
+    refused: {
+      zero: 'لا تغييرات رفضها الخادم',
+      one: 'تغيير واحد رفضه الخادم',
+      two: 'تغييران رفضهما الخادم',
+      few: '{n} تغييرات رفضها الخادم',
+      many: '{n} تغييرًا رفضه الخادم',
+      other: '{n} تغيير رفضه الخادم',
+    },
+    receiptsUnsent: {
+      zero: 'لا صور إيصالات على هذا الهاتف وحده',
+      one: 'صورة إيصال واحدة ما زالت على هذا الهاتف وحده',
+      two: 'صورتا إيصال ما زالتا على هذا الهاتف وحده',
+      few: '{n} صور إيصالات ما زالت على هذا الهاتف وحده',
+      many: '{n} صورة إيصال ما زالت على هذا الهاتف وحده',
+      other: '{n} صورة إيصال ما زالت على هذا الهاتف وحده',
+    },
+    draftsUnsent: {
+      zero: 'لا مصروفات كنت ما زلت تكتبها',
+      one: 'مصروف واحد كنت ما زلت تكتبه',
+      two: 'مصروفان كنت ما زلت تكتبهما',
+      few: '{n} مصروفات كنت ما زلت تكتبها',
+      many: '{n} مصروفًا كنت ما زلت تكتبه',
+      other: '{n} مصروف كنت ما زلت تكتبه',
+    },
+    backupKeyTitle: 'مفتاح نسختك الاحتياطية على هذا الجهاز وحده',
+    backupKeyWarning:
+      'تسجيل الخروج ينسى مفتاح استرداد نسختك الاحتياطية. سيبقى الملف على Drive، لكن لا شيء يفتحه من دون ذلك المفتاح — ولا أنت. دوّنه قبل أن تخرج.',
+    offlineHint: 'لا يمكن إرسال أي شيء الآن. نزّل نسخة قبل أن تخرج.',
+    syncNow: 'زامن الآن',
+    syncing: 'جارٍ الإرسال…',
+    syncFailed: 'تعذّر إرسال كل شيء. حاول مرة أخرى، أو نزّل نسخة.',
+    copyNow: 'تنزيل نسخة',
+    copying: 'جارٍ التجهيز…',
+    copyFailed: 'تعذّر إنشاء الملف.',
+    copyExcludesPhotos:
+      'الملف يحمل سجلاتك، لا صور الإيصالات. أرسل الصور أولًا إن كنت تريد الاحتفاظ بها.',
+    copySaved: 'تم حفظ {file}',
+    copyShareTitle: 'بيانات Waves الخاصة بك',
   },
   devices: {
     couldNotSignOut: 'تعذّر تسجيل خروج الأجهزة الأخرى. حاول مرة أخرى.',

--- a/apps/mobile/src/lib/deviceCopy.ts
+++ b/apps/mobile/src/lib/deviceCopy.ts
@@ -1,0 +1,91 @@
+/**
+ * "Download a copy" — the native half of the sign-out snapshot.
+ *
+ * Signing out wipes this device's mirror, its queue and its drafts, so the one
+ * thing the sheet has to be able to offer is a copy taken *before* that
+ * happens. This writes the pure snapshot from `@waves/core` (`deviceSnapshot`)
+ * to a cache file, hands it to the system share sheet — where the person picks
+ * Files, Drive, mail, whatever they trust — and deletes the temporary
+ * afterwards, exactly as the export screen does with a server export.
+ *
+ * It never touches the network. That is the point: the copy has to work in the
+ * case it exists for, which is a device holding changes that could not be sent.
+ *
+ * One thing it deliberately does not hold: unsent receipt photographs. This is
+ * a JSON file somebody may keep for years, and base64 image bytes would turn a
+ * few kilobytes into tens of megabytes. The sheet says so in words rather than
+ * letting the file quietly not contain them.
+ */
+
+import * as FileSystem from 'expo-file-system';
+import * as Sharing from 'expo-sharing';
+
+import {
+  deviceSnapshot,
+  snapshotFilename,
+  type DeviceDraft,
+  type MirrorState,
+  type QueuedMutation,
+} from '@waves/core';
+
+export interface DeviceCopyResult {
+  readonly filename: string;
+  readonly sizeBytes: number;
+  /** False when the platform has no share sheet — the file was still written. */
+  readonly shared: boolean;
+}
+
+/**
+ * Take the copy and offer it to the share sheet.
+ *
+ * Resolves once the share sheet has been dismissed (or immediately, on a
+ * platform without one). The caller shows the filename and size; anything
+ * thrown lands in its own error line.
+ */
+export async function saveDeviceCopy(input: {
+  readonly mirror: MirrorState;
+  readonly queue: readonly QueuedMutation[];
+  /** The autosaved forms, read by the caller — the same ones it counted. */
+  readonly drafts: readonly DeviceDraft[];
+  readonly ownerId: string;
+  readonly dialogTitle: string;
+}): Promise<DeviceCopyResult> {
+  const exportedAt = new Date().toISOString();
+  const snapshot = deviceSnapshot({
+    mirror: input.mirror,
+    queue: input.queue,
+    drafts: input.drafts,
+    ownerId: input.ownerId,
+    exportedAt,
+  });
+  // Indented: this file is read by a person in a moment of "did I lose it?",
+  // and the few extra kilobytes buy a file they can actually scroll.
+  const body = JSON.stringify(snapshot, null, 2);
+  const filename = snapshotFilename(exportedAt);
+
+  // expo-file-system 57 API: File/Paths rather than the old string paths.
+  const file = new FileSystem.File(FileSystem.Paths.cache, filename);
+  if (file.exists) file.delete();
+  file.create();
+  file.write(body);
+
+  let shared = false;
+  try {
+    if (await Sharing.isAvailableAsync()) {
+      await Sharing.shareAsync(file.uri, {
+        mimeType: 'application/json',
+        dialogTitle: input.dialogTitle,
+        UTI: 'public.json',
+      });
+      shared = true;
+    }
+  } finally {
+    try {
+      if (file.exists) file.delete();
+    } catch {
+      // Best-effort privacy cleanup; the share result still drives the UI.
+    }
+  }
+
+  return { filename, sizeBytes: body.length, shared };
+}

--- a/packages/core/src/sync/departure.ts
+++ b/packages/core/src/sync/departure.ts
@@ -1,0 +1,178 @@
+/**
+ * What leaving takes with it, and how to keep a copy of it first.
+ *
+ * Signing out wipes this device's mirror (see the mobile `SyncProvider`): the
+ * rows, the queue, the drafts and the receipt bytes all go, because the next
+ * person to hold the phone must not find the last account's ledger in it.
+ * Everything the server already has comes back on the next sign-in — but a
+ * mutation still sitting in the queue has reached nobody, a refusal has been
+ * told "no" and is being kept only here, and a draft was never submitted at all.
+ * Those are the whole risk, and they are what this file counts and what a
+ * snapshot preserves.
+ *
+ * Drafts are not part of {@link unsentWork} because they are not queue work —
+ * they live in their own table behind an async read, so the screen counts them
+ * and hands them to {@link deviceSnapshot} rather than this file going after
+ * them.
+ *
+ * Pure on purpose: the counting is arithmetic over the queue and the snapshot is
+ * a plain object, so both are unit-testable without a device, a network or a
+ * filesystem. The screen that writes the file and the sheet that shows the
+ * numbers stay thin shells around this.
+ */
+
+import type { MirrorRow, MirrorState } from './mirror';
+import { personalScope } from './protocol';
+import { pendingMutations, rejectedMutations, type QueuedMutation } from './queue';
+
+/**
+ * Unsent work, split the way a person thinks about it: the private ledger on
+ * the Me tab, and everything else (groups, expenses, captures, tags).
+ *
+ * `refused` is counted apart from the two because it is not waiting for a
+ * network — the server has already said no, and another minute of signal will
+ * not clear it. Telling someone "3 changes are still sending" when one of them
+ * will never send is the kind of reassurance that loses data.
+ */
+export interface UnsentWork {
+  /** Pending mutations on the personal-finance scope (A48). */
+  readonly personal: number;
+  /** Pending mutations on every other scope — groups, captures, tags, packs. */
+  readonly other: number;
+  /** Mutations the server refused. They need a person, not a retry. */
+  readonly refused: number;
+  /** Everything above, which is also "how much would be lost". */
+  readonly total: number;
+}
+
+/** Nothing queued, nothing refused — the answer for a device that is up to date. */
+export const NO_UNSENT_WORK: UnsentWork = { personal: 0, other: 0, refused: 0, total: 0 };
+
+/**
+ * Count what has not reached the account yet.
+ *
+ * `ownerId` decides which scope key counts as the personal ledger; an empty one
+ * (signed out already, which should not happen here) simply puts everything in
+ * `other` rather than guessing.
+ */
+export function unsentWork(queue: readonly QueuedMutation[], ownerId: string): UnsentWork {
+  const scope = ownerId ? personalScope(ownerId) : null;
+  let personal = 0;
+  let other = 0;
+  for (const item of pendingMutations(queue)) {
+    if (scope !== null && item.groupId === scope) personal += 1;
+    else other += 1;
+  }
+  const refused = rejectedMutations(queue).length;
+  return { personal, other, refused, total: personal + other + refused };
+}
+
+/**
+ * One autosaved form, exactly as the device store holds it.
+ *
+ * `value` is deliberately `unknown` and is never looked inside: a draft is
+ * whatever screen wrote it, it is free-typed text, and a snapshot that reshaped
+ * it would be a snapshot that could lose a field the day a form gains one.
+ * It goes into the file the way it came out of the store.
+ */
+export interface DeviceDraft {
+  readonly key: string;
+  readonly value: unknown;
+  /** ISO timestamp of the last autosave. */
+  readonly savedAt: string;
+}
+
+/** Marks a file as ours before anything tries to read it. */
+export const SNAPSHOT_FORMAT = 'waves.device.snapshot';
+/** The envelope version. Bumped only when the shape below changes. */
+export const SNAPSHOT_VERSION = 1;
+
+/**
+ * Everything this device holds for one account, in one plain JSON object.
+ *
+ * Deliberately the *raw* mirror rows rather than a prettied-up ledger: a
+ * readable per-group PDF already exists (`groupExport`), and the job here is
+ * different — this is the copy somebody takes because they are about to erase
+ * the original, so losing a field nobody thought to render would be the one
+ * unforgivable outcome. The queue rides along in `unsent`, and the autosaved
+ * forms in `drafts`, for the same reason: neither exists anywhere else in the
+ * world.
+ */
+export interface DeviceSnapshot {
+  readonly format: typeof SNAPSHOT_FORMAT;
+  readonly version: number;
+  /** ISO timestamp the copy was taken. */
+  readonly exportedAt: string;
+  readonly ownerId: string;
+  /** Per-scope sync cursors, so a reader can tell how current the copy is. */
+  readonly cursors: Readonly<Record<string, number>>;
+  /** Mirror rows by table, each table's rows ordered by their id. */
+  readonly tables: Readonly<Record<string, readonly MirrorRow[]>>;
+  /** Mutations that never reached the server, refusals included, in queue order. */
+  readonly unsent: readonly QueuedMutation[];
+  /**
+   * Autosaved forms, ordered by key. These have never been submitted, so unlike
+   * the mirror there is no server copy to come back — the sign-out wipe deletes
+   * the drafts table outright, and this file is the only place they survive.
+   */
+  readonly drafts: readonly DeviceDraft[];
+  readonly counts: {
+    readonly rows: number;
+    readonly unsent: number;
+    readonly drafts: number;
+  };
+}
+
+/**
+ * Build the snapshot. Ordering is fixed (tables by name, rows by key, queue by
+ * `seq`, drafts by key) so the same device state produces the same bytes twice —
+ * a diffable file, and a test that can assert on it without sorting first.
+ *
+ * The drafts are handed in rather than fetched: they live in the device store
+ * behind an async read, and this function stays pure so the whole snapshot is
+ * testable without a filesystem.
+ */
+export function deviceSnapshot(input: {
+  readonly mirror: MirrorState;
+  readonly queue: readonly QueuedMutation[];
+  readonly drafts: readonly DeviceDraft[];
+  readonly ownerId: string;
+  readonly exportedAt: string;
+}): DeviceSnapshot {
+  const source = input.mirror;
+  const tables: Record<string, readonly MirrorRow[]> = {};
+  let rows = 0;
+  for (const table of Object.keys(source.tables).sort()) {
+    const byId = source.tables[table as keyof typeof source.tables] ?? {};
+    const ordered = Object.keys(byId)
+      .sort()
+      .map((id) => byId[id])
+      .filter((row): row is MirrorRow => row !== undefined);
+    rows += ordered.length;
+    tables[table] = ordered;
+  }
+  const unsent = [...input.queue].sort((a, b) => a.seq - b.seq);
+  const drafts = [...input.drafts].sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
+  return {
+    format: SNAPSHOT_FORMAT,
+    version: SNAPSHOT_VERSION,
+    exportedAt: input.exportedAt,
+    ownerId: input.ownerId,
+    cursors: { ...source.cursors },
+    tables,
+    unsent,
+    drafts,
+    counts: { rows, unsent: unsent.length, drafts: drafts.length },
+  };
+}
+
+/**
+ * The filename a snapshot is saved under — dated, so two copies taken on
+ * different days sit beside each other in a downloads folder instead of one
+ * quietly replacing the other. Colons are stripped: they are legal in an ISO
+ * timestamp and illegal in a filename on Android and Windows alike.
+ */
+export function snapshotFilename(exportedAt: string): string {
+  const stamp = exportedAt.replace(/[:.]/g, '-').replace(/Z$/, '');
+  return `waves-device-copy-${stamp}.json`;
+}

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -1,4 +1,5 @@
 export * from './protocol';
 export * from './queue';
 export * from './mirror';
+export * from './departure';
 export * from './expenseWrite';

--- a/packages/core/test/departure.test.ts
+++ b/packages/core/test/departure.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Signing out erases this device's copy, so what the sheet says is about to be
+ * lost has to be right: an undercount is data thrown away by someone who was
+ * told there was nothing to keep.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  deviceSnapshot,
+  emptyMirror,
+  applyOutcomes,
+  enqueue,
+  MutationKind,
+  personalScope,
+  reconcile,
+  snapshotFilename,
+  SyncRejectionCode,
+  SyncTable,
+  unsentWork,
+  type MutationEnvelope,
+  type QueuedMutation,
+} from '../src/sync/index.js';
+
+const OWNER = '11111111-1111-4111-8111-111111111111';
+const GROUP = '22222222-2222-4222-8222-222222222222';
+
+function envelope(kind: MutationKind, groupId: string, id: string): MutationEnvelope {
+  return {
+    clientMutationId: id,
+    kind,
+    groupId,
+    clientCreatedAt: '2026-09-08T10:00:00.000Z',
+    payload: {},
+  };
+}
+
+function queueOf(...envelopes: MutationEnvelope[]): QueuedMutation[] {
+  return envelopes.reduce<QueuedMutation[]>((queue, item) => enqueue(queue, item), []);
+}
+
+describe('unsentWork', () => {
+  it('is empty for an empty queue', () => {
+    expect(unsentWork([], OWNER)).toEqual({ personal: 0, other: 0, refused: 0, total: 0 });
+  });
+
+  it('separates the personal ledger from everything else', () => {
+    const queue = queueOf(
+      envelope(MutationKind.PersonalUpsert, personalScope(OWNER), 'p1'),
+      envelope(MutationKind.PersonalDelete, personalScope(OWNER), 'p2'),
+      envelope(MutationKind.ExpenseCreate, GROUP, 'e1'),
+      envelope(MutationKind.CaptureCreate, OWNER, 'c1'),
+    );
+
+    expect(unsentWork(queue, OWNER)).toEqual({
+      personal: 2,
+      other: 2,
+      refused: 0,
+      total: 4,
+    });
+  });
+
+  it('counts a refusal apart from what is still on its way', () => {
+    const { queue } = applyOutcomes(
+      queueOf(
+        envelope(MutationKind.ExpenseCreate, GROUP, 'e1'),
+        envelope(MutationKind.ExpenseCreate, GROUP, 'e2'),
+      ),
+      [
+        {
+          clientMutationId: 'e2',
+          status: 'rejected',
+          code: SyncRejectionCode.ValidationFailed,
+          message: 'The server refused this change',
+        },
+      ],
+    );
+
+    // The refused one is still in the queue — it is the only copy — but it is
+    // not "sending", so it must not be counted as pending.
+    expect(unsentWork(queue, OWNER)).toEqual({
+      personal: 0,
+      other: 1,
+      refused: 1,
+      total: 2,
+    });
+  });
+
+  it('puts everything in `other` when nobody is signed in', () => {
+    const queue = queueOf(envelope(MutationKind.PersonalUpsert, personalScope(OWNER), 'p1'));
+    expect(unsentWork(queue, '')).toMatchObject({ personal: 0, other: 1, total: 1 });
+  });
+});
+
+describe('deviceSnapshot', () => {
+  const mirror = reconcile(emptyMirror(), [
+    {
+      table: SyncTable.Groups,
+      seq: 2,
+      groupId: GROUP,
+      row: { id: GROUP, name: 'Goa' },
+    },
+    {
+      table: SyncTable.Expenses,
+      seq: 3,
+      groupId: GROUP,
+      row: { id: 'b-expense', description: 'Second' },
+    },
+    {
+      table: SyncTable.Expenses,
+      seq: 4,
+      groupId: GROUP,
+      row: { id: 'a-expense', description: 'First' },
+    },
+  ]).state;
+
+  it('carries the rows, the cursors and the unsent queue', () => {
+    const queue = queueOf(envelope(MutationKind.ExpenseCreate, GROUP, 'e1'));
+    const snapshot = deviceSnapshot({
+      mirror,
+      queue,
+      drafts: [],
+      ownerId: OWNER,
+      exportedAt: '2026-09-08T10:30:00.000Z',
+    });
+
+    expect(snapshot.format).toBe('waves.device.snapshot');
+    expect(snapshot.ownerId).toBe(OWNER);
+    expect(snapshot.cursors[GROUP]).toBe(4);
+    expect(snapshot.tables[SyncTable.Groups]).toHaveLength(1);
+    expect(snapshot.counts).toEqual({ rows: 3, unsent: 1, drafts: 0 });
+    // The queue is the only copy of an unsent change; it has to be in the file.
+    expect(snapshot.unsent[0]?.clientMutationId).toBe('e1');
+  });
+
+  it('carries the drafts whole, ordered by key', () => {
+    const snapshot = deviceSnapshot({
+      mirror,
+      queue: [],
+      drafts: [
+        { key: 'expense:zzz', value: { description: 'Chai' }, savedAt: '2026-09-08T09:00:00.000Z' },
+        { key: 'expense:aaa', value: { description: 'Auto' }, savedAt: '2026-09-08T08:00:00.000Z' },
+      ],
+      ownerId: OWNER,
+      exportedAt: '2026-09-08T10:30:00.000Z',
+    });
+
+    expect(snapshot.drafts.map((draft) => draft.key)).toEqual(['expense:aaa', 'expense:zzz']);
+    expect(snapshot.counts.drafts).toBe(2);
+    // A draft was never submitted, so nothing else holds it — the value goes in
+    // exactly as the store handed it over, unread and unreshaped.
+    expect(snapshot.drafts[0]?.value).toEqual({ description: 'Auto' });
+    expect(snapshot.drafts[0]?.savedAt).toBe('2026-09-08T08:00:00.000Z');
+  });
+
+  it('is deterministic — same state, same bytes', () => {
+    const input = {
+      mirror,
+      queue: queueOf(envelope(MutationKind.ExpenseCreate, GROUP, 'e1')),
+      drafts: [
+        { key: 'expense:zzz', value: { description: 'Chai' }, savedAt: '2026-09-08T09:00:00.000Z' },
+        { key: 'expense:aaa', value: { description: 'Auto' }, savedAt: '2026-09-08T08:00:00.000Z' },
+      ],
+      ownerId: OWNER,
+      exportedAt: '2026-09-08T10:30:00.000Z',
+    };
+    expect(JSON.stringify(deviceSnapshot(input))).toBe(JSON.stringify(deviceSnapshot(input)));
+    // Rows are ordered by id, not by the order they arrived in.
+    expect(deviceSnapshot(input).tables[SyncTable.Expenses]?.map((row) => row.id)).toEqual([
+      'a-expense',
+      'b-expense',
+    ]);
+  });
+
+  it('names the file with a stamp no filesystem objects to', () => {
+    const name = snapshotFilename('2026-09-08T10:30:00.000Z');
+    expect(name).toBe('waves-device-copy-2026-09-08T10-30-00-000.json');
+    expect(name).not.toContain(':');
+  });
+});


### PR DESCRIPTION
Signing out wipes this device's mirror, its unsent mutation queue, its unsent receipt bytes, its drafts and its backup recovery key. That is correct — the next person to hold the phone must not find the last account's ledger on it — but the confirmation was an OS alert reading "Nothing is deleted", which for anyone holding unsent work was simply untrue.

## What the sheet does

- Counts what is about to be lost, by name: changes to groups, personal-ledger records (the Me tab), changes the server refused, receipt photos still only on this phone, and half-typed drafts.
- Warns when this device holds a backup recovery key nobody has confirmed writing down — that loss happens even when everything is synced, so it shows in the reassuring branch too.
- Offers **Sync now** (mutation queue *and* receipt uploads, in the order `resumeReceiptUploads` uses, so the attachment rows come back down) and **Download a copy** — a plain JSON snapshot of the mirror, the unsent queue and the drafts, handed to the system share sheet.
- Never blocks the sign-out. Somebody handing back a borrowed phone must be able to leave now; the warning is honest and the door stays unlocked.

The copy is JSON, not image bytes, so when receipts are unsent the sheet says plainly that the file does not hold the photos.

## Shape

`unsentWork()` and `deviceSnapshot()` are pure functions in `@waves/core` — the counting is arithmetic over the queue and the snapshot is a plain object, both unit-testable with no device, network or filesystem. The mobile side is a thin shell: `deviceCopy.ts` follows the export screen's expo-file-system 57 pattern (write to cache, share, delete), and `SignOutSheet.tsx` reads drafts and the key state only once the sheet is actually opened, so the Profile tab does no disk work for a closed sheet.

## Notes

- Strings land in all four locales (en/ta/hi/ar), Arabic with its full plural set.
- `allSafeBody` was rescoped from "everything on this device" to "every change on this device … your ledger comes back", so the recovery-key warning is an addition rather than a contradiction.
- A `flush()` that fails is recorded on the engine rather than thrown, so the sheet checks the engine's status afterwards — a sync that sent nothing used to look exactly like one that sent everything.

## Tests

`packages/core/test/departure.test.ts` — bucket counting (personal vs the rest vs refused), refusals counted apart from work still in flight, snapshot determinism and ordering, drafts carried whole. Full core suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a sign-out review sheet that highlights unsent changes, drafts, receipts, and backup recovery-key risks before signing out.
  - Users can sync pending data or save a device copy to share before leaving.
  - Added clearer options to stay signed in or proceed with sign-out.
- **Localization**
  - Added translated sign-out warnings and actions in English, Tamil, Hindi, and Arabic.
- **Bug Fixes**
  - Replaced the native sign-out confirmation prompt with the new in-app review experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->