### PR TITLE
Sign in through the phone's own account sheet, not a browser tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,6 +642,55 @@ tells you what happened to each one — `suppressed` means we chose not to mail 
 list), `failed` means Resend refused it, and NULL after a run means it will be
 retried. `email_events` is the trail, one row per send plus one per report.
 
+## Signing in without a browser
+
+Tapping Google or Apple used to send somebody out of the app: Waves asked
+Supabase for an `/authorize` URL, a browser tab opened on `<project-ref>.supabase.co`,
+Supabase bounced it on to the provider, and a redirect came back through
+`waves://auth`. It works, and it is still the fallback — but it shows a domain
+that is neither ours nor Google's on the way to somebody's own account.
+
+The native path (`apps/mobile/src/lib/nativeIdentity.ts`) presents the sheet the
+OS already has — Play services on Android, `expo-apple-authentication` on iOS —
+and hands the **identity token** it issues to `signInWithIdToken`. Same
+mechanism the Drive link uses (`lib/cloud/nativeGoogle.ts`), asking who you are
+instead of for your files.
+
+It applies to a **fresh sign-in only**. Supabase has no id-token form of
+`linkIdentity`, so a guest upgrading in place (ADR-006, the common path here)
+still goes out through the browser. So does every case the sheet cannot serve:
+no Play services, no native module in the binary, Apple off iOS, the web app,
+and a build with no OAuth client registered for its signature. None of those
+surfaces as an error — the browser flow runs and the person signs in.
+
+Google's client ids are the Drive ones, because they are the same ids: Google
+allows one iOS client per bundle id, and identifies an Android build by its
+package name and signing certificate rather than by anything in the bundle. Set
+the neutral names instead if a build offers sign-in but no backup; either works.
+
+| Variable                           | Where              | What it does                                         |
+| ---------------------------------- | ------------------ | ---------------------------------------------------- |
+| `EXPO_PUBLIC_GOOGLE_CLIENT_ID_WEB` | `apps/mobile/.env` | names the Cloud project; falls back to the Drive one |
+| `EXPO_PUBLIC_GOOGLE_CLIENT_ID_IOS` | `apps/mobile/.env` | the iOS client and its URL scheme; same fallback     |
+
+**What the consoles need.** Google, per signing key:
+
+1. An **Android** OAuth client bound to `app.waves.mobile` plus that key's SHA-1
+   — the debug keystore's and the release keystore's are different clients.
+   Nothing reads its id; registering it is the point. Without one Play services
+   refuses with `DEVELOPER_ERROR` (status 10) before Google ever sees the
+   request, and Waves quietly uses the browser instead.
+2. An **iOS** client bound to the bundle id, for iOS builds.
+3. In Supabase → Authentication → Providers → Google, put the **Web** client id
+   in _Client ID_ and list every id whose tokens should be accepted under
+   **Authorized Client IDs** — the web one (the audience of an Android native
+   token) and the iOS one. A token whose `aud` is not listed is rejected, which
+   is the only check standing in for the nonce Google's SDK does not let us set.
+
+Apple needs nothing new: the native iOS path already ran before this change, and
+its provider config is the section below — including the client-id order, which
+is load-bearing.
+
 ## Sign in with Apple
 
 Back, and live since 2026-09-05. This section previously said it had been

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -69,7 +69,13 @@ function googleMapsKey(platform: 'android' | 'ios'): string | undefined {
 }
 
 /**
- * The Drive-backup sign-in plugin, for iOS builds that have a client id.
+ * The Google sign-in plugin, for iOS builds that have a client id.
+ *
+ * Two features ride on it — logging in (`lib/nativeIdentity.ts`) and linking
+ * Drive for backup (`lib/cloud/nativeGoogle.ts`) — and they share one client
+ * id because Google allows exactly one iOS client per bundle id. Either name
+ * therefore configures both; the neutral one wins so a build that offers
+ * sign-in without backup need not set something called `..._DRIVE_...`.
  *
  * Android needs nothing here: the native module autolinks, and Google matches
  * the app by package name and signing certificate rather than by anything
@@ -83,7 +89,9 @@ function googleMapsKey(platform: 'android' | 'ios'): string | undefined {
  * throws without one, and an unconfigured clone must still be able to prebuild.
  */
 function googleSignInPlugin(): [string, { iosUrlScheme: string }] | undefined {
-  const iosClientId = process.env.EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_IOS;
+  const iosClientId =
+    process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID_IOS ||
+    process.env.EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_IOS;
   if (!iosClientId) return undefined;
   const bare = iosClientId.replace(/\.apps\.googleusercontent\.com$/, '');
   return [
@@ -114,19 +122,19 @@ export default (): ExpoConfig => {
       : config.ios,
   };
 
-  const drive = googleSignInPlugin();
-  const withDrive: ExpoConfig = drive
-    ? { ...withPush, plugins: [...(withPush.plugins ?? []), drive] }
+  const googleSignIn = googleSignInPlugin();
+  const withGoogleSignIn: ExpoConfig = googleSignIn
+    ? { ...withPush, plugins: [...(withPush.plugins ?? []), googleSignIn] }
     : withPush;
 
   const organization = process.env.SENTRY_ORG;
   const project = process.env.SENTRY_PROJECT;
-  if (!organization || !project) return withDrive;
+  if (!organization || !project) return withGoogleSignIn;
 
   return {
-    ...withDrive,
+    ...withGoogleSignIn,
     plugins: [
-      ...(withDrive.plugins ?? []),
+      ...(withGoogleSignIn.plugins ?? []),
       [
         '@sentry/react-native/expo',
         { organization, project, url: process.env.SENTRY_URL ?? 'https://sentry.io/' },

--- a/apps/mobile/src/app/settings/backup.tsx
+++ b/apps/mobile/src/app/settings/backup.tsx
@@ -53,6 +53,7 @@ import { useBackup, type BackupOutcome } from '@/lib/backup/useBackup';
 import { BackupFrequency } from '@/lib/backup/schedule';
 import { formatRecoveryKey } from '@/lib/backup/recoveryKey';
 import type { RestoreScan } from '@/lib/backup/engine';
+import { CloudAuthError } from '@/lib/cloud/oauth';
 import { friendlyError } from '@/lib/errors';
 import { SyncNetworkPreference } from '@/lib/syncNetwork';
 
@@ -119,13 +120,42 @@ export default function BackupSettingsScreen() {
           ? t.backup.phaseUploading
           : null;
 
+  /**
+   * Why linking failed, said in a way that points at whoever can fix it.
+   *
+   * "Try again" is honest advice for a dropped connection and a lie for a build
+   * Google refuses to issue tokens to — no client registered for this package
+   * name and signing certificate, or no client id in the bundle at all. Those
+   * are settled before the app is installed and no tap changes them, so they
+   * get the same sentence the screen already uses for a build that cannot do
+   * this: "not available in this build".
+   *
+   * The status code is the whole diagnosis for whoever is building and noise
+   * for everybody else, so it is appended in development only. It is already in
+   * the crash report either way — `lib/cloud/nativeGoogle` files these on the
+   * way out, which is also why this does not run a `CloudAuthError` back
+   * through `friendlyError`: that would report the same failure twice.
+   */
+  const connectFailure = (caught: unknown): string => {
+    if (!(caught instanceof CloudAuthError)) {
+      return friendlyError(caught, t.backup.connectFailed, 'backup.connect');
+    }
+    // `play-services` deserves its own sentence — Google's services being
+    // absent or stale is the one fault here the person can fix themselves — and
+    // will get one as soon as `backup.connectNoPlayServices` exists in all four
+    // locale tables. Until then it reads as an ordinary failure, which is at
+    // least not wrong.
+    const sentence = caught.fault === 'not-set-up' ? t.backup.unavailable : t.backup.connectFailed;
+    return __DEV__ && caught.status ? `${sentence} (${caught.status})` : sentence;
+  };
+
   const onConnect = async (): Promise<void> => {
     setBusy(true);
     setError(null);
     try {
       await backup.connect();
     } catch (caught) {
-      setError(friendlyError(caught, t.backup.connectFailed, 'backup.connect'));
+      setError(connectFailure(caught));
     } finally {
       setBusy(false);
     }

--- a/apps/mobile/src/lib/auth.tsx
+++ b/apps/mobile/src/lib/auth.tsx
@@ -1,8 +1,6 @@
 import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
-import { Platform } from 'react-native';
 import type { Session } from '@/lib/backend';
 import { makeRedirectUri } from 'expo-auth-session';
-import * as Crypto from 'expo-crypto';
 import * as Linking from 'expo-linking';
 import * as WebBrowser from 'expo-web-browser';
 
@@ -17,6 +15,7 @@ import {
   type Viewer,
 } from '@waves/core';
 
+import { appleNativeSignIn, googleNativeSignIn } from './nativeIdentity';
 import { identifyForReporting, reportHandled } from './observability';
 import { claimCode } from './oauthClaim';
 import { refreshPushToken, revokePushToken } from './push';
@@ -119,67 +118,6 @@ async function oauthThroughBrowser(
   // app that was restarted mid-sign-in. Their session is the one to keep.
   const { data: current } = await backend.auth.getSession();
   return current.session;
-}
-
-/**
- * Sign in with Apple's native sheet — iOS only.
- *
- * The module is a native one, so it is required lazily behind a catch: a build
- * that predates the `expo-apple-authentication` dependency (Android, web, or an
- * old dev client) must fall back to the browser flow rather than crash at
- * launch (see the native-module rule).
- */
-type AppleAuthModule = typeof import('expo-apple-authentication');
-
-function loadAppleAuth(): AppleAuthModule | null {
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    return require('expo-apple-authentication') as AppleAuthModule;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Present Apple's native sheet and hand back the identity token plus, only on
- * the very first authorization, the person's name — Apple returns it once and
- * never again. `undefined` means they dismissed the sheet.
- *
- * The token is bound to this one request with a nonce: Apple is given its
- * SHA-256 and stamps that into the identity token, Supabase is given the raw
- * value and checks the hash matches. Without it, an identity token captured
- * anywhere — another app, a log, an old device — is a valid sign-in here.
- */
-async function appleNativeCredential(apple: AppleAuthModule): Promise<
-  | {
-      identityToken: string;
-      nonce: string;
-      fullName: {
-        givenName: string | null;
-        middleName: string | null;
-        familyName: string | null;
-      } | null;
-    }
-  | undefined
-> {
-  const nonce = Crypto.randomUUID();
-  const hashedNonce = await Crypto.digestStringAsync(Crypto.CryptoDigestAlgorithm.SHA256, nonce);
-  try {
-    const credential = await apple.signInAsync({
-      requestedScopes: [
-        apple.AppleAuthenticationScope.FULL_NAME,
-        apple.AppleAuthenticationScope.EMAIL,
-      ],
-      nonce: hashedNonce,
-    });
-    if (!credential.identityToken) {
-      throw new Error('Apple sign-in returned no identity token');
-    }
-    return { identityToken: credential.identityToken, nonce, fullName: credential.fullName };
-  } catch (error) {
-    if ((error as { code?: string }).code === 'ERR_REQUEST_CANCELED') return undefined;
-    throw error;
-  }
 }
 
 /**
@@ -378,9 +316,13 @@ interface AuthValue {
     password: string,
     intent: 'sign_in' | 'sign_up',
   ) => Promise<PasswordOutcome>;
-  /** Google. Links to the current account when there is one, for the same reason. */
+  /**
+   * Google. The phone's own sheet for a fresh sign-in, the browser when this
+   * build or device cannot present one — and always the browser for a link,
+   * because linking an identity has no id-token form.
+   */
   withGoogle: () => Promise<void>;
-  /** Apple. Native sheet on iOS for a fresh sign-in; browser otherwise and for links. */
+  /** Apple. The same three cases, through the same seam (`lib/nativeIdentity`). */
   withApple: () => Promise<void>;
   updateProfile: (patch: Partial<Profile>) => Promise<void>;
   /** Re-read the session after it changes underneath us (e.g. a linked email). */
@@ -633,36 +575,52 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
       async withGoogle() {
         const action = planAuth(viewerFrom(session), AuthMethod.Google);
+        // Native first, and only for a fresh sign-in: Supabase has no id-token
+        // form of `linkIdentity`, so a guest upgrading (the ADR-006 common
+        // path) has to go out through the browser however good the sheet is.
+        if (action.call === 'signInWithOAuth') {
+          const outcome = await googleNativeSignIn();
+          if (outcome.kind === 'dismissed') return;
+          if (outcome.kind === 'credential') {
+            const { data, error } = await backend.auth.signInWithIdToken({
+              provider: 'google',
+              token: outcome.credential.idToken,
+            });
+            if (error) throw error;
+            setSession(data.session);
+            return;
+          }
+          // `unavailable`: no module, no Play services, no OAuth client for
+          // this build's signature. The browser flow below is what this phone
+          // can still do, so it runs — the person sees a sign-in, not a fault.
+        }
         const next = await oauthThroughBrowser(OAuthMethod.Google, action.call === 'linkIdentity');
         if (next !== undefined) setSession(next);
       },
 
       async withApple() {
         const action = planAuth(viewerFrom(session), AuthMethod.Apple);
-        // The native id-token flow is a fresh sign-in only: Supabase has no
-        // id-token form of linkIdentity, so a guest upgrading (the ADR-006
-        // common path) still goes through the browser, exactly like Google.
-        if (Platform.OS === 'ios' && action.call === 'signInWithOAuth') {
-          const apple = loadAppleAuth();
-          if (apple) {
-            const credential = await appleNativeCredential(apple);
-            if (credential === undefined) return; // sheet dismissed
+        // Same shape as Google, and the same reason for the same limit: this is
+        // a fresh sign-in only, and everything else falls through.
+        if (action.call === 'signInWithOAuth') {
+          const outcome = await appleNativeSignIn();
+          if (outcome.kind === 'dismissed') return;
+          if (outcome.kind === 'credential') {
             const { data, error } = await backend.auth.signInWithIdToken({
               provider: 'apple',
-              token: credential.identityToken,
-              nonce: credential.nonce,
+              token: outcome.credential.identityToken,
+              nonce: outcome.credential.nonce,
             });
             if (error) throw error;
             // Apple hands over the name only on the first authorization; seed
             // the profile with it before it is gone for good.
-            const name = appleFullName(credential.fullName);
+            const name = appleFullName(outcome.credential.fullName);
             if (name && data.user) {
               await persistAppleName(data.user.id, name);
             }
             setSession(data.session);
             return;
           }
-          // No native module in this build — fall through to the browser.
         }
         const next = await oauthThroughBrowser(OAuthMethod.Apple, action.call === 'linkIdentity');
         if (next !== undefined) setSession(next);

--- a/apps/mobile/src/lib/cloud/nativeGoogle.ts
+++ b/apps/mobile/src/lib/cloud/nativeGoogle.ts
@@ -27,7 +27,10 @@
 
 import { Platform } from 'react-native';
 
+import { reportHandled } from '@/lib/observability';
+
 import { clientId, webClientId } from './config';
+import { CloudAuthError, type CloudAuthFault } from './oauth';
 import type { CloudTokens } from './types';
 
 type SigninModule = typeof import('@react-native-google-signin/google-signin');
@@ -111,9 +114,87 @@ function configure(module: SigninModule): void {
 /** The module, configured — or a thrown failure the caller turns into a sentence. */
 function ready(): SigninModule {
   const module = load();
-  if (!module) throw new Error('the Google authorization module is missing from this build');
-  configure(module);
+  if (!module) {
+    throw fail('cloud.googleConfigure', 'not-set-up', null, 'no Google authorization module');
+  }
+  try {
+    configure(module);
+  } catch (error) {
+    // `webClientId` throws when the build names no Cloud project. That is the
+    // same kind of fault as a missing module — this build cannot ask — and it
+    // must not arrive at the screen as a bare Error saying so in developer
+    // English.
+    throw fail('cloud.googleConfigure', 'not-set-up', null, detailOf(error));
+  }
   return module;
+}
+
+/**
+ * The status code Play services returns when it will not even put the request
+ * to Google: it found no OAuth client registered for this build's package name
+ * and signing certificate.
+ *
+ * It is the one failure on this path that is certainly ours rather than the
+ * network's, and the SDK does not name it — `statusCodes` stops at cancellation
+ * and "sign in first" — so it arrives as a bare rejection carrying the string
+ * `'10'`, is recognised by nothing, and collapses into the same "try again" as
+ * a dropped connection. It is not a try-again: every retry from now until
+ * somebody opens the Google Cloud console fails identically.
+ */
+const DEVELOPER_ERROR = '10';
+
+/** A rejection's message, whatever kind of thing was thrown. */
+function detailOf(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return typeof error === 'string' ? error : 'no detail';
+}
+
+/**
+ * The provider's status code, or null when the rejection carried none.
+ *
+ * The SDK's own type guard first, because that is the supported way to read
+ * one — and then the field directly, because the guard only admits codes the
+ * library knows about and `DEVELOPER_ERROR` is precisely a code it does not.
+ */
+function statusOf(module: SigninModule | null, error: unknown): string | null {
+  if (module?.isErrorWithCode(error)) return String(error.code);
+  if (typeof error !== 'object' || error === null) return null;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === 'string' || typeof code === 'number' ? String(code) : null;
+}
+
+/**
+ * Classify what Play services raised, and file it before it goes anywhere near
+ * a sentence.
+ *
+ * Reporting happens here rather than at the screen because this is the only
+ * place the status code still exists — by the time the failure has been turned
+ * into "Could not link that account" the diagnosis is gone, and a build with no
+ * Sentry DSN drops it silently, which is how this path came to be undiagnosable
+ * from anything short of `adb logcat` on the device in question.
+ */
+function classify(module: SigninModule | null, error: unknown, where: string): CloudAuthError {
+  const status = statusOf(module, error);
+  const detail = detailOf(error);
+  const developerError = status === DEVELOPER_ERROR || detail.includes('DEVELOPER_ERROR');
+  const fault: CloudAuthFault = developerError
+    ? 'not-set-up'
+    : status !== null && status === module?.statusCodes.PLAY_SERVICES_NOT_AVAILABLE
+      ? 'play-services'
+      : 'failed';
+  return fail(where, fault, status, detail);
+}
+
+/** Report a classified failure, and hand it back to be thrown. */
+function fail(
+  where: string,
+  fault: CloudAuthFault,
+  status: string | null,
+  detail: string,
+): CloudAuthError {
+  const error = new CloudAuthError(fault, status, detail);
+  reportHandled(error, where);
+  return error;
 }
 
 function tokensFrom(accessToken: string): CloudTokens {
@@ -148,7 +229,7 @@ export async function nativeAuthorize(): Promise<CloudTokens | null> {
     return tokensFrom(tokens.accessToken);
   } catch (error) {
     if (isCancellation(module, error)) return null;
-    throw error;
+    throw classify(module, error, 'cloud.googleAuthorize');
   }
 }
 
@@ -179,7 +260,10 @@ export async function nativeReauthorize(previous: CloudTokens): Promise<CloudTok
     // this without asking: the grant is not usable now, and asking belongs to
     // the person tapping Connect rather than to a backup running behind them.
     if (isGone(module, error)) return null;
-    throw error;
+    // Everything else is worth a report even though nobody is watching: a
+    // renewal runs behind a scheduled backup, so this is the one half of the
+    // flow that has no screen to say anything on.
+    throw classify(module, error, 'cloud.googleReauthorize');
   }
 }
 

--- a/apps/mobile/src/lib/cloud/oauth.ts
+++ b/apps/mobile/src/lib/cloud/oauth.ts
@@ -13,10 +13,60 @@
  * grant is gone or merely that the network is. Both are decisions about tokens
  * rather than about how they were obtained, which is why they outlived the
  * transport.
+ *
+ * And one judgement the new flow added: *why* asking for consent failed. The
+ * browser flow answered that in the URL it came back on; Play services answers
+ * it in a status code, and a code nobody classifies is a code nobody sees.
  */
 
 import { CloudHttpError } from './http';
 import type { CloudTokens } from './types';
+
+/**
+ * Why an authorization attempt failed, in the only three kinds that lead
+ * anywhere different.
+ *
+ * The distinction that matters is between a fault of the *build* and a fault of
+ * the *moment*. "Try again" is the right advice for exactly one of them, and
+ * offering it for the others is how somebody ends up tapping a button forty
+ * times against a Google Cloud project that has never had a client registered
+ * for this app.
+ *
+ *   * `not-set-up` — this build cannot ask, and no amount of retrying changes
+ *     that: no native module, no client id, or Google refusing the request
+ *     outright because it recognises neither the package name nor the signing
+ *     certificate (`DEVELOPER_ERROR`). Somebody has to open a console.
+ *   * `play-services` — the phone cannot ask. Google's own services are absent
+ *     or too old, which the person can actually fix.
+ *   * `failed` — everything else: a dropped connection, a timeout, a rejection
+ *     nobody has seen before. This one really is worth another tap.
+ */
+export type CloudAuthFault = 'not-set-up' | 'play-services' | 'failed';
+
+/**
+ * A failed attempt at consent, carrying enough to choose a sentence.
+ *
+ * The provider's own status code rides along because it is the entire diagnosis
+ * and is meaningless in a user interface — `10` tells whoever is building
+ * exactly what is wrong and tells the person holding the phone nothing at all.
+ * It reaches the crash report always, and the screen only in development.
+ *
+ * Nothing identifying is ever put in here: not the access token, not the
+ * account, not the client id. A status code and the SDK's own sentence.
+ */
+export class CloudAuthError extends Error {
+  constructor(
+    readonly fault: CloudAuthFault,
+    /** The provider's status code, when it gave one. `'10'` is DEVELOPER_ERROR. */
+    readonly status: string | null,
+    detail: string,
+  ) {
+    super(
+      `cloud authorization failed (${fault}${status === null ? '' : `, ${status}`}): ${detail}`,
+    );
+    this.name = 'CloudAuthError';
+  }
+}
 
 /**
  * The OAuth error codes that mean the grant is gone and only a new consent will

--- a/apps/mobile/src/lib/nativeIdentity.ts
+++ b/apps/mobile/src/lib/nativeIdentity.ts
@@ -195,13 +195,15 @@ const DEVELOPER_ERROR = '10';
 export async function googleNativeSignIn(): Promise<NativeSignIn<GoogleCredential>> {
   const module = loadGoogle();
   const webClientId = googleWebClientId();
+  const iosClientId = googleIosClientId();
   if (!module || !webClientId || Platform.OS === 'web') return unavailable;
+  if (Platform.OS === 'ios' && !iosClientId) return unavailable;
 
   try {
     module.GoogleSignin.configure({
       webClientId,
       offlineAccess: false,
-      ...(Platform.OS === 'ios' ? { iosClientId: googleIosClientId() } : {}),
+      ...(Platform.OS === 'ios' ? { iosClientId } : {}),
     });
     await module.GoogleSignin.hasPlayServices({ showPlayServicesUpdateDialog: false });
     const response = await module.GoogleSignin.signIn();

--- a/apps/mobile/src/lib/nativeIdentity.ts
+++ b/apps/mobile/src/lib/nativeIdentity.ts
@@ -1,0 +1,338 @@
+/**
+ * Signing in the way the phone does it, rather than the way a browser does.
+ *
+ * The flow this replaces sent somebody out of the app entirely: Waves asked
+ * Supabase for an `/authorize` URL, a browser tab opened on Supabase's domain,
+ * Supabase bounced it on to Google's consent page, and a redirect came back
+ * through `waves://auth` carrying a code. It works, and it is still here (see
+ * `oauthThroughBrowser` in `lib/auth.tsx`) — but it shows the person a domain
+ * that is not ours and not Google's on the way to their own account, and a
+ * chrome tab is not what signing into an app is supposed to look like.
+ *
+ * What replaces it is the sheet the operating system already knows how to
+ * present: Play services on Android, `expo-apple-authentication` on iOS. Both
+ * end the same way — an **identity token**, a short-lived JWT saying who this
+ * is, signed by Google or by Apple. That token is handed to Supabase through
+ * `signInWithIdToken`, so the round trip through a browser and through
+ * Supabase's own domain simply does not happen. This is the same mechanism the
+ * Drive link already uses for authorization (`lib/cloud/nativeGoogle.ts`); the
+ * difference is only what is asked for — who you are, rather than access to
+ * your files.
+ *
+ * Three things this module is careful about.
+ *
+ * **It never decides the sign-in.** It hands back a credential, a dismissal, or
+ * "this build/phone cannot do it". Which Supabase call the credential feeds is
+ * `lib/auth.tsx`'s business, because that depends on whether somebody is
+ * already signed in (ADR-006: a guest is *linked*, never re-signed-in) — and
+ * Supabase has no id-token form of `linkIdentity`, so an upgrade cannot use
+ * this path at all.
+ *
+ * **`unavailable` is not a failure.** A build without the native module, a
+ * phone without Play services, Apple on Android, a device with no OAuth client
+ * registered for its signature: every one of them still has the browser flow,
+ * which is why that flow stays. The caller falls through to it, so the person
+ * gets a working sign-in and never a message about a mechanism they did not ask
+ * for.
+ *
+ * **Native modules are required lazily.** A JS bundle can reach a binary older
+ * than the dependency — an OTA update onto a previous native build is the
+ * ordinary way — and a bare top-level import would take the app down at launch
+ * rather than costing it one tile on the sign-in screen.
+ */
+
+import { Platform } from 'react-native';
+import * as Crypto from 'expo-crypto';
+
+import { reportHandled } from '@/lib/observability';
+
+/**
+ * How a native sheet ended.
+ *
+ * `dismissed` and `unavailable` are different on purpose and the caller acts on
+ * both: somebody who closed the sheet meant to, and must be left where they
+ * were; a build that cannot present one gets the browser instead.
+ */
+export type NativeSignIn<T> =
+  | { readonly kind: 'credential'; readonly credential: T }
+  | { readonly kind: 'dismissed' }
+  | { readonly kind: 'unavailable' };
+
+/** Google's answer: a JWT saying who this is, for Supabase to verify. */
+export interface GoogleCredential {
+  readonly idToken: string;
+}
+
+/** Apple's answer, plus the two things only Apple attaches to it. */
+export interface AppleCredential {
+  readonly identityToken: string;
+  /**
+   * The raw nonce. Apple was given its SHA-256 and stamped that into the token;
+   * Supabase is given this and checks the hash matches, which is what stops an
+   * identity token captured anywhere else from being a valid sign-in here.
+   */
+  readonly nonce: string;
+  /** Sent on the first authorization only — after that Apple never sends it again. */
+  readonly fullName: {
+    givenName: string | null;
+    middleName: string | null;
+    familyName: string | null;
+  } | null;
+}
+
+const dismissed = { kind: 'dismissed' } as const;
+const unavailable = { kind: 'unavailable' } as const;
+
+/* -------------------------------------------------------------------------- */
+/* Google                                                                      */
+/* -------------------------------------------------------------------------- */
+
+type SigninModule = typeof import('@react-native-google-signin/google-signin');
+
+let signinModule: SigninModule | null | undefined;
+
+function loadGoogle(): SigninModule | null {
+  if (signinModule !== undefined) return signinModule;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    signinModule = require('@react-native-google-signin/google-signin') as SigninModule;
+  } catch {
+    signinModule = null;
+  }
+  return signinModule;
+}
+
+/**
+ * Stand a fake SDK in, for tests — the real one is reached through `require`,
+ * which is exactly what a test runner cannot satisfy.
+ */
+export function setGoogleSigninForTests(module: SigninModule | null): void {
+  signinModule = module;
+}
+
+/**
+ * The Cloud project this build signs in against.
+ *
+ * There is no *sign-in* client id distinct from the Drive one in any real
+ * setup: Google allows one iOS client per bundle id, identifies an Android
+ * build by its package name and signing certificate rather than by a string in
+ * the bundle, and a web client id is an identifier for the project rather than
+ * a credential for a browser. So the Drive names are read as a fallback — a
+ * build that already links Drive needs no new environment to sign in natively —
+ * while the neutral names exist so a build that offers sign-in and no backup
+ * does not have to set something called `..._DRIVE_...`.
+ *
+ * `EXPO_PUBLIC_*` is inlined by Metro at build time, so each name is spelled out
+ * statically: a computed `process.env[key]` is not substituted and reads as
+ * undefined in a release bundle.
+ */
+function googleWebClientId(): string | undefined {
+  const id =
+    process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID_WEB ||
+    process.env.EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_WEB;
+  return id && id.length > 0 ? id : undefined;
+}
+
+function googleIosClientId(): string | undefined {
+  const id =
+    process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID_IOS ||
+    process.env.EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_IOS;
+  return id && id.length > 0 ? id : undefined;
+}
+
+/**
+ * Whether Google's own sheet can be presented at all — asked before the tile is
+ * even offered a native path, so an unconfigured build falls through to the
+ * browser without a round trip that was always going to fail.
+ *
+ * Android needs only the web client id, because the app itself is identified by
+ * its signature. iOS needs its own client id too, since Apple builds are matched
+ * by bundle id. Web has neither: there is no native sheet in a page.
+ */
+export function googleNativeAvailable(): boolean {
+  if (Platform.OS === 'web') return false;
+  if (!googleWebClientId()) return false;
+  if (Platform.OS === 'ios' && !googleIosClientId()) return false;
+  return loadGoogle() !== null;
+}
+
+/**
+ * The status code Play services returns when it will not even put the request
+ * to Google: it found no OAuth client registered for this build's package name
+ * and signing certificate. The SDK's `statusCodes` does not name it, so it
+ * arrives as a bare `'10'` and would otherwise read as an ordinary failure —
+ * and it is the opposite of one, because every retry from now until somebody
+ * opens the Google Cloud console fails identically.
+ *
+ * Here it is still only `unavailable`: sign-in falls back to the browser and
+ * the person gets in. But it is reported, because a build in that state is
+ * silently paying for a sheet nobody will ever see.
+ */
+const DEVELOPER_ERROR = '10';
+
+/**
+ * Present Google's sheet and come back with an identity token.
+ *
+ * `offlineAccess` stays off. It returns a code meant to be exchanged for a
+ * refresh token *by a server holding the client secret*; sign-in wants the
+ * identity token the sheet already produces, and a refresh token on the phone
+ * would outlive the grant.
+ *
+ * The Play-services check does not offer to install anything. That dialog is
+ * right on the backup screen, where somebody asked for Drive and needs to know
+ * why they cannot have it; on the sign-in screen it would interrupt a person
+ * who tapped Google with an errand about an unrelated app, when the browser
+ * behind this can serve them perfectly well.
+ *
+ * No custom nonce: the installed SDK's original sign-in API takes none (its
+ * `SignInParams` is `loginHint` and nothing else), so there is no value to bind
+ * the token to and hash into it. Supabase still checks the signature, the
+ * issuer, the expiry and — the part that matters here — that the audience is
+ * this project's own client id, which is the check the "Authorized Client IDs"
+ * list in the Supabase Google provider exists to satisfy. Apple below does
+ * carry a nonce, because its API accepts one.
+ */
+export async function googleNativeSignIn(): Promise<NativeSignIn<GoogleCredential>> {
+  const module = loadGoogle();
+  const webClientId = googleWebClientId();
+  if (!module || !webClientId || Platform.OS === 'web') return unavailable;
+
+  try {
+    module.GoogleSignin.configure({
+      webClientId,
+      offlineAccess: false,
+      ...(Platform.OS === 'ios' ? { iosClientId: googleIosClientId() } : {}),
+    });
+    await module.GoogleSignin.hasPlayServices({ showPlayServicesUpdateDialog: false });
+    const response = await module.GoogleSignin.signIn();
+    if (!module.isSuccessResponse(response)) return dismissed;
+
+    const idToken = response.data.idToken;
+    if (!idToken) {
+      // A success with no token means the web client id names a project that
+      // did not issue one — a configuration fault, not a network one, and the
+      // browser flow is the working path while it stands.
+      reportHandled(new Error('Google sign-in returned no identity token'), 'auth.googleNative');
+      return unavailable;
+    }
+    return { kind: 'credential', credential: { idToken } };
+  } catch (error) {
+    if (isGoogleCancellation(module, error)) return dismissed;
+    reportHandled(googleFault(module, error), 'auth.googleNative');
+    return unavailable;
+  }
+}
+
+/** Whether a rejection means "they closed it", which is a decision, not a fault. */
+function isGoogleCancellation(module: SigninModule, error: unknown): boolean {
+  if (!module.isErrorWithCode(error)) return false;
+  return error.code === module.statusCodes.SIGN_IN_CANCELLED;
+}
+
+/**
+ * The rejection, with its status code kept in the message.
+ *
+ * The code is the whole diagnosis and it exists nowhere else by the time this
+ * has become "we opened a browser instead" — `DEVELOPER_ERROR` in particular is
+ * indistinguishable from a dropped connection without it.
+ */
+function googleFault(module: SigninModule, error: unknown): Error {
+  const status = googleStatusOf(module, error);
+  const detail = error instanceof Error ? error.message : String(error);
+  const named =
+    status === DEVELOPER_ERROR ? ' (DEVELOPER_ERROR: no OAuth client for this build)' : '';
+  return new Error(`Google native sign-in failed [${status ?? 'no status'}]${named}: ${detail}`);
+}
+
+/**
+ * The provider's status code, or null when the rejection carried none. The
+ * SDK's own guard first, because that is the supported way to read one, and
+ * then the field directly, because the guard admits only codes the library
+ * knows about and `DEVELOPER_ERROR` is precisely one it does not.
+ */
+function googleStatusOf(module: SigninModule, error: unknown): string | null {
+  if (module.isErrorWithCode(error)) return String(error.code);
+  if (typeof error !== 'object' || error === null) return null;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === 'string' || typeof code === 'number' ? String(code) : null;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Apple                                                                       */
+/* -------------------------------------------------------------------------- */
+
+type AppleAuthModule = typeof import('expo-apple-authentication');
+
+let appleModule: AppleAuthModule | null | undefined;
+
+function loadApple(): AppleAuthModule | null {
+  if (appleModule !== undefined) return appleModule;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    appleModule = require('expo-apple-authentication') as AppleAuthModule;
+  } catch {
+    appleModule = null;
+  }
+  return appleModule;
+}
+
+/** Stand a fake module in, for tests. See `setGoogleSigninForTests`. */
+export function setAppleAuthForTests(module: AppleAuthModule | null): void {
+  appleModule = module;
+}
+
+/**
+ * Whether Apple's own sheet can be presented — iOS only, and only on a build
+ * carrying the module. Everywhere else Apple sign-in still exists; it just goes
+ * through the browser, which is what App Store guideline 4.8 asks for on the
+ * platforms where the native sheet is not a thing.
+ */
+export function appleNativeAvailable(): boolean {
+  return Platform.OS === 'ios' && loadApple() !== null;
+}
+
+/**
+ * Present Apple's native sheet and come back with an identity token.
+ *
+ * The token is bound to this one request with a nonce: Apple is given its
+ * SHA-256 and stamps that into the identity token, Supabase is given the raw
+ * value and checks the hash matches. Without it, an identity token captured
+ * anywhere — another app, a log, an old device — is a valid sign-in here. The
+ * two halves must not be swapped: the hash goes out, the raw value stays.
+ */
+export async function appleNativeSignIn(): Promise<NativeSignIn<AppleCredential>> {
+  if (Platform.OS !== 'ios') return unavailable;
+  const apple = loadApple();
+  if (!apple) return unavailable;
+
+  const nonce = Crypto.randomUUID();
+  const hashedNonce = await Crypto.digestStringAsync(Crypto.CryptoDigestAlgorithm.SHA256, nonce);
+  try {
+    const credential = await apple.signInAsync({
+      requestedScopes: [
+        apple.AppleAuthenticationScope.FULL_NAME,
+        apple.AppleAuthenticationScope.EMAIL,
+      ],
+      nonce: hashedNonce,
+    });
+    if (!credential.identityToken) {
+      reportHandled(new Error('Apple sign-in returned no identity token'), 'auth.appleNative');
+      return unavailable;
+    }
+    return {
+      kind: 'credential',
+      credential: {
+        identityToken: credential.identityToken,
+        nonce,
+        fullName: credential.fullName,
+      },
+    };
+  } catch (error) {
+    if ((error as { code?: string }).code === 'ERR_REQUEST_CANCELED') return dismissed;
+    // Anything else — a simulator with no Apple account, a device that refuses
+    // the sheet — is a build that cannot use this path right now, and the
+    // browser flow behind it can still sign them in.
+    reportHandled(error, 'auth.appleNative');
+    return unavailable;
+  }
+}

--- a/apps/mobile/test/backupAccountScope.test.ts
+++ b/apps/mobile/test/backupAccountScope.test.ts
@@ -58,6 +58,11 @@ vi.mock('react-native', () => ({
 
 vi.mock('expo-web-browser', () => ({ maybeCompleteAuthSession: () => undefined }));
 
+// The provider classifies a failed authorization and files it with the crash
+// reporter, which reaches Sentry — and Sentry reaches into react-native by deep
+// path, which the mock above cannot stand in for.
+vi.mock('@/lib/observability', () => ({ reportHandled: vi.fn() }));
+
 vi.mock('expo-auth-session', () => ({
   AuthRequest: class {},
   exchangeCodeAsync: async () => ({}),

--- a/apps/mobile/test/driveNativeAuth.test.ts
+++ b/apps/mobile/test/driveNativeAuth.test.ts
@@ -15,9 +15,19 @@
  *     say, because that is the one signal the engine acts on;
  *   * a dismissed sheet is **not an error**, because they meant it;
  *   * unlinking tells **Google**, not only this phone's keystore.
+ *
+ * And one the flow added: a refusal has to say *which* refusal it was. Play
+ * services answers "why" with a status code the SDK's own `statusCodes` does
+ * not name, so an unclassified failure is a failure nobody can act on — the
+ * screen says "try again" for a build Google will never issue a token to.
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Classification files the failure with the crash reporter on the way past,
+// which pulls the native Sentry pipeline; stub it, and assert on it.
+const reportHandled = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/observability', () => ({ reportHandled }));
 
 const platform = { OS: 'android' };
 
@@ -34,15 +44,21 @@ const { googleDrive } = await import('../src/lib/cloud/googleDrive');
 const { setSigninModuleForTests } = await import('../src/lib/cloud/nativeGoogle');
 const { isConfigured } = await import('../src/lib/cloud/config');
 const { CloudHttpError } = await import('../src/lib/cloud/http');
+const { CloudAuthError } = await import('../src/lib/cloud/oauth');
 
 const SIGN_IN_CANCELLED = 'SIGN_IN_CANCELLED';
 const SIGN_IN_REQUIRED = 'SIGN_IN_REQUIRED';
+const PLAY_SERVICES_NOT_AVAILABLE = 'PLAY_SERVICES_NOT_AVAILABLE';
+/** Not in the SDK's `statusCodes`; Android rejects with the bare number. */
+const DEVELOPER_ERROR = '10';
 
 interface FakeState {
   /** What the interactive sheet does. */
-  signIn: 'success' | 'cancelled' | 'throws-cancelled';
+  signIn: 'success' | 'cancelled' | 'throws-cancelled' | 'developer-error' | 'network';
+  /** Whether Google's services are there to present the sheet at all. */
+  play: 'present' | 'missing';
   /** What a silent renewal finds. */
-  silent: 'success' | 'nobody' | 'required';
+  silent: 'success' | 'nobody' | 'required' | 'throws';
   /** Whether native revoke completes or throws after a partial Play-services failure. */
   revoke: 'success' | 'throws';
   accessToken: string;
@@ -50,6 +66,7 @@ interface FakeState {
 
 const state: FakeState = {
   signIn: 'success',
+  play: 'present',
   silent: 'success',
   revoke: 'success',
   accessToken: 'token-1',
@@ -73,15 +90,28 @@ function fakeModule() {
   return {
     GoogleSignin: {
       configure: (params: unknown) => calls.configured(params),
-      hasPlayServices: async () => true,
+      async hasPlayServices() {
+        if (state.play === 'missing') throw cancelled(PLAY_SERVICES_NOT_AVAILABLE);
+        return true;
+      },
       async signIn() {
         calls.signIn();
         if (state.signIn === 'throws-cancelled') throw cancelled(SIGN_IN_CANCELLED);
+        if (state.signIn === 'developer-error') {
+          // Exactly what RNGoogleSigninModule rejects with: the bare number, and
+          // a message pointing at the library's troubleshooting page.
+          throw Object.assign(
+            new Error('DEVELOPER_ERROR: Follow troubleshooting instructions at ...'),
+            { code: DEVELOPER_ERROR },
+          );
+        }
+        if (state.signIn === 'network') throw new Error('network error');
         if (state.signIn === 'cancelled') return { type: 'cancelled', data: null };
         return { type: 'success', data: { user: { email: 'someone@example.com' } } };
       },
       async signInSilently() {
         calls.signInSilently();
+        if (state.silent === 'throws') throw new Error('network error');
         if (state.silent === 'required') throw cancelled(SIGN_IN_REQUIRED);
         if (state.silent === 'nobody') return { type: 'noSavedCredentialFound', data: null };
         return { type: 'success', data: { user: { email: 'someone@example.com' } } };
@@ -106,7 +136,7 @@ function fakeModule() {
     isSuccessResponse: (response: { type: string }) => response.type === 'success',
     isErrorWithCode: (error: unknown) =>
       typeof error === 'object' && error !== null && 'code' in error,
-    statusCodes: { SIGN_IN_CANCELLED, SIGN_IN_REQUIRED },
+    statusCodes: { SIGN_IN_CANCELLED, SIGN_IN_REQUIRED, PLAY_SERVICES_NOT_AVAILABLE },
   };
 }
 
@@ -114,6 +144,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   platform.OS = 'android';
   state.signIn = 'success';
+  state.play = 'present';
   state.silent = 'success';
   state.revoke = 'success';
   state.accessToken = 'token-1';
@@ -159,6 +190,74 @@ describe('asking for consent', () => {
     // Android reports this by rejecting rather than resolving.
     state.signIn = 'throws-cancelled';
     await expect(googleDrive.connect()).resolves.toBeNull();
+  });
+});
+
+describe('saying which refusal it was', () => {
+  it('calls DEVELOPER_ERROR what it is: a build nothing can be retried into', async () => {
+    state.signIn = 'developer-error';
+    // The screen offers "try again" for `failed` and does not for `not-set-up`,
+    // which is the entire point of classifying: no Android OAuth client is
+    // registered for this package name and signing certificate, and tapping the
+    // button again cannot register one.
+    await expect(googleDrive.connect()).rejects.toMatchObject({
+      fault: 'not-set-up',
+      status: DEVELOPER_ERROR,
+    });
+  });
+
+  it('separates Google services being absent from the request being refused', async () => {
+    state.play = 'missing';
+    await expect(googleDrive.connect()).rejects.toMatchObject({ fault: 'play-services' });
+    expect(calls.signIn).not.toHaveBeenCalled();
+  });
+
+  it('leaves an ordinary failure retryable, because it is', async () => {
+    state.signIn = 'network';
+    await expect(googleDrive.connect()).rejects.toMatchObject({ fault: 'failed', status: null });
+  });
+
+  it('says so when the build carries no module to ask with', async () => {
+    setSigninModuleForTests(null);
+    await expect(googleDrive.connect()).rejects.toMatchObject({ fault: 'not-set-up' });
+  });
+
+  it('says so when the build names no Cloud project', async () => {
+    delete process.env.EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_WEB;
+    await expect(googleDrive.connect()).rejects.toMatchObject({ fault: 'not-set-up' });
+  });
+
+  it('files the status code with the crash reporter, and nothing identifying', async () => {
+    state.signIn = 'developer-error';
+    await expect(googleDrive.connect()).rejects.toBeInstanceOf(CloudAuthError);
+
+    expect(reportHandled).toHaveBeenCalledTimes(1);
+    const [reported, where] = reportHandled.mock.calls[0] as [Error, string];
+    expect(where).toBe('cloud.googleAuthorize');
+    // The code is the diagnosis and the reason this is reported at all.
+    expect(reported.message).toContain(DEVELOPER_ERROR);
+    expect(reported.message).toContain('DEVELOPER_ERROR');
+    // The account and the token are not, and must never ride along.
+    expect(reported.message).not.toContain('someone@example.com');
+    expect(reported.message).not.toContain('token-1');
+  });
+
+  it('reports a renewal that fails behind a scheduled backup, where no screen would', async () => {
+    // The half of the flow with nobody watching: a silent renewal runs under
+    // AutoBackup, so a failure there that is not reported is invisible
+    // entirely. A grant that is merely *gone* is still not this — that resolves
+    // to null and becomes the 401 the engine already knows how to act on.
+    state.silent = 'throws';
+    const expired = { accessToken: 'token-1', refreshToken: null, expiresAt: Date.now() - 1_000 };
+
+    await expect(googleDrive.ensureValid(expired)).rejects.toMatchObject({ fault: 'failed' });
+    expect(reportHandled).toHaveBeenCalledWith(expect.anything(), 'cloud.googleReauthorize');
+  });
+
+  it('does not report a cancellation — they meant it', async () => {
+    state.signIn = 'throws-cancelled';
+    await googleDrive.connect();
+    expect(reportHandled).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/mobile/test/nativeIdentity.test.ts
+++ b/apps/mobile/test/nativeIdentity.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Signing in without leaving the app.
+ *
+ * The browser flow this sits in front of is still there and still correct, so
+ * what is worth pinning down here is not "does a token come back" — it is the
+ * three-way answer this module gives, because every one of them means something
+ * different to the person holding the phone:
+ *
+ *   * a **credential**, which the caller feeds to `signInWithIdToken`;
+ *   * **dismissed**, which is a decision and must leave them exactly where they
+ *     were — no error, no browser opening behind their back;
+ *   * **unavailable**, which is this build or this phone saying it cannot
+ *     present the sheet, and is the one case that must fall through to the
+ *     browser rather than surface as a failure.
+ *
+ * That last one is the whole reason the module exists in this shape. A device
+ * with no OAuth client registered for its signing certificate refuses *every*
+ * native attempt, for ever; if that read as an error the sign-in button would
+ * simply be broken, and the browser flow that would have worked never runs.
+ *
+ * And the nonce, which is the one piece of cryptography here: Apple is given
+ * the SHA-256 and Supabase is given the raw value. Swapping them silently
+ * disables the replay protection rather than breaking anything visibly, so it
+ * is asserted in both directions.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Failures are filed with the crash reporter on the way past, which pulls the
+// native Sentry pipeline; stub it, and assert on it.
+const reportHandled = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/observability', () => ({ reportHandled }));
+
+const platform = { OS: 'android' };
+
+vi.mock('react-native', () => ({
+  Platform: {
+    get OS() {
+      return platform.OS;
+    },
+    select: (o: Record<string, unknown>) => o[platform.OS] ?? o.default,
+  },
+}));
+
+// Hashing is native; a legible stand-in keeps "which value went where" visible
+// in the assertions rather than hidden behind sixty-four hex characters.
+vi.mock('expo-crypto', () => ({
+  randomUUID: () => 'raw-nonce',
+  digestStringAsync: async (_algorithm: string, value: string) => `sha256:${value}`,
+  CryptoDigestAlgorithm: { SHA256: 'SHA-256' },
+}));
+
+const {
+  appleNativeAvailable,
+  appleNativeSignIn,
+  googleNativeAvailable,
+  googleNativeSignIn,
+  setAppleAuthForTests,
+  setGoogleSigninForTests,
+} = await import('../src/lib/nativeIdentity');
+
+const SIGN_IN_CANCELLED = 'SIGN_IN_CANCELLED';
+const SIGN_IN_REQUIRED = 'SIGN_IN_REQUIRED';
+const PLAY_SERVICES_NOT_AVAILABLE = 'PLAY_SERVICES_NOT_AVAILABLE';
+/** Not in the SDK's `statusCodes`; Android rejects with the bare number. */
+const DEVELOPER_ERROR = '10';
+
+interface GoogleState {
+  signIn: 'success' | 'no-token' | 'cancelled' | 'throws-cancelled' | 'developer-error' | 'network';
+  play: 'present' | 'missing';
+}
+
+const google: GoogleState = { signIn: 'success', play: 'present' };
+const apple = { signIn: 'success' as 'success' | 'no-token' | 'cancelled' | 'throws' };
+
+const calls = {
+  configured: vi.fn(),
+  playServices: vi.fn(),
+  signIn: vi.fn(),
+  appleSignIn: vi.fn(),
+};
+
+function withCode(code: string): Error & { code: string } {
+  return Object.assign(new Error('refused'), { code });
+}
+
+/** Only the surface `nativeIdentity` actually touches. */
+function fakeGoogleModule() {
+  return {
+    GoogleSignin: {
+      configure: (params: unknown) => calls.configured(params),
+      async hasPlayServices(params: unknown) {
+        calls.playServices(params);
+        if (google.play === 'missing') throw withCode(PLAY_SERVICES_NOT_AVAILABLE);
+        return true;
+      },
+      async signIn() {
+        calls.signIn();
+        if (google.signIn === 'throws-cancelled') throw withCode(SIGN_IN_CANCELLED);
+        if (google.signIn === 'developer-error') {
+          // Exactly what RNGoogleSigninModule rejects with: the bare number, and
+          // a message pointing at the library's troubleshooting page.
+          throw Object.assign(
+            new Error('DEVELOPER_ERROR: Follow troubleshooting instructions at ...'),
+            { code: DEVELOPER_ERROR },
+          );
+        }
+        if (google.signIn === 'network') throw new Error('network error');
+        if (google.signIn === 'cancelled') return { type: 'cancelled', data: null };
+        return {
+          type: 'success',
+          data: {
+            idToken: google.signIn === 'no-token' ? null : 'google-id-token',
+            user: { email: 'someone@example.com' },
+          },
+        };
+      },
+    },
+    isSuccessResponse: (response: { type: string }) => response.type === 'success',
+    isErrorWithCode: (error: unknown) =>
+      typeof error === 'object' && error !== null && 'code' in error,
+    statusCodes: { SIGN_IN_CANCELLED, SIGN_IN_REQUIRED, PLAY_SERVICES_NOT_AVAILABLE },
+  };
+}
+
+function fakeAppleModule() {
+  return {
+    AppleAuthenticationScope: { FULL_NAME: 'full-name', EMAIL: 'email' },
+    async signInAsync(params: unknown) {
+      calls.appleSignIn(params);
+      if (apple.signIn === 'cancelled') throw withCode('ERR_REQUEST_CANCELED');
+      if (apple.signIn === 'throws') throw new Error('the sheet would not open');
+      return {
+        identityToken: apple.signIn === 'no-token' ? null : 'apple-identity-token',
+        fullName: { givenName: 'Ada', middleName: null, familyName: 'Lovelace' },
+      };
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  platform.OS = 'android';
+  google.signIn = 'success';
+  google.play = 'present';
+  apple.signIn = 'success';
+  delete process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID_WEB;
+  delete process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID_IOS;
+  delete process.env.EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_WEB;
+  delete process.env.EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_IOS;
+  process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID_WEB = 'web-client.apps.googleusercontent.com';
+  setGoogleSigninForTests(
+    fakeGoogleModule() as unknown as Parameters<typeof setGoogleSigninForTests>[0],
+  );
+  setAppleAuthForTests(fakeAppleModule() as unknown as Parameters<typeof setAppleAuthForTests>[0]);
+});
+
+describe('Google, through the phone rather than a browser', () => {
+  it('comes back with the identity token the sheet issued', async () => {
+    const outcome = await googleNativeSignIn();
+    expect(outcome).toEqual({ kind: 'credential', credential: { idToken: 'google-id-token' } });
+  });
+
+  it('asks only who they are — not for their Drive', async () => {
+    await googleNativeSignIn();
+    const [params] = calls.configured.mock.calls[0] as [Record<string, unknown>];
+    expect(params.webClientId).toBe('web-client.apps.googleusercontent.com');
+    // The default scopes (email and profile) are what a sign-in needs. Naming
+    // Drive's scope here would put a file-access consent in front of somebody
+    // who only tapped "continue with Google".
+    expect(params.scopes).toBeUndefined();
+    // A code meant for a server holding a client secret. There is no such
+    // server, and asking for one would put a longer-lived grant on a phone.
+    expect(params.offlineAccess).toBe(false);
+  });
+
+  it('does not interrupt a sign-in with an errand about Play services', async () => {
+    await googleNativeSignIn();
+    // The update dialog belongs on the backup screen, where somebody asked for
+    // Drive. Here the browser behind this serves them without a word.
+    expect(calls.playServices).toHaveBeenCalledWith({ showPlayServicesUpdateDialog: false });
+  });
+
+  it('treats a dismissed sheet as a decision, not a failure', async () => {
+    google.signIn = 'cancelled';
+    await expect(googleNativeSignIn()).resolves.toEqual({ kind: 'dismissed' });
+    expect(reportHandled).not.toHaveBeenCalled();
+  });
+
+  it('treats a cancellation raised as an error the same way', async () => {
+    // Android reports this by rejecting rather than resolving.
+    google.signIn = 'throws-cancelled';
+    await expect(googleNativeSignIn()).resolves.toEqual({ kind: 'dismissed' });
+    expect(reportHandled).not.toHaveBeenCalled();
+  });
+
+  it('falls back rather than fails when no OAuth client matches this build', async () => {
+    google.signIn = 'developer-error';
+    // `unavailable`, not an error: every retry until somebody opens the Google
+    // Cloud console fails identically, and the browser flow still works.
+    await expect(googleNativeSignIn()).resolves.toEqual({ kind: 'unavailable' });
+  });
+
+  it('files the status code, because it exists nowhere else afterwards', async () => {
+    google.signIn = 'developer-error';
+    await googleNativeSignIn();
+
+    expect(reportHandled).toHaveBeenCalledTimes(1);
+    const [reported, where] = reportHandled.mock.calls[0] as [Error, string];
+    expect(where).toBe('auth.googleNative');
+    expect(reported.message).toContain(DEVELOPER_ERROR);
+    expect(reported.message).toContain('DEVELOPER_ERROR');
+    // The account and the token are the two things that must never ride along.
+    expect(reported.message).not.toContain('someone@example.com');
+    expect(reported.message).not.toContain('google-id-token');
+  });
+
+  it('falls back when Google services are absent, without ever asking', async () => {
+    google.play = 'missing';
+    await expect(googleNativeSignIn()).resolves.toEqual({ kind: 'unavailable' });
+    expect(calls.signIn).not.toHaveBeenCalled();
+  });
+
+  it('falls back on an ordinary failure too — the browser may still work', async () => {
+    google.signIn = 'network';
+    await expect(googleNativeSignIn()).resolves.toEqual({ kind: 'unavailable' });
+    expect(reportHandled).toHaveBeenCalledTimes(1);
+  });
+
+  it('says unavailable, and quietly, when the build carries no module', async () => {
+    setGoogleSigninForTests(null);
+    await expect(googleNativeSignIn()).resolves.toEqual({ kind: 'unavailable' });
+    // An OTA bundle on an older binary is an ordinary state of the world, not
+    // an incident.
+    expect(reportHandled).not.toHaveBeenCalled();
+  });
+
+  it('says unavailable when the build names no Cloud project', async () => {
+    delete process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID_WEB;
+    await expect(googleNativeSignIn()).resolves.toEqual({ kind: 'unavailable' });
+    expect(calls.signIn).not.toHaveBeenCalled();
+  });
+
+  it('reports a success that carried no token — that is a misconfiguration', async () => {
+    google.signIn = 'no-token';
+    await expect(googleNativeSignIn()).resolves.toEqual({ kind: 'unavailable' });
+    expect(reportHandled).toHaveBeenCalledTimes(1);
+  });
+
+  it('reads the Drive client ids when no sign-in-specific ones are set', async () => {
+    // One Cloud project, one iOS client per bundle id: a build that already
+    // links Drive needs no new environment to sign in natively.
+    delete process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID_WEB;
+    process.env.EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_WEB = 'drive-web.apps.googleusercontent.com';
+
+    await googleNativeSignIn();
+    expect(calls.configured).toHaveBeenCalledWith(
+      expect.objectContaining({ webClientId: 'drive-web.apps.googleusercontent.com' }),
+    );
+  });
+
+  it('names the iOS client on iOS, where the app is matched by bundle id', async () => {
+    platform.OS = 'ios';
+    process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID_IOS = 'ios-client.apps.googleusercontent.com';
+
+    await googleNativeSignIn();
+    expect(calls.configured).toHaveBeenCalledWith(
+      expect.objectContaining({ iosClientId: 'ios-client.apps.googleusercontent.com' }),
+    );
+  });
+
+  describe('whether the native path is offered at all', () => {
+    it('is, on a configured Android build carrying the module', () => {
+      expect(googleNativeAvailable()).toBe(true);
+    });
+
+    it('is not on web, where there is no sheet to present', () => {
+      platform.OS = 'web';
+      expect(googleNativeAvailable()).toBe(false);
+    });
+
+    it('is not on iOS without its own client id', () => {
+      platform.OS = 'ios';
+      expect(googleNativeAvailable()).toBe(false);
+      process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID_IOS = 'ios-client.apps.googleusercontent.com';
+      expect(googleNativeAvailable()).toBe(true);
+    });
+
+    it('is not on a binary that predates the module', () => {
+      setGoogleSigninForTests(null);
+      expect(googleNativeAvailable()).toBe(false);
+    });
+  });
+});
+
+describe('Apple, and the nonce that binds the token to this request', () => {
+  beforeEach(() => {
+    platform.OS = 'ios';
+  });
+
+  it('hands Apple the hash and keeps the raw value for Supabase', async () => {
+    const outcome = await appleNativeSignIn();
+    expect(outcome).toMatchObject({
+      kind: 'credential',
+      credential: { identityToken: 'apple-identity-token', nonce: 'raw-nonce' },
+    });
+    // The half that goes out is the digest. If these two were swapped nothing
+    // would break visibly — Supabase would simply stop being able to check
+    // anything, which is the failure worth a test.
+    const [params] = calls.appleSignIn.mock.calls[0] as [{ nonce: string }];
+    expect(params.nonce).toBe('sha256:raw-nonce');
+  });
+
+  it('brings back the name Apple sends exactly once', async () => {
+    const outcome = await appleNativeSignIn();
+    expect(outcome).toMatchObject({
+      credential: { fullName: { givenName: 'Ada', familyName: 'Lovelace' } },
+    });
+  });
+
+  it('treats a dismissed sheet as a decision, not a failure', async () => {
+    apple.signIn = 'cancelled';
+    await expect(appleNativeSignIn()).resolves.toEqual({ kind: 'dismissed' });
+    expect(reportHandled).not.toHaveBeenCalled();
+  });
+
+  it('falls back rather than fails when the sheet will not open', async () => {
+    apple.signIn = 'throws';
+    await expect(appleNativeSignIn()).resolves.toEqual({ kind: 'unavailable' });
+    expect(reportHandled).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a sheet that returned no token', async () => {
+    apple.signIn = 'no-token';
+    await expect(appleNativeSignIn()).resolves.toEqual({ kind: 'unavailable' });
+    expect(reportHandled).toHaveBeenCalledTimes(1);
+  });
+
+  it('never presents anything off iOS — that is the browser flow’s job', async () => {
+    platform.OS = 'android';
+    await expect(appleNativeSignIn()).resolves.toEqual({ kind: 'unavailable' });
+    expect(calls.appleSignIn).not.toHaveBeenCalled();
+    expect(appleNativeAvailable()).toBe(false);
+  });
+
+  it('is not offered on a binary that predates the module', () => {
+    setAppleAuthForTests(null);
+    expect(appleNativeAvailable()).toBe(false);
+  });
+});

--- a/apps/mobile/test/nativeIdentity.test.ts
+++ b/apps/mobile/test/nativeIdentity.test.ts
@@ -269,6 +269,18 @@ describe('Google, through the phone rather than a browser', () => {
     );
   });
 
+  it('falls back quietly on iOS when the build has no iOS client id', async () => {
+    platform.OS = 'ios';
+    delete process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID_IOS;
+    delete process.env.EXPO_PUBLIC_GOOGLE_DRIVE_CLIENT_ID_IOS;
+
+    await expect(googleNativeSignIn()).resolves.toEqual({ kind: 'unavailable' });
+    expect(calls.configured).not.toHaveBeenCalled();
+    expect(calls.playServices).not.toHaveBeenCalled();
+    expect(calls.signIn).not.toHaveBeenCalled();
+    expect(reportHandled).not.toHaveBeenCalled();
+  });
+
   describe('whether the native path is offered at all', () => {
     it('is, on a configured Android build carrying the module', () => {
       expect(googleNativeAvailable()).toBe(true);


### PR DESCRIPTION
Tapping "Continue with Google" opened a browser tab on `<project-ref>.supabase.co`, which bounced to Google's consent page, which redirected back to `waves://auth`. Three domains, one of them ours only by association — and the moment somebody is deciding whether to trust the app with their identity is the worst possible moment to hand them to a URL bar.

## After

- **Google**: the Play services account sheet (the same module the Drive backup already uses) returns an ID token, handed to `signInWithIdToken`. No browser, no redirect, the account picker with the faces on it.
- **Apple**: the native sheet, same shape, through the same seam. It already had a native path; it now follows one rule with Google instead of its own.
- Both go through the existing backend port (`signInWithIdToken` is already on the `BackendAuth` allow-list), so nothing new reaches for `@supabase/supabase-js`.

## When the browser still runs

Native is attempted **only** for a fresh sign-in. Supabase has no ID-token form of `linkIdentity`, so a guest or an existing user adding a provider keeps the browser flow — that was already Apple's rule, now stated once for both.

Within a native attempt: dismissed → stop, no error and no browser (they meant it); credential → `signInWithIdToken`; unavailable → fall through to the browser silently. "Unavailable" covers no native module, web, no client id, no Play services, `DEVELOPER_ERROR`, and a success carrying no token. The ordinary states of the world are silent; the diagnosable ones go to `reportHandled` with the status code but never the account address or the token — asserted in tests.

## Nonce

Apple's raw-vs-hashed pair is unchanged and covered: the SHA-256 digest goes to Apple, the raw value to Supabase. Google carries no nonce — the installed `@react-native-google-signin` edition exposes it only on the Universal/One-Tap API, which this version does not export; this matches Supabase's own documented React Native Google flow.

## Also here: the Drive link error stopped lying

Play services' `DEVELOPER_ERROR` (status 10) was being collapsed into "Could not link that account. Try again." together with a missing native module and a missing client id — retry advice for three faults no retry can fix. Failures are now classified (`not-set-up` / `play-services` / `failed`), carry their status code to `reportHandled`, and the backup screen says which one happened (with the raw code appended in `__DEV__`).

## Deployment note

For native Google to actually run rather than fall back, the Google Cloud project needs an **Android** OAuth client for the package + signing SHA-1, and the Supabase Google provider needs the **Web** client id in its authorized client ids. Until both exist the app behaves exactly as it does today — the browser flow.

## Tests

`apps/mobile/test/nativeIdentity.test.ts` (new) and additions to `driveNativeAuth.test.ts`: each refusal classified, the fallback chosen for each unavailable cause, the Apple nonce halves, and the assertion that no token or account address enters a report.