### PR TITLE
Stop the dashboard printing one number twice, and give a draft its own row back

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -15,7 +15,7 @@ import {
   View,
 } from 'react-native';
 
-import { dayNumber, type GuestGate } from '@waves/core';
+import { balanceDeckSlides, dayNumber, type BalanceSlide, type GuestGate } from '@waves/core';
 import {
   Avatar,
   Button,
@@ -89,7 +89,7 @@ export default function HomeScreen() {
   const { hidden: balanceHidden, ready: balanceReady, toggle: toggleBalance } = useBalanceHidden();
   // The carousel's live scroll offset, owned here so the hero background and the
   // balance deck share one value: the background crossfades between the slide
-  // colours (SLIDE_GRADIENTS) exactly as the deck moves. Lazy-init, never
+  // colours (SLIDE_STYLE) exactly as the deck moves. Lazy-init, never
   // re-read through `.current` in render (the ref lint the compiler enforces).
   const [heroScrollX] = useState(() => new Animated.Value(0));
   // Each slide fills the hero's inner width; a slide's snap point is that plus
@@ -242,6 +242,14 @@ export default function HomeScreen() {
     owing: 0n,
   };
 
+  // Which figures the balance deck is worth swiping through, decided from the
+  // headline totals in @waves/core. Two slides for money that runs one way,
+  // three when it runs both — a gross slide appears only where the net is
+  // hiding a side, so no two slides ever carry the same number under two names.
+  // The screen and the deck read the same answer: the colour layers, the
+  // watermarks and the dot pager all count this one list.
+  const deck = balanceDeckSlides(headline);
+
   // The ids of the trips running today, so their rows can wear an "on trip"
   // tag. "Running" is decided in the trip's own timezone, not the phone's — a
   // Goa trip run from Dubai turns over at midnight in Goa (the same rule
@@ -286,9 +294,9 @@ export default function HomeScreen() {
                 the swipe. Native-driven opacity off the shared scroll value —
                 smooth at 60fps and free at rest. The first layer sits opaque
                 behind everything as the base while the balance loads. */}
-          {SLIDE_GRADIENTS.map((colors, index) => (
+          {deck.map((slide, index) => (
             <Animated.View
-              key={colors[0]}
+              key={slide}
               pointerEvents="none"
               style={[
                 StyleSheet.absoluteFill,
@@ -307,13 +315,13 @@ export default function HomeScreen() {
                     },
               ]}
             >
-              <Gradient colors={colors} radius={0} style={{ flex: 1 }} />
+              <Gradient colors={SLIDE_STYLE[slide].gradient} radius={0} style={{ flex: 1 }} />
             </Animated.View>
           ))}
 
           {/* The corner watermark — a faint glyph per slide that crossfades
                 as you swipe, off the same scroll value as the colour. */}
-          <HeroBackdrop scrollX={heroScrollX} snap={heroSnap} />
+          <HeroBackdrop slides={deck} scrollX={heroScrollX} snap={heroSnap} />
 
           {/* Greeting row: face + "Hi, {name}" over the time of day, then the
                 white controls the reference tucks top-right — sync, a shortcut to
@@ -368,6 +376,7 @@ export default function HomeScreen() {
             <HeroBalanceSkeleton />
           ) : (
             <HeroBalance
+              slides={deck}
               primary={headline}
               monthSpent={summary.monthSpent}
               locale={locale}
@@ -409,7 +418,7 @@ export default function HomeScreen() {
             </Row>
 
             {/* The swipe pager, right under the buttons. */}
-            <HeroDots count={SLIDE_KEYS.length} scrollX={heroScrollX} snap={heroSnap} />
+            <HeroDots count={deck.length} scrollX={heroScrollX} snap={heroSnap} />
           </View>
         </View>
       </TourTarget>
@@ -708,7 +717,11 @@ function HeroPill({
         flexDirection: 'row',
         alignItems: 'center',
         gap: theme.spacing.xs,
-        paddingVertical: theme.spacing.sm + 2,
+        // Padding, not `hitSlop`: the pill is wrapped in the tour's anchor View,
+        // which measures to the pill exactly, and a hit area reaching outside its
+        // own parent is not offered the touch. So the target has to be the box.
+        // Two lots of `md` over a 22pt line clears the 44pt floor.
+        paddingVertical: theme.spacing.md,
         paddingHorizontal: theme.spacing.lg,
         borderRadius: theme.radius.pill,
         backgroundColor: '#FFFFFF',
@@ -1129,44 +1142,33 @@ function todayIn(timeZone: string): string {
 }
 
 /**
- * One saturated wash per balance slide, so the whole hero takes a colour of its
- * own as you swipe — green for where you stand, teal for what you're owed, indigo
- * for what you've spent. Each is a two-stop diagonal gradient, dark enough that
- * the white ink clears AA on either stop in both themes (like a bank card, the
- * hero keeps its colour whichever theme is on). Money's own red/green still lives
- * on the ledger rows below, where owe-vs-owed has to be told apart at a glance.
+ * How each balance slide dresses the hero: one saturated wash so the whole card
+ * takes a colour of its own as you swipe — green for where you stand, teal for
+ * what is owed to you, copper for what you owe, indigo for what you've spent —
+ * and one watermark glyph, a faint oversized outline riding the corner. Each
+ * gradient is two diagonal stops, dark enough that the white ink clears AA on
+ * either stop in both themes (like a bank card, the hero keeps its colour
+ * whichever theme is on). Money's own red/green still lives on the ledger rows
+ * below, where owe-vs-owed has to be told apart at a glance.
  *
- * The order matches the slides in `HeroBalance` (net, owed, month); the hero
- * crossfades between them driven by the carousel's scroll position.
+ * Keyed by slide rather than positional, because the deck itself is decided per
+ * person (`balanceDeckSlides`) — a two-slide deck must paint its month slide
+ * indigo, not inherit whatever colour sat second in a fixed list.
  */
-const SLIDE_GRADIENTS = [
-  ['#1F6B49', '#0C3A27'], // net — green
-  ['#12667A', '#06323D'], // owed — teal
-  ['#463F86', '#221C46'], // month — indigo
-] as const;
+const SLIDE_STYLE: Record<
+  BalanceSlide,
+  { readonly gradient: readonly [string, string]; readonly icon: keyof typeof Ionicons.glyphMap }
+> = {
+  net: { gradient: ['#1F6B49', '#0C3A27'], icon: 'wallet-outline' },
+  owed: { gradient: ['#12667A', '#06323D'], icon: 'trending-up-outline' },
+  owing: { gradient: ['#8A4B12', '#40220A'], icon: 'trending-down-outline' },
+  month: { gradient: ['#463F86', '#221C46'], icon: 'calendar-outline' },
+};
 
-/**
- * The slides the deck actually carries, in order. Everything that has to agree
- * on "how many" counts this — the dot pager, the colour layers, the watermarks
- * — so the answer comes from the content rather than from the length of the
- * palette that happens to paint it.
- */
-const SLIDE_KEYS = ['net', 'owed', 'month'] as const;
-
-/**
- * One watermark glyph per slide, in the same order (net, owed, month). It rides
- * the corner of the hero as a faint, oversized outline and crossfades on the
- * same scroll value as the colour, so the mark swaps as you swipe: a wallet for
- * where you stand, a rising line for what is owed to you, a calendar for the
- * month's spend. Kept large + low-alpha so it reads as texture behind the
- * balance, not a literal icon competing with it.
- */
-const SLIDE_ICONS = ['wallet-outline', 'trending-up-outline', 'calendar-outline'] as const;
-
-/** The first slide's green, reused for the accents that sit on white (the
+/** The net slide's green, reused for the accents that sit on white (the
     add-expense pill's ink) and the badge ring — a fixed brand green, not the
     animated hero colour. */
-const HERO_GREEN = SLIDE_GRADIENTS[0];
+const HERO_GREEN = SLIDE_STYLE.net.gradient;
 
 /**
  * The hero's two lines, in one place. `HeroBalanceSkeleton` builds itself to
@@ -1184,18 +1186,24 @@ const HERO_AMOUNT_STYLE = {
 } as const;
 
 /**
- * The swipeable balance inside the hero: three views of where you stand, one per
+ * The swipeable balance inside the hero: a few views of where you stand, one per
  * swipe, riding transparent on the hero's colour — net first (the number you see
- * on load), then what is owed to you, then what you have spent this month. All in
- * your primary currency, because a total across currencies is a number that does
- * not exist (ADR-004). A dot pager beneath is the "swipe me" signal; the three
- * slides are the same shape, so the block never jumps as you move between them.
+ * on load), then whichever gross side the net is hiding, then what you have spent
+ * this month. All in your primary currency, because a total across currencies is
+ * a number that does not exist (ADR-004). A dot pager beneath is the "swipe me"
+ * signal; every slide is the same shape, so the block never jumps as you move
+ * between them.
+ *
+ * Which slides those are is `balanceDeckSlides`' call, made once by the screen
+ * and passed down — so the deck, the colour washes and the pager cannot disagree
+ * about what is in the carousel.
  *
  * The scroll offset (`scrollX`) and the slide geometry (`cardWidth`/`gap`/`snap`)
  * are owned by the screen and passed in, so the same value that lays the deck out
  * also drives the hero's colour crossfade — the two can never fall out of step.
  */
 function HeroBalance({
+  slides,
   primary,
   monthSpent,
   locale,
@@ -1208,6 +1216,8 @@ function HeroBalance({
   snap,
   settling,
 }: {
+  /** The deck, in swipe order — the screen's `balanceDeckSlides(primary)`. */
+  slides: readonly BalanceSlide[];
   primary: CurrencyTotal;
   /** My share of this month's spend, per currency (from useHomeSummary). */
   monthSpent: readonly { currency: string; amount: bigint }[];
@@ -1225,10 +1235,8 @@ function HeroBalance({
   /** The figure is the local one and a fresher answer is on its way. */
   settling: boolean;
 }) {
-  // The three balance views the dashboard leads with, one per swipe: where you
-  // stand overall (net), what is owed to you, and what you have spent this month
-  // — all in your primary currency, which is the one the headline is already in
-  // (no total across currencies, ADR-004).
+  // Every figure is in the primary currency, which is the one the headline is
+  // already in (no total across currencies, ADR-004).
   const monthAmount = monthSpent.find((entry) => entry.currency === primary.currency)?.amount ?? 0n;
   // The net slide is the only one whose sign is information, so it shows that
   // sign on the figure itself — a signed headline number is what gets read at a
@@ -1238,52 +1246,26 @@ function HeroBalance({
   const netDirection =
     primary.net === 0n ? t.allSettled : primary.net > 0n ? t.dashHero.netOwed : t.dashHero.netOwe;
 
-  const slides = [
-    {
-      key: 'net',
-      node: (
-        <MetricSlide
-          label={`${netDirection} · ${primary.currency}`}
-          amount={primary.net}
-          currency={primary.currency}
-          locale={locale}
-          hidden={hidden}
-          onToggleHide={onToggleHide}
-          settling={settling}
-          // Square is square: a "+₹0" would be a direction where there is none.
-          showSign={primary.net !== 0n}
-        />
-      ),
-    },
-    {
-      key: 'owed',
-      node: (
-        <MetricSlide
-          label={`${t.dashHero.owedToYou} · ${primary.currency}`}
-          amount={primary.owed}
-          currency={primary.currency}
-          locale={locale}
-          hidden={hidden}
-          onToggleHide={onToggleHide}
-          settling={settling}
-        />
-      ),
-    },
-    {
-      key: 'month',
-      node: (
-        <MetricSlide
-          label={`${t.dashHero.monthSpent} · ${primary.currency}`}
-          amount={monthAmount}
-          currency={primary.currency}
-          locale={locale}
-          hidden={hidden}
-          onToggleHide={onToggleHide}
-          settling={settling}
-        />
-      ),
-    },
-  ];
+  // What one slide says. The gross pair name their whole side — "Receivables",
+  // "Payables" — against the net's "Net receivable": the labels have to say why
+  // two figures differ, because the deck only ever shows them together when
+  // they do.
+  const metricFor = (
+    slide: BalanceSlide,
+  ): { label: string; amount: bigint; showSign?: boolean } => {
+    const label = (heading: string): string => `${heading} · ${primary.currency}`;
+    switch (slide) {
+      case 'net':
+        // Square is square: a "+₹0" would be a direction where there is none.
+        return { label: label(netDirection), amount: primary.net, showSign: primary.net !== 0n };
+      case 'owed':
+        return { label: label(t.dashHero.owedToYou), amount: primary.owed };
+      case 'owing':
+        return { label: label(t.dashHero.owedByYou), amount: primary.owing };
+      case 'month':
+        return { label: label(t.dashHero.monthSpent), amount: monthAmount };
+    }
+  };
 
   // Each slide fills the hero's inner width (`cardWidth`), snapping one-to-one.
   // No peek of the next slide: they are transparent on the hero's colour, so a
@@ -1311,7 +1293,7 @@ function HeroBalance({
     >
       {slides.map((slide, index) => (
         <Animated.View
-          key={slide.key}
+          key={slide}
           style={{
             width: cardWidth,
             // The centred slide sits at full size; the one being dragged in
@@ -1333,7 +1315,14 @@ function HeroBalance({
             ],
           }}
         >
-          {slide.node}
+          <MetricSlide
+            {...metricFor(slide)}
+            currency={primary.currency}
+            locale={locale}
+            hidden={hidden}
+            onToggleHide={onToggleHide}
+            settling={settling}
+          />
         </Animated.View>
       ))}
     </Animated.ScrollView>
@@ -1470,13 +1459,21 @@ function HeroBalanceSkeleton() {
  * it to the rounded corner (`overflow: 'hidden'`) and `pointerEvents none` so
  * it never eats a tap; white at low alpha reads the same on green/teal/indigo.
  */
-function HeroBackdrop({ scrollX, snap }: { scrollX: Animated.Value; snap: number }) {
+function HeroBackdrop({
+  slides,
+  scrollX,
+  snap,
+}: {
+  slides: readonly BalanceSlide[];
+  scrollX: Animated.Value;
+  snap: number;
+}) {
   const theme = useTheme();
   return (
     <View pointerEvents="none" style={StyleSheet.absoluteFill}>
-      {SLIDE_ICONS.map((icon, index) => (
+      {slides.map((slide, index) => (
         <Animated.View
-          key={icon}
+          key={slide}
           style={{
             position: 'absolute',
             right: -44,
@@ -1488,7 +1485,7 @@ function HeroBackdrop({ scrollX, snap }: { scrollX: Animated.Value; snap: number
             }),
           }}
         >
-          <Ionicons name={icon} size={208} color={theme.color.onBrand} />
+          <Ionicons name={SLIDE_STYLE[slide].icon} size={208} color={theme.color.onBrand} />
         </Animated.View>
       ))}
     </View>

--- a/apps/mobile/src/app/captures.tsx
+++ b/apps/mobile/src/app/captures.tsx
@@ -13,19 +13,19 @@
 import { useCallback, useMemo, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { FlashList } from '@shopify/flash-list';
+import { randomUUID } from 'expo-crypto';
 import { router } from 'expo-router';
 import {
   Alert,
   Pressable,
   RefreshControl,
   ScrollView,
-  TextInput,
   useWindowDimensions,
   View,
 } from 'react-native';
 
+import { peopleSignatureKey } from '@waves/core';
 import {
-  Avatar,
   Button,
   directionalIcon,
   Divider,
@@ -37,22 +37,37 @@ import {
   Screen,
   Sheet,
   Text,
-  tintForKey,
   useTabBarClearance,
   useTheme,
 } from '@waves/ui';
 
 import { CategoryBadge } from '@/components/Category';
+import {
+  DestinationPicker,
+  type DestinationSelection,
+  type PersonChoice,
+} from '@/components/DestinationPicker';
 import { PendingMark } from '@/components/PendingMark';
 import { InboxSkeleton } from '@/components/Skeletons';
 import { dayHeading } from '@/data/activity';
-import { useCaptures, useDeleteCapture, useGroups, useHomeSummary } from '@/data/hooks';
-import { groupLabel, type CaptureRow, type GroupRow } from '@/data/types';
-import { fill, plural, useStrings, type UiStrings } from '@/i18n';
+import {
+  useAddGhostMember,
+  useCaptures,
+  useCreateGroup,
+  useDeleteCapture,
+  useGroupPeopleSignatures,
+  useGroups,
+  useHomeSummary,
+  useOneToOneGroupIds,
+  usePeopleBalances,
+} from '@/data/hooks';
+import { groupLabel, GroupType, type CaptureRow } from '@/data/types';
+import { plural, useStrings, type UiStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
-import { assignCaptureHref, matchesAssignGroupQuery } from '@/lib/captureAssign';
+import { assignCaptureHref } from '@/lib/captureAssign';
 import { foldedCaptureCount } from '@/lib/captureBatch';
 import { buildCaptureFeedItems, type CaptureFeedItem } from '@/lib/captureFeed';
+import { friendlyError } from '@/lib/errors';
 import { usePullRefresh } from '@/lib/pullRefresh';
 
 /**
@@ -63,63 +78,17 @@ type CaptureMenu =
   { kind: 'capture'; capture: CaptureRow } | { kind: 'batch'; items: CaptureRow[] } | null;
 
 /**
- * The pill on a row's second line that names its one action: "Add to a group"
- * when the capture is loose, or "Add to Goa Trip" when it was pre-aimed at one.
- * Brand-soft and filled when aimed (a real destination to confirm), a quiet
- * dashed outline when still open — so a labelled affordance replaces the old
- * invisible "the whole card is secretly tappable". The chip is a label, not its
- * own button: the card's tap is what assigns.
- *
- * It shares its line with the place the spend happened, and the two used to
- * shrink together: on a narrow row the label was squeezed away entirely and the
- * chip rendered as a bare "+" and an ellipsis — a mark that reads as breakage
- * rather than an action. The label is the row's one action, and a place name is
- * context that already truncates happily, so the chip holds its width and the
- * place gives way first. The cap keeps a very long group name from swallowing
- * the whole line (and, with no shrink left, spilling over the amount).
- */
-function AssignChip({ label, aimed }: { label: string; aimed: boolean }): React.JSX.Element {
-  const theme = useTheme();
-  const ink = aimed ? theme.color.brand : theme.color.textMuted;
-  return (
-    <View
-      style={{
-        flexDirection: 'row',
-        alignItems: 'center',
-        gap: 3,
-        paddingVertical: 3,
-        // Logical, not left/right, so the plus-then-label pill mirrors in RTL.
-        paddingStart: 6,
-        paddingEnd: 9,
-        borderRadius: theme.radius.pill,
-        backgroundColor: aimed ? theme.color.brandSoft : theme.color.surfaceMuted,
-        borderWidth: aimed ? 0 : 1,
-        borderColor: theme.color.border,
-        borderStyle: 'dashed',
-        flexShrink: 0,
-        maxWidth: '70%',
-      }}
-    >
-      <Ionicons name="add" size={13} color={ink} />
-      <Text
-        variant="micro"
-        numberOfLines={1}
-        style={{ color: ink, fontWeight: '600', flexShrink: 1 }}
-      >
-        {label}
-      </Text>
-    </View>
-  );
-}
-
-/**
  * One capture, in the card grammar this screen now speaks (Mobbin: Phantom
  * Recent Activity, Apple Wallet Daily Cash): a leading category glyph — always
  * the category colour, never the bill's thumbnail — the note over a muted place
  * line, and the amount at the trailing edge, all on a soft rounded card.
  *
  * The whole card taps to assign — adding it to a group is the one thing you do
- * with a capture, so it is the card's own gesture, not a control to hunt for.
+ * with a capture, so it is the card's own gesture, not a control to hunt for. It
+ * used to say so on a chip under the title ("Add to a group"), which spent the
+ * row's second line restating the one gesture the card has; the line now carries
+ * where the spend happened, and carries nothing at all when the spend has no
+ * place — an empty line is a title with room, not a row missing something.
  * The quieter things (edit, delete) fold behind a single ⋯ at the trailing edge,
  * which opens the actions sheet; the two used to sit on the row as a pencil and
  * an always-red trash, which crowded the amount and put "delete" a mis-tap from
@@ -134,7 +103,6 @@ function CaptureListRow({
   t,
   onAssign,
   onMore,
-  targetGroupName = null,
   hideLocation = false,
   bare = false,
 }: {
@@ -144,10 +112,6 @@ function CaptureListRow({
   onAssign: () => void;
   /** Open the row's overflow sheet (add to group, edit, delete). */
   onMore: () => void;
-  /** The group this capture was tagged for, resolved to its display name — so the
-   *  assign chip reads "Add to Goa Trip". Null when it was not pre-aimed (or the
-   *  aimed group is one the viewer can no longer assign into). */
-  targetGroupName?: string | null;
   /** Inside a batch the description IS the line that matters, so the place is
    *  suppressed there — the batch stands for one outing, one location. */
   hideLocation?: boolean;
@@ -209,23 +173,12 @@ function CaptureListRow({
           <Text variant="subheading" numberOfLines={1}>
             {title}
           </Text>
-          {/* Line two spells the one thing you do with a capture — add it to a
-              group — and names the group when the capture was pre-aimed at one, so
-              the action is labelled rather than hidden in the card's tap. The
-              place and the unsynced mark trail it, muted. Inside a batch the chip
-              is dropped: the batch's own line already says how its items assign. */}
-          {!bare || subtitle || capture.pending ? (
+          {/* Line two is context, not an instruction: where the spend happened,
+              and the unsynced mark when the row is still queued. With neither, it
+              is absent entirely and the title has the row to itself — the line
+              used to be spent on a chip repeating the card's own tap. */}
+          {subtitle || capture.pending ? (
             <Row style={{ gap: theme.spacing.xs, alignItems: 'center' }}>
-              {!bare ? (
-                <AssignChip
-                  label={
-                    targetGroupName
-                      ? fill(t.captures.addTo, { name: targetGroupName })
-                      : t.captures.assign
-                  }
-                  aimed={Boolean(targetGroupName)}
-                />
-              ) : null}
               {locationName ? (
                 <Ionicons name="location-outline" size={13} color={theme.color.textFaint} />
               ) : null}
@@ -513,12 +466,24 @@ export default function CapturesScreen() {
   const deleteCapture = useDeleteCapture();
   const groups = useGroups();
   const summary = useHomeSummary(profile?.id ?? null);
+  // The people the picker can point a draft at, and the raw material for
+  // deciding whether a chosen set of them already share a group. All read from
+  // the mirror, so the picker works with no network (ADR-005).
+  const people = usePeopleBalances(profile?.id ?? null);
+  const oneToOne = useOneToOneGroupIds();
+  const signatures = useGroupPeopleSignatures(profile?.id ?? null);
+  const createGroup = useCreateGroup();
 
-  // Which capture is being assigned, if any — drives the group-picker sheet.
+  // Which capture is being assigned, if any — drives the destination sheet.
   const [assigning, setAssigning] = useState<CaptureRow | null>(null);
-  // The picker's own search text, so a long group list stays one tap from any
-  // group. Cleared whenever the sheet opens on a fresh capture.
-  const [query, setQuery] = useState('');
+  // The id a group made from picked people will take, minted before the create
+  // so the ghosts and the expense behind it can already name it — the
+  // offline-first pattern the voice review and "add a person" both use. Retired
+  // for a fresh one the moment it is spent, so a second new group in the same
+  // session is not handed the same id.
+  const [newGroupId, setNewGroupId] = useState(() => randomUUID());
+  const [newMemberId, setNewMemberId] = useState(() => randomUUID());
+  const addGhost = useAddGhostMember(newGroupId);
   // FlashList recycles row components, so batch expansion lives with the screen
   // and is keyed by batch id rather than inside the recycled row instance.
   const [openBatchIds, setOpenBatchIds] = useState<ReadonlySet<string>>(() => new Set());
@@ -540,19 +505,46 @@ export default function CapturesScreen() {
     [groups.data, summary, profile?.id],
   );
 
-  // Group rows matching the picker's search text, by name. Only worth showing a
-  // search field once the list is long enough to scroll (below); until then the
-  // memo just passes every group through.
-  const visibleGroups = useMemo(() => {
-    if (!query.trim()) return assignableGroups;
-    return assignableGroups.filter((group) =>
-      matchesAssignGroupQuery(groupLabel(group, summary.membersFor(group.id), profile?.id), query),
-    );
-  }, [assignableGroups, query, summary, profile?.id]);
+  // The people the picker offers, by name. A contact is somebody whose balance
+  // with the viewer is explained by a single group (`only_group_id`) that is a
+  // true 1:1 — you and them and nobody else. A whole trip is never a person,
+  // even when it happens to be the only group you share with someone.
+  const peopleChoices = useMemo(() => {
+    const byGroup = new Map<string, PersonChoice>();
+    for (const row of people.data ?? []) {
+      if (!row.only_group_id || !oneToOne.data.has(row.only_group_id)) continue;
+      // One entry per 1:1 group — a person has a row per currency, and they all
+      // carry the same display name.
+      byGroup.set(row.only_group_id, {
+        personKey: row.person_key,
+        name: row.display_name,
+        groupId: row.only_group_id,
+      });
+    }
+    return [...byGroup.values()].sort((a, b) => a.name.localeCompare(b.name));
+  }, [people.data, oneToOne.data]);
 
-  // Past this many groups the picker earns a search field; a short list is
-  // faster to eyeball than to type through.
-  const showSearch = assignableGroups.length > 6;
+  // A set of people → the group they already share, if any. First match wins;
+  // it only ever answers "these exact people already have a group together".
+  const groupBySignature = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const sig of signatures.data) {
+      const key = peopleSignatureKey(sig.names);
+      if (!map.has(key)) map.set(key, sig.groupId);
+    }
+    return map;
+  }, [signatures.data]);
+
+  // Which row the picker opens with ticked: the group the capture was tagged
+  // for at capture time, when it is still one the viewer can assign into. That
+  // pre-aim used to be spelled out on the row itself and skip the picker
+  // entirely; it is now a suggestion the picker shows and a tap confirms.
+  const pickerSelection: DestinationSelection = useMemo(() => {
+    const targetId = assigning?.target_group_id;
+    return targetId && assignableGroups.some((group) => group.id === targetId)
+      ? { kind: 'existing', groupId: targetId }
+      : { kind: 'none' };
+  }, [assigning?.target_group_id, assignableGroups]);
   // How tall the picker sheet is ever allowed to get. A ceiling, not a height:
   // the sheet hugs its rows and only starts scrolling here. In points off the
   // window rather than the '80%' it used to pass, because a percentage height
@@ -567,7 +559,6 @@ export default function CapturesScreen() {
   const waitingCount = useMemo(() => foldedCaptureCount(rows), [rows]);
 
   const openAssign = useCallback((capture: CaptureRow): void => {
-    setQuery('');
     setAssigning(capture);
   }, []);
 
@@ -643,21 +634,82 @@ export default function CapturesScreen() {
     ],
   );
 
-  const closeAssign = useCallback((): void => {
-    setAssigning(null);
-    setQuery('');
-  }, []);
+  const closeAssign = useCallback((): void => setAssigning(null), []);
 
   // Hand the capture's own values to the add-expense form as prefill, and carry
   // its id so that saving there can close the capture (useAssignCapture). The
   // href is built by the shared helper so the "New group" flow, which routes to
   // the very same form, hands it identical params.
   const assignTo = useCallback(
-    (capture: CaptureRow, group: GroupRow): void => {
+    (capture: CaptureRow, groupId: string): void => {
       closeAssign();
-      router.push(assignCaptureHref(capture, group.id));
+      router.push(assignCaptureHref(capture, groupId));
     },
     [closeAssign],
+  );
+
+  // The People tab, confirmed: this draft is with these people. If they already
+  // share a group it is that group's expense — the same assignment a Groups-tab
+  // tap makes. If they do not, the group is made here and the draft assigned
+  // into it: a lone name is the 1:1 "add a person" case, several is a real
+  // group, and both are named after whoever is in them the way WhatsApp does.
+  //
+  // The create rides the offline queue like every other write (ADR-005), and the
+  // ids were minted up front, so the add-expense screen this pushes to can name
+  // the group and the members before the server has ever heard of them.
+  const assignToPeople = useCallback(
+    async (names: string[]): Promise<void> => {
+      const capture = assigning;
+      if (!capture) return;
+      const clean = [...new Set(names.map((name) => name.trim()).filter(Boolean))];
+      if (clean.length === 0) return;
+
+      const shared = groupBySignature.get(peopleSignatureKey(clean));
+      if (shared) {
+        assignTo(capture, shared);
+        return;
+      }
+
+      const groupId = newGroupId;
+      closeAssign();
+      try {
+        await createGroup.mutateAsync({
+          groupId,
+          creatorMemberId: newMemberId,
+          name: clean.join(', '),
+          type: GroupType.Other,
+          // The draft's own currency: it is the money actually spent with these
+          // people, and a fresh group has nothing better to go on.
+          currency: capture.currency,
+        });
+        for (const name of clean) await addGhost.mutateAsync(name);
+      } catch (caught) {
+        // With no group to assign into there is nowhere to push, so say why and
+        // leave the draft exactly where it was rather than opening a form over a
+        // group that was never made.
+        Alert.alert(
+          t.captures.title,
+          friendlyError(caught, t.captures.couldNotSave, 'captures.newPeopleGroup'),
+        );
+        return;
+      }
+      // Spent — the next new group needs its own pair of ids.
+      setNewGroupId(randomUUID());
+      setNewMemberId(randomUUID());
+      router.push(assignCaptureHref(capture, groupId));
+    },
+    [
+      addGhost,
+      assigning,
+      assignTo,
+      closeAssign,
+      createGroup,
+      groupBySignature,
+      newGroupId,
+      newMemberId,
+      t.captures.couldNotSave,
+      t.captures.title,
+    ],
   );
 
   const closeMenu = useCallback((): void => setMenu(null), []);
@@ -722,25 +774,17 @@ export default function CapturesScreen() {
           );
         case 'single': {
           const capture = item.capture;
-          // The group this capture was pre-aimed at, if it is still one the viewer
-          // can assign into — the chip names it and the tap goes straight there.
-          const targetGroup = capture.target_group_id
-            ? (assignableGroups.find((group) => group.id === capture.target_group_id) ?? null)
-            : null;
-          const targetGroupName = targetGroup
-            ? groupLabel(targetGroup, summary.membersFor(targetGroup.id), profile?.id)
-            : null;
           return (
             <CaptureListRow
               capture={capture}
               locale={locale}
               t={t}
-              targetGroupName={targetGroupName}
-              // A pre-aimed capture skips the picker — the chip said where it is
-              // going, so tapping should not ask again; a loose one opens it.
-              onAssign={
-                targetGroup ? () => assignTo(capture, targetGroup) : () => openAssign(capture)
-              }
+              // Every row opens the picker, pre-aimed or not. It used to skip
+              // straight to the group a capture was tagged for, which was fair
+              // while a chip on the row named that group; with the chip gone the
+              // jump would be unannounced, so the picker opens with that group
+              // already ticked and one more tap confirms it.
+              onAssign={() => openAssign(capture)}
               onMore={() => openCaptureMenu(capture)}
             />
           );
@@ -748,76 +792,15 @@ export default function CapturesScreen() {
       }
     },
     [
-      assignTo,
-      assignableGroups,
       locale,
       openAssign,
       openBatchIds,
       openBatchMenu,
       openCaptureMenu,
-      profile?.id,
-      summary,
       t,
       theme.spacing.md,
       theme.spacing.xs,
       toggleBatch,
-    ],
-  );
-
-  const renderGroupPickerItem = useCallback(
-    (group: GroupRow) => {
-      const label = groupLabel(group, summary.membersFor(group.id), profile?.id);
-      return (
-        <Pressable
-          key={group.id}
-          accessibilityRole="button"
-          accessibilityLabel={label}
-          onPress={() => {
-            // The Modal stays mounted through its fade-out, so this can fire a
-            // frame after the backdrop cleared `assigning`.
-            if (assigning) assignTo(assigning, group);
-          }}
-          style={({ pressed }) => ({
-            flexDirection: 'row',
-            alignItems: 'center',
-            gap: theme.spacing.md,
-            paddingVertical: theme.spacing.md,
-            opacity: pressed ? 0.6 : 1,
-          })}
-        >
-          {/* The group's own avatar and colour carry its identity — the flat-row
-              look the dashboard's GroupCard uses. */}
-          <Avatar
-            name={label}
-            emoji={group.cover_emoji ?? undefined}
-            size={44}
-            tint={tintForKey(group.id)}
-          />
-          <View style={{ flex: 1, minWidth: 0 }}>
-            <Text variant="subheading" numberOfLines={1}>
-              {label}
-            </Text>
-            <Text variant="caption" tone="muted" numberOfLines={1}>
-              {plural(locale, summary.memberCountFor(group.id), t.memberCount)}
-            </Text>
-          </View>
-          <Ionicons
-            name={directionalIcon('chevron-forward')}
-            size={iconSize.md}
-            color={theme.color.textFaint}
-          />
-        </Pressable>
-      );
-    },
-    [
-      assignTo,
-      assigning,
-      locale,
-      profile?.id,
-      summary,
-      t.memberCount,
-      theme.color.textFaint,
-      theme.spacing.md,
     ],
   );
 
@@ -946,122 +929,60 @@ export default function CapturesScreen() {
           </Row>
         ) : null}
 
-        {/* Search only earns its place on a long list (see `showSearch`);
-                a rounded field with a leading glyph, the picker grammar Mobbin
-                shows across Starling/Swarm/Canva. */}
-        {showSearch ? (
-          <Row
-            style={{
-              gap: theme.spacing.sm,
-              alignItems: 'center',
-              backgroundColor: theme.color.surfaceMuted,
-              borderRadius: theme.radius.md,
-              paddingHorizontal: theme.spacing.md,
-            }}
-          >
-            <Ionicons name="search" size={iconSize.md} color={theme.color.textFaint} />
-            <TextInput
-              value={query}
-              onChangeText={setQuery}
-              placeholder={t.captures.assignSearch}
-              placeholderTextColor={theme.color.textFaint}
-              accessibilityLabel={t.captures.assignSearch}
-              autoCorrect={false}
-              style={{
-                flex: 1,
-                fontSize: 16,
-                color: theme.color.text,
-                paddingVertical: theme.spacing.md,
-              }}
-            />
-          </Row>
-        ) : null}
+        {/* The same picker the voice review opens, so "where does this go?" is
+            one control in the app rather than two that drifted apart — and the
+            drafts inbox inherits its People tab, which this screen never had.
 
-        {/* A plain ScrollView, not the FlashList this screen uses everywhere
-            else — and the exception is the whole point of the fix. FlashList's
-            container is `flex: 1` by construction, so it cannot size itself to
-            its rows: it needs a height handed down, and the fixed one this sheet
-            used to compute (a fraction of the window) left a person with two
-            groups staring at a half-screen of white below the last row. The
-            picker holds the groups you are a member of — a handful, and already
-            filtered by the search field above once there are more than six — so
-            rendering them all costs nothing, and `flexShrink` lets the sheet hug
-            them and only start scrolling at `pickerMaxHeight`. */}
+            A plain ScrollView, not the FlashList this screen uses everywhere
+            else, and the exception is deliberate: FlashList's container is
+            `flex: 1` by construction, so it cannot size itself to its rows — it
+            needs a height handed down, and a fixed fraction of the window left a
+            person with two groups staring at a half-screen of white. The picker
+            holds the groups you are in and the people you already share one
+            with — a handful, and filtered by its own search once there are more
+            — so rendering them all costs nothing, and `flexShrink` lets the
+            sheet hug them and only start scrolling at `pickerMaxHeight`. */}
         <ScrollView
           showsVerticalScrollIndicator={false}
           keyboardShouldPersistTaps="handled"
           style={{ flexShrink: 1 }}
         >
-          {/* Start a group and drop this into it — so a capture with no fitting
-              group is no longer a dead end (it used to only say "make one
-              first"). Mirrors the "Create group" affordance the Wise/Starling
-              pickers lead with. */}
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel={t.captures.assignNew}
-            onPress={() => {
-              // Carry the capture through group creation so new-group can hand
-              // it back and finish the assignment — read the id before
-              // closeAssign clears `assigning`.
-              const captureId = assigning?.id;
-              closeAssign();
-              router.push(
-                captureId
-                  ? { pathname: '/new-group', params: { assignCaptureId: captureId } }
-                  : '/new-group',
-              );
+          <DestinationPicker
+            // Remount per capture, so the tab and any half-made people selection
+            // start fresh on each open rather than carrying over from the last.
+            key={assigning?.id ?? 'closed'}
+            selection={pickerSelection}
+            // The sheet's own heading already says what this is; a second
+            // "SAVE TO" line under it would only say it again.
+            eyebrow={null}
+            // Neither pinned default belongs here: a draft already *is*
+            // unassigned, and "just me" writes to the personal ledger, which
+            // this screen has no path to.
+            pinned={[]}
+            createRow={{ label: t.captures.assignNew }}
+            emptyGroups={t.captures.noGroups}
+            // A group with no name of its own reads as its members here, which
+            // needs the membership only the home summary holds.
+            labelFor={(group) => groupLabel(group, summary.membersFor(group.id), profile?.id)}
+            groups={assignableGroups}
+            people={peopleChoices}
+            t={t}
+            onChoose={(choice) => {
+              // The Sheet stays mounted through its fade-out, so this can fire a
+              // frame after the backdrop cleared `assigning`.
+              const capture = assigning;
+              if (!capture) return;
+              if (choice.kind === 'existing') {
+                assignTo(capture, choice.groupId);
+              } else if (choice.kind === 'create') {
+                // Carry the capture through group creation so new-group can hand
+                // it back and finish the assignment.
+                closeAssign();
+                router.push({ pathname: '/new-group', params: { assignCaptureId: capture.id } });
+              }
             }}
-            style={({ pressed }) => ({
-              flexDirection: 'row',
-              alignItems: 'center',
-              gap: theme.spacing.md,
-              paddingVertical: theme.spacing.md,
-              opacity: pressed ? 0.6 : 1,
-            })}
-          >
-            <View
-              style={{
-                width: 44,
-                height: 44,
-                borderRadius: 22,
-                alignItems: 'center',
-                justifyContent: 'center',
-                backgroundColor: theme.color.surfaceMuted,
-                borderWidth: 1,
-                borderColor: theme.color.border,
-                borderStyle: 'dashed',
-              }}
-            >
-              <Ionicons name="add" size={iconSize.lg} color={theme.color.brand} />
-            </View>
-            <View style={{ flex: 1, minWidth: 0 }}>
-              <Text variant="subheading" numberOfLines={1}>
-                {t.captures.assignNew}
-              </Text>
-              <Text variant="caption" tone="muted" numberOfLines={1}>
-                {t.captures.assignNewBody}
-              </Text>
-            </View>
-            {/* Every row in this list leaves the sheet for another screen, so
-                every row wears the chevron that says so — this one used to be
-                the odd one out, tappable but unmarked. `directionalIcon` turns
-                it around when the app runs right-to-left. */}
-            <Ionicons
-              name={directionalIcon('chevron-forward')}
-              size={iconSize.md}
-              color={theme.color.textFaint}
-            />
-          </Pressable>
-
-          <View style={{ height: 1, backgroundColor: theme.color.border }} />
-
-          {assignableGroups.length === 0 || visibleGroups.length === 0 ? (
-            <Text variant="caption" tone="muted" style={{ paddingVertical: theme.spacing.lg }}>
-              {assignableGroups.length === 0 ? t.captures.noGroups : t.captures.assignNoMatch}
-            </Text>
-          ) : (
-            visibleGroups.map(renderGroupPickerItem)
-          )}
+            onResolvePeople={(names) => void assignToPeople(names)}
+          />
         </ScrollView>
       </Sheet>
 

--- a/apps/mobile/src/app/voice.tsx
+++ b/apps/mobile/src/app/voice.tsx
@@ -39,6 +39,7 @@ import {
   encodeTxn,
   guessCategory,
   minorUnitScale,
+  peopleSignatureKey,
   type ExpenseLocation,
   type SplitParams,
 } from '@waves/core';
@@ -52,7 +53,6 @@ import {
   MoneyText,
   Row,
   Screen,
-  SegmentedTabs,
   Text,
   useScreenClearance,
   useTheme,
@@ -78,6 +78,12 @@ import { isRtl, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { useDefaultCurrency } from '@/lib/currency';
 import { friendlyError } from '@/lib/errors';
+import {
+  DestinationPicker,
+  GROUP_TYPE_ICON,
+  type DestinationSelection,
+  type PersonChoice,
+} from '@/components/DestinationPicker';
 import { VoiceMicPanel } from '@/components/VoiceMicPanel';
 import { LocationField } from '@/components/LocationField';
 import { CategoryBadge } from '@/components/Category';
@@ -149,14 +155,6 @@ type Dest =
   // the group are skipped at save, so re-speaking adds no duplicate.
   | { kind: 'add-member'; groupId: string; names: string[]; groupName: string };
 
-/** A person the batch can be assigned to on the review — an existing friend
- *  (reuses their 1:1 group) surfaced by name in the picker. */
-interface PersonChoice {
-  personKey: string;
-  name: string;
-  groupId: string;
-}
-
 /**
  * What a returning transcript does — the full-screen mic is reused for two jobs,
  * and the job is fixed the moment the mic is opened, not read off the transcript.
@@ -176,15 +174,6 @@ const EQUAL: SplitParams = { kind: 'equal' };
 /** Today as `YYYY-MM-DD` — the expense date a spoken expense is filed under. */
 function today(): string {
   return new Date().toISOString().slice(0, 10);
-}
-
-/** A set of people as one order-independent, case-insensitive key, so "Ravi, Sam"
- *  and "sam, ravi" hash the same — the test for "do these people already share a
- *  group". Names are trimmed, lowercased, de-duplicated, sorted, NUL-joined. */
-function sigKey(names: readonly string[]): string {
-  return [...new Set(names.map((name) => name.trim().toLowerCase()).filter(Boolean))]
-    .sort()
-    .join('\0');
 }
 
 /**
@@ -834,7 +823,7 @@ export default function VoiceScreen() {
   const groupBySignature = useMemo(() => {
     const map = new Map<string, string>();
     for (const sig of signatures.data) {
-      const key = sigKey(sig.names);
+      const key = peopleSignatureKey(sig.names);
       if (!map.has(key)) map.set(key, sig.groupId);
     }
     return map;
@@ -850,7 +839,7 @@ export default function VoiceScreen() {
     if (clean.length === 0) return;
     groupCreated.current = false;
     ghostMemberIds.current = null;
-    const match = groupBySignature.get(sigKey(clean));
+    const match = groupBySignature.get(peopleSignatureKey(clean));
     if (match) {
       setDest({ kind: 'existing', groupId: match });
     } else {
@@ -1334,6 +1323,22 @@ export default function VoiceScreen() {
 
   const current = describeDest(dest, groupRows, t);
 
+  // The destination as the picker reads it. The picker only needs to know which
+  // row carries the check, so the kinds it has no row for — a spoken settle-up,
+  // a nudge, "add Ravi to the trip" — read as nothing selected. (It is never
+  // opened over one of those; the answer card is.)
+  const pickerSelection: DestinationSelection =
+    dest.kind === 'unassigned' ||
+    dest.kind === 'me' ||
+    dest.kind === 'create' ||
+    dest.kind === 'existing'
+      ? dest.kind === 'existing'
+        ? { kind: 'existing', groupId: dest.groupId }
+        : { kind: dest.kind }
+      : dest.kind === 'people'
+        ? { kind: 'people', names: dest.ghostNames }
+        : { kind: 'none' };
+
   // With no group chosen the batch is a draft (it lands in the capture inbox),
   // so the button says so; once a group is picked it writes real expenses and
   // the label counts them.
@@ -1714,21 +1719,34 @@ export default function VoiceScreen() {
                 // people re-seed from the current destination rather than keeping
                 // stale state from the last open.
                 key={pickerOpen ? 'open' : 'closed'}
-                dest={dest}
-                requested={requested}
-                onChoose={(next) => {
+                selection={pickerSelection}
+                eyebrow={t.voice.saveTo}
+                // The "new group" row is offered whenever a name was heard,
+                // whatever the destination now stands at.
+                createRow={
+                  requested
+                    ? { label: t.voice.newGroupNamed.replace('{name}', requested.name) }
+                    : null
+                }
+                onChoose={(choice) => {
                   // A change of destination is a change of group/ghost to make,
                   // so drop the once-only latches for the new one.
                   groupCreated.current = false;
                   ghostMemberIds.current = null;
-                  setDest(next);
+                  // 'create' is the picker naming a row, not a destination: the
+                  // group id and my member id were minted when the name was
+                  // heard, and this screen holds them.
+                  if (choice.kind === 'create') {
+                    if (requested) setDest({ kind: 'create', ...requested });
+                  } else {
+                    setDest(choice);
+                  }
                   setPickerOpen(false);
                 }}
                 onResolvePeople={resolvePeople}
                 people={peopleChoices}
                 groups={groupRows}
                 t={t}
-                theme={theme}
               />
             </ScrollView>
           </Pressable>
@@ -1770,448 +1788,6 @@ function describeDest(
     emoji: group.cover_emoji,
     icon: GROUP_TYPE_ICON[group.type] ?? 'people-outline',
   };
-}
-
-/** One Ionicon per group type, the fallback when a group has no cover emoji —
- * echoing the new-group picker and the dashboard's category glyphs. */
-const GROUP_TYPE_ICON: Record<GroupType, React.ComponentProps<typeof Ionicons>['name']> = {
-  [GroupType.Trip]: 'airplane',
-  [GroupType.Home]: 'home',
-  [GroupType.Couple]: 'heart',
-  [GroupType.Event]: 'sparkles',
-  [GroupType.Friends]: 'people-circle',
-  [GroupType.Other]: 'people-outline',
-};
-
-type PickerRow = {
-  key: string;
-  label: string;
-  // A row wears either the group's own cover emoji or, lacking one, an Ionicon
-  // — the inbox and "new group" rows only ever use an icon.
-  icon: React.ComponentProps<typeof Ionicons>['name'];
-  emoji?: string | null;
-  selected: boolean;
-  onPress: () => void;
-};
-
-/**
- * The one choice a Save needs: where the expenses land. Split into two tabs —
- * Groups and People — under a pinned "Unassigned" default, because a flat list of
- * groups then people grew long enough to bury one under the other. No recency or
- * frequency badges: they made the reader read the row twice; the plain name is the
- * signal. The selected row carries a check.
- */
-function DestinationPicker({
-  dest,
-  requested,
-  onChoose,
-  onResolvePeople,
-  people,
-  groups,
-  t,
-  theme,
-}: {
-  dest: Dest;
-  requested: { groupId: string; memberId: string; name: string } | null;
-  onChoose: (dest: Dest) => void;
-  /** The People-tab selection, confirmed. The parent decides whether these
-   *  people already share a group (assign to it) or need a new one. */
-  onResolvePeople: (names: string[]) => void;
-  people: PersonChoice[];
-  groups: GroupRow[];
-  t: ReturnType<typeof useStrings>['t'];
-  theme: ReturnType<typeof useTheme>;
-}) {
-  // Open on whichever tab the current destination lives in, so the choice reads
-  // back: the People tab for a people destination, and also for an existing group
-  // that is really a 1:1 contact (its id is one the People tab represents);
-  // otherwise Groups. Re-seeded on each open by the remount key at the call site.
-  const [tab, setTab] = useState<'groups' | 'people'>(
-    dest.kind === 'people' ||
-      (dest.kind === 'existing' && people.some((person) => person.groupId === dest.groupId))
-      ? 'people'
-      : 'groups',
-  );
-  // People are chosen as a set and confirmed — a group is one place, but an
-  // expense can be with several people at once. Seeded from a people destination
-  // so the running selection reads back when the sheet reopens.
-  const [picked, setPicked] = useState<string[]>(() =>
-    dest.kind === 'people' ? dest.ghostNames : [],
-  );
-  // One box for both jobs, the way WhatsApp's new-group search is: it filters the
-  // contacts you already have and, for a name nobody matches, adds a new person.
-  const [query, setQuery] = useState('');
-
-  const isPicked = (name: string): boolean =>
-    picked.some((entry) => entry.toLowerCase() === name.toLowerCase());
-  const togglePicked = (name: string): void => {
-    const trimmed = name.trim();
-    if (!trimmed) return;
-    setPicked((current) =>
-      current.some((entry) => entry.toLowerCase() === trimmed.toLowerCase())
-        ? current.filter((entry) => entry.toLowerCase() !== trimmed.toLowerCase())
-        : [...current, trimmed],
-    );
-  };
-  const addTyped = (): void => {
-    const trimmed = query.trim();
-    if (!trimmed) return;
-    if (!isPicked(trimmed)) togglePicked(trimmed);
-    setQuery('');
-  };
-
-  // Pinned defaults above the tabs: the capture inbox (a Save with no destination
-  // lands here) and "Just me" (a private personal expense). Neither is a group
-  // nor a person, so both stay in view whichever tab is open.
-  const pinnedRows: PickerRow[] = [
-    {
-      key: 'unassigned',
-      label: t.captures.unassigned,
-      // The inbox row wears the dashboard's captures glyph, so "Unassigned" here
-      // and the captures card on Home read as the same place.
-      icon: 'file-tray-full-outline',
-      selected: dest.kind === 'unassigned',
-      onPress: () => onChoose({ kind: 'unassigned' }),
-    },
-    {
-      key: 'me',
-      label: t.voice.justMe,
-      icon: 'person-circle-outline',
-      selected: dest.kind === 'me',
-      onPress: () => onChoose({ kind: 'me' }),
-    },
-  ];
-
-  const groupRows: PickerRow[] = [];
-  // Driven by the persisted request, not the current destination, so the "new
-  // group" row stays offered after the reader switches to the inbox or a group.
-  if (requested) {
-    groupRows.push({
-      key: 'create',
-      label: t.voice.newGroupNamed.replace('{name}', requested.name),
-      icon: 'add-circle-outline',
-      selected: dest.kind === 'create',
-      onPress: () => onChoose({ kind: 'create', ...requested }),
-    });
-  }
-  // Newest group first: the one you just made is the one you are most likely
-  // saving into, so it sits at the top of the list rather than lost in creation
-  // order. Every row carries its own cover emoji (or a type glyph as a fallback)
-  // so a trip, a home and an event are told apart at a glance instead of a
-  // column of identical people icons.
-  // A person's 1:1 group is their row on the People tab, not a group in its own
-  // right — showing it in both tabs lists the same conversation twice. So the
-  // groups the People tab already represents are dropped here.
-  const personGroupIds = new Set(people.map((person) => person.groupId));
-  const sorted = [...groups]
-    .filter((group) => !personGroupIds.has(group.id))
-    .sort((a, b) => {
-      // Newest first by creation time; when two groups share a timestamp (made
-      // in the same request), fall back to id so the order is stable across
-      // renders rather than flipping on every re-sort.
-      if (a.created_at !== b.created_at) return a.created_at < b.created_at ? 1 : -1;
-      return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
-    });
-  for (const group of sorted) {
-    groupRows.push({
-      key: group.id,
-      label: groupLabel(group),
-      icon: GROUP_TYPE_ICON[group.type] ?? 'people-outline',
-      emoji: group.cover_emoji,
-      selected: dest.kind === 'existing' && dest.groupId === group.id,
-      onPress: () => onChoose({ kind: 'existing', groupId: group.id }),
-    });
-  }
-
-  // Existing contacts, filtered by the search box. Picked names still tick even
-  // when the filter would hide them, so the running selection never disappears.
-  const q = query.trim().toLowerCase();
-  const contacts = people.filter(
-    (person) => q.length === 0 || person.name.toLowerCase().includes(q),
-  );
-  // A typed name that is not already an existing contact — offered as an "add"
-  // row so a brand-new person can join the selection without leaving the search.
-  const typedIsNew =
-    query.trim().length > 0 && !people.some((person) => person.name.toLowerCase() === q);
-
-  const renderRow = (row: PickerRow, showDivider: boolean): React.JSX.Element => (
-    <View key={row.key}>
-      <Pressable
-        onPress={row.onPress}
-        accessibilityRole="button"
-        accessibilityState={{ selected: row.selected }}
-        style={({ pressed }) => ({
-          flexDirection: 'row',
-          alignItems: 'center',
-          gap: theme.spacing.md,
-          paddingVertical: theme.spacing.md,
-          paddingHorizontal: theme.spacing.lg,
-          opacity: pressed ? 0.6 : 1,
-        })}
-      >
-        <View
-          style={{
-            width: 36,
-            height: 36,
-            borderRadius: 18,
-            alignItems: 'center',
-            justifyContent: 'center',
-            backgroundColor: row.selected ? theme.color.brandSoft : theme.color.surfaceMuted,
-          }}
-        >
-          {row.emoji ? (
-            <Text style={{ fontSize: 18 }}>{row.emoji}</Text>
-          ) : (
-            <Ionicons
-              name={row.icon}
-              size={iconSize.md}
-              color={row.selected ? theme.color.brand : theme.color.textMuted}
-            />
-          )}
-        </View>
-        <Text
-          numberOfLines={1}
-          style={{
-            flex: 1,
-            color: row.selected ? theme.color.brand : theme.color.text,
-            fontWeight: row.selected ? '600' : '400',
-          }}
-        >
-          {row.label}
-        </Text>
-        <Ionicons
-          name={row.selected ? 'checkmark-circle' : 'ellipse-outline'}
-          size={iconSize.md}
-          color={row.selected ? theme.color.brand : theme.color.border}
-        />
-      </Pressable>
-      {showDivider ? <Divider /> : null}
-    </View>
-  );
-
-  return (
-    <View style={{ gap: theme.spacing.lg }}>
-      <Text variant="micro" tone="faint" style={{ letterSpacing: 0.8 }}>
-        {t.voice.saveTo.toUpperCase()}
-      </Text>
-
-      {/* The defaults, pinned above the tabs — one grouped card, the same control
-          shape the rest of the picker uses. */}
-      <Card padded={false} flat style={{ overflow: 'hidden' }}>
-        {pinnedRows.map((row, index) => renderRow(row, index < pinnedRows.length - 1))}
-      </Card>
-
-      {/* Groups and People are their own tab: a flat list of every group then
-          every person grew long enough to bury one under the other. */}
-      <SegmentedTabs
-        value={tab}
-        onChange={setTab}
-        tabs={[
-          { value: 'groups', label: t.voice.groupsTab },
-          { value: 'people', label: t.voice.peopleTab },
-        ]}
-      />
-
-      {tab === 'groups' ? (
-        groupRows.length > 0 ? (
-          <Card padded={false} flat style={{ overflow: 'hidden' }}>
-            {groupRows.map((row, index) => renderRow(row, index < groupRows.length - 1))}
-          </Card>
-        ) : (
-          <Text tone="muted" align="center" style={{ paddingVertical: theme.spacing.lg }}>
-            {t.voice.noGroups}
-          </Text>
-        )
-      ) : (
-        <View style={{ gap: theme.spacing.md }}>
-          {/* Search + add, kept at the top so the keyboard never hides it. Filters
-              existing contacts; a name nobody matches is added as a new person. */}
-          <Row
-            style={{
-              gap: theme.spacing.sm,
-              paddingHorizontal: theme.spacing.md,
-              paddingVertical: theme.spacing.xs,
-              borderRadius: theme.radius.md,
-              borderWidth: 1,
-              borderColor: theme.color.border,
-              backgroundColor: theme.color.surface,
-              alignItems: 'center',
-            }}
-          >
-            <Ionicons name="search" size={iconSize.md} color={theme.color.textFaint} />
-            <TextInput
-              value={query}
-              onChangeText={setQuery}
-              placeholder={t.voice.searchPeople}
-              placeholderTextColor={theme.color.textFaint}
-              accessibilityLabel={t.voice.searchPeople}
-              onSubmitEditing={addTyped}
-              returnKeyType="done"
-              autoCorrect={false}
-              style={{ flex: 1, fontSize: 15, color: theme.color.text, paddingVertical: 6 }}
-            />
-            {query.trim().length > 0 ? (
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel={t.voice.addPerson}
-                onPress={addTyped}
-                hitSlop={8}
-                style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1 })}
-              >
-                <Ionicons name="add-circle" size={iconSize.lg} color={theme.color.brand} />
-              </Pressable>
-            ) : null}
-          </Row>
-
-          {/* The running selection as removable chips, so several people read at a
-              glance and any one comes back off with a tap. */}
-          {picked.length > 0 ? (
-            <View
-              style={{ flexDirection: 'row', flexWrap: 'wrap', gap: theme.spacing.xs }}
-              accessibilityLabel={t.voice.peopleTab}
-            >
-              {picked.map((name) => (
-                <Pressable
-                  key={name}
-                  accessibilityRole="button"
-                  accessibilityLabel={name}
-                  onPress={() => togglePicked(name)}
-                  style={({ pressed }) => ({
-                    flexDirection: 'row',
-                    alignItems: 'center',
-                    gap: 4,
-                    paddingLeft: theme.spacing.md,
-                    paddingRight: theme.spacing.sm,
-                    paddingVertical: 6,
-                    borderRadius: theme.radius.pill,
-                    backgroundColor: theme.color.brand,
-                    opacity: pressed ? 0.7 : 1,
-                  })}
-                >
-                  <Text
-                    variant="caption"
-                    numberOfLines={1}
-                    style={{ color: theme.color.onBrand, fontWeight: '600', maxWidth: 160 }}
-                  >
-                    {name}
-                  </Text>
-                  <Ionicons name="close" size={iconSize.sm} color={theme.color.onBrand} />
-                </Pressable>
-              ))}
-            </View>
-          ) : null}
-
-          {/* The contacts (filtered), each a toggle, plus an "add" row for a typed
-              name that is nobody you already know. */}
-          {contacts.length > 0 || typedIsNew ? (
-            <Card padded={false} flat style={{ overflow: 'hidden' }}>
-              {contacts.map((person, index) => {
-                const on = isPicked(person.name);
-                return (
-                  <View key={person.groupId}>
-                    <Pressable
-                      onPress={() => togglePicked(person.name)}
-                      accessibilityRole="checkbox"
-                      accessibilityState={{ checked: on }}
-                      accessibilityLabel={person.name}
-                      style={({ pressed }) => ({
-                        flexDirection: 'row',
-                        alignItems: 'center',
-                        gap: theme.spacing.md,
-                        paddingVertical: theme.spacing.md,
-                        paddingHorizontal: theme.spacing.lg,
-                        opacity: pressed ? 0.6 : 1,
-                      })}
-                    >
-                      <View
-                        style={{
-                          width: 36,
-                          height: 36,
-                          borderRadius: 18,
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          backgroundColor: on ? theme.color.brandSoft : theme.color.surfaceMuted,
-                        }}
-                      >
-                        <Ionicons
-                          name="person-outline"
-                          size={iconSize.md}
-                          color={on ? theme.color.brand : theme.color.textMuted}
-                        />
-                      </View>
-                      <Text
-                        numberOfLines={1}
-                        style={{
-                          flex: 1,
-                          color: on ? theme.color.brand : theme.color.text,
-                          fontWeight: on ? '600' : '400',
-                        }}
-                      >
-                        {person.name}
-                      </Text>
-                      <Ionicons
-                        name={on ? 'checkmark-circle' : 'ellipse-outline'}
-                        size={iconSize.md}
-                        color={on ? theme.color.brand : theme.color.border}
-                      />
-                    </Pressable>
-                    {index < contacts.length - 1 || typedIsNew ? <Divider /> : null}
-                  </View>
-                );
-              })}
-              {typedIsNew ? (
-                <Pressable
-                  onPress={addTyped}
-                  accessibilityRole="button"
-                  accessibilityLabel={t.voice.addPerson}
-                  style={({ pressed }) => ({
-                    flexDirection: 'row',
-                    alignItems: 'center',
-                    gap: theme.spacing.md,
-                    paddingVertical: theme.spacing.md,
-                    paddingHorizontal: theme.spacing.lg,
-                    opacity: pressed ? 0.6 : 1,
-                  })}
-                >
-                  <View
-                    style={{
-                      width: 36,
-                      height: 36,
-                      borderRadius: 18,
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      backgroundColor: theme.color.surfaceMuted,
-                    }}
-                  >
-                    <Ionicons
-                      name="person-add-outline"
-                      size={iconSize.md}
-                      color={theme.color.brand}
-                    />
-                  </View>
-                  <Text numberOfLines={1} style={{ flex: 1, color: theme.color.brand }}>
-                    {t.voice.addNamed.replace('{name}', query.trim())}
-                  </Text>
-                </Pressable>
-              ) : null}
-            </Card>
-          ) : (
-            <Text tone="muted" align="center" style={{ paddingVertical: theme.spacing.lg }}>
-              {t.voice.noPeople}
-            </Text>
-          )}
-
-          {/* One confirm: the parent decides whether the picked people already
-              share a group (assign to it) or need a fresh one. */}
-          <Button
-            label={picked.length > 0 ? t.voice.confirmPeople : t.voice.selectPeople}
-            onPress={() => onResolvePeople(picked)}
-            disabled={picked.length === 0}
-          />
-        </View>
-      )}
-    </View>
-  );
 }
 
 /**

--- a/apps/mobile/src/components/ActivityDateFilter.tsx
+++ b/apps/mobile/src/components/ActivityDateFilter.tsx
@@ -20,9 +20,8 @@
 import { useState } from 'react';
 import { Pressable, ScrollView, View } from 'react-native';
 
-import { Button, Row, Text, useTheme } from '@waves/ui';
+import { Button, Row, Sheet, Text, useTheme } from '@waves/ui';
 
-import { SheetOverlay } from '@/components/expense/SheetOverlay';
 import { RangeCalendar } from '@/components/RangeCalendar';
 import { useStrings } from '@/i18n';
 import { gregorianFormatter } from '@/lib/calendarGrid';
@@ -110,54 +109,76 @@ export function ActivityDateFilter({
     end.getTime() === p.end.getTime();
 
   return (
-    <SheetOverlay title={t.activityFilter.open} onClose={onClose}>
-      <View style={{ gap: theme.spacing.lg }}>
-        {/* One-tap presets — the common ranges, applied immediately. */}
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          // A gutter past the last chip, the same one the payment rails and the
-          // payer lane carry: the four ranges do not fit a narrow phone, and a
-          // chip sliced off flush at the card's edge reads as a broken layout
-          // rather than as "there is more this way". `paddingEnd`, not
-          // `paddingRight`, so the gutter follows the row when Arabic reverses
-          // it and the cut lands on the trailing side either way.
-          contentContainerStyle={{ gap: theme.spacing.sm, paddingEnd: theme.spacing.xl }}
-        >
-          {presets.map((p) => {
-            const active = activePreset(p);
-            return (
-              <Pressable
-                key={p.label}
-                accessibilityRole="button"
-                accessibilityLabel={p.label}
-                accessibilityState={{ selected: active }}
-                onPress={() => applyPreset(p)}
-                style={({ pressed }) => ({
-                  paddingVertical: theme.spacing.sm,
-                  paddingHorizontal: theme.spacing.md,
-                  borderRadius: theme.radius.pill,
-                  borderWidth: 1,
-                  borderColor: active ? theme.color.brand : theme.color.border,
-                  backgroundColor: active ? theme.color.brandSoft : theme.color.surface,
-                  opacity: pressed ? 0.7 : 1,
-                })}
-              >
-                <Text
-                  variant="caption"
-                  style={{
-                    color: active ? theme.color.brand : theme.color.text,
-                    fontWeight: '600',
-                  }}
-                >
-                  {p.label}
-                </Text>
-              </Pressable>
-            );
-          })}
-        </ScrollView>
+    /* A real Modal (`Sheet`), not an in-tree overlay. The bottom bar is
+       rendered once at the root over the whole stack, so a sheet drawn inside
+       this screen is painted *under* it: the calendar's last rows and the
+       Apply/Clear pair ended up behind the bar, with the bar's own white
+       surface reading as a second box over the sheet's. A modal is its own
+       window above everything the app has drawn, so the only thing left below
+       the sheet is the system navigation bar — which `Sheet` already leaves a
+       foot for. */
+    <Sheet visible onClose={onClose} closeLabel={t.common.close} style={{ maxHeight: '90%' }}>
+      {/* flexShrink all the way down, or the scroll never engages: a child at
+          its full content height inside a capped card is clipped, not
+          scrolled. */}
+      <View style={{ gap: theme.spacing.lg, flexShrink: 1 }}>
+        <Text variant="heading">{t.activityFilter.open}</Text>
 
-        {/* The selected range, read-only — it echoes the calendar taps below.
+        {/* The range is chosen in here and committed by the pinned row below:
+            the calendar is the tall part, so it is the part that scrolls. The
+            two actions never scroll out of reach — a picker whose Apply button
+            has to be hunted for is the bug this sheet was reported with. */}
+        <ScrollView
+          showsVerticalScrollIndicator={false}
+          style={{ flexShrink: 1 }}
+          contentContainerStyle={{ gap: theme.spacing.lg }}
+        >
+          {/* One-tap presets — the common ranges, applied immediately. */}
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            // A gutter past the last chip, the same one the payment rails and the
+            // payer lane carry: the four ranges do not fit a narrow phone, and a
+            // chip sliced off flush at the card's edge reads as a broken layout
+            // rather than as "there is more this way". `paddingEnd`, not
+            // `paddingRight`, so the gutter follows the row when Arabic reverses
+            // it and the cut lands on the trailing side either way.
+            contentContainerStyle={{ gap: theme.spacing.sm, paddingEnd: theme.spacing.xl }}
+          >
+            {presets.map((p) => {
+              const active = activePreset(p);
+              return (
+                <Pressable
+                  key={p.label}
+                  accessibilityRole="button"
+                  accessibilityLabel={p.label}
+                  accessibilityState={{ selected: active }}
+                  onPress={() => applyPreset(p)}
+                  style={({ pressed }) => ({
+                    paddingVertical: theme.spacing.sm,
+                    paddingHorizontal: theme.spacing.md,
+                    borderRadius: theme.radius.pill,
+                    borderWidth: 1,
+                    borderColor: active ? theme.color.brand : theme.color.border,
+                    backgroundColor: active ? theme.color.brandSoft : theme.color.surface,
+                    opacity: pressed ? 0.7 : 1,
+                  })}
+                >
+                  <Text
+                    variant="caption"
+                    style={{
+                      color: active ? theme.color.brand : theme.color.text,
+                      fontWeight: '600',
+                    }}
+                  >
+                    {p.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </ScrollView>
+
+          {/* The selected range, read-only — it echoes the calendar taps below.
 
             Both halves shrink and truncate rather than push each other about:
             the dates are formatted long ("Sat, 12 Sept") in the reader's own
@@ -166,27 +187,28 @@ export function ActivityDateFilter({
             the card's padding and clipped at the screen edge — the leading one
             keeping its gutter, which is what makes the row look lopsided rather
             than full. */}
-        <Row style={{ justifyContent: 'space-between', alignItems: 'baseline' }}>
-          <Text variant="caption" tone="muted" numberOfLines={1} style={{ flexShrink: 1 }}>
-            {t.activityFilter.from} · {showDate(start)}
-          </Text>
-          <Text variant="caption" tone="muted" numberOfLines={1} style={{ flexShrink: 1 }}>
-            {t.activityFilter.to} · {showDate(end ?? start)}
-          </Text>
-        </Row>
+          <Row style={{ justifyContent: 'space-between', alignItems: 'baseline' }}>
+            <Text variant="caption" tone="muted" numberOfLines={1} style={{ flexShrink: 1 }}>
+              {t.activityFilter.from} · {showDate(start)}
+            </Text>
+            <Text variant="caption" tone="muted" numberOfLines={1} style={{ flexShrink: 1 }}>
+              {t.activityFilter.to} · {showDate(end ?? start)}
+            </Text>
+          </Row>
 
-        {/* One inline calendar: tap the start day, then the end day. */}
-        <RangeCalendar
-          earliest={earliest}
-          latest={latest}
-          locale={locale}
-          start={start}
-          end={end}
-          onSelect={(s, e) => {
-            setStart(s);
-            setEnd(e);
-          }}
-        />
+          {/* One inline calendar: tap the start day, then the end day. */}
+          <RangeCalendar
+            earliest={earliest}
+            latest={latest}
+            locale={locale}
+            start={start}
+            end={end}
+            onSelect={(s, e) => {
+              setStart(s);
+              setEnd(e);
+            }}
+          />
+        </ScrollView>
 
         <Row style={{ gap: theme.spacing.sm }}>
           {initial || start ? (
@@ -219,6 +241,6 @@ export function ActivityDateFilter({
           </View>
         </Row>
       </View>
-    </SheetOverlay>
+    </Sheet>
   );
 }

--- a/apps/mobile/src/components/DestinationPicker.tsx
+++ b/apps/mobile/src/components/DestinationPicker.tsx
@@ -1,0 +1,557 @@
+/**
+ * Where an expense lands: the one picker both the voice review and the drafts
+ * inbox open.
+ *
+ * It was written for the voice review — the screen you reach by speaking an
+ * expense — and the drafts inbox grew a second, thinner one of its own: a flat
+ * list of groups, no way to point a spend at a person. Two pickers for one
+ * question is one too many, so this is the voice one lifted out whole, with the
+ * few things that genuinely differ between the two screens handed in as props:
+ * the pinned defaults (the inbox has none — a draft already *is* unassigned,
+ * and "just me" is a personal-ledger write that screen has no path for), the
+ * "new group" row's wording, and how a group with no name of its own is
+ * labelled.
+ *
+ * Groups and People are their own tab, because a flat list of every group then
+ * every person grew long enough to bury one under the other. A group is one
+ * place, so it is chosen and the sheet closes; people are a set — an expense can
+ * be with several at once — so they are ticked and confirmed, and the parent
+ * decides whether they already share a group or need a fresh one.
+ */
+
+import { useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { Pressable, TextInput, View } from 'react-native';
+
+import { Button, Card, Divider, iconSize, Row, SegmentedTabs, Text, useTheme } from '@waves/ui';
+
+import { groupLabel, GroupType, type GroupRow } from '@/data/types';
+import { matchesAssignGroupQuery } from '@/lib/captureAssign';
+import type { UiStrings } from '@/i18n';
+
+/** A person this expense can be pointed at: an existing 1:1 contact, surfaced by
+ *  name, whose own group is reused rather than a second one being made. */
+export interface PersonChoice {
+  personKey: string;
+  name: string;
+  groupId: string;
+}
+
+/** A single-tap choice: one place, chosen, sheet closed. People are not here —
+ *  they are a set, and arrive through `onResolvePeople` once confirmed. */
+export type DestinationChoice =
+  | { kind: 'unassigned' }
+  | { kind: 'me' }
+  | { kind: 'create' }
+  | { kind: 'existing'; groupId: string };
+
+/** Which row reads back as chosen. `none` is a picker opened on nothing yet. */
+export type DestinationSelection =
+  | { kind: 'none' }
+  | { kind: 'unassigned' }
+  | { kind: 'me' }
+  | { kind: 'create' }
+  | { kind: 'existing'; groupId: string }
+  | { kind: 'people'; names: readonly string[] };
+
+/** One Ionicon per group type, the fallback when a group has no cover emoji —
+ * echoing the new-group picker and the dashboard's category glyphs. */
+export const GROUP_TYPE_ICON: Record<GroupType, React.ComponentProps<typeof Ionicons>['name']> = {
+  [GroupType.Trip]: 'airplane',
+  [GroupType.Home]: 'home',
+  [GroupType.Couple]: 'heart',
+  [GroupType.Event]: 'sparkles',
+  [GroupType.Friends]: 'people-circle',
+  [GroupType.Other]: 'people-outline',
+};
+
+type PickerRow = {
+  key: string;
+  label: string;
+  // A row wears either the group's own cover emoji or, lacking one, an Ionicon
+  // — the inbox and "new group" rows only ever use an icon.
+  icon: React.ComponentProps<typeof Ionicons>['name'];
+  emoji?: string | null;
+  selected: boolean;
+  onPress: () => void;
+};
+
+/** Past this many groups the Groups tab earns a search field; a short list is
+ *  faster to eyeball than to type through. */
+const GROUP_SEARCH_THRESHOLD = 6;
+
+export function DestinationPicker({
+  selection,
+  groups,
+  people,
+  t,
+  eyebrow = null,
+  pinned = ['unassigned', 'me'],
+  createRow = null,
+  emptyGroups,
+  labelFor = (group) => groupLabel(group),
+  onChoose,
+  onResolvePeople,
+}: {
+  /** Which row carries the check — the destination as it stands. */
+  selection: DestinationSelection;
+  groups: readonly GroupRow[];
+  people: readonly PersonChoice[];
+  t: UiStrings;
+  /** The small caps line above the list ("SAVE TO"). Null where the sheet
+   *  already carries a heading of its own and a second one would only repeat it. */
+  eyebrow?: string | null;
+  /** Which of the two non-group defaults stay pinned above the tabs. Empty on a
+   *  screen where neither is a destination it can write to. */
+  pinned?: readonly ('unassigned' | 'me')[];
+  /** The "start a new group" row, when the calling screen offers one. */
+  createRow?: { label: string } | null;
+  /** What the Groups tab says when there are none. */
+  emptyGroups?: string;
+  /** How a group is named — the inbox resolves a nameless group to its members,
+   *  which needs data only that screen holds. */
+  labelFor?: (group: GroupRow) => string;
+  onChoose: (choice: DestinationChoice) => void;
+  /** The People-tab selection, confirmed. The parent decides whether these
+   *  people already share a group (assign to it) or need a new one. */
+  onResolvePeople: (names: string[]) => void;
+}) {
+  const theme = useTheme();
+  // Open on whichever tab the current destination lives in, so the choice reads
+  // back: the People tab for a people destination, and also for an existing group
+  // that is really a 1:1 contact (its id is one the People tab represents);
+  // otherwise Groups. Re-seeded on each open by the remount key at the call site.
+  const [tab, setTab] = useState<'groups' | 'people'>(
+    selection.kind === 'people' ||
+      (selection.kind === 'existing' &&
+        people.some((person) => person.groupId === selection.groupId))
+      ? 'people'
+      : 'groups',
+  );
+  // People are chosen as a set and confirmed — a group is one place, but an
+  // expense can be with several people at once. Seeded from a people destination
+  // so the running selection reads back when the sheet reopens.
+  const [picked, setPicked] = useState<string[]>(() =>
+    selection.kind === 'people' ? [...selection.names] : [],
+  );
+  // One box for both jobs, the way WhatsApp's new-group search is: it filters the
+  // contacts you already have and, for a name nobody matches, adds a new person.
+  const [query, setQuery] = useState('');
+  // The Groups tab's own filter, separate from the People one so switching tabs
+  // never carries a half-typed name across into the other list.
+  const [groupQuery, setGroupQuery] = useState('');
+
+  const isPicked = (name: string): boolean =>
+    picked.some((entry) => entry.toLowerCase() === name.toLowerCase());
+  const togglePicked = (name: string): void => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    setPicked((current) =>
+      current.some((entry) => entry.toLowerCase() === trimmed.toLowerCase())
+        ? current.filter((entry) => entry.toLowerCase() !== trimmed.toLowerCase())
+        : [...current, trimmed],
+    );
+  };
+  const addTyped = (): void => {
+    const trimmed = query.trim();
+    if (!trimmed) return;
+    if (!isPicked(trimmed)) togglePicked(trimmed);
+    setQuery('');
+  };
+
+  // Pinned defaults above the tabs: the capture inbox (a Save with no destination
+  // lands here) and "Just me" (a private personal expense). Neither is a group
+  // nor a person, so both stay in view whichever tab is open.
+  const pinnedRows: PickerRow[] = [];
+  if (pinned.includes('unassigned')) {
+    pinnedRows.push({
+      key: 'unassigned',
+      label: t.captures.unassigned,
+      // The inbox row wears the dashboard's captures glyph, so "Unassigned" here
+      // and the captures card on Home read as the same place.
+      icon: 'file-tray-full-outline',
+      selected: selection.kind === 'unassigned',
+      onPress: () => onChoose({ kind: 'unassigned' }),
+    });
+  }
+  if (pinned.includes('me')) {
+    pinnedRows.push({
+      key: 'me',
+      label: t.voice.justMe,
+      icon: 'person-circle-outline',
+      selected: selection.kind === 'me',
+      onPress: () => onChoose({ kind: 'me' }),
+    });
+  }
+
+  const groupRows: PickerRow[] = [];
+  // Driven by the calling screen, not the current destination, so the "new
+  // group" row stays offered after the reader switches to the inbox or a group.
+  if (createRow) {
+    groupRows.push({
+      key: 'create',
+      label: createRow.label,
+      icon: 'add-circle-outline',
+      selected: selection.kind === 'create',
+      onPress: () => onChoose({ kind: 'create' }),
+    });
+  }
+  // Newest group first: the one you just made is the one you are most likely
+  // saving into, so it sits at the top of the list rather than lost in creation
+  // order. Every row carries its own cover emoji (or a type glyph as a fallback)
+  // so a trip, a home and an event are told apart at a glance instead of a
+  // column of identical people icons.
+  // A person's 1:1 group is their row on the People tab, not a group in its own
+  // right — showing it in both tabs lists the same conversation twice. So the
+  // groups the People tab already represents are dropped here.
+  const personGroupIds = new Set(people.map((person) => person.groupId));
+  const sorted = [...groups]
+    .filter((group) => !personGroupIds.has(group.id))
+    .sort((a, b) => {
+      // Newest first by creation time; when two groups share a timestamp (made
+      // in the same request), fall back to id so the order is stable across
+      // renders rather than flipping on every re-sort.
+      if (a.created_at !== b.created_at) return a.created_at < b.created_at ? 1 : -1;
+      return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+    });
+  // Whether the filter is offered is decided by how many groups there are, not
+  // by how many survive the filter — otherwise typing past the last match would
+  // take the field away with the rows.
+  const showGroupSearch = sorted.length > GROUP_SEARCH_THRESHOLD;
+  const visibleGroups = showGroupSearch
+    ? sorted.filter((group) => matchesAssignGroupQuery(labelFor(group), groupQuery))
+    : sorted;
+  for (const group of visibleGroups) {
+    groupRows.push({
+      key: group.id,
+      label: labelFor(group),
+      icon: GROUP_TYPE_ICON[group.type] ?? 'people-outline',
+      emoji: group.cover_emoji,
+      selected: selection.kind === 'existing' && selection.groupId === group.id,
+      onPress: () => onChoose({ kind: 'existing', groupId: group.id }),
+    });
+  }
+
+  // Existing contacts, filtered by the search box. Picked names still tick even
+  // when the filter would hide them, so the running selection never disappears.
+  const q = query.trim().toLowerCase();
+  const contacts = people.filter(
+    (person) => q.length === 0 || person.name.toLowerCase().includes(q),
+  );
+  // A typed name that is not already an existing contact — offered as an "add"
+  // row so a brand-new person can join the selection without leaving the search.
+  const typedIsNew =
+    query.trim().length > 0 && !people.some((person) => person.name.toLowerCase() === q);
+
+  /** The rounded search field both tabs wear, so filtering groups and filtering
+   *  people are visibly the same gesture. The People one does a second job — a
+   *  name nobody matches is added rather than searched for — which is what the
+   *  submit handler and the trailing "+" are; the Groups one passes neither. */
+  const searchField = (
+    value: string,
+    onChangeText: (next: string) => void,
+    placeholder: string,
+    onSubmit?: () => void,
+    trailing?: React.ReactNode,
+  ): React.JSX.Element => (
+    <Row
+      style={{
+        gap: theme.spacing.sm,
+        paddingHorizontal: theme.spacing.md,
+        paddingVertical: theme.spacing.xs,
+        borderRadius: theme.radius.md,
+        borderWidth: 1,
+        borderColor: theme.color.border,
+        backgroundColor: theme.color.surface,
+        alignItems: 'center',
+      }}
+    >
+      <Ionicons name="search" size={iconSize.md} color={theme.color.textFaint} />
+      <TextInput
+        value={value}
+        onChangeText={onChangeText}
+        placeholder={placeholder}
+        placeholderTextColor={theme.color.textFaint}
+        accessibilityLabel={placeholder}
+        onSubmitEditing={onSubmit}
+        returnKeyType="done"
+        autoCorrect={false}
+        style={{ flex: 1, fontSize: 15, color: theme.color.text, paddingVertical: 6 }}
+      />
+      {trailing}
+    </Row>
+  );
+
+  const renderRow = (row: PickerRow, showDivider: boolean): React.JSX.Element => (
+    <View key={row.key}>
+      <Pressable
+        onPress={row.onPress}
+        accessibilityRole="button"
+        accessibilityState={{ selected: row.selected }}
+        style={({ pressed }) => ({
+          flexDirection: 'row',
+          alignItems: 'center',
+          gap: theme.spacing.md,
+          paddingVertical: theme.spacing.md,
+          paddingHorizontal: theme.spacing.lg,
+          opacity: pressed ? 0.6 : 1,
+        })}
+      >
+        <View
+          style={{
+            width: 36,
+            height: 36,
+            borderRadius: 18,
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: row.selected ? theme.color.brandSoft : theme.color.surfaceMuted,
+          }}
+        >
+          {row.emoji ? (
+            <Text style={{ fontSize: 18 }}>{row.emoji}</Text>
+          ) : (
+            <Ionicons
+              name={row.icon}
+              size={iconSize.md}
+              color={row.selected ? theme.color.brand : theme.color.textMuted}
+            />
+          )}
+        </View>
+        <Text
+          numberOfLines={1}
+          style={{
+            flex: 1,
+            color: row.selected ? theme.color.brand : theme.color.text,
+            fontWeight: row.selected ? '600' : '400',
+          }}
+        >
+          {row.label}
+        </Text>
+        <Ionicons
+          name={row.selected ? 'checkmark-circle' : 'ellipse-outline'}
+          size={iconSize.md}
+          color={row.selected ? theme.color.brand : theme.color.border}
+        />
+      </Pressable>
+      {showDivider ? <Divider /> : null}
+    </View>
+  );
+
+  return (
+    <View style={{ gap: theme.spacing.lg }}>
+      {eyebrow ? (
+        <Text variant="micro" tone="faint" style={{ letterSpacing: 0.8 }}>
+          {eyebrow.toUpperCase()}
+        </Text>
+      ) : null}
+
+      {/* The defaults, pinned above the tabs — one grouped card, the same control
+          shape the rest of the picker uses. */}
+      {pinnedRows.length > 0 ? (
+        <Card padded={false} flat style={{ overflow: 'hidden' }}>
+          {pinnedRows.map((row, index) => renderRow(row, index < pinnedRows.length - 1))}
+        </Card>
+      ) : null}
+
+      {/* Groups and People are their own tab: a flat list of every group then
+          every person grew long enough to bury one under the other. */}
+      <SegmentedTabs
+        value={tab}
+        onChange={setTab}
+        tabs={[
+          { value: 'groups', label: t.voice.groupsTab },
+          { value: 'people', label: t.voice.peopleTab },
+        ]}
+      />
+
+      {tab === 'groups' ? (
+        <View style={{ gap: theme.spacing.md }}>
+          {showGroupSearch ? searchField(groupQuery, setGroupQuery, t.captures.assignSearch) : null}
+          {groupRows.length > 0 ? (
+            <Card padded={false} flat style={{ overflow: 'hidden' }}>
+              {groupRows.map((row, index) => renderRow(row, index < groupRows.length - 1))}
+            </Card>
+          ) : null}
+          {/* Said below the card, not instead of it: "new group" is a row in that
+              card, so a search that matches no group still leaves one row
+              standing and the list would otherwise look like a hit. And a filter
+              that matched nothing is not an empty shelf — say which it is, or a
+              person retypes a name that was never going to land. */}
+          {visibleGroups.length === 0 ? (
+            <Text tone="muted" align="center" style={{ paddingVertical: theme.spacing.lg }}>
+              {groupQuery.trim() ? t.captures.assignNoMatch : (emptyGroups ?? t.voice.noGroups)}
+            </Text>
+          ) : null}
+        </View>
+      ) : (
+        <View style={{ gap: theme.spacing.md }}>
+          {/* Search + add, kept at the top so the keyboard never hides it. Filters
+              existing contacts; a name nobody matches is added as a new person. */}
+          {searchField(
+            query,
+            setQuery,
+            t.voice.searchPeople,
+            addTyped,
+            query.trim().length > 0 ? (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={t.voice.addPerson}
+                onPress={addTyped}
+                hitSlop={8}
+                style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1 })}
+              >
+                <Ionicons name="add-circle" size={iconSize.lg} color={theme.color.brand} />
+              </Pressable>
+            ) : null,
+          )}
+
+          {/* The running selection as removable chips, so several people read at a
+              glance and any one comes back off with a tap. */}
+          {picked.length > 0 ? (
+            <View
+              style={{ flexDirection: 'row', flexWrap: 'wrap', gap: theme.spacing.xs }}
+              accessibilityLabel={t.voice.peopleTab}
+            >
+              {picked.map((name) => (
+                <Pressable
+                  key={name}
+                  accessibilityRole="button"
+                  accessibilityLabel={name}
+                  onPress={() => togglePicked(name)}
+                  style={({ pressed }) => ({
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    gap: 4,
+                    paddingLeft: theme.spacing.md,
+                    paddingRight: theme.spacing.sm,
+                    paddingVertical: 6,
+                    borderRadius: theme.radius.pill,
+                    backgroundColor: theme.color.brand,
+                    opacity: pressed ? 0.7 : 1,
+                  })}
+                >
+                  <Text
+                    variant="caption"
+                    numberOfLines={1}
+                    style={{ color: theme.color.onBrand, fontWeight: '600', maxWidth: 160 }}
+                  >
+                    {name}
+                  </Text>
+                  <Ionicons name="close" size={iconSize.sm} color={theme.color.onBrand} />
+                </Pressable>
+              ))}
+            </View>
+          ) : null}
+
+          {/* The contacts (filtered), each a toggle, plus an "add" row for a typed
+              name that is nobody you already know. */}
+          {contacts.length > 0 || typedIsNew ? (
+            <Card padded={false} flat style={{ overflow: 'hidden' }}>
+              {contacts.map((person, index) => {
+                const on = isPicked(person.name);
+                return (
+                  <View key={person.groupId}>
+                    <Pressable
+                      onPress={() => togglePicked(person.name)}
+                      accessibilityRole="checkbox"
+                      accessibilityState={{ checked: on }}
+                      accessibilityLabel={person.name}
+                      style={({ pressed }) => ({
+                        flexDirection: 'row',
+                        alignItems: 'center',
+                        gap: theme.spacing.md,
+                        paddingVertical: theme.spacing.md,
+                        paddingHorizontal: theme.spacing.lg,
+                        opacity: pressed ? 0.6 : 1,
+                      })}
+                    >
+                      <View
+                        style={{
+                          width: 36,
+                          height: 36,
+                          borderRadius: 18,
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          backgroundColor: on ? theme.color.brandSoft : theme.color.surfaceMuted,
+                        }}
+                      >
+                        <Ionicons
+                          name="person-outline"
+                          size={iconSize.md}
+                          color={on ? theme.color.brand : theme.color.textMuted}
+                        />
+                      </View>
+                      <Text
+                        numberOfLines={1}
+                        style={{
+                          flex: 1,
+                          color: on ? theme.color.brand : theme.color.text,
+                          fontWeight: on ? '600' : '400',
+                        }}
+                      >
+                        {person.name}
+                      </Text>
+                      <Ionicons
+                        name={on ? 'checkmark-circle' : 'ellipse-outline'}
+                        size={iconSize.md}
+                        color={on ? theme.color.brand : theme.color.border}
+                      />
+                    </Pressable>
+                    {index < contacts.length - 1 || typedIsNew ? <Divider /> : null}
+                  </View>
+                );
+              })}
+              {typedIsNew ? (
+                <Pressable
+                  onPress={addTyped}
+                  accessibilityRole="button"
+                  accessibilityLabel={t.voice.addPerson}
+                  style={({ pressed }) => ({
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    gap: theme.spacing.md,
+                    paddingVertical: theme.spacing.md,
+                    paddingHorizontal: theme.spacing.lg,
+                    opacity: pressed ? 0.6 : 1,
+                  })}
+                >
+                  <View
+                    style={{
+                      width: 36,
+                      height: 36,
+                      borderRadius: 18,
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      backgroundColor: theme.color.surfaceMuted,
+                    }}
+                  >
+                    <Ionicons
+                      name="person-add-outline"
+                      size={iconSize.md}
+                      color={theme.color.brand}
+                    />
+                  </View>
+                  <Text numberOfLines={1} style={{ flex: 1, color: theme.color.brand }}>
+                    {t.voice.addNamed.replace('{name}', query.trim())}
+                  </Text>
+                </Pressable>
+              ) : null}
+            </Card>
+          ) : (
+            <Text tone="muted" align="center" style={{ paddingVertical: theme.spacing.lg }}>
+              {t.voice.noPeople}
+            </Text>
+          )}
+
+          {/* One confirm: the parent decides whether the picked people already
+              share a group (assign to it) or need a fresh one. */}
+          <Button
+            label={picked.length > 0 ? t.voice.confirmPeople : t.voice.selectPeople}
+            onPress={() => onResolvePeople(picked)}
+            disabled={picked.length === 0}
+          />
+        </View>
+      )}
+    </View>
+  );
+}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1315,8 +1315,10 @@ export interface UiStrings {
      *  figure is shown absolute, so the direction lives in the label). */
     netOwed: string;
     netOwe: string;
-    /** Owed-to-you slide label: the gross total others owe you. */
+    /** Gross-slide labels: the whole of one side, before the net folds the
+     *  two together. Only ever shown for the side the net figure omits. */
     owedToYou: string;
+    owedByYou: string;
     /** Balance-deck slide label: your spend so far in the current month. */
     monthSpent: string;
     /** The hero greeting over the name: "Hi, {name}". */
@@ -3825,6 +3827,7 @@ const en: UiStrings = {
     netOwed: 'Net receivable',
     netOwe: 'Net payable',
     owedToYou: 'Receivables',
+    owedByYou: 'Payables',
     monthSpent: 'Monthly spend',
     hi: 'Hi, {name}',
     morning: 'Good morning',
@@ -6273,6 +6276,7 @@ const ta: UiStrings = {
     netOwed: 'நிகர வரவு',
     netOwe: 'நிகர கொடுபாடு',
     owedToYou: 'பெறவேண்டியவை',
+    owedByYou: 'கொடுக்கவேண்டியவை',
     monthSpent: 'மாதச் செலவு',
     hi: 'வணக்கம், {name}',
     morning: 'காலை வணக்கம்',
@@ -8773,6 +8777,7 @@ const hi: UiStrings = {
     netOwed: 'शुद्ध प्राप्य',
     netOwe: 'शुद्ध देय',
     owedToYou: 'प्राप्य',
+    owedByYou: 'देय',
     monthSpent: 'मासिक ख़र्च',
     hi: 'नमस्ते, {name}',
     morning: 'शुभ प्रभात',
@@ -11256,6 +11261,7 @@ const ar: UiStrings = {
     netOwed: 'صافي المستحق لك',
     netOwe: 'صافي المستحق عليك',
     owedToYou: 'مستحقاتك',
+    owedByYou: 'مستحقات عليك',
     monthSpent: 'الإنفاق الشهري',
     hi: 'مرحباً، {name}',
     morning: 'صباح الخير',

--- a/packages/core/src/balances/heroSlides.ts
+++ b/packages/core/src/balances/heroSlides.ts
@@ -1,0 +1,51 @@
+/**
+ * Which figures the dashboard's balance deck is worth swiping through.
+ *
+ * The deck was a fixed three: your net standing, the gross total owed to you,
+ * and this month's spend. But `net` and `owed` are the same arithmetic whenever
+ * you owe nobody — `net = owed − owing`, so with `owing` at zero the first two
+ * slides print one number under two labels ("Net receivable ₹500", then
+ * "Receivables ₹500"). That is the common case for anybody who only ever
+ * fronts money, and two labels over one number reads as a bug, not as two facts.
+ *
+ * A net figure only conceals something when money is moving both ways. So the
+ * gross slide earns its place exactly then, and it carries the side the
+ * headline is *not* already showing: what you still owe when you are up
+ * overall, what is still coming to you when you are down.
+ *
+ * This decides slides, never amounts — the amounts are `CurrencyTotals`, one
+ * currency at a time, because there is no total across currencies (ADR-004).
+ * It lives in @waves/core so the phone and the web dashboard cannot disagree
+ * about which of their own numbers are worth showing (TDR §1).
+ */
+
+import type { CurrencyTotals } from './totals';
+
+/**
+ * A slide in the deck: where you stand, the gross owed to you, the gross you
+ * owe, and what you have spent this month.
+ */
+export type BalanceSlide = 'net' | 'owed' | 'owing' | 'month';
+
+/**
+ * The deck for one currency's totals, in swipe order.
+ *
+ * Two slides when your money runs one way, three when it runs both. The month's
+ * spend is a different quantity from the balance entirely — money you are on
+ * the hook for, whoever has paid — so it is always there to swipe to.
+ *
+ * What this rules out is the pair that was equal *by construction*, on every
+ * launch, for a whole class of users. Two slides can still land on the same
+ * amount by arithmetic accident (owed ₹400 against owing ₹200 nets to ₹200),
+ * and that is a coincidence between two genuinely different facts rather than
+ * the same fact told twice.
+ */
+export function balanceDeckSlides(totals: CurrencyTotals): readonly BalanceSlide[] {
+  // One-sided: the net *is* the gross, and the empty side is a zero that needs
+  // no slide of its own — "Payables ₹0" is already what "Net receivable" said.
+  if (totals.owed === 0n || totals.owing === 0n) return ['net', 'month'];
+  // Two-sided: show the side the net nets away. A net of exactly zero belongs
+  // here too — it is the one headline that says nothing at all about the sums
+  // standing behind it, so the gross beside it is the whole story.
+  return ['net', totals.net > 0n ? 'owing' : 'owed', 'month'];
+}

--- a/packages/core/src/balances/index.ts
+++ b/packages/core/src/balances/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
 export * from './balances';
 export * from './totals';
+export * from './heroSlides';

--- a/packages/core/src/group/index.ts
+++ b/packages/core/src/group/index.ts
@@ -1,1 +1,2 @@
 export * from './icon';
+export * from './people';

--- a/packages/core/src/group/people.ts
+++ b/packages/core/src/group/people.ts
@@ -1,0 +1,18 @@
+/**
+ * "Do these people already share a group?" — as one comparable key.
+ *
+ * A set of names is chosen in a picker, not typed in an order that means
+ * anything, so "Ravi, Sam" and "sam, ravi" have to hash the same. Names are
+ * trimmed, lowercased, de-duplicated, sorted and NUL-joined (NUL because it is
+ * the one character a display name never carries, so "a, b" cannot collide with
+ * a single person literally called "a,b").
+ *
+ * Deliberately names, not member ids: the people a picker offers are typed or
+ * tapped by name, and "they already have a group" is a claim about the people,
+ * not about which membership rows happen to represent them.
+ */
+export function peopleSignatureKey(names: readonly string[]): string {
+  return [...new Set(names.map((name) => name.trim().toLowerCase()).filter(Boolean))]
+    .sort()
+    .join('\0');
+}

--- a/packages/core/src/group/people.ts
+++ b/packages/core/src/group/people.ts
@@ -3,16 +3,22 @@
  *
  * A set of names is chosen in a picker, not typed in an order that means
  * anything, so "Ravi, Sam" and "sam, ravi" have to hash the same. Names are
- * trimmed, lowercased, de-duplicated, sorted and NUL-joined (NUL because it is
- * the one character a display name never carries, so "a, b" cannot collide with
- * a single person literally called "a,b").
+ * trimmed, accent-folded, lowercased, de-duplicated, sorted and NUL-joined (NUL
+ * because it is the one character a display name never carries, so "a, b"
+ * cannot collide with a single person literally called "a,b").
  *
  * Deliberately names, not member ids: the people a picker offers are typed or
  * tapped by name, and "they already have a group" is a claim about the people,
  * not about which membership rows happen to represent them.
  */
+function normalizePersonName(name: string): string {
+  return name
+    .trim()
+    .normalize('NFKD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLocaleLowerCase();
+}
+
 export function peopleSignatureKey(names: readonly string[]): string {
-  return [...new Set(names.map((name) => name.trim().toLowerCase()).filter(Boolean))]
-    .sort()
-    .join('\0');
+  return [...new Set(names.map(normalizePersonName).filter(Boolean))].sort().join('\0');
 }

--- a/packages/core/test/heroSlides.test.ts
+++ b/packages/core/test/heroSlides.test.ts
@@ -1,0 +1,105 @@
+/**
+ * The dashboard hero's balance deck (`balanceDeckSlides`).
+ *
+ * Reported as "the net receivable number is the same as the receivable number
+ * — why do we show both?". It was: with nothing owing, `net = owed − 0 = owed`,
+ * so the first two slides were one figure under two labels. These tests pin the
+ * rule that replaced the fixed deck — a gross slide only when the net is
+ * actually hiding one — and pin it against `totalsByCurrency`, so the inputs
+ * are the same shape the home screen really feeds it.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { balanceDeckSlides, totalsByCurrency, type CurrencyTotals } from '../src/index.js';
+
+const INR = 'INR';
+
+/** The totals for one currency, built the way `useHomeSummary` builds them. */
+function totalsOf(...groupBalances: bigint[]): CurrencyTotals {
+  const totals = totalsByCurrency(groupBalances.map((balance) => [INR, balance] as const));
+  return totals[0] ?? { currency: INR, net: 0n, owed: 0n, owing: 0n };
+}
+
+describe('balanceDeckSlides', () => {
+  it('drops the gross slide when you are only ever owed — the reported duplicate', () => {
+    // Two groups, both in your favour: ₹500 and ₹300.
+    const totals = totalsOf(50000n, 30000n);
+    // The duplication itself: with nothing owing, the two figures are one figure.
+    expect(totals.owed).toBe(80000n);
+    expect(totals.owing).toBe(0n);
+    expect(totals.net).toBe(totals.owed);
+
+    expect(balanceDeckSlides(totals)).toEqual(['net', 'month']);
+  });
+
+  it('drops it just the same when you only ever owe', () => {
+    const totals = totalsOf(-20000n, -5000n);
+    expect(totals.net).toBe(-totals.owing);
+    expect(balanceDeckSlides(totals)).toEqual(['net', 'month']);
+  });
+
+  it('someone with no groups at all gets the plain two', () => {
+    expect(balanceDeckSlides(totalsOf())).toEqual(['net', 'month']);
+  });
+
+  it('up overall but still owing somebody: the deck shows what you owe', () => {
+    // Owed ₹500 in one group, owing ₹200 in another → net ₹300. The headline
+    // alone would never mention the ₹200.
+    const totals = totalsOf(50000n, -20000n);
+    expect(totals).toMatchObject({ net: 30000n, owed: 50000n, owing: 20000n });
+    expect(balanceDeckSlides(totals)).toEqual(['net', 'owing', 'month']);
+  });
+
+  it('down overall but still owed: the deck shows what is coming to you', () => {
+    const totals = totalsOf(30000n, -50000n);
+    expect(totals).toMatchObject({ net: -20000n, owed: 30000n, owing: 50000n });
+    expect(balanceDeckSlides(totals)).toEqual(['net', 'owed', 'month']);
+  });
+
+  it('a net of zero with money moving both ways still gets a gross slide', () => {
+    // "All settled ₹0" is true and tells you nothing: ₹500 is owed to you and
+    // ₹500 by you. The gross beside it is the only thing that says so.
+    const totals = totalsOf(50000n, -50000n);
+    expect(totals).toMatchObject({ net: 0n, owed: 50000n, owing: 50000n });
+    expect(balanceDeckSlides(totals)).toEqual(['net', 'owed', 'month']);
+  });
+
+  it('never puts the same figure on the net and gross slides by construction', () => {
+    // The one guarantee: over every arrangement of a lender and a borrower, a
+    // gross slide appears only where it is the side the net omits — so the pair
+    // can only ever coincide by arithmetic accident (owed ₹400 over owing ₹200),
+    // never because one is defined as the other.
+    for (let owed = 0; owed <= 6; owed += 1) {
+      for (let owing = 0; owing <= 6; owing += 1) {
+        const totals = totalsOf(BigInt(owed) * 100n, -BigInt(owing) * 100n);
+        const deck = balanceDeckSlides(totals);
+        const gross = deck.find((slide) => slide === 'owed' || slide === 'owing');
+        if (gross === undefined) {
+          // No gross slide means one side is empty — i.e. the net already is it.
+          expect(totals.owed === 0n || totals.owing === 0n).toBe(true);
+          continue;
+        }
+        // The slide shown is the side the net figure hides, never the side it
+        // already leads with.
+        expect(gross).toBe(totals.net > 0n ? 'owing' : 'owed');
+        const shown = gross === 'owed' ? totals.owed : totals.owing;
+        expect(shown).toBeGreaterThan(0n);
+      }
+    }
+  });
+
+  it('reads one currency, never a mixture (ADR-004)', () => {
+    // Rupees in your favour, dollars against you. `totalsByCurrency` keeps them
+    // apart, so each currency's deck is decided on its own totals — the INR
+    // headline must not sprout a gross slide because of a USD debt.
+    const totals = totalsByCurrency([
+      ['INR', 50000n],
+      ['USD', -4000n],
+    ] as const);
+    const inr = totals.find((entry) => entry.currency === 'INR');
+    const usd = totals.find((entry) => entry.currency === 'USD');
+    expect(inr && balanceDeckSlides(inr)).toEqual(['net', 'month']);
+    expect(usd && balanceDeckSlides(usd)).toEqual(['net', 'month']);
+  });
+});

--- a/packages/core/test/peopleSignature.test.ts
+++ b/packages/core/test/peopleSignature.test.ts
@@ -19,6 +19,13 @@ describe('a set of people as one key', () => {
     expect(peopleSignatureKey(['  ravi ', 'SAM'])).toBe(peopleSignatureKey(['Ravi', 'Sam']));
   });
 
+  it('ignores accents so typed or spoken names reuse the same existing group', () => {
+    expect(peopleSignatureKey(['José', 'Chloé'])).toBe(peopleSignatureKey(['jose', 'chloe']));
+    expect(peopleSignatureKey(['São Paulo Rider', 'Financé'])).toBe(
+      peopleSignatureKey(['Sao Paulo Rider', 'Finance']),
+    );
+  });
+
   it('counts the same person named twice once', () => {
     expect(peopleSignatureKey(['Ravi', 'ravi', 'Sam'])).toBe(peopleSignatureKey(['Ravi', 'Sam']));
   });

--- a/packages/core/test/peopleSignature.test.ts
+++ b/packages/core/test/peopleSignature.test.ts
@@ -1,0 +1,42 @@
+/**
+ * The "do these people already share a group?" key.
+ *
+ * The question is asked from two screens now — the voice review and the drafts
+ * inbox — and both must answer it the same way, or the same three friends get a
+ * second group from one screen and reuse the first from the other.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { peopleSignatureKey } from '../src/index';
+
+describe('a set of people as one key', () => {
+  it('ignores the order they were picked in', () => {
+    expect(peopleSignatureKey(['Ravi', 'Sam'])).toBe(peopleSignatureKey(['Sam', 'Ravi']));
+  });
+
+  it('ignores case and the spaces around a typed name', () => {
+    expect(peopleSignatureKey(['  ravi ', 'SAM'])).toBe(peopleSignatureKey(['Ravi', 'Sam']));
+  });
+
+  it('counts the same person named twice once', () => {
+    expect(peopleSignatureKey(['Ravi', 'ravi', 'Sam'])).toBe(peopleSignatureKey(['Ravi', 'Sam']));
+  });
+
+  it('drops names that are nothing but whitespace', () => {
+    expect(peopleSignatureKey(['Ravi', '   ', ''])).toBe(peopleSignatureKey(['Ravi']));
+  });
+
+  it('tells different people apart', () => {
+    expect(peopleSignatureKey(['Ravi'])).not.toBe(peopleSignatureKey(['Ravi', 'Sam']));
+    expect(peopleSignatureKey(['Ravi'])).not.toBe(peopleSignatureKey(['Sam']));
+  });
+
+  it('does not let a comma in one name look like two people', () => {
+    expect(peopleSignatureKey(['a,b'])).not.toBe(peopleSignatureKey(['a', 'b']));
+  });
+
+  it('is empty when nobody is picked', () => {
+    expect(peopleSignatureKey([])).toBe('');
+  });
+});


### PR DESCRIPTION
Three reports from one session of actually using the app.

## The hero deck said the same number twice

Slide 1 was "Net receivable" (`owed − owing`), slide 2 was "Receivables" (`owed`). Those are the same number whenever `owing === 0` — anyone who only ever fronts money and owes nobody, which is the ordinary case. Not a coincidence, arithmetic, so the duplicate showed on nearly every launch. They differ only when you are owed in one group *and* owe in another, which is the case slide 2 was written for.

`balanceDeckSlides()` in `@waves/core` now decides the deck from the totals:
- one side zero → `[net, month]`. The net *is* the gross; the surviving label is the one that carries direction.
- both sides real → `[net, the side the net hides, month]` — Payables when you are up overall, Receivables when you are down. A net of exactly zero counts as two-sided, since "All settled" says nothing about the sums behind it.

No new quantity: `owing` was already computed by `totalsByCurrency` and never shown. The dot pager, the colour washes and the corner watermarks now all count that one list instead of a fixed three, so a two-slide deck gets two dots — the three positional arrays that had to stay in lockstep collapsed into one record keyed by slide.

## A standalone draft had a chip where its location should be

Every standalone row in the drafts inbox carried a "+ Add to group" chip on line two, and on a narrow row the chip held its width while the place name was the thing that gave way. The chip is gone. Line two is the location when the draft has one; with nothing to show, the line is not rendered and the title takes the row.

Tapping the row opens the picker — and a pre-aimed draft opens it with that group already ticked, so nothing that used to be one tap became two.

The picker itself is now one component. The voice review's picker (pinned defaults, Groups/People tabs, typed names, one confirm) moved to `components/DestinationPicker.tsx` and both screens render it; ~440 lines came out of `voice.tsx`. The People tab genuinely assigns to individuals: people who already share a group reuse that group, otherwise the 1:1 group and its ghost members are minted through the offline queue exactly as `friends/add-person` does — no direct RPC. The people-matching key moved into core as `peopleSignatureKey` with tests, since it was about to exist twice.

## The Activity date filter was painted under the bottom bar

It was drawn inside the screen's own tree, but the bottom bar is rendered once at the root over the whole stack — so the calendar's last rows and the Apply/Clear pair sat behind the bar, and the bar's own white surface read as a second box over the sheet. It is a real `Sheet` now (its own window, above everything the app draws), with the calendar scrolling and the two actions pinned where they cannot scroll away.

## Tests

`heroSlides.test.ts` (deck composition across zero/one/both-sided totals) and `peopleSignature.test.ts`. Full core suite green: 966 files, 14,381 tests.