### PR TITLE
Put contacts beside the label, and give Create room to breathe

### DIFF
--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -48,7 +48,7 @@ import { deviceCountry, fill, useStrings } from '@/i18n';
 
 /**
  * Where the icon comes from when the name has not said anything yet — which is
- * the state this screen opens in, and the state a group called "Ravi and Asha"
+ * the state this screen opens in, and the state a group called "Alex and Sam"
  * stays in. The kind of group is a real answer to "what is this", so it is a
  * better fallback than one fixed emoji for everybody.
  */
@@ -594,21 +594,35 @@ export default function NewGroupScreen() {
 
         {/* People sit directly under the name — they are the group, so nothing
             optional (kind, dates, budget) comes between naming it and saying who
-            is in it. Contacts is a real button, not a corner link; a typed name
-            is the quieter second way. Nobody's address book is uploaded
-            (ADR-006). */}
+            is in it. Contacts is still a real button, not a corner link — it has
+            just moved onto the end of the title row instead of taking a
+            full-width line of its own, so the typed name (the quieter second
+            way) sits directly under the label it belongs to. Nobody's address
+            book is uploaded (ADR-006). */}
         <Card style={{ gap: theme.spacing.md }}>
           <InfoDisclosure
             title={t.extras.addPeopleByName}
             info={t.extras.ghostNote}
             titleVariant="caption"
-          />
-          <Button
-            label={t.people.browseContacts}
-            variant="secondary"
-            fullWidth
-            onPress={openContactPicker}
-            icon={<Ionicons name="people-outline" size={iconSize.base} color={theme.color.brand} />}
+            // `right` is InfoDisclosure's own title-row slot: the title flexes,
+            // this sits at the end of the same Row (start/end, not left/right,
+            // so RTL mirrors it), and the folded-out explanation still spans the
+            // full width underneath.
+            right={
+              <Button
+                // The short label is what fits beside a title at `sm`; the full
+                // "browse my contacts" is what the button still announces, so
+                // shortening the text costs nothing to a screen reader.
+                label={t.people.contacts}
+                accessibilityLabel={t.people.browseContacts}
+                variant="secondary"
+                size="sm"
+                onPress={openContactPicker}
+                icon={
+                  <Ionicons name="people-outline" size={iconSize.base} color={theme.color.brand} />
+                }
+              />
+            }
           />
           <Row>
             <TextInput
@@ -834,11 +848,17 @@ export default function NewGroupScreen() {
       {/* The primary action is pinned rather than parked at the foot of a long
           scroll: name, kind, country, dates, simplify and people all sit above
           it, and "just make the group" should not depend on scrolling past all
-          of them first. */}
+          of them first.
+
+          The bottom padding is a plain spacing token, not useScreenClearance:
+          the Screen above already applies the bottom safe-area inset on this
+          screen, so a clearance hook would count the gesture bar twice. This is
+          only the breathing room between the button and that inset. */}
       <View
         style={{
           paddingHorizontal: theme.spacing.xl,
           paddingTop: theme.spacing.md,
+          paddingBottom: theme.spacing.md,
           gap: theme.spacing.sm,
           borderTopWidth: 1,
           borderTopColor: theme.color.border,

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -10505,7 +10505,7 @@ const ar: UiStrings = {
     title: 'إضافة شخص',
     subtitle: 'تتبّع ما يدين لك به أحدهم — لا يحتاج إلى التطبيق، ولا إلى إنشاء مجموعة.',
     nameLabel: 'اسمه',
-    namePlaceholder: 'مثل: أليكس',
+    namePlaceholder: 'مثال: أليكس',
     amountLabel: 'المبلغ',
     directionQuestion: 'في أي اتجاه؟',
     theyOweMe: 'يدين لي',

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -2977,7 +2977,7 @@ const en: UiStrings = {
     title: 'Add a person',
     subtitle: 'Track what someone owes you — nobody needs the app, and no group to set up.',
     nameLabel: 'Their name',
-    namePlaceholder: 'e.g. Ravi',
+    namePlaceholder: 'e.g. Alex',
     amountLabel: 'Amount',
     directionQuestion: 'Which way?',
     theyOweMe: 'They owe me',
@@ -3949,7 +3949,7 @@ const en: UiStrings = {
       'Pick the guests who are the same person. Their balances are combined under one name.',
     empty: 'No guests to merge — only people without a Waves account can be merged.',
     nameLabel: 'Name for the merged person',
-    namePlaceholder: 'e.g. Ravi',
+    namePlaceholder: 'e.g. Alex',
     warningTitle: 'This can’t be undone',
     warningBody:
       'Their separate balances are combined into one person for good. There’s no way to split them back apart.',
@@ -4312,7 +4312,7 @@ const en: UiStrings = {
   people: {
     invite: 'Invite',
     addSomeone: 'Add someone',
-    namePlaceholder: 'Rahul',
+    namePlaceholder: 'e.g. Alex',
     contactPlaceholder: 'Email or phone, if you want to send them the link',
     phoneNeedsCountryCode: 'Add the country code to that number, like +91.',
     yetToJoin: { one: '{n} yet to join', other: '{n} yet to join' },
@@ -5445,7 +5445,7 @@ const ta: UiStrings = {
     subtitle:
       'யார் உங்களுக்குத் தர வேண்டும் என்பதைக் கண்காணி — அவருக்கு ஆப் தேவையில்லை, குழுவும் தேவையில்லை.',
     nameLabel: 'அவரது பெயர்',
-    namePlaceholder: 'எ.கா. ரவி',
+    namePlaceholder: 'எ.கா. அலெக்ஸ்',
     amountLabel: 'தொகை',
     directionQuestion: 'எந்தப் பக்கம்?',
     theyOweMe: 'அவர் எனக்குத் தர வேண்டும்',
@@ -6442,7 +6442,7 @@ const ta: UiStrings = {
       'ஒரே நபராக இருக்கும் விருந்தினர்களைத் தேர்ந்தெடுக்கவும். அவர்களின் இருப்புகள் ஒரே பெயரின் கீழ் இணைக்கப்படும்.',
     empty: 'இணைக்க விருந்தினர்கள் இல்லை — Waves கணக்கு இல்லாதவர்களை மட்டுமே இணைக்க முடியும்.',
     nameLabel: 'இணைந்த நபருக்கான பெயர்',
-    namePlaceholder: 'எ.கா. ரவி',
+    namePlaceholder: 'எ.கா. அலெக்ஸ்',
     warningTitle: 'இதை மீட்டெடுக்க முடியாது',
     warningBody:
       'அவர்களின் தனித்தனி இருப்புகள் நிரந்தரமாக ஒரே நபராக இணைக்கப்படும். மீண்டும் பிரிக்க வழி இல்லை.',
@@ -6822,7 +6822,7 @@ const ta: UiStrings = {
   people: {
     invite: 'அழை',
     addSomeone: 'ஒருவரைச் சேர்',
-    namePlaceholder: 'ராகுல்',
+    namePlaceholder: 'எ.கா. அலெக்ஸ்',
     contactPlaceholder: 'இணைப்பை அனுப்ப விரும்பினால் மின்னஞ்சல் அல்லது தொலைபேசி',
     phoneNeedsCountryCode: 'அந்த எண்ணுடன் நாட்டுக் குறியீட்டைச் சேர்க்கவும், எடுத்துக்காட்டாக +91.',
     yetToJoin: { one: '{n} பேர் இன்னும் சேரவில்லை', other: '{n} பேர் இன்னும் சேரவில்லை' },
@@ -8015,7 +8015,7 @@ const hi: UiStrings = {
     title: 'एक व्यक्ति जोड़ें',
     subtitle: 'किसी को आप पर कितना देना है, यह रखें — न उन्हें ऐप चाहिए, न कोई समूह बनाना है।',
     nameLabel: 'उनका नाम',
-    namePlaceholder: 'जैसे रवि',
+    namePlaceholder: 'जैसे एलेक्स',
     amountLabel: 'राशि',
     directionQuestion: 'किस ओर?',
     theyOweMe: 'वे मुझे देंगे',
@@ -8987,7 +8987,7 @@ const hi: UiStrings = {
     empty:
       'मर्ज करने के लिए कोई मेहमान नहीं — केवल बिना Waves खाते वाले लोग ही मर्ज किए जा सकते हैं.',
     nameLabel: 'मर्ज किए गए व्यक्ति का नाम',
-    namePlaceholder: 'जैसे रवि',
+    namePlaceholder: 'जैसे एलेक्स',
     warningTitle: 'इसे पहले जैसा नहीं किया जा सकता',
     warningBody:
       'उनके अलग-अलग बैलेंस हमेशा के लिए एक व्यक्ति में जोड़ दिए जाते हैं। इन्हें वापस अलग करने का कोई तरीका नहीं है.',
@@ -9352,7 +9352,7 @@ const hi: UiStrings = {
   people: {
     invite: 'बुलाएँ',
     addSomeone: 'किसी को जोड़ें',
-    namePlaceholder: 'राहुल',
+    namePlaceholder: 'जैसे एलेक्स',
     contactPlaceholder: 'ईमेल या फ़ोन, अगर उन्हें लिंक भेजना हो',
     phoneNeedsCountryCode: 'उस नंबर में देश का कोड जोड़ें, जैसे +91।',
     yetToJoin: { one: '{n} अभी जुड़ना बाकी', other: '{n} अभी जुड़ना बाकी' },
@@ -10505,7 +10505,7 @@ const ar: UiStrings = {
     title: 'إضافة شخص',
     subtitle: 'تتبّع ما يدين لك به أحدهم — لا يحتاج إلى التطبيق، ولا إلى إنشاء مجموعة.',
     nameLabel: 'اسمه',
-    namePlaceholder: 'مثل: رافي',
+    namePlaceholder: 'مثل: أليكس',
     amountLabel: 'المبلغ',
     directionQuestion: 'في أي اتجاه؟',
     theyOweMe: 'يدين لي',
@@ -11531,7 +11531,7 @@ const ar: UiStrings = {
     subtitle: 'اختر الضيوف الذين هم الشخص نفسه. تُجمع أرصدتهم تحت اسم واحد.',
     empty: 'لا يوجد ضيوف للدمج — يمكن دمج من ليس لديهم حساب Waves فقط.',
     nameLabel: 'اسم الشخص المدمج',
-    namePlaceholder: 'مثال: رافي',
+    namePlaceholder: 'مثال: أليكس',
     warningTitle: 'لا يمكن التراجع عن هذا',
     warningBody: 'تُجمع أرصدتهم المنفصلة في شخص واحد نهائيًا. لا توجد طريقة لفصلهم مرة أخرى.',
     cta: 'دمج',
@@ -11942,7 +11942,7 @@ const ar: UiStrings = {
   people: {
     invite: 'دعوة',
     addSomeone: 'أضف شخصًا',
-    namePlaceholder: 'راكيش',
+    namePlaceholder: 'مثال: أليكس',
     contactPlaceholder: 'بريد أو هاتف، إن أردت إرسال الرابط إليه',
     phoneNeedsCountryCode: 'أضِف رمز الدولة إلى هذا الرقم أولًا.',
     yetToJoin: {

--- a/apps/mobile/test/strings.test.ts
+++ b/apps/mobile/test/strings.test.ts
@@ -85,6 +85,27 @@ describe('the string tables', () => {
     }
   });
 
+  it('uses the same person-name example across add, merge and group people fields', () => {
+    const examples = {
+      en: 'e.g. Alex',
+      ta: 'எ.கா. அலெக்ஸ்',
+      hi: 'जैसे एलेक्स',
+      ar: 'مثال: أليكس',
+    } as const;
+
+    for (const language of LANGUAGES) {
+      expect(STRINGS_BY_LANGUAGE[language].addPerson.namePlaceholder, language).toBe(
+        examples[language],
+      );
+      expect(STRINGS_BY_LANGUAGE[language].mergePeople.namePlaceholder, language).toBe(
+        examples[language],
+      );
+      expect(STRINGS_BY_LANGUAGE[language].people.namePlaceholder, language).toBe(
+        examples[language],
+      );
+    }
+  });
+
   it('actually translated every language rather than copying English', () => {
     // The failure this catches is a half-done language: the table exists, the
     // keys are all there, and half the app is still in English. It went


### PR DESCRIPTION
The new-group screen, three small things the user asked for after using it.

**Contacts is no longer a full-width bar.** "Browse my contacts" used to sit on its own line between the section title and the typed-name field, which gave a secondary action the weight of a primary one. It now sits at the end of the title row as a small button, using `InfoDisclosure`'s existing `right` slot — so the folded-out ⓘ explanation still spans the full card width instead of being squeezed beside it. The visible label shortens to "Contacts" (an existing four-locale key); the spoken label stays "Browse my contacts".

**The sample name is no longer culture-specific.** The person-name placeholder read `Rahul` in English, `e.g. Ravi` on the add-person and merge screens, and `راكيش` in Arabic. All twelve values (en/ta/hi/ar × add-person, merge-people, people) now read `e.g. Alex` and its transliterations, so the same example name follows you across the flow. The English `people` entry also gains the `e.g. ` prefix its siblings already had. The tag placeholder ("Client dinner") is a thing, not a person, and is untouched.

**Create has room under it.** The pinned footer set `paddingTop` but no `paddingBottom`, so the button ended flush against the Android gesture pill. It now mirrors its own top padding. Deliberately a plain padding and not `useBottomClearance`: `Screen edges={['top','bottom']}` already sums `insets.bottom` onto the screen's padding, so a clearance hook would count the navigation bar twice. That reasoning is a comment on the footer so the next person does not "fix" it.

## Verification

`pnpm lint`, `pnpm --filter @waves/mobile typecheck`, and `pnpm --filter @waves/mobile test` (81 files, 1041 tests) all pass. `pnpm format` is clean.

Not verified on hardware: whether 12pt of footer breath reads as enough over a real gesture pill versus a three-button nav bar, and whether "Contacts" plus its icon crowds the flexing title in Tamil and Arabic, which are longer than the English. Both are a one-token change if the device says otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jhzmZz5fkjnZZ14YxHGfS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the new-group screen with a more compact inline contacts action and improved accessibility labeling.
  - Added clearer spacing around the bottom action area.

- **Style**
  - Updated example names and placeholder text across supported languages, including localized “Alex” examples and clearer “e.g.” guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->