### PR TITLE
Show who is already someone on the merge screen, and prefer their name

### DIFF
--- a/apps/mobile/src/app/friends/merge.tsx
+++ b/apps/mobile/src/app/friends/merge.tsx
@@ -13,6 +13,15 @@
  * already one identity by their account and must never be folded under a made-up
  * name, which the RPC also enforces.
  *
+ * Who is offered comes from group membership, not from balances. The screen used
+ * to read the balance list, which drops anybody square with you and carries no
+ * address — so a guest you had given a phone number to could not be seen at all,
+ * and nothing on a row said which of two names was the one you already knew.
+ * Both are the whole point of this screen: it now shows every guest you share a
+ * group with, says what makes each of them somebody already (their number or
+ * address, and how far they reach), and pre-fills the merged name from the
+ * identified one. Pre-fills only — the field stays editable.
+ *
  * Assigning a device contact only *names* the merged person. It never creates a
  * new guest and never asks which group to add anyone to — the people being
  * merged are already in their groups. If the contact's name matches a guest on
@@ -27,7 +36,7 @@
 import { useMemo, useRef, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { router, useLocalSearchParams } from 'expo-router';
 import {
   ActivityIndicator,
@@ -59,26 +68,21 @@ import {
   useTheme,
 } from '@waves/ui';
 
-import {
-  ensureGroupJoinToken,
-  fetchPeopleBalances,
-  fetchPersonGroupBalances,
-  groupJoinLink,
-  mergeGhosts,
-  type PersonBalanceRow,
-} from '@/data/api';
+import { ensureGroupJoinToken, groupJoinLink, mergeGhosts } from '@/data/api';
+import { useGroups, useMergeCandidates } from '@/data/hooks';
 import {
   canMerge,
   defaultMergeName,
-  isMergeable,
+  hasContact,
   memberIdsForMerge,
   mergeErrorMessage,
+  type MergeCandidate,
 } from '@/data/mergePeople';
 import { ContactPicker, type PickedContact } from '@/components/ContactPicker';
 import { PeopleSkeleton } from '@/components/Skeletons';
 import { friendlyError } from '@/lib/errors';
 import { useSync } from '@/sync';
-import { fill, plural, useStrings } from '@/i18n';
+import { fill, plural, useStrings, type UiStrings } from '@/i18n';
 
 /** One group the merged person belongs to, for the post-merge invite sheet. */
 interface InviteGroup {
@@ -94,7 +98,6 @@ export default function MergePeopleScreen() {
   // button hidden behind the bar, unreachable by scrolling.
   const clearance = useTabBarClearance();
   const { t, locale } = useStrings();
-  const queryClient = useQueryClient();
   const { flush } = useSync();
 
   // People pre-picked on the Friends tab (its multiselect merge) arrive as a
@@ -114,25 +117,17 @@ export default function MergePeopleScreen() {
     [params.keys],
   );
 
-  const people = useQuery({ queryKey: ['people', 'balances'], queryFn: fetchPeopleBalances });
-
-  // One selectable row per guest. A guest unsettled in two currencies is two
-  // balance rows but one person, so collapse by `person_key`; the first row
-  // carries the member id and name the rest of the screen needs.
-  const guests = useMemo(() => {
-    const byKey = new Map<string, PersonBalanceRow>();
-    for (const row of people.data ?? []) {
-      if (!isMergeable(row)) continue;
-      if (!byKey.has(row.person_key)) byKey.set(row.person_key, row);
-    }
-    return [...byKey.values()];
-  }, [people.data]);
+  // Every guest you share a group with, from the mirror — whatever the balance,
+  // and carrying the address that says which of them you already know.
+  const people = useMergeCandidates(t.misc.someone);
+  const guests = people.data;
+  const groups = useGroups();
 
   const [selected, setSelected] = useState<ReadonlySet<string>>(() => new Set(initialKeys));
-  const [name, setName] = useState(() =>
-    decodeURIComponent(typeof params.name === 'string' ? params.name : ''),
-  );
-  const [nameTouched, setNameTouched] = useState(false);
+  // Null until somebody types (or assigns a contact): the field then shows the
+  // suggestion below, which follows the picks. Not state that has to be kept in
+  // step — a derived name cannot drift out of it.
+  const [typedName, setTypedName] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   // The device contact assigned to name the merge (if any). Held only for its
@@ -150,7 +145,38 @@ export default function MergePeopleScreen() {
   // not), so the invite prompt can list them without another round-trip.
   const pendingInviteGroups = useRef<InviteGroup[]>([]);
 
-  const selectedRows = guests.filter((row) => selected.has(row.person_key));
+  const selectedRows = useMemo(
+    () => guests.filter((row) => selected.has(row.person_key)),
+    [guests, selected],
+  );
+  /** The guests not in the merge yet — what the "add a person" list offers. */
+  const remaining = useMemo(
+    () => guests.filter((row) => !selected.has(row.person_key)),
+    [guests, selected],
+  );
+
+  // The name the merge would keep if nobody typed one: the identified person's
+  // (see `defaultMergeName`). It follows the picks, so removing the person it
+  // came from moves it to whoever is left, and the caption below says it is a
+  // suggestion rather than a decision.
+  const suggestedName = useMemo(
+    () =>
+      defaultMergeName(
+        selectedRows.map((row) => ({
+          display_name: row.display_name,
+          phone: row.phone,
+          email: row.email,
+          group_count: row.group_ids.length,
+        })),
+      ),
+    [selectedRows],
+  );
+  // The name the Friends tab guessed before this screen had the fuller picture —
+  // used only until the candidates are read off the mirror, so the field is
+  // never blank for a frame.
+  const seededName = decodeURIComponent(typeof params.name === 'string' ? params.name : '');
+  const name = typedName ?? (suggestedName || seededName);
+  const showingSuggestion = typedName === null && name.trim().length > 0;
 
   const toggle = (personKey: string): void => {
     setError(null);
@@ -158,10 +184,6 @@ export default function MergePeopleScreen() {
       const next = new Set(prev);
       if (next.has(personKey)) next.delete(personKey);
       else next.add(personKey);
-      // Keep the name in step with the pick until the person types their own.
-      if (!nameTouched) {
-        setName(defaultMergeName(guests.filter((row) => next.has(row.person_key))));
-      }
       return next;
     });
   };
@@ -186,8 +208,7 @@ export default function MergePeopleScreen() {
     setPickedContact(contact);
     // Assigning a contact is naming the merged person: the contact's name wins,
     // and it stops auto-tracking the picks from here on.
-    setNameTouched(true);
-    setName(contact.name);
+    setTypedName(contact.name);
     setError(null);
     setPickingContact(false);
   };
@@ -195,15 +216,23 @@ export default function MergePeopleScreen() {
   const ready = canMerge(selectedRows) && name.trim().length > 0;
   const nothingToMergeYet = guests.length === 0;
 
-  /** The groups the currently-selected guests span, deduped by group id. */
-  const gatherInviteGroups = async (): Promise<InviteGroup[]> => {
-    const rows = (
-      await Promise.all([...selected].map((key) => fetchPersonGroupBalances(key)))
-    ).flat();
+  /**
+   * The groups the currently-selected guests span, deduped by group id. Read off
+   * the mirror the candidates came from — no round-trip, and it holds for a
+   * person you are square with, whose balance rows would list no groups at all.
+   */
+  const gatherInviteGroups = (): InviteGroup[] => {
     const byId = new Map<string, InviteGroup>();
-    for (const row of rows) {
-      if (!byId.has(row.group_id)) {
-        byId.set(row.group_id, { id: row.group_id, name: row.group_name, emoji: row.cover_emoji });
+    const known = new Map(groups.data.map((group) => [group.id, group]));
+    for (const row of selectedRows) {
+      for (const groupId of row.group_ids) {
+        if (byId.has(groupId)) continue;
+        const group = known.get(groupId);
+        byId.set(groupId, {
+          id: groupId,
+          name: group?.name ?? null,
+          emoji: group?.cover_emoji ?? null,
+        });
       }
     }
     return [...byId.values()];
@@ -211,11 +240,10 @@ export default function MergePeopleScreen() {
 
   const merge = useMutation({
     mutationFn: () => mergeGhosts(memberIdsForMerge(selectedRows), name.trim()),
-    onSuccess: async () => {
+    onSuccess: () => {
       // The merge is written server-side by the RPC; pull it into the mirror so
-      // the now-local Friends list (ADR-005) folds it without waiting for the
-      // next background sync. The invalidate keeps this screen's own list fresh.
-      await queryClient.invalidateQueries({ queryKey: ['people', 'balances'] });
+      // the now-local Friends list (ADR-005) — and this screen, which reads the
+      // same rows — folds it without waiting for the next background sync.
       void flush();
       const groups = pendingInviteGroups.current;
       // Nothing to invite into (no groups resolved) → this screen is done.
@@ -248,15 +276,9 @@ export default function MergePeopleScreen() {
         text: t.mergePeople.cta,
         style: 'destructive',
         onPress: () => {
-          void (async () => {
-            // Snapshot the groups before the write, from the pre-merge keys.
-            try {
-              pendingInviteGroups.current = await gatherInviteGroups();
-            } catch {
-              pendingInviteGroups.current = [];
-            }
-            merge.mutate();
-          })();
+          // Snapshot the groups before the write, from the pre-merge picks.
+          pendingInviteGroups.current = gatherInviteGroups();
+          merge.mutate();
         },
       },
     ]);
@@ -323,14 +345,6 @@ export default function MergePeopleScreen() {
         >
           {people.isLoading ? (
             <PeopleSkeleton />
-          ) : people.isError ? (
-            <EmptyState
-              title={t.loadError}
-              body={t.loadErrorBody}
-              action={
-                <Button label={t.retry} variant="secondary" onPress={() => people.refetch()} />
-              }
-            />
           ) : nothingToMergeYet ? (
             <EmptyState title={t.mergePeople.title} body={t.mergePeople.empty} />
           ) : (
@@ -352,10 +366,7 @@ export default function MergePeopleScreen() {
                 >
                   <TextInput
                     value={name}
-                    onChangeText={(value) => {
-                      setNameTouched(true);
-                      setName(value);
-                    }}
+                    onChangeText={setTypedName}
                     editable={selectedRows.length > 0}
                     accessibilityLabel={t.mergePeople.nameLabel}
                     placeholder={t.mergePeople.namePlaceholder}
@@ -370,10 +381,19 @@ export default function MergePeopleScreen() {
                   />
                   <Ionicons name="pencil" size={iconSize.md} color={theme.color.textFaint} />
                 </Row>
+                {/* Say out loud that the name is a suggestion. It is filled from
+                    the person we already have details for, which is right often
+                    enough to save a typing — and wrong often enough that it must
+                    never read as settled. */}
+                {showingSuggestion ? (
+                  <Text variant="micro" tone="muted">
+                    {t.mergePeople.nameSuggested}
+                  </Text>
+                ) : null}
               </View>
 
               {/* Only the people actually being merged — not the whole roster.
-                  Each is removable; the button below assigns a contact name. */}
+                  Each is removable; the list below adds more. */}
               <View style={{ gap: theme.spacing.sm }}>
                 <Text variant="caption" tone="muted">
                   {selectedRows.length > 0
@@ -386,11 +406,9 @@ export default function MergePeopleScreen() {
                       <View key={row.person_key}>
                         <MergeMemberRow
                           name={row.display_name}
-                          subtitle={
-                            row.group_count === 1
-                              ? t.tabs.inOneGroup
-                              : plural(locale, row.group_count, t.tabs.acrossGroups)
-                          }
+                          subtitle={identityLine(row, locale, t)}
+                          identified={hasContact(row)}
+                          identifiedLabel={t.mergePeople.hasContact}
                           removeLabel={fill(t.pickers.removeName, { name: row.display_name })}
                           onRemove={() => toggle(row.person_key)}
                         />
@@ -399,6 +417,53 @@ export default function MergePeopleScreen() {
                     ))}
                   </Card>
                 ) : null}
+              </View>
+
+              {/* Everybody else you could merge — the step this screen lost, and
+                  without which a person who was not pre-picked on Friends could
+                  not be reached at all. Each row says what makes them somebody
+                  already: the number or address you wrote down, and how many
+                  groups they turn up in. Identified people sort first. */}
+              <View style={{ gap: theme.spacing.sm }}>
+                <Text variant="caption" tone="muted">
+                  {t.mergePeople.addGuestTitle}
+                </Text>
+                {remaining.length === 0 ? (
+                  <Text variant="caption" tone="muted">
+                    {t.mergePeople.noMoreGuests}
+                  </Text>
+                ) : (
+                  <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+                    {remaining.map((row, index) => (
+                      <View key={row.person_key}>
+                        <ListRow
+                          title={row.display_name}
+                          subtitle={identityLine(row, locale, t)}
+                          // The tick the selected rows wear has nowhere to go on
+                          // a ListRow, so the fact it stands for is spoken here
+                          // instead — the number itself is already on the row.
+                          accessibilityLabel={[
+                            row.display_name,
+                            hasContact(row) ? t.mergePeople.hasContact : '',
+                            identityLine(row, locale, t),
+                          ]
+                            .filter(Boolean)
+                            .join(', ')}
+                          leading={<Avatar name={row.display_name} size={40} ghost />}
+                          trailing={
+                            <Ionicons
+                              name="add-circle"
+                              size={iconSize.xl}
+                              color={theme.color.brand}
+                            />
+                          }
+                          onPress={() => toggle(row.person_key)}
+                        />
+                        {index < remaining.length - 1 ? <Divider /> : null}
+                      </View>
+                    ))}
+                  </Card>
+                )}
               </View>
 
               {/* Give the merged person a real identity: assign them a device
@@ -546,20 +611,44 @@ export default function MergePeopleScreen() {
 }
 
 /**
- * One person in the merge selection: their name, where their balance sits, and
- * a remove control. No avatar — the identity being built is the name at the top,
- * so the rows stay a compact, glanceable list rather than a stack of circles.
- * Removing is the only edit here — there is no "unpick to unmerged," only "not
- * part of this merge," so it reads as a delete, not a toggle.
+ * What makes this guest somebody already, in one line.
+ *
+ * The number or address you wrote down when you invited them comes first — it is
+ * the nearest thing to proof of a particular human a guest can carry, and it is
+ * the whole reason one of two same-looking names is the one to keep. Their reach
+ * across groups follows it. Joined the way the rest of the app joins facts on a
+ * row, so bidi text lays out on its own rather than through hardcoded sides.
+ */
+function identityLine(person: MergeCandidate, locale: string, t: UiStrings): string {
+  const address = person.phone?.trim() || person.email?.trim() || '';
+  const reach =
+    person.group_ids.length === 1
+      ? t.tabs.inOneGroup
+      : plural(locale, person.group_ids.length, t.tabs.acrossGroups);
+  return [address, reach].filter(Boolean).join(' · ');
+}
+
+/**
+ * One person in the merge selection: their name, what makes them somebody
+ * already, and a remove control. No avatar — the identity being built is the
+ * name at the top, so the rows stay a compact, glanceable list rather than a
+ * stack of circles. Removing is the only edit here — there is no "unpick to
+ * unmerged," only "not part of this merge," so it reads as a delete, not a
+ * toggle.
  */
 function MergeMemberRow({
   name,
   subtitle,
+  identified,
+  identifiedLabel,
   removeLabel,
   onRemove,
 }: {
   name: string;
   subtitle: string;
+  /** We hold an address for them — the tick that says "this one is a real someone". */
+  identified: boolean;
+  identifiedLabel: string;
   removeLabel: string;
   onRemove: () => void;
 }): React.JSX.Element {
@@ -567,9 +656,19 @@ function MergeMemberRow({
   return (
     <Row style={{ paddingVertical: theme.spacing.sm, alignItems: 'center', minHeight: 44 }}>
       <View style={{ flex: 1 }}>
-        <Text variant="subheading" numberOfLines={1}>
-          {name}
-        </Text>
+        <Row style={{ alignItems: 'center', gap: theme.spacing.xs }}>
+          <Text variant="subheading" numberOfLines={1} style={{ flexShrink: 1 }}>
+            {name}
+          </Text>
+          {identified ? (
+            <MaterialCommunityIcons
+              name="account-check"
+              size={iconSize.sm}
+              color={theme.color.brand}
+              accessibilityLabel={identifiedLabel}
+            />
+          ) : null}
+        </Row>
         <Text variant="caption" tone="muted" numberOfLines={1}>
           {subtitle}
         </Text>

--- a/apps/mobile/src/app/friends/merge.tsx
+++ b/apps/mobile/src/app/friends/merge.tsx
@@ -76,9 +76,9 @@ import {
   contactNameMatch,
   defaultMergeName,
   hasContact,
-  isPicked,
   memberIdsForMerge,
   mergeErrorMessage,
+  suggestMergeCluster,
   type MergeCandidate,
 } from '@/data/mergePeople';
 import { ContactPicker, type PickedContact } from '@/components/ContactPicker';
@@ -93,6 +93,9 @@ import { fill, plural, useStrings, type UiStrings } from '@/i18n';
  * hiding anybody behind a search box they would have to guess at.
  */
 const ROSTER_PAGE = 25;
+
+/** Nothing ticked. Hoisted so it is one stable object, not a new set per render. */
+const EMPTY: ReadonlySet<string> = new Set();
 
 /** One group the merged person belongs to, for the post-merge invite sheet. */
 interface InviteGroup {
@@ -133,7 +136,29 @@ export default function MergePeopleScreen() {
   const guests = people.data;
   const groups = useGroups();
 
-  const [selected, setSelected] = useState<ReadonlySet<string>>(() => new Set(initialKeys));
+  // Two guests you wrote the same number against are almost certainly one
+  // person. Say so by ticking them — both, separately, each removable, each
+  // named in the confirmation — rather than by folding them into one row behind
+  // the user's back (see `suggestMergeCluster`). The roster arrives from the
+  // mirror a beat after mount, so this has to be derived rather than seeded: an
+  // effect writing the selection would fight every sync that re-derives the
+  // roster, and would re-impose itself over picks already made.
+  const suggestion = useMemo(() => {
+    if (initialKeys.size > 0) return null;
+    const cluster = suggestMergeCluster(guests);
+    return cluster.length >= 2 ? new Set(cluster.map((row) => row.person_key)) : null;
+  }, [guests, initialKeys]);
+
+  // What is ticked before the user has touched anything: their own pre-picks
+  // from Friends if there were any, else the suggestion, else nothing.
+  const baseKeys: ReadonlySet<string> = initialKeys.size > 0 ? initialKeys : (suggestion ?? EMPTY);
+  // Null until the user picks for themselves; from then on it is theirs alone
+  // and the suggestion is ignored, however the roster moves underneath.
+  const [picked, setPicked] = useState<ReadonlySet<string> | null>(null);
+  const selected = picked ?? baseKeys;
+  /** The ticks are the screen's proposal, not the user's — the list says so. */
+  const suggested = picked === null && suggestion !== null;
+
   // Null until somebody types (or assigns a contact): the field then shows the
   // suggestion below, which follows the picks. Not state that has to be kept in
   // step — a derived name cannot drift out of it.
@@ -160,12 +185,12 @@ export default function MergePeopleScreen() {
   const pendingInviteGroups = useRef<InviteGroup[]>([]);
 
   const selectedRows = useMemo(
-    () => guests.filter((row) => isPicked(row, selected)),
+    () => guests.filter((row) => selected.has(row.person_key)),
     [guests, selected],
   );
   /** The guests not in the merge yet — what the "add a person" list offers. */
   const remaining = useMemo(
-    () => guests.filter((row) => !isPicked(row, selected)),
+    () => guests.filter((row) => !selected.has(row.person_key)),
     [guests, selected],
   );
   const shownRemaining = showAllGuests ? remaining : remaining.slice(0, ROSTER_PAGE);
@@ -201,13 +226,13 @@ export default function MergePeopleScreen() {
   const toggle = (row: MergeCandidate): void => {
     setError(null);
     setContactNotice(null);
-    setSelected((prev) => {
-      const next = new Set(prev);
-      if (isPicked(row, prev)) {
-        // A seeded pick may be spelled as one of their member ids rather than
-        // their person key (see `isPicked`), so drop every spelling of them.
+    // Folded from whatever is ticked *now*, so two taps in a row before React
+    // has re-rendered still land on the real set rather than on a snapshot.
+    setPicked((prev) => {
+      const current = prev ?? baseKeys;
+      const next = new Set(current);
+      if (current.has(row.person_key)) {
         next.delete(row.person_key);
-        for (const id of row.member_ids) next.delete(id);
       } else if (!row.pending) {
         // Adding somebody the server has not seen would make the RPC refuse the
         // whole merge, and say of them that they are not a guest you share a
@@ -236,7 +261,7 @@ export default function MergePeopleScreen() {
     const contact = chosen[0];
     if (!contact) return;
     const { pick, ambiguous } = contactNameMatch(guests, contact.name);
-    if (pick) setSelected((prev) => new Set(prev).add(pick.person_key));
+    if (pick) setPicked((prev) => new Set(prev ?? baseKeys).add(pick.person_key));
     setContactNotice(
       ambiguous ? fill(t.mergePeople.contactAmbiguous, { name: contact.name }) : null,
     );
@@ -443,6 +468,13 @@ export default function MergePeopleScreen() {
                     ? plural(locale, selectedRows.length, t.mergePeople.peopleHeader)
                     : t.mergePeople.needTwo}
                 </Text>
+                {/* These were ticked by the screen, not by the user. Saying so
+                    is what keeps it a suggestion: they share a number, which is
+                    good evidence and not proof, and the next line says plainly
+                    that removing anybody is expected. */}
+                {suggested && selectedRows.length > 0 ? (
+                  <Callout tone="info">{t.mergePeople.suggestedPicks}</Callout>
+                ) : null}
                 {selectedRows.length > 0 ? (
                   <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
                     {selectedRows.map((row, index) => (

--- a/apps/mobile/src/app/friends/merge.tsx
+++ b/apps/mobile/src/app/friends/merge.tsx
@@ -76,6 +76,7 @@ import {
   contactNameMatch,
   defaultMergeName,
   hasContact,
+  isPicked,
   memberIdsForMerge,
   mergeErrorMessage,
   type MergeCandidate,
@@ -159,12 +160,12 @@ export default function MergePeopleScreen() {
   const pendingInviteGroups = useRef<InviteGroup[]>([]);
 
   const selectedRows = useMemo(
-    () => guests.filter((row) => selected.has(row.person_key)),
+    () => guests.filter((row) => isPicked(row, selected)),
     [guests, selected],
   );
   /** The guests not in the merge yet — what the "add a person" list offers. */
   const remaining = useMemo(
-    () => guests.filter((row) => !selected.has(row.person_key)),
+    () => guests.filter((row) => !isPicked(row, selected)),
     [guests, selected],
   );
   const shownRemaining = showAllGuests ? remaining : remaining.slice(0, ROSTER_PAGE);
@@ -197,18 +198,22 @@ export default function MergePeopleScreen() {
   /** Somebody in the merge whose membership has not reached the server yet. */
   const pendingPicked = selectedRows.some((row) => row.pending);
 
-  const toggle = (personKey: string): void => {
+  const toggle = (row: MergeCandidate): void => {
     setError(null);
     setContactNotice(null);
     setSelected((prev) => {
       const next = new Set(prev);
-      if (next.has(personKey)) next.delete(personKey);
-      // Adding somebody the server has not seen would make the RPC refuse the
-      // whole merge, and say of them that they are not a guest you share a group
-      // with — untrue, about a person this very screen is listing. Removing one
-      // always works, so only the add is blocked.
-      else if (!guests.some((row) => row.person_key === personKey && row.pending)) {
-        next.add(personKey);
+      if (isPicked(row, prev)) {
+        // A seeded pick may be spelled as one of their member ids rather than
+        // their person key (see `isPicked`), so drop every spelling of them.
+        next.delete(row.person_key);
+        for (const id of row.member_ids) next.delete(id);
+      } else if (!row.pending) {
+        // Adding somebody the server has not seen would make the RPC refuse the
+        // whole merge, and say of them that they are not a guest you share a
+        // group with — untrue, about a person this very screen is listing.
+        // Removing one always works, so only the add is blocked.
+        next.add(row.person_key);
       }
       return next;
     });
@@ -449,7 +454,7 @@ export default function MergePeopleScreen() {
                           identified={hasContact(row)}
                           identifiedLabel={t.mergePeople.hasContact}
                           removeLabel={fill(t.pickers.removeName, { name: row.display_name })}
-                          onRemove={() => toggle(row.person_key)}
+                          onRemove={() => toggle(row)}
                         />
                         {index < selectedRows.length - 1 ? <Divider /> : null}
                       </View>
@@ -509,7 +514,7 @@ export default function MergePeopleScreen() {
                             }
                             // Inert while their membership is only in the queue:
                             // the server would refuse the whole merge over them.
-                            onPress={row.pending ? undefined : () => toggle(row.person_key)}
+                            onPress={row.pending ? undefined : () => toggle(row)}
                           />
                           {index < shownRemaining.length - 1 ? <Divider /> : null}
                         </View>

--- a/apps/mobile/src/app/friends/merge.tsx
+++ b/apps/mobile/src/app/friends/merge.tsx
@@ -24,9 +24,10 @@
  *
  * Assigning a device contact only *names* the merged person. It never creates a
  * new guest and never asks which group to add anyone to — the people being
- * merged are already in their groups. If the contact's name matches a guest on
- * the list, that guest is ticked; either way the contact's name becomes the
- * merged name and is held so the invite step below can offer it.
+ * merged are already in their groups. A contact whose name fits exactly one
+ * guest ticks them; a name that fits several ticks nobody and says so, because a
+ * name three people share is not evidence about any of them. Either way the
+ * contact's name becomes the merged name and is held for the invite step below.
  *
  * After the merge, the person can be invited to the groups they now span. There
  * is no targeted send in this app — invites are one durable join link per group
@@ -72,6 +73,7 @@ import { ensureGroupJoinToken, groupJoinLink, mergeGhosts } from '@/data/api';
 import { useGroups, useMergeCandidates } from '@/data/hooks';
 import {
   canMerge,
+  contactNameMatch,
   defaultMergeName,
   hasContact,
   memberIdsForMerge,
@@ -83,6 +85,13 @@ import { PeopleSkeleton } from '@/components/Skeletons';
 import { friendlyError } from '@/lib/errors';
 import { useSync } from '@/sync';
 import { fill, plural, useStrings, type UiStrings } from '@/i18n';
+
+/**
+ * How much of the mergeable roster is drawn before asking. It is every ghost in
+ * every active group, so it has no ceiling; this keeps a cold open cheap without
+ * hiding anybody behind a search box they would have to guess at.
+ */
+const ROSTER_PAGE = 25;
 
 /** One group the merged person belongs to, for the post-merge invite sheet. */
 interface InviteGroup {
@@ -129,6 +138,10 @@ export default function MergePeopleScreen() {
   // step — a derived name cannot drift out of it.
   const [typedName, setTypedName] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // Set when a picked contact's name fits more than one guest — the screen says
+  // so and picks nobody, rather than quietly ticking several different humans.
+  const [contactNotice, setContactNotice] = useState<string | null>(null);
+  const [showAllGuests, setShowAllGuests] = useState(false);
 
   // The device contact assigned to name the merge (if any). Held only for its
   // name and to show the "assigned" state — it is never turned into a guest.
@@ -154,6 +167,7 @@ export default function MergePeopleScreen() {
     () => guests.filter((row) => !selected.has(row.person_key)),
     [guests, selected],
   );
+  const shownRemaining = showAllGuests ? remaining : remaining.slice(0, ROSTER_PAGE);
 
   // The name the merge would keep if nobody typed one: the identified person's
   // (see `defaultMergeName`). It follows the picks, so removing the person it
@@ -173,38 +187,54 @@ export default function MergePeopleScreen() {
   );
   // The name the Friends tab guessed before this screen had the fuller picture —
   // used only until the candidates are read off the mirror, so the field is
-  // never blank for a frame.
-  const seededName = decodeURIComponent(typeof params.name === 'string' ? params.name : '');
+  // never blank for a frame. Read raw for the same reason `keys` above is:
+  // `useLocalSearchParams` has already decoded it, and a second pass throws on a
+  // name containing a literal %.
+  const seededName = typeof params.name === 'string' ? params.name : '';
   const name = typedName ?? (suggestedName || seededName);
   const showingSuggestion = typedName === null && name.trim().length > 0;
 
+  /** Somebody in the merge whose membership has not reached the server yet. */
+  const pendingPicked = selectedRows.some((row) => row.pending);
+
   const toggle = (personKey: string): void => {
     setError(null);
+    setContactNotice(null);
     setSelected((prev) => {
       const next = new Set(prev);
       if (next.has(personKey)) next.delete(personKey);
-      else next.add(personKey);
+      // Adding somebody the server has not seen would make the RPC refuse the
+      // whole merge, and say of them that they are not a guest you share a group
+      // with — untrue, about a person this very screen is listing. Removing one
+      // always works, so only the add is blocked.
+      else if (!guests.some((row) => row.person_key === personKey && row.pending)) {
+        next.add(personKey);
+      }
       return next;
     });
   };
 
   /**
-   * A contact was picked. It only names the merge: if its name matches somebody
-   * already on this list, that is exactly the recognition this screen is built
-   * on — tick them, the same as tapping their row would. Either way the contact
-   * becomes the merged name and is held for the invite step. No guest is
-   * created, and no group is chosen — the merge is over the people already here.
+   * A contact was picked. It only names the merge: the contact's name becomes
+   * the merged name and is held for the invite step. No guest is created, and no
+   * group is chosen — the merge is over the people already here.
+   *
+   * A name match ticks somebody only when it is unambiguous. It used to tick
+   * every guest wearing that name, which was survivable while the roster was
+   * only people carrying a live debt; now that it is every guest in every group,
+   * one contact called "Alex" could silently sweep three different humans into
+   * an irreversible merge whose confirmation named nobody. So a single match is
+   * ticked (that is the recognition this screen is built on), several matches
+   * tick nobody and say so, and the person picks the one they meant.
    */
   const onPickContact = (chosen: readonly PickedContact[]): void => {
     const contact = chosen[0];
     if (!contact) return;
-    const needle = contact.name.trim().toLowerCase();
-    const matches = guests.filter((row) => row.display_name.trim().toLowerCase() === needle);
-    setSelected((prev) => {
-      const next = new Set(prev);
-      for (const row of matches) next.add(row.person_key);
-      return next;
-    });
+    const { pick, ambiguous } = contactNameMatch(guests, contact.name);
+    if (pick) setSelected((prev) => new Set(prev).add(pick.person_key));
+    setContactNotice(
+      ambiguous ? fill(t.mergePeople.contactAmbiguous, { name: contact.name }) : null,
+    );
     setPickedContact(contact);
     // Assigning a contact is naming the merged person: the contact's name wins,
     // and it stops auto-tracking the picks from here on.
@@ -213,7 +243,7 @@ export default function MergePeopleScreen() {
     setPickingContact(false);
   };
 
-  const ready = canMerge(selectedRows) && name.trim().length > 0;
+  const ready = canMerge(selectedRows) && !pendingPicked && name.trim().length > 0;
   const nothingToMergeYet = guests.length === 0;
 
   /**
@@ -268,9 +298,17 @@ export default function MergePeopleScreen() {
   // Merging is permanent, so the "this can't be undone" warning is a dialog on
   // tap — the person confirms it deliberately — rather than a line they may
   // skim past. Only the confirm proceeds to the write.
+  //
+  // It names everybody being folded, so an extra pick — from a contact match, or
+  // a mis-tap on a long roster — is visible in the last moment before it stops
+  // being reversible. A warning that says only "this can't be undone" cannot be
+  // checked against anything.
   const confirmMerge = (): void => {
     if (!ready || merge.isPending) return;
-    Alert.alert(t.mergePeople.warningTitle, t.mergePeople.warningBody, [
+    const who = fill(t.mergePeople.warningWho, {
+      people: selectedRows.map((row) => row.display_name).join(', '),
+    });
+    Alert.alert(t.mergePeople.warningTitle, `${who}\n\n${t.mergePeople.warningBody}`, [
       { text: t.common.cancel, style: 'cancel' },
       {
         text: t.mergePeople.cta,
@@ -407,6 +445,7 @@ export default function MergePeopleScreen() {
                         <MergeMemberRow
                           name={row.display_name}
                           subtitle={identityLine(row, locale, t)}
+                          spoken={identitySpoken(row, locale, t)}
                           identified={hasContact(row)}
                           identifiedLabel={t.mergePeople.hasContact}
                           removeLabel={fill(t.pickers.removeName, { name: row.display_name })}
@@ -422,8 +461,17 @@ export default function MergePeopleScreen() {
               {/* Everybody else you could merge — the step this screen lost, and
                   without which a person who was not pre-picked on Friends could
                   not be reached at all. Each row says what makes them somebody
-                  already: the number or address you wrote down, and how many
-                  groups they turn up in. Identified people sort first. */}
+                  already: the number or address you wrote down, how many groups
+                  they turn up in, and whether they are still waiting to sync.
+                  Ready-and-identified people sort first.
+
+                  Drawn a page at a time rather than all at once: the roster is
+                  every ghost in every active group, which is unbounded, and this
+                  screen cannot hand it to a FlashList — the list would have to
+                  own the whole scroll (nesting one inside this ScrollView
+                  defeats it), which would put the name field in a header that
+                  remounts and loses focus mid-typing. A "show the rest" tap is
+                  the honest trade. */}
               <View style={{ gap: theme.spacing.sm }}>
                 <Text variant="caption" tone="muted">
                   {t.mergePeople.addGuestTitle}
@@ -433,43 +481,61 @@ export default function MergePeopleScreen() {
                     {t.mergePeople.noMoreGuests}
                   </Text>
                 ) : (
-                  <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
-                    {remaining.map((row, index) => (
-                      <View key={row.person_key}>
-                        <ListRow
-                          title={row.display_name}
-                          subtitle={identityLine(row, locale, t)}
-                          // The tick the selected rows wear has nowhere to go on
-                          // a ListRow, so the fact it stands for is spoken here
-                          // instead — the number itself is already on the row.
-                          accessibilityLabel={[
-                            row.display_name,
-                            hasContact(row) ? t.mergePeople.hasContact : '',
-                            identityLine(row, locale, t),
-                          ]
-                            .filter(Boolean)
-                            .join(', ')}
-                          leading={<Avatar name={row.display_name} size={40} ghost />}
-                          trailing={
-                            <Ionicons
-                              name="add-circle"
-                              size={iconSize.xl}
-                              color={theme.color.brand}
-                            />
-                          }
-                          onPress={() => toggle(row.person_key)}
-                        />
-                        {index < remaining.length - 1 ? <Divider /> : null}
-                      </View>
-                    ))}
-                  </Card>
+                  <>
+                    <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+                      {shownRemaining.map((row, index) => (
+                        <View key={row.person_key}>
+                          <ListRow
+                            title={row.display_name}
+                            subtitle={identityLine(row, locale, t)}
+                            // The tick the selected rows wear has nowhere to go
+                            // on a ListRow, so the fact it stands for is spoken
+                            // here instead — the number itself is on the row.
+                            accessibilityLabel={[
+                              row.display_name,
+                              hasContact(row) ? t.mergePeople.hasContact : '',
+                              identitySpoken(row, locale, t),
+                            ]
+                              .filter(Boolean)
+                              .join(', ')}
+                            accessibilityState={{ disabled: row.pending }}
+                            leading={<Avatar name={row.display_name} size={40} ghost />}
+                            trailing={
+                              <Ionicons
+                                name={row.pending ? 'cloud-upload-outline' : 'add-circle'}
+                                size={iconSize.xl}
+                                color={row.pending ? theme.color.textFaint : theme.color.brand}
+                              />
+                            }
+                            // Inert while their membership is only in the queue:
+                            // the server would refuse the whole merge over them.
+                            onPress={row.pending ? undefined : () => toggle(row.person_key)}
+                          />
+                          {index < shownRemaining.length - 1 ? <Divider /> : null}
+                        </View>
+                      ))}
+                    </Card>
+                    {shownRemaining.length < remaining.length ? (
+                      <Button
+                        label={plural(
+                          locale,
+                          remaining.length - shownRemaining.length,
+                          t.mergePeople.showAllGuests,
+                        )}
+                        variant="ghost"
+                        fullWidth
+                        onPress={() => setShowAllGuests(true)}
+                      />
+                    ) : null}
+                  </>
                 )}
               </View>
 
               {/* Give the merged person a real identity: assign them a device
-                  contact. A contact whose name matches a guest ticks it; either
-                  way the contact's name becomes the merged name (see
-                  onPickContact). No guest is created and no group is chosen. */}
+                  contact. A contact whose name fits exactly one guest ticks
+                  them; several matches tick nobody and say so. Either way the
+                  contact's name becomes the merged name (see onPickContact). No
+                  guest is created and no group is chosen. */}
               <Button
                 label={
                   pickedContact
@@ -488,6 +554,17 @@ export default function MergePeopleScreen() {
                   />
                 }
               />
+
+              {/* The contact's name fitted several guests. Nobody was ticked —
+                  this says why, and the roster above is where they choose. */}
+              {contactNotice ? <Callout tone="info">{contactNotice}</Callout> : null}
+
+              {/* Somebody in the merge is still only in the queue. Saying so
+                  here beats the server's refusal, which would call them a person
+                  you share no group with. */}
+              {pendingPicked ? (
+                <Callout tone="warning">{t.mergePeople.pendingBlocked}</Callout>
+              ) : null}
 
               {error ? <Callout tone="negative">{error}</Callout> : null}
 
@@ -610,22 +687,55 @@ export default function MergePeopleScreen() {
   );
 }
 
+/** The one address we hold for this guest — a number first, else an email. */
+function contactAddress(person: MergeCandidate): string {
+  return person.phone?.trim() || person.email?.trim() || '';
+}
+
+/** The facts the identity line is made of, unformatted. */
+function identityParts(
+  person: MergeCandidate,
+  locale: string,
+  t: UiStrings,
+): { address: string; reach: string; pending: string } {
+  return {
+    address: contactAddress(person),
+    reach:
+      person.group_ids.length === 1
+        ? t.tabs.inOneGroup
+        : plural(locale, person.group_ids.length, t.tabs.acrossGroups),
+    pending: person.pending ? t.mergePeople.pendingTag : '',
+  };
+}
+
 /**
  * What makes this guest somebody already, in one line.
  *
  * The number or address you wrote down when you invited them comes first — it is
  * the nearest thing to proof of a particular human a guest can carry, and it is
  * the whole reason one of two same-looking names is the one to keep. Their reach
- * across groups follows it. Joined the way the rest of the app joins facts on a
- * row, so bidi text lays out on its own rather than through hardcoded sides.
+ * across groups follows it, and whether they are still waiting to sync last.
+ *
+ * The address is wrapped in a Unicode isolate (U+2068 … U+2069) because it is
+ * the one strongly-LTR run in a line that is otherwise the UI language: without
+ * it a leading `+` walks to the wrong end of an Arabic subtitle. `ListRow`'s
+ * subtitle takes a string, not a node, so the isolation is in the text rather
+ * than in a nested `writingDirection` Text the way `friends/person/[key]` does
+ * it. Screen readers skip the controls, but {@link identitySpoken} is built from
+ * the bare address anyway so nothing depends on that.
  */
 function identityLine(person: MergeCandidate, locale: string, t: UiStrings): string {
-  const address = person.phone?.trim() || person.email?.trim() || '';
-  const reach =
-    person.group_ids.length === 1
-      ? t.tabs.inOneGroup
-      : plural(locale, person.group_ids.length, t.tabs.acrossGroups);
-  return [address, reach].filter(Boolean).join(' · ');
+  const { address, reach, pending } = identityParts(person, locale, t);
+  // Spelled as escapes on purpose: FSI and PDI are invisible, and a copy-paste
+  // or an editor that strips format characters would silently undo the fix.
+  const isolated = address ? `\u2068${address}\u2069` : '';
+  return [isolated, reach, pending].filter(Boolean).join(' · ');
+}
+
+/** The same facts for a spoken label — no isolate controls, comma-separated. */
+function identitySpoken(person: MergeCandidate, locale: string, t: UiStrings): string {
+  const { address, reach, pending } = identityParts(person, locale, t);
+  return [address, reach, pending].filter(Boolean).join(', ');
 }
 
 /**
@@ -639,6 +749,7 @@ function identityLine(person: MergeCandidate, locale: string, t: UiStrings): str
 function MergeMemberRow({
   name,
   subtitle,
+  spoken,
   identified,
   identifiedLabel,
   removeLabel,
@@ -646,6 +757,8 @@ function MergeMemberRow({
 }: {
   name: string;
   subtitle: string;
+  /** The same line without the bidi isolate controls, for a screen reader. */
+  spoken: string;
   /** We hold an address for them — the tick that says "this one is a real someone". */
   identified: boolean;
   identifiedLabel: string;
@@ -669,7 +782,7 @@ function MergeMemberRow({
             />
           ) : null}
         </Row>
-        <Text variant="caption" tone="muted" numberOfLines={1}>
+        <Text variant="caption" tone="muted" numberOfLines={1} accessibilityLabel={spoken}>
           {subtitle}
         </Text>
       </View>

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -519,6 +519,11 @@ export function useMergeCandidates(someoneLabel: string): LocalRead<MergeCandida
           left_at: member.left_at,
           invite_email: member.invite_email ?? null,
           invite_phone: member.invite_phone ?? null,
+          // A ghost added offline is a queue row with a client-chosen id the
+          // server has never seen. The merge RPC would refuse the whole merge
+          // over it, so the flag travels and the screen shows them as not ready
+          // rather than either hiding them or letting them poison a pick.
+          pending: member.pending === true,
         });
       }
     }

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -94,6 +94,7 @@ import {
   countOthersInGroup,
   type PersonContribution,
 } from './peopleBalances';
+import { buildMergeCandidates, type MergeCandidate, type MergeableMember } from './mergePeople';
 import { totalsByCurrency } from './totals';
 import { serialiseExpense } from './serialiseExpense';
 import { putImage, removeRestrictedImage } from '@/lib/storage';
@@ -477,6 +478,54 @@ function lastActivityByMember(
     bump(settlement.to, settlement.at);
   }
   return latest;
+}
+
+/**
+ * Everybody you could merge into one person — from the mirror, so it reads the
+ * same with no signal (ADR-005).
+ *
+ * Deliberately *not* built on `usePeopleBalances`. That list is a list of debts:
+ * it drops anybody square with you, and it carries no address, so a guest you
+ * gave a phone number to and then settled up with vanished from the merge screen
+ * altogether — the one person you were most likely trying to merge a stray name
+ * into. This walks memberships instead, which is also where the invite address
+ * lives.
+ *
+ * Only groups you are still in are read: the merge RPC refuses a member of a
+ * group you are not in, so offering one would be a merge that cannot go through.
+ */
+export function useMergeCandidates(someoneLabel: string): LocalRead<MergeCandidate[]> {
+  const { mirror, queue } = useSync();
+  const { profile } = useAuth();
+  const profileId = profile?.id ?? null;
+
+  const candidates = useMemo(() => {
+    if (!profileId) return [];
+    const merges = new Map(ghostMerges(mirror).map((merge) => [merge.member_id, merge]));
+    const members: MergeableMember[] = [];
+    for (const group of materialiseGroups(mirror, queue) as unknown as GroupRow[]) {
+      const rows = materialiseMembers(mirror, queue, {
+        groupId: group.id,
+      }) as unknown as MemberRow[];
+      if (!rows.some((member) => member.profile_id === profileId && member.left_at === null)) {
+        continue;
+      }
+      for (const member of rows) {
+        members.push({
+          id: member.id,
+          group_id: group.id,
+          profile_id: member.profile_id,
+          ghost_name: member.ghost_name,
+          left_at: member.left_at,
+          invite_email: member.invite_email ?? null,
+          invite_phone: member.invite_phone ?? null,
+        });
+      }
+    }
+    return buildMergeCandidates(members, merges, someoneLabel);
+  }, [mirror, queue, profileId, someoneLabel]);
+
+  return useLocalRead(candidates);
 }
 
 /**

--- a/apps/mobile/src/data/mergePeople.ts
+++ b/apps/mobile/src/data/mergePeople.ts
@@ -13,7 +13,7 @@
  * are most likely to be merging *into* — so the balance list, which drops
  * anybody square with you, is the wrong roster to pick from.
  */
-import { digitsOf, fold, samePhone } from '@/lib/contactMatch';
+import { sameAddress } from '@/lib/contactMatch';
 
 import type { PersonBalanceRow } from './api';
 
@@ -107,13 +107,6 @@ export function hasContact(person: Pick<NamedPerson, 'phone' | 'email'>): boolea
   return Boolean(person.phone?.trim() || person.email?.trim());
 }
 
-function contactKey(member: Pick<MergeableMember, 'invite_email' | 'invite_phone'>): string | null {
-  const email = member.invite_email?.trim();
-  if (email) return `email:${fold(email)}`;
-  const phone = member.invite_phone ? digitsOf(member.invite_phone) : '';
-  return phone ? `phone:${phone}` : null;
-}
-
 /**
  * Build the mergeable people out of raw memberships.
  *
@@ -143,31 +136,22 @@ export function buildMergeCandidates(
   }
 
   const byKey = new Map<string, Draft>();
-  const phoneKeys: { phone: string; key: string }[] = [];
   for (const member of members) {
     if (member.left_at !== null) continue;
     if (!isMergeable({ is_ghost: member.profile_id === null })) continue;
 
     const merge = merges.get(member.id) ?? null;
-    const contact = contactKey(member);
-    const phoneForKey = member.invite_phone?.trim() ?? '';
-    const existingPhoneKey =
-      !merge && phoneForKey
-        ? phoneKeys.find((entry) => samePhone(entry.phone, phoneForKey))?.key
-        : undefined;
     // A ghost merge the viewer recorded is their own proof that two rows are one
-    // human. Failing that, a shared invite address/number is the same kind of
-    // local proof across groups; without either, a ghost stays keyed to its own
-    // membership so two same-named people are never auto-folded.
-    const key = merge?.person_id ?? existingPhoneKey ?? contact ?? member.id;
-    if (
-      !merge &&
-      phoneForKey &&
-      contact?.startsWith('phone:') &&
-      !phoneKeys.some((entry) => entry.key === key)
-    ) {
-      phoneKeys.push({ phone: phoneForKey, key });
-    }
+    // human; failing that a ghost stays keyed to its own membership.
+    //
+    // Nothing else may enter this expression. It has to spell identity exactly
+    // as `personKeyOf` and the SQL's COALESCE(profile_id, person_id, member id)
+    // do, because the key travels: Friends, the group ledger and the simplify
+    // sheet all push it into `friends/person/[key]`, which hands it straight to
+    // two server RPCs. A locally-invented key opens that screen empty. A shared
+    // invite number is worth *suggesting* a merge over — see
+    // {@link suggestMergeCluster} — but it may not decide who somebody is.
+    const key = merge?.person_id ?? member.id;
     let draft = byKey.get(key);
     if (!draft) {
       draft = {
@@ -221,21 +205,35 @@ export function buildMergeCandidates(
 }
 
 /**
- * Whether this candidate is one of the picked, by person key or by any of the
- * memberships behind them.
+ * The people to pre-tick: a guest and everybody carrying the same invite
+ * address. A suggestion — never an identity.
  *
- * The Friends tab keys people the ledger's way — a recorded merge, else the
- * `group_member` id (`personKeyOf`) — and hands those keys to this screen. This
- * screen keys them by shared invite address as well, so the very people it
- * exists to surface are exactly the ones whose key it does *not* spell the same
- * way. Matching on the memberships too means a pre-picked person still arrives
- * picked instead of quietly falling off the screen built to show them.
+ * Two ghosts you wrote the same number against are almost certainly one human,
+ * and saying so is the whole of what the original report asked for. What this
+ * deliberately does *not* do is fold them into one person behind the user's
+ * back. They stay two candidates, both ticked, both named in the confirmation
+ * dialog, and either can be unticked — so the merge that gets written is one the
+ * user asserted, exactly as it is for a name match (see {@link contactNameMatch}
+ * — a heuristic may propose an identity, it may not decide one).
+ *
+ * It is a star around the first guest with a partner, not a transitive closure:
+ * `samePhone` allows a shorter number to be the tail of a longer one, so "same
+ * address" is not an equivalence relation — A can match both B and C while B and
+ * C match nothing. Closing over that would invent a group nobody's data
+ * supports. One seed and its direct matches is a claim we can actually stand
+ * behind, and the user sees every member of it before anything is written.
+ *
+ * People still waiting to sync are left out: they cannot be picked at all.
  */
-export function isPicked(
-  row: Pick<MergeCandidate, 'person_key' | 'member_ids'>,
-  picked: ReadonlySet<string>,
-): boolean {
-  return picked.has(row.person_key) || row.member_ids.some((id) => picked.has(id));
+export function suggestMergeCluster(candidates: readonly MergeCandidate[]): MergeCandidate[] {
+  const usable = candidates.filter((row) => !row.pending && hasContact(row));
+  for (const seed of usable) {
+    const partners = usable.filter(
+      (other) => other.person_key !== seed.person_key && sameAddress(seed, other),
+    );
+    if (partners.length > 0) return [seed, ...partners];
+  }
+  return [];
 }
 
 /** What a picked device contact's name resolves to on the mergeable roster. */

--- a/apps/mobile/src/data/mergePeople.ts
+++ b/apps/mobile/src/data/mergePeople.ts
@@ -40,6 +40,13 @@ export interface MergeableMember {
   readonly invite_email?: string | null;
   /** E.164. */
   readonly invite_phone?: string | null;
+  /**
+   * True while this membership exists only in the local queue (ADR-005) — added
+   * offline, or still on its way up. The merge RPC looks the row up in
+   * `group_members` and refuses the *whole* merge if it is not there yet, so a
+   * pending person can be shown but must never be picked.
+   */
+  readonly pending?: boolean;
 }
 
 /** A merge the viewer has already recorded against a membership (A38). */
@@ -68,6 +75,18 @@ export interface MergeCandidate {
   readonly phone: string | null;
   /** The address recorded against them when they were invited, if any. */
   readonly email: string | null;
+  /**
+   * Any one of their memberships is still only in the local queue.
+   *
+   * The server checks *every* member id it is handed and refuses the whole merge
+   * if one of them is not a row it can see, so this is deliberately "any", not
+   * "all": one unsynced membership is enough to make the merge fail, and it
+   * would fail saying this person is not a guest you share a group with —
+   * untrue, and about somebody the screen itself just listed. So they are shown
+   * (hiding a person you added a minute ago is its own lie) and cannot be
+   * picked until the queue drains.
+   */
+  readonly pending: boolean;
 }
 
 /** Everything {@link defaultMergeName} weighs — a candidate, or just a name. */
@@ -120,6 +139,7 @@ export function buildMergeCandidates(
     ghostName: string;
     phone: string | null;
     email: string | null;
+    pending: boolean;
   }
 
   const byKey = new Map<string, Draft>();
@@ -158,9 +178,11 @@ export function buildMergeCandidates(
         ghostName: '',
         phone: null,
         email: null,
+        pending: false,
       };
       byKey.set(key, draft);
     }
+    if (member.pending === true) draft.pending = true;
     if (!draft.member_ids.includes(member.id)) draft.member_ids.push(member.id);
     if (!draft.group_ids.includes(member.group_id)) draft.group_ids.push(member.group_id);
 
@@ -182,9 +204,13 @@ export function buildMergeCandidates(
     display_name: draft.mergedName || draft.ghostName || someoneLabel,
     phone: draft.phone,
     email: draft.email,
+    pending: draft.pending,
   }));
 
   candidates.sort((a, b) => {
+    // Anybody who cannot be picked yet sinks below everybody who can.
+    const byReady = Number(a.pending) - Number(b.pending);
+    if (byReady !== 0) return byReady;
     const byIdentity = Number(hasContact(b)) - Number(hasContact(a));
     if (byIdentity !== 0) return byIdentity;
     const byReach = b.group_ids.length - a.group_ids.length;
@@ -192,6 +218,42 @@ export function buildMergeCandidates(
     return a.display_name.localeCompare(b.display_name);
   });
   return candidates;
+}
+
+/** What a picked device contact's name resolves to on the mergeable roster. */
+export interface ContactNameMatch {
+  /** The one guest that name unambiguously fits, or null. */
+  readonly pick: MergeCandidate | null;
+  /** The name fits several different people, so it fits nobody in particular. */
+  readonly ambiguous: boolean;
+}
+/**
+ * Who a picked contact's name points at.
+ *
+ * Ticking somebody because a device contact carries their name is the whole
+ * recognition this screen runs on — but only when the name points at exactly one
+ * person. It used to tick *every* guest wearing that name, which was survivable
+ * while the roster was only people carrying a live debt; over every guest in
+ * every group, one contact called "Alex" could sweep three different humans into
+ * a merge that cannot be undone. So several matches tick nobody and the screen
+ * says why: a name shared by three people is not evidence about any of them.
+ *
+ * Anybody still waiting to sync is excluded outright — they cannot be picked by
+ * hand either, so a contact must not pick them by the side door.
+ */
+export function contactNameMatch(
+  guests: readonly MergeCandidate[],
+  contactName: string,
+): ContactNameMatch {
+  const needle = contactName.trim().toLowerCase();
+  if (!needle) return { pick: null, ambiguous: false };
+  const matches = guests.filter(
+    (row) => !row.pending && row.display_name.trim().toLowerCase() === needle,
+  );
+  return {
+    pick: matches.length === 1 ? (matches[0] ?? null) : null,
+    ambiguous: matches.length > 1,
+  };
 }
 
 /**
@@ -262,12 +324,17 @@ function mostCommonName(rows: readonly NamedPerson[]): string {
  * stays editable, so a wrong guess costs one tap to fix.
  */
 export function defaultMergeName(rows: readonly NamedPerson[]): string {
-  const identified = rows.filter((row) => hasContact(row));
-  if (identified.length > 0) return mostCommonName(identified);
+  // Each tier falls through on a blank winner rather than returning it: an
+  // identified person whose name is empty says nothing, and swallowing the
+  // lower tiers to hand back '' would leave the field blank when a perfectly
+  // good name was sitting one tier down.
+  const byContact = mostCommonName(rows.filter((row) => hasContact(row)));
+  if (byContact) return byContact;
 
   const reach = rows.reduce((most, row) => Math.max(most, row.group_count ?? 0), 0);
   if (reach > 1) {
-    return mostCommonName(rows.filter((row) => (row.group_count ?? 0) === reach));
+    const byReach = mostCommonName(rows.filter((row) => (row.group_count ?? 0) === reach));
+    if (byReach) return byReach;
   }
 
   return mostCommonName(rows);

--- a/apps/mobile/src/data/mergePeople.ts
+++ b/apps/mobile/src/data/mergePeople.ts
@@ -13,6 +13,8 @@
  * are most likely to be merging *into* — so the balance list, which drops
  * anybody square with you, is the wrong roster to pick from.
  */
+import { digitsOf, fold, samePhone } from '@/lib/contactMatch';
+
 import type { PersonBalanceRow } from './api';
 
 /**
@@ -86,6 +88,13 @@ export function hasContact(person: Pick<NamedPerson, 'phone' | 'email'>): boolea
   return Boolean(person.phone?.trim() || person.email?.trim());
 }
 
+function contactKey(member: Pick<MergeableMember, 'invite_email' | 'invite_phone'>): string | null {
+  const email = member.invite_email?.trim();
+  if (email) return `email:${fold(email)}`;
+  const phone = member.invite_phone ? digitsOf(member.invite_phone) : '';
+  return phone ? `phone:${phone}` : null;
+}
+
 /**
  * Build the mergeable people out of raw memberships.
  *
@@ -114,14 +123,31 @@ export function buildMergeCandidates(
   }
 
   const byKey = new Map<string, Draft>();
+  const phoneKeys: { phone: string; key: string }[] = [];
   for (const member of members) {
     if (member.left_at !== null) continue;
     if (!isMergeable({ is_ghost: member.profile_id === null })) continue;
 
     const merge = merges.get(member.id) ?? null;
+    const contact = contactKey(member);
+    const phoneForKey = member.invite_phone?.trim() ?? '';
+    const existingPhoneKey =
+      !merge && phoneForKey
+        ? phoneKeys.find((entry) => samePhone(entry.phone, phoneForKey))?.key
+        : undefined;
     // A ghost merge the viewer recorded is their own proof that two rows are one
-    // human; failing that a ghost stays keyed to its own membership.
-    const key = merge?.person_id ?? member.id;
+    // human. Failing that, a shared invite address/number is the same kind of
+    // local proof across groups; without either, a ghost stays keyed to its own
+    // membership so two same-named people are never auto-folded.
+    const key = merge?.person_id ?? existingPhoneKey ?? contact ?? member.id;
+    if (
+      !merge &&
+      phoneForKey &&
+      contact?.startsWith('phone:') &&
+      !phoneKeys.some((entry) => entry.key === key)
+    ) {
+      phoneKeys.push({ phone: phoneForKey, key });
+    }
     let draft = byKey.get(key);
     if (!draft) {
       draft = {

--- a/apps/mobile/src/data/mergePeople.ts
+++ b/apps/mobile/src/data/mergePeople.ts
@@ -220,6 +220,24 @@ export function buildMergeCandidates(
   return candidates;
 }
 
+/**
+ * Whether this candidate is one of the picked, by person key or by any of the
+ * memberships behind them.
+ *
+ * The Friends tab keys people the ledger's way — a recorded merge, else the
+ * `group_member` id (`personKeyOf`) — and hands those keys to this screen. This
+ * screen keys them by shared invite address as well, so the very people it
+ * exists to surface are exactly the ones whose key it does *not* spell the same
+ * way. Matching on the memberships too means a pre-picked person still arrives
+ * picked instead of quietly falling off the screen built to show them.
+ */
+export function isPicked(
+  row: Pick<MergeCandidate, 'person_key' | 'member_ids'>,
+  picked: ReadonlySet<string>,
+): boolean {
+  return picked.has(row.person_key) || row.member_ids.some((id) => picked.has(id));
+}
+
 /** What a picked device contact's name resolves to on the mergeable roster. */
 export interface ContactNameMatch {
   /** The one guest that name unambiguously fits, or null. */

--- a/apps/mobile/src/data/mergePeople.ts
+++ b/apps/mobile/src/data/mergePeople.ts
@@ -2,10 +2,16 @@
  * The pure logic behind merging same-person ghosts on the Friends screen.
  *
  * Kept free of React and the network so it can be reasoned about and tested on
- * its own: what may be merged, which member ids a selection resolves to, the
+ * its own: who may be merged, which member ids a selection resolves to, the
  * name to pre-fill, and how a server error becomes something a person can read.
  * The screen wires these to state and the `mergeGhosts` RPC; the rules live
  * here.
+ *
+ * The candidates are built from group membership, not from balances. A guest is
+ * a person you can merge whether or not they currently owe you anything, and a
+ * guest you gave a phone number to when you invited them is exactly the one you
+ * are most likely to be merging *into* — so the balance list, which drops
+ * anybody square with you, is the wrong roster to pick from.
  */
 import type { PersonBalanceRow } from './api';
 
@@ -18,30 +24,175 @@ export function isMergeable(row: Pick<PersonBalanceRow, 'is_ghost'>): boolean {
   return row.is_ghost;
 }
 
+/** One group membership, as much of it as the candidate list reads. */
+export interface MergeableMember {
+  /** The `group_members` row id — per-group, and what the merge RPC takes. */
+  readonly id: string;
+  readonly group_id: string;
+  /** Their profile id, or null for a ghost. Only ghosts are offered. */
+  readonly profile_id: string | null;
+  readonly ghost_name: string | null;
+  /** Set once they have left; somebody gone is not somebody you merge. */
+  readonly left_at: string | null;
+  /** Where their invite was written — the one address this app records. */
+  readonly invite_email?: string | null;
+  /** E.164. */
+  readonly invite_phone?: string | null;
+}
+
+/** A merge the viewer has already recorded against a membership (A38). */
+export interface RecordedMerge {
+  readonly person_id: string;
+  readonly display_name: string;
+}
+
+/**
+ * One person the merge screen can offer, with whatever makes them *someone*
+ * already: an address you wrote down, and the groups they turn up in.
+ *
+ * `member_ids` is every membership folded under this person, not one of them —
+ * a person you merged before is several rows in several groups, and the merge
+ * has to carry all of them.
+ */
+export interface MergeCandidate {
+  /** COALESCE(merge person_id, member_id) — a ghost's key (see `personKeyOf`). */
+  readonly person_key: string;
+  /** Every group membership behind this person. */
+  readonly member_ids: readonly string[];
+  /** The groups they appear in — the invite step's list, and their reach. */
+  readonly group_ids: readonly string[];
+  readonly display_name: string;
+  /** The number recorded against them when they were invited, if any. */
+  readonly phone: string | null;
+  /** The address recorded against them when they were invited, if any. */
+  readonly email: string | null;
+}
+
+/** Everything {@link defaultMergeName} weighs — a candidate, or just a name. */
+export interface NamedPerson {
+  readonly display_name: string;
+  readonly phone?: string | null;
+  readonly email?: string | null;
+  /** How many groups they turn up in. Absent reads as "unknown", never as reach. */
+  readonly group_count?: number;
+}
+
+/**
+ * Whether we hold an address for this person — the strongest thing short of an
+ * account that says "this is a particular human", and the reason their name
+ * should be the one the merge keeps.
+ */
+export function hasContact(person: Pick<NamedPerson, 'phone' | 'email'>): boolean {
+  return Boolean(person.phone?.trim() || person.email?.trim());
+}
+
+/**
+ * Build the mergeable people out of raw memberships.
+ *
+ * Group memberships in, one row per human out: ghosts only (see
+ * {@link isMergeable}), people who have left dropped, and everything the viewer
+ * has already merged folded under the one person key so a second merge extends
+ * that person rather than splitting them.
+ *
+ * Ordered identified-first, then by name: the person you have details for is
+ * the one you are merging a stray name *into*, so they lead the list.
+ */
+export function buildMergeCandidates(
+  members: readonly MergeableMember[],
+  merges: ReadonlyMap<string, RecordedMerge>,
+  someoneLabel = 'Someone',
+): MergeCandidate[] {
+  interface Draft {
+    person_key: string;
+    member_ids: string[];
+    group_ids: string[];
+    /** The name the viewer gave the merge — it outranks any single ghost name. */
+    mergedName: string;
+    ghostName: string;
+    phone: string | null;
+    email: string | null;
+  }
+
+  const byKey = new Map<string, Draft>();
+  for (const member of members) {
+    if (member.left_at !== null) continue;
+    if (!isMergeable({ is_ghost: member.profile_id === null })) continue;
+
+    const merge = merges.get(member.id) ?? null;
+    // A ghost merge the viewer recorded is their own proof that two rows are one
+    // human; failing that a ghost stays keyed to its own membership.
+    const key = merge?.person_id ?? member.id;
+    let draft = byKey.get(key);
+    if (!draft) {
+      draft = {
+        person_key: key,
+        member_ids: [],
+        group_ids: [],
+        mergedName: '',
+        ghostName: '',
+        phone: null,
+        email: null,
+      };
+      byKey.set(key, draft);
+    }
+    if (!draft.member_ids.includes(member.id)) draft.member_ids.push(member.id);
+    if (!draft.group_ids.includes(member.group_id)) draft.group_ids.push(member.group_id);
+
+    const merged = merge?.display_name?.trim() ?? '';
+    if (merged && !draft.mergedName) draft.mergedName = merged;
+    const ghost = member.ghost_name?.trim() ?? '';
+    if (ghost && !draft.ghostName) draft.ghostName = ghost;
+
+    const phone = member.invite_phone?.trim() ?? '';
+    if (phone && !draft.phone) draft.phone = phone;
+    const email = member.invite_email?.trim() ?? '';
+    if (email && !draft.email) draft.email = email;
+  }
+
+  const candidates: MergeCandidate[] = [...byKey.values()].map((draft) => ({
+    person_key: draft.person_key,
+    member_ids: draft.member_ids,
+    group_ids: draft.group_ids,
+    display_name: draft.mergedName || draft.ghostName || someoneLabel,
+    phone: draft.phone,
+    email: draft.email,
+  }));
+
+  candidates.sort((a, b) => {
+    const byIdentity = Number(hasContact(b)) - Number(hasContact(a));
+    if (byIdentity !== 0) return byIdentity;
+    const byReach = b.group_ids.length - a.group_ids.length;
+    if (byReach !== 0) return byReach;
+    return a.display_name.localeCompare(b.display_name);
+  });
+  return candidates;
+}
+
 /**
  * The distinct group-member ids behind a set of picked people.
  *
- * A ghost can surface as several rows — one per currency they are unsettled in —
- * but is a single member, and a merge acts on members. De-duplicating here means
- * picking "person1" who owes both ₹ and € counts once, not twice.
+ * A person can be several memberships — one per group, and more still once a
+ * previous merge has folded them — and a merge acts on members, so every one of
+ * them has to travel. De-duplicating here means a person picked twice (or a
+ * membership two picked people share) counts once, not twice.
  */
-export function memberIdsForMerge(rows: readonly Pick<PersonBalanceRow, 'member_id'>[]): string[] {
-  return [...new Set(rows.map((row) => row.member_id))];
-}
-
-/** A merge needs at least two distinct people; one person is nothing to merge. */
-export function canMerge(rows: readonly Pick<PersonBalanceRow, 'member_id'>[]): boolean {
-  return memberIdsForMerge(rows).length >= 2;
+export function memberIdsForMerge(rows: readonly Pick<MergeCandidate, 'member_ids'>[]): string[] {
+  return [...new Set(rows.flatMap((row) => [...row.member_ids]))];
 }
 
 /**
- * The name to pre-fill on the merge screen: the most common display name among
- * the picked people, ties broken by the order they were picked. Blank or
- * whitespace-only names are ignored; if nothing usable remains it returns an
- * empty string, and the screen keeps the confirm button disabled until a name
- * is typed.
+ * A merge needs at least two distinct *people*; one person is nothing to merge.
+ *
+ * Counted by person key, not by membership — somebody already merged across
+ * three groups is three member ids and still only one person, and offering to
+ * "merge" them with themselves would write nothing and mean nothing.
  */
-export function defaultMergeName(rows: readonly Pick<PersonBalanceRow, 'display_name'>[]): string {
+export function canMerge(rows: readonly Pick<MergeCandidate, 'person_key'>[]): boolean {
+  return new Set(rows.map((row) => row.person_key)).size >= 2;
+}
+
+/** The most common name in a set, ties broken by the order they were picked. */
+function mostCommonName(rows: readonly NamedPerson[]): string {
   const counts = new Map<string, number>();
   const order: string[] = [];
   for (const row of rows) {
@@ -60,6 +211,40 @@ export function defaultMergeName(rows: readonly Pick<PersonBalanceRow, 'display_
     }
   }
   return best;
+}
+
+/**
+ * The name to pre-fill on the merge screen — the identified person's, wherever
+ * one of the picked people is identified.
+ *
+ * Merging is nearly always a stray "person1" being folded into somebody you
+ * actually know, so the surviving name should be the known one rather than
+ * whichever spelling happened to turn up most often. In order:
+ *
+ * 1. Somebody with an address you recorded — a phone number or an email is the
+ *    nearest thing to proof of a particular human that a guest can carry.
+ * 2. Failing that, whoever turns up in the most groups, when that is more than
+ *    one: a name you have written down in three places is a real person's, and
+ *    a name in exactly one group tells you nothing the others don't.
+ * 3. Failing both, the most common name among the picks — the old rule, kept
+ *    for the case where nothing distinguishes anybody.
+ *
+ * Within each tier the most common name wins, ties broken by pick order. Blank
+ * and whitespace-only names are ignored throughout; if nothing usable remains
+ * it returns an empty string and the screen keeps the confirm button disabled
+ * until a name is typed. The screen only ever *pre-fills* with this — the field
+ * stays editable, so a wrong guess costs one tap to fix.
+ */
+export function defaultMergeName(rows: readonly NamedPerson[]): string {
+  const identified = rows.filter((row) => hasContact(row));
+  if (identified.length > 0) return mostCommonName(identified);
+
+  const reach = rows.reduce((most, row) => Math.max(most, row.group_count ?? 0), 0);
+  if (reach > 1) {
+    return mostCommonName(rows.filter((row) => (row.group_count ?? 0) === reach));
+  }
+
+  return mostCommonName(rows);
 }
 
 /** The strings {@link mergeErrorMessage} needs — a subset of the i18n block. */

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1404,6 +1404,11 @@ export interface UiStrings {
     empty: string;
     nameLabel: string;
     namePlaceholder: string;
+    /** Caption under the name field while it still holds the suggested name,
+     *  so a pre-filled name reads as a default rather than a decision. */
+    nameSuggested: string;
+    /** Spoken label for the tick beside a guest we hold contact details for. */
+    hasContact: string;
     warningTitle: string;
     warningBody: string;
     cta: string;
@@ -3950,6 +3955,8 @@ const en: UiStrings = {
     empty: 'No guests to merge — only people without a Waves account can be merged.',
     nameLabel: 'Name for the merged person',
     namePlaceholder: 'e.g. Ravi',
+    nameSuggested: 'Suggested from the person you have details for. Tap to change.',
+    hasContact: 'You have their contact details',
     warningTitle: 'This can’t be undone',
     warningBody:
       'Their separate balances are combined into one person for good. There’s no way to split them back apart.',
@@ -6443,6 +6450,8 @@ const ta: UiStrings = {
     empty: 'இணைக்க விருந்தினர்கள் இல்லை — Waves கணக்கு இல்லாதவர்களை மட்டுமே இணைக்க முடியும்.',
     nameLabel: 'இணைந்த நபருக்கான பெயர்',
     namePlaceholder: 'எ.கா. ரவி',
+    nameSuggested: 'உங்களிடம் விவரங்கள் உள்ள நபரிடமிருந்து பரிந்துரைக்கப்பட்டது. மாற்ற தட்டவும்.',
+    hasContact: 'உங்களிடம் அவர்களின் தொடர்பு விவரங்கள் உள்ளன',
     warningTitle: 'இதை மீட்டெடுக்க முடியாது',
     warningBody:
       'அவர்களின் தனித்தனி இருப்புகள் நிரந்தரமாக ஒரே நபராக இணைக்கப்படும். மீண்டும் பிரிக்க வழி இல்லை.',
@@ -8988,6 +8997,8 @@ const hi: UiStrings = {
       'मर्ज करने के लिए कोई मेहमान नहीं — केवल बिना Waves खाते वाले लोग ही मर्ज किए जा सकते हैं.',
     nameLabel: 'मर्ज किए गए व्यक्ति का नाम',
     namePlaceholder: 'जैसे रवि',
+    nameSuggested: 'जिस व्यक्ति के विवरण आपके पास हैं, उससे सुझाया गया. बदलने के लिए टैप करें.',
+    hasContact: 'आपके पास उनके संपर्क विवरण हैं',
     warningTitle: 'इसे पहले जैसा नहीं किया जा सकता',
     warningBody:
       'उनके अलग-अलग बैलेंस हमेशा के लिए एक व्यक्ति में जोड़ दिए जाते हैं। इन्हें वापस अलग करने का कोई तरीका नहीं है.',
@@ -11532,6 +11543,8 @@ const ar: UiStrings = {
     empty: 'لا يوجد ضيوف للدمج — يمكن دمج من ليس لديهم حساب Waves فقط.',
     nameLabel: 'اسم الشخص المدمج',
     namePlaceholder: 'مثال: رافي',
+    nameSuggested: 'مقترح من الشخص الذي لديك بياناته. انقر لتغييره.',
+    hasContact: 'لديك بيانات الاتصال الخاصة به',
     warningTitle: 'لا يمكن التراجع عن هذا',
     warningBody: 'تُجمع أرصدتهم المنفصلة في شخص واحد نهائيًا. لا توجد طريقة لفصلهم مرة أخرى.',
     cta: 'دمج',

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1409,6 +1409,8 @@ export interface UiStrings {
     nameSuggested: string;
     /** Spoken label for the tick beside a guest we hold contact details for. */
     hasContact: string;
+    /** Says the ticked people were suggested by a shared number, not chosen. */
+    suggestedPicks: string;
     /** Row line for a guest whose membership is still only in the local queue. */
     pendingTag: string;
     /** Why the merge is held while one of the picked people has not synced. */
@@ -3969,6 +3971,8 @@ const en: UiStrings = {
     namePlaceholder: 'e.g. Ravi',
     nameSuggested: 'Suggested from the person you have details for. Tap to change.',
     hasContact: 'You have their contact details',
+    suggestedPicks:
+      'These share a phone number or email, so they’re probably one person. Remove anyone who isn’t.',
     pendingTag: 'Waiting to sync',
     pendingBlocked:
       'Someone in this merge hasn’t reached the server yet. You can merge them once this device is back online.',
@@ -6470,6 +6474,8 @@ const ta: UiStrings = {
     namePlaceholder: 'எ.கா. ரவி',
     nameSuggested: 'உங்களிடம் விவரங்கள் உள்ள நபரிடமிருந்து பரிந்துரைக்கப்பட்டது. மாற்ற தட்டவும்.',
     hasContact: 'உங்களிடம் அவர்களின் தொடர்பு விவரங்கள் உள்ளன',
+    suggestedPicks:
+      'இவர்கள் ஒரே தொலைபேசி எண் அல்லது மின்னஞ்சலைப் பகிர்கிறார்கள், எனவே இவர்கள் ஒரே நபராக இருக்கலாம். ஒரே நபர் இல்லாதவர்களை நீக்கவும்.',
     pendingTag: 'ஒத்திசைவுக்குக் காத்திருக்கிறது',
     pendingBlocked:
       'இந்த இணைப்பில் உள்ள ஒருவர் இன்னும் சேவையகத்தை அடையவில்லை. இந்தச் சாதனம் மீண்டும் ஆன்லைனுக்கு வந்ததும் அவர்களை இணைக்கலாம்.',
@@ -9024,6 +9030,8 @@ const hi: UiStrings = {
     namePlaceholder: 'जैसे रवि',
     nameSuggested: 'जिस व्यक्ति के विवरण आपके पास हैं, उससे सुझाया गया. बदलने के लिए टैप करें.',
     hasContact: 'आपके पास उनके संपर्क विवरण हैं',
+    suggestedPicks:
+      'इनका फ़ोन नंबर या ईमेल एक ही है, इसलिए ये शायद एक ही व्यक्ति हैं. जो न हो उसे हटा दें.',
     pendingTag: 'सिंक होना बाकी है',
     pendingBlocked:
       'इस मर्ज में शामिल कोई व्यक्ति अभी सर्वर तक नहीं पहुँचा है. यह डिवाइस दोबारा ऑनलाइन होने पर आप उन्हें मर्ज कर सकते हैं.',
@@ -11576,6 +11584,8 @@ const ar: UiStrings = {
     namePlaceholder: 'مثال: رافي',
     nameSuggested: 'مقترح من الشخص الذي لديك بياناته. انقر لتغييره.',
     hasContact: 'لديك بيانات الاتصال الخاصة به',
+    suggestedPicks:
+      'يشترك هؤلاء في رقم هاتف أو بريد إلكتروني، لذا من المرجّح أنهم شخص واحد. أزِل من ليس منهم.',
     pendingTag: 'في انتظار المزامنة',
     pendingBlocked:
       'أحد المشمولين في هذا الدمج لم يصل إلى الخادم بعد. يمكنك دمجهم بمجرد عودة هذا الجهاز إلى الاتصال.',

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1409,6 +1409,18 @@ export interface UiStrings {
     nameSuggested: string;
     /** Spoken label for the tick beside a guest we hold contact details for. */
     hasContact: string;
+    /** Row line for a guest whose membership is still only in the local queue. */
+    pendingTag: string;
+    /** Why the merge is held while one of the picked people has not synced. */
+    pendingBlocked: string;
+    /** A picked contact's name fitted several guests, so none was ticked.
+     *  `{name}` is the contact's name. */
+    contactAmbiguous: string;
+    /** Names everybody being folded, in the irreversibility dialog.
+     *  `{people}` is the comma-joined list. */
+    warningWho: string;
+    /** Draws the rest of the mergeable roster. `{n}` is how many are hidden. */
+    showAllGuests: PluralForms;
     warningTitle: string;
     warningBody: string;
     cta: string;
@@ -3957,6 +3969,12 @@ const en: UiStrings = {
     namePlaceholder: 'e.g. Ravi',
     nameSuggested: 'Suggested from the person you have details for. Tap to change.',
     hasContact: 'You have their contact details',
+    pendingTag: 'Waiting to sync',
+    pendingBlocked:
+      'Someone in this merge hasn’t reached the server yet. You can merge them once this device is back online.',
+    contactAmbiguous: 'More than one guest is called {name}. Pick the right one below.',
+    warningWho: 'Merging: {people}',
+    showAllGuests: { one: 'Show 1 more', other: 'Show {n} more' },
     warningTitle: 'This can’t be undone',
     warningBody:
       'Their separate balances are combined into one person for good. There’s no way to split them back apart.',
@@ -6452,6 +6470,13 @@ const ta: UiStrings = {
     namePlaceholder: 'எ.கா. ரவி',
     nameSuggested: 'உங்களிடம் விவரங்கள் உள்ள நபரிடமிருந்து பரிந்துரைக்கப்பட்டது. மாற்ற தட்டவும்.',
     hasContact: 'உங்களிடம் அவர்களின் தொடர்பு விவரங்கள் உள்ளன',
+    pendingTag: 'ஒத்திசைவுக்குக் காத்திருக்கிறது',
+    pendingBlocked:
+      'இந்த இணைப்பில் உள்ள ஒருவர் இன்னும் சேவையகத்தை அடையவில்லை. இந்தச் சாதனம் மீண்டும் ஆன்லைனுக்கு வந்ததும் அவர்களை இணைக்கலாம்.',
+    contactAmbiguous:
+      '{name} என்ற பெயரில் ஒன்றுக்கு மேற்பட்ட விருந்தினர்கள் உள்ளனர். கீழே சரியானவரைத் தேர்ந்தெடுக்கவும்.',
+    warningWho: 'இணைக்கப்படுபவர்கள்: {people}',
+    showAllGuests: { one: 'மேலும் 1 நபரைக் காட்டு', other: 'மேலும் {n} நபர்களைக் காட்டு' },
     warningTitle: 'இதை மீட்டெடுக்க முடியாது',
     warningBody:
       'அவர்களின் தனித்தனி இருப்புகள் நிரந்தரமாக ஒரே நபராக இணைக்கப்படும். மீண்டும் பிரிக்க வழி இல்லை.',
@@ -8999,6 +9024,12 @@ const hi: UiStrings = {
     namePlaceholder: 'जैसे रवि',
     nameSuggested: 'जिस व्यक्ति के विवरण आपके पास हैं, उससे सुझाया गया. बदलने के लिए टैप करें.',
     hasContact: 'आपके पास उनके संपर्क विवरण हैं',
+    pendingTag: 'सिंक होना बाकी है',
+    pendingBlocked:
+      'इस मर्ज में शामिल कोई व्यक्ति अभी सर्वर तक नहीं पहुँचा है. यह डिवाइस दोबारा ऑनलाइन होने पर आप उन्हें मर्ज कर सकते हैं.',
+    contactAmbiguous: '{name} नाम के एक से ज़्यादा मेहमान हैं. नीचे से सही व्यक्ति चुनें.',
+    warningWho: 'मर्ज हो रहे हैं: {people}',
+    showAllGuests: { one: '1 और दिखाएँ', other: '{n} और दिखाएँ' },
     warningTitle: 'इसे पहले जैसा नहीं किया जा सकता',
     warningBody:
       'उनके अलग-अलग बैलेंस हमेशा के लिए एक व्यक्ति में जोड़ दिए जाते हैं। इन्हें वापस अलग करने का कोई तरीका नहीं है.',
@@ -11545,6 +11576,19 @@ const ar: UiStrings = {
     namePlaceholder: 'مثال: رافي',
     nameSuggested: 'مقترح من الشخص الذي لديك بياناته. انقر لتغييره.',
     hasContact: 'لديك بيانات الاتصال الخاصة به',
+    pendingTag: 'في انتظار المزامنة',
+    pendingBlocked:
+      'أحد المشمولين في هذا الدمج لم يصل إلى الخادم بعد. يمكنك دمجهم بمجرد عودة هذا الجهاز إلى الاتصال.',
+    contactAmbiguous: 'هناك أكثر من ضيف باسم {name}. اختر الشخص الصحيح أدناه.',
+    warningWho: 'يجري دمج: {people}',
+    showAllGuests: {
+      zero: 'لا مزيد لعرضه',
+      one: 'عرض واحد آخر',
+      two: 'عرض اثنين آخرين',
+      few: 'عرض {n} آخرين',
+      many: 'عرض {n} آخر',
+      other: 'عرض {n} آخر',
+    },
     warningTitle: 'لا يمكن التراجع عن هذا',
     warningBody: 'تُجمع أرصدتهم المنفصلة في شخص واحد نهائيًا. لا توجد طريقة لفصلهم مرة أخرى.',
     cta: 'دمج',

--- a/apps/mobile/test/mergePeople.test.ts
+++ b/apps/mobile/test/mergePeople.test.ts
@@ -1,22 +1,54 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  buildMergeCandidates,
   canMerge,
   defaultMergeName,
+  hasContact,
   isMergeable,
   memberIdsForMerge,
   mergeErrorMessage,
+  type MergeableMember,
   type MergeErrorStrings,
+  type RecordedMerge,
 } from '@/data/mergePeople';
 
-/** A minimal person row — only the fields the merge logic reads. */
-function row(over: Partial<{ member_id: string; display_name: string; is_ghost: boolean }> = {}) {
+/** A minimal picked person — only the fields the merge logic reads. */
+function row(
+  over: Partial<{
+    person_key: string;
+    member_ids: readonly string[];
+    display_name: string;
+    phone: string | null;
+    email: string | null;
+    group_count: number;
+  }> = {},
+) {
+  const key = over.person_key ?? 'm1';
   return {
-    member_id: over.member_id ?? 'm1',
+    person_key: key,
+    member_ids: over.member_ids ?? [key],
     display_name: over.display_name ?? 'person1',
-    is_ghost: over.is_ghost ?? true,
+    phone: over.phone ?? null,
+    email: over.email ?? null,
+    group_count: over.group_count ?? 1,
   };
 }
+
+/** A membership as `buildMergeCandidates` takes them. */
+function member(over: Partial<MergeableMember> = {}): MergeableMember {
+  return {
+    id: over.id ?? 'm1',
+    group_id: over.group_id ?? 'g1',
+    profile_id: over.profile_id ?? null,
+    ghost_name: 'ghost_name' in over ? (over.ghost_name ?? null) : 'person1',
+    left_at: over.left_at ?? null,
+    invite_email: over.invite_email ?? null,
+    invite_phone: over.invite_phone ?? null,
+  };
+}
+
+const noMerges = new Map<string, RecordedMerge>();
 
 describe('isMergeable', () => {
   it('allows a ghost', () => {
@@ -28,19 +60,129 @@ describe('isMergeable', () => {
   });
 });
 
+describe('hasContact', () => {
+  it('is true for a number or an address', () => {
+    expect(hasContact({ phone: '+919876543210', email: null })).toBe(true);
+    expect(hasContact({ phone: null, email: 'ravi@example.com' })).toBe(true);
+  });
+
+  it('is false for nothing, and for whitespace pretending to be something', () => {
+    expect(hasContact({ phone: null, email: null })).toBe(false);
+    expect(hasContact({ phone: '  ', email: '' })).toBe(false);
+  });
+});
+
+describe('buildMergeCandidates', () => {
+  it('offers a guest carrying a phone number — the person you are merging into', () => {
+    // The bug this fixes: this guest had a number and no debt, so the balance
+    // list the screen used to read dropped them entirely.
+    const candidates = buildMergeCandidates(
+      [member({ id: 'a', ghost_name: 'Ravi', invite_phone: '+919876543210' })],
+      noMerges,
+    );
+    expect(candidates).toEqual([
+      {
+        person_key: 'a',
+        member_ids: ['a'],
+        group_ids: ['g1'],
+        display_name: 'Ravi',
+        phone: '+919876543210',
+        email: null,
+      },
+    ]);
+  });
+
+  it('refuses a real account holder — a profile id is already one identity', () => {
+    const candidates = buildMergeCandidates(
+      [member({ id: 'a', profile_id: 'p1', ghost_name: null })],
+      noMerges,
+    );
+    expect(candidates).toEqual([]);
+  });
+
+  it('drops somebody who has left', () => {
+    expect(
+      buildMergeCandidates([member({ id: 'a', left_at: '2026-01-01T00:00:00Z' })], noMerges),
+    ).toEqual([]);
+  });
+
+  it('folds a person the viewer already merged into one candidate, carrying every membership', () => {
+    const merges = new Map<string, RecordedMerge>([
+      ['a', { person_id: 'P', display_name: 'Ravi' }],
+      ['b', { person_id: 'P', display_name: 'Ravi' }],
+    ]);
+    const candidates = buildMergeCandidates(
+      [
+        member({ id: 'a', group_id: 'g1', ghost_name: 'person1' }),
+        member({ id: 'b', group_id: 'g2', ghost_name: 'ravi' }),
+      ],
+      merges,
+    );
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.person_key).toBe('P');
+    expect(candidates[0]?.member_ids).toEqual(['a', 'b']);
+    expect(candidates[0]?.group_ids).toEqual(['g1', 'g2']);
+    // The name the viewer gave the merge outranks either ghost's own name.
+    expect(candidates[0]?.display_name).toBe('Ravi');
+  });
+
+  it('never folds two unmerged ghosts who happen to share a name', () => {
+    const candidates = buildMergeCandidates(
+      [
+        member({ id: 'a', group_id: 'g1', ghost_name: 'Ravi' }),
+        member({ id: 'b', group_id: 'g2', ghost_name: 'Ravi' }),
+      ],
+      noMerges,
+    );
+    expect(candidates.map((c) => c.person_key)).toEqual(['a', 'b']);
+  });
+
+  it('falls back to the given label for a nameless ghost', () => {
+    const candidates = buildMergeCandidates([member({ ghost_name: null })], noMerges, 'Someone');
+    expect(candidates[0]?.display_name).toBe('Someone');
+  });
+
+  it('leads with the identified person, then the widest reach, then the name', () => {
+    const merges = new Map<string, RecordedMerge>([
+      ['b', { person_id: 'P', display_name: 'Bea' }],
+      ['c', { person_id: 'P', display_name: 'Bea' }],
+    ]);
+    const candidates = buildMergeCandidates(
+      [
+        member({ id: 'a', group_id: 'g1', ghost_name: 'Zoya' }),
+        member({ id: 'b', group_id: 'g1', ghost_name: 'Bea' }),
+        member({ id: 'c', group_id: 'g2', ghost_name: 'Bea' }),
+        member({ id: 'd', group_id: 'g1', ghost_name: 'Ravi', invite_phone: '+919876543210' }),
+      ],
+      merges,
+    );
+    expect(candidates.map((c) => c.display_name)).toEqual(['Ravi', 'Bea', 'Zoya']);
+  });
+});
+
 describe('memberIdsForMerge', () => {
   it('returns the distinct member ids', () => {
-    expect(memberIdsForMerge([row({ member_id: 'a' }), row({ member_id: 'b' })])).toEqual([
+    expect(memberIdsForMerge([row({ member_ids: ['a'] }), row({ member_ids: ['b'] })])).toEqual([
       'a',
       'b',
     ]);
   });
 
-  it('counts one ghost seen in two currencies as a single member', () => {
-    // Same person1, unsettled in both ₹ and € — two rows, one member.
-    const inr = row({ member_id: 'a' });
-    const eur = row({ member_id: 'a' });
-    expect(memberIdsForMerge([inr, eur])).toEqual(['a']);
+  it('carries every membership of an already-merged person, not just one', () => {
+    // A person merged across two groups is two member ids and one person; the
+    // RPC has to be handed both or the merge extends only half of them.
+    expect(
+      memberIdsForMerge([
+        row({ person_key: 'P', member_ids: ['a', 'b'] }),
+        row({ member_ids: ['c'] }),
+      ]),
+    ).toEqual(['a', 'b', 'c']);
+  });
+
+  it('counts a membership two picks share only once', () => {
+    expect(memberIdsForMerge([row({ member_ids: ['a'] }), row({ member_ids: ['a'] })])).toEqual([
+      'a',
+    ]);
   });
 
   it('is empty for no selection', () => {
@@ -51,23 +193,71 @@ describe('memberIdsForMerge', () => {
 describe('canMerge', () => {
   it('needs at least two distinct people', () => {
     expect(canMerge([])).toBe(false);
-    expect(canMerge([row({ member_id: 'a' })])).toBe(false);
-    expect(canMerge([row({ member_id: 'a' }), row({ member_id: 'b' })])).toBe(true);
+    expect(canMerge([row({ person_key: 'a' })])).toBe(false);
+    expect(canMerge([row({ person_key: 'a' }), row({ person_key: 'b' })])).toBe(true);
   });
 
-  it('does not count the same member twice (two currencies of one ghost)', () => {
-    expect(canMerge([row({ member_id: 'a' }), row({ member_id: 'a' })])).toBe(false);
+  it('does not count one already-merged person as two, however many groups they span', () => {
+    expect(canMerge([row({ person_key: 'P', member_ids: ['a', 'b'] })])).toBe(false);
   });
 
   it('allows three or more', () => {
     expect(
-      canMerge([row({ member_id: 'a' }), row({ member_id: 'b' }), row({ member_id: 'c' })]),
+      canMerge([row({ person_key: 'a' }), row({ person_key: 'b' }), row({ person_key: 'c' })]),
     ).toBe(true);
   });
 });
 
 describe('defaultMergeName', () => {
-  it('picks the most common name', () => {
+  it('keeps the name of the person whose number we have, over the more common one', () => {
+    // The report this rule comes from: one guest has a phone number, the others
+    // are strays. The known name is the one worth keeping.
+    const rows = [
+      row({ person_key: 'a', display_name: 'person1' }),
+      row({ person_key: 'b', display_name: 'person1' }),
+      row({ person_key: 'c', display_name: 'Ravi', phone: '+919876543210' }),
+    ];
+    expect(defaultMergeName(rows)).toBe('Ravi');
+  });
+
+  it('takes an email as identity too', () => {
+    const rows = [
+      row({ person_key: 'a', display_name: 'person1' }),
+      row({ person_key: 'b', display_name: 'Ravi', email: 'ravi@example.com' }),
+    ];
+    expect(defaultMergeName(rows)).toBe('Ravi');
+  });
+
+  it('prefers the most common name among the identified, not across everyone', () => {
+    const rows = [
+      row({ person_key: 'a', display_name: 'person1' }),
+      row({ person_key: 'b', display_name: 'person1' }),
+      row({ person_key: 'c', display_name: 'Ravi', phone: '+911111111111' }),
+      row({ person_key: 'd', display_name: 'Ravi K', email: 'ravi@example.com' }),
+      row({ person_key: 'e', display_name: 'Ravi', phone: '+912222222222' }),
+    ];
+    expect(defaultMergeName(rows)).toBe('Ravi');
+  });
+
+  it('falls back to whoever reaches the most groups when nobody has an address', () => {
+    const rows = [
+      row({ person_key: 'a', display_name: 'person1', group_count: 1 }),
+      row({ person_key: 'b', display_name: 'person1', group_count: 1 }),
+      row({ person_key: 'c', display_name: 'Ravi', group_count: 3 }),
+    ];
+    expect(defaultMergeName(rows)).toBe('Ravi');
+  });
+
+  it('does not treat being in one group as reach — that says nothing about anybody', () => {
+    const rows = [
+      row({ person_key: 'a', display_name: 'Ravi', group_count: 1 }),
+      row({ person_key: 'b', display_name: 'person1', group_count: 1 }),
+      row({ person_key: 'c', display_name: 'person1', group_count: 1 }),
+    ];
+    expect(defaultMergeName(rows)).toBe('person1');
+  });
+
+  it('picks the most common name when nothing distinguishes anybody', () => {
     const rows = [
       row({ display_name: 'Ravi' }),
       row({ display_name: 'person1' }),
@@ -92,6 +282,10 @@ describe('defaultMergeName', () => {
 
   it('trims the chosen name', () => {
     expect(defaultMergeName([row({ display_name: '  person1  ' })])).toBe('person1');
+  });
+
+  it('works on a bare list of names — the Friends tab has nothing else to give', () => {
+    expect(defaultMergeName([{ display_name: 'Ravi' }, { display_name: 'Ravi' }])).toBe('Ravi');
   });
 
   it('returns empty string when nothing usable remains', () => {

--- a/apps/mobile/test/mergePeople.test.ts
+++ b/apps/mobile/test/mergePeople.test.ts
@@ -7,9 +7,9 @@ import {
   defaultMergeName,
   hasContact,
   isMergeable,
-  isPicked,
   memberIdsForMerge,
   mergeErrorMessage,
+  suggestMergeCluster,
   type MergeableMember,
   type MergeCandidate,
   type MergeErrorStrings,
@@ -100,7 +100,7 @@ describe('buildMergeCandidates', () => {
     );
     expect(candidates).toEqual([
       {
-        person_key: 'phone:919876543210',
+        person_key: 'a',
         member_ids: ['a'],
         group_ids: ['g1'],
         display_name: 'Ravi',
@@ -156,7 +156,10 @@ describe('buildMergeCandidates', () => {
     expect(candidates.map((c) => c.person_key)).toEqual(['a', 'b']);
   });
 
-  it('folds the same invited phone across groups before any manual merge exists', () => {
+  it('does NOT fold two ghosts sharing an invite number — that is a suggestion, not an identity', () => {
+    // A shared number is good evidence and not proof, and the key it would have
+    // to change is the one the SQL and `personKeyOf` both spell. They stay two
+    // people here; `suggestMergeCluster` is what proposes the merge.
     const candidates = buildMergeCandidates(
       [
         member({ id: 'a', group_id: 'g1', ghost_name: 'Ravi', invite_phone: '+91 98765 43210' }),
@@ -164,21 +167,21 @@ describe('buildMergeCandidates', () => {
       ],
       noMerges,
     );
-    expect(candidates).toHaveLength(1);
-    expect(candidates[0]?.member_ids).toEqual(['a', 'b']);
-    expect(candidates[0]?.group_ids).toEqual(['g1', 'g2']);
+    expect(candidates.map((c) => c.person_key)).toEqual(['a', 'b']);
   });
 
-  it('folds the same invited email across groups case-insensitively', () => {
+  it('keys every candidate the way personKeyOf and the SQL do', () => {
+    // person_key travels into `friends/person/[key]`, which hands it to two
+    // server RPCs. Anything but a merge person id or a member id opens empty.
+    const merges = new Map<string, RecordedMerge>([['b', { person_id: 'P', display_name: 'Bea' }]]);
     const candidates = buildMergeCandidates(
       [
-        member({ id: 'a', group_id: 'g1', ghost_name: 'Chloé', invite_email: 'Chloe@Example.com' }),
-        member({ id: 'b', group_id: 'g2', ghost_name: 'Chloe', invite_email: 'chloé@example.com' }),
+        member({ id: 'a', invite_phone: '+919876543210', invite_email: 'ravi@example.com' }),
+        member({ id: 'b', group_id: 'g2' }),
       ],
-      noMerges,
+      merges,
     );
-    expect(candidates).toHaveLength(1);
-    expect(candidates[0]?.member_ids).toEqual(['a', 'b']);
+    expect(candidates.map((c) => c.person_key).sort()).toEqual(['P', 'a']);
   });
 
   it('falls back to the given label for a nameless ghost', () => {
@@ -242,24 +245,65 @@ describe('buildMergeCandidates', () => {
   });
 });
 
-describe('isPicked', () => {
-  it('matches on the person key', () => {
-    const row = candidate({ person_key: 'phone:919876543210', member_ids: ['a'] });
-    expect(isPicked(row, new Set(['phone:919876543210']))).toBe(true);
+describe('suggestMergeCluster', () => {
+  it('proposes the two guests sharing a number, as two separate people', () => {
+    const guests = [
+      candidate({ person_key: 'a', display_name: 'Ravi', phone: '+91 98765 43210' }),
+      candidate({ person_key: 'b', display_name: 'Ravi', phone: '९८७६५४३२१०' }),
+      candidate({ person_key: 'c', display_name: 'Zoya', phone: '+911111111111' }),
+    ];
+    const cluster = suggestMergeCluster(guests);
+    // Two candidates, not one folded row: the user ticks off a real pair, and
+    // `canMerge` therefore sees two people and lets the merge be recorded.
+    expect(cluster.map((row) => row.person_key)).toEqual(['a', 'b']);
+    expect(canMerge(cluster)).toBe(true);
   });
 
-  it('matches a key seeded as one of their member ids', () => {
-    // The Friends tab keys an unmerged ghost by its group_member id; this screen
-    // may key the same person by their shared invite number. Without this, the
-    // identified person falls off the screen built to show them.
-    const row = candidate({ person_key: 'phone:919876543210', member_ids: ['a', 'b'] });
-    expect(isPicked(row, new Set(['b']))).toBe(true);
+  it('proposes on a shared email too, ignoring case and accents', () => {
+    const guests = [
+      candidate({ person_key: 'a', display_name: 'Chloé', email: 'Chloe@Example.com' }),
+      candidate({ person_key: 'b', display_name: 'Chloe', email: 'chloé@example.com' }),
+    ];
+    expect(suggestMergeCluster(guests).map((row) => row.person_key)).toEqual(['a', 'b']);
   });
 
-  it('is false for somebody else', () => {
-    const row = candidate({ person_key: 'a', member_ids: ['a'] });
-    expect(isPicked(row, new Set(['z']))).toBe(false);
-    expect(isPicked(row, new Set())).toBe(false);
+  it('proposes nothing when nobody shares an address', () => {
+    const guests = [
+      candidate({ person_key: 'a', phone: '+911111111111' }),
+      candidate({ person_key: 'b', phone: '+912222222222' }),
+      candidate({ person_key: 'c' }),
+    ];
+    expect(suggestMergeCluster(guests)).toEqual([]);
+  });
+
+  it('proposes nothing from names alone — a shared name is not evidence', () => {
+    const guests = [
+      candidate({ person_key: 'a', display_name: 'Ravi' }),
+      candidate({ person_key: 'b', display_name: 'Ravi' }),
+    ];
+    expect(suggestMergeCluster(guests)).toEqual([]);
+  });
+
+  it('leaves out anybody still waiting to sync — they cannot be picked at all', () => {
+    const guests = [
+      candidate({ person_key: 'a', phone: '+919876543210' }),
+      candidate({ person_key: 'b', phone: '+919876543210', pending: true }),
+    ];
+    expect(suggestMergeCluster(guests)).toEqual([]);
+  });
+
+  it('is a star around one guest, never a transitive closure', () => {
+    // samePhone lets a shorter number be the tail of a longer one, so it is not
+    // an equivalence relation: a matches both b and c while b and c do not match
+    // each other. Closing over that would invent a group the data never claimed.
+    const guests = [
+      candidate({ person_key: 'a', phone: '9876543210' }),
+      candidate({ person_key: 'b', phone: '+919876543210' }),
+      candidate({ person_key: 'c', phone: '+449876543210' }),
+    ];
+    expect(suggestMergeCluster(guests).map((row) => row.person_key)).toEqual(['a', 'b', 'c']);
+    // ...and from b's side, c is not a partner at all.
+    expect(suggestMergeCluster(guests.slice(1)).map((row) => row.person_key)).toEqual([]);
   });
 });
 

--- a/apps/mobile/test/mergePeople.test.ts
+++ b/apps/mobile/test/mergePeople.test.ts
@@ -7,6 +7,7 @@ import {
   defaultMergeName,
   hasContact,
   isMergeable,
+  isPicked,
   memberIdsForMerge,
   mergeErrorMessage,
   type MergeableMember,
@@ -238,6 +239,27 @@ describe('buildMergeCandidates', () => {
       merges,
     );
     expect(candidates.map((c) => c.display_name)).toEqual(['Ravi', 'Bea', 'Zoya']);
+  });
+});
+
+describe('isPicked', () => {
+  it('matches on the person key', () => {
+    const row = candidate({ person_key: 'phone:919876543210', member_ids: ['a'] });
+    expect(isPicked(row, new Set(['phone:919876543210']))).toBe(true);
+  });
+
+  it('matches a key seeded as one of their member ids', () => {
+    // The Friends tab keys an unmerged ghost by its group_member id; this screen
+    // may key the same person by their shared invite number. Without this, the
+    // identified person falls off the screen built to show them.
+    const row = candidate({ person_key: 'phone:919876543210', member_ids: ['a', 'b'] });
+    expect(isPicked(row, new Set(['b']))).toBe(true);
+  });
+
+  it('is false for somebody else', () => {
+    const row = candidate({ person_key: 'a', member_ids: ['a'] });
+    expect(isPicked(row, new Set(['z']))).toBe(false);
+    expect(isPicked(row, new Set())).toBe(false);
   });
 });
 

--- a/apps/mobile/test/mergePeople.test.ts
+++ b/apps/mobile/test/mergePeople.test.ts
@@ -3,12 +3,14 @@ import { describe, expect, it } from 'vitest';
 import {
   buildMergeCandidates,
   canMerge,
+  contactNameMatch,
   defaultMergeName,
   hasContact,
   isMergeable,
   memberIdsForMerge,
   mergeErrorMessage,
   type MergeableMember,
+  type MergeCandidate,
   type MergeErrorStrings,
   type RecordedMerge,
 } from '@/data/mergePeople';
@@ -45,6 +47,21 @@ function member(over: Partial<MergeableMember> = {}): MergeableMember {
     left_at: over.left_at ?? null,
     invite_email: over.invite_email ?? null,
     invite_phone: over.invite_phone ?? null,
+    pending: over.pending ?? false,
+  };
+}
+
+/** A candidate as the screen holds them, for the contact-match rule. */
+function candidate(over: Partial<MergeCandidate> = {}): MergeCandidate {
+  const key = over.person_key ?? 'k1';
+  return {
+    person_key: key,
+    member_ids: over.member_ids ?? [key],
+    group_ids: over.group_ids ?? ['g1'],
+    display_name: over.display_name ?? 'person1',
+    phone: over.phone ?? null,
+    email: over.email ?? null,
+    pending: over.pending ?? false,
   };
 }
 
@@ -88,6 +105,7 @@ describe('buildMergeCandidates', () => {
         display_name: 'Ravi',
         phone: '+919876543210',
         email: null,
+        pending: false,
       },
     ]);
   });
@@ -167,6 +185,44 @@ describe('buildMergeCandidates', () => {
     expect(candidates[0]?.display_name).toBe('Someone');
   });
 
+  it('marks a ghost added offline as pending — the server has never seen that row', () => {
+    const candidates = buildMergeCandidates(
+      [member({ id: 'a', ghost_name: 'Ravi', invite_phone: '+919876543210', pending: true })],
+      noMerges,
+    );
+    expect(candidates[0]?.pending).toBe(true);
+    // Still listed, with their details: hiding somebody you added a minute ago
+    // is its own confusion. The screen makes the row inert instead.
+    expect(candidates[0]?.display_name).toBe('Ravi');
+    expect(candidates[0]?.phone).toBe('+919876543210');
+  });
+
+  it('treats one unsynced membership as enough to hold the whole person back', () => {
+    // The RPC checks every member id it is handed and refuses the lot, so
+    // "pending" has to be any, not all.
+    const merges = new Map<string, RecordedMerge>([
+      ['a', { person_id: 'P', display_name: 'Ravi' }],
+      ['b', { person_id: 'P', display_name: 'Ravi' }],
+    ]);
+    const candidates = buildMergeCandidates(
+      [member({ id: 'a', group_id: 'g1' }), member({ id: 'b', group_id: 'g2', pending: true })],
+      merges,
+    );
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.pending).toBe(true);
+  });
+
+  it('sinks the not-yet-mergeable below everybody who can be picked', () => {
+    const candidates = buildMergeCandidates(
+      [
+        member({ id: 'a', ghost_name: 'Ravi', invite_phone: '+911111111111', pending: true }),
+        member({ id: 'b', ghost_name: 'Zoya' }),
+      ],
+      noMerges,
+    );
+    expect(candidates.map((c) => c.display_name)).toEqual(['Zoya', 'Ravi']);
+  });
+
   it('leads with the identified person, then the widest reach, then the name', () => {
     const merges = new Map<string, RecordedMerge>([
       ['b', { person_id: 'P', display_name: 'Bea' }],
@@ -182,6 +238,50 @@ describe('buildMergeCandidates', () => {
       merges,
     );
     expect(candidates.map((c) => c.display_name)).toEqual(['Ravi', 'Bea', 'Zoya']);
+  });
+});
+
+describe('contactNameMatch', () => {
+  it('ticks the one guest the contact name unambiguously fits', () => {
+    const guests = [
+      candidate({ person_key: 'a', display_name: 'Ravi' }),
+      candidate({ person_key: 'b', display_name: 'Zoya' }),
+    ];
+    expect(contactNameMatch(guests, ' ravi ')).toEqual({ pick: guests[0], ambiguous: false });
+  });
+
+  it('ticks NOBODY when the name fits several different people', () => {
+    // The whole point: three humans called Alex must not be swept into one
+    // irreversible merge because a device contact carries that name.
+    const guests = [
+      candidate({ person_key: 'a', display_name: 'Alex' }),
+      candidate({ person_key: 'b', display_name: 'alex' }),
+      candidate({ person_key: 'c', display_name: 'ALEX ' }),
+    ];
+    expect(contactNameMatch(guests, 'Alex')).toEqual({ pick: null, ambiguous: true });
+  });
+
+  it('never reaches somebody still waiting to sync', () => {
+    const guests = [candidate({ person_key: 'a', display_name: 'Ravi', pending: true })];
+    expect(contactNameMatch(guests, 'Ravi')).toEqual({ pick: null, ambiguous: false });
+  });
+
+  it('leaves a pending namesake out of the ambiguity count', () => {
+    const guests = [
+      candidate({ person_key: 'a', display_name: 'Ravi' }),
+      candidate({ person_key: 'b', display_name: 'Ravi', pending: true }),
+    ];
+    expect(contactNameMatch(guests, 'Ravi')).toEqual({ pick: guests[0], ambiguous: false });
+  });
+
+  it('matches nobody on a blank name, and says nothing is ambiguous', () => {
+    const guests = [candidate({ display_name: 'Ravi' })];
+    expect(contactNameMatch(guests, '   ')).toEqual({ pick: null, ambiguous: false });
+  });
+
+  it('matches nobody when no guest wears the name', () => {
+    const guests = [candidate({ display_name: 'Ravi' })];
+    expect(contactNameMatch(guests, 'Zoya')).toEqual({ pick: null, ambiguous: false });
   });
 });
 
@@ -277,6 +377,24 @@ describe('defaultMergeName', () => {
     const rows = [
       row({ person_key: 'a', display_name: 'Ravi', group_count: 1 }),
       row({ person_key: 'b', display_name: 'person1', group_count: 1 }),
+      row({ person_key: 'c', display_name: 'person1', group_count: 1 }),
+    ];
+    expect(defaultMergeName(rows)).toBe('person1');
+  });
+
+  it('falls through to the next tier when the identified pick has no usable name', () => {
+    const rows = [
+      row({ person_key: 'a', display_name: '  ', phone: '+919876543210' }),
+      row({ person_key: 'b', display_name: 'Ravi', group_count: 3 }),
+      row({ person_key: 'c', display_name: 'person1', group_count: 1 }),
+    ];
+    expect(defaultMergeName(rows)).toBe('Ravi');
+  });
+
+  it('falls through both tiers to the plain most-common rule', () => {
+    const rows = [
+      row({ person_key: 'a', display_name: '', phone: '+919876543210' }),
+      row({ person_key: 'b', display_name: '   ', group_count: 3 }),
       row({ person_key: 'c', display_name: 'person1', group_count: 1 }),
     ];
     expect(defaultMergeName(rows)).toBe('person1');

--- a/apps/mobile/test/mergePeople.test.ts
+++ b/apps/mobile/test/mergePeople.test.ts
@@ -82,7 +82,7 @@ describe('buildMergeCandidates', () => {
     );
     expect(candidates).toEqual([
       {
-        person_key: 'a',
+        person_key: 'phone:919876543210',
         member_ids: ['a'],
         group_ids: ['g1'],
         display_name: 'Ravi',
@@ -135,6 +135,31 @@ describe('buildMergeCandidates', () => {
       noMerges,
     );
     expect(candidates.map((c) => c.person_key)).toEqual(['a', 'b']);
+  });
+
+  it('folds the same invited phone across groups before any manual merge exists', () => {
+    const candidates = buildMergeCandidates(
+      [
+        member({ id: 'a', group_id: 'g1', ghost_name: 'Ravi', invite_phone: '+91 98765 43210' }),
+        member({ id: 'b', group_id: 'g2', ghost_name: 'Ravi', invite_phone: '०९८७६५४३२१०' }),
+      ],
+      noMerges,
+    );
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.member_ids).toEqual(['a', 'b']);
+    expect(candidates[0]?.group_ids).toEqual(['g1', 'g2']);
+  });
+
+  it('folds the same invited email across groups case-insensitively', () => {
+    const candidates = buildMergeCandidates(
+      [
+        member({ id: 'a', group_id: 'g1', ghost_name: 'Chloé', invite_email: 'Chloe@Example.com' }),
+        member({ id: 'b', group_id: 'g2', ghost_name: 'Chloe', invite_email: 'chloé@example.com' }),
+      ],
+      noMerges,
+    );
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.member_ids).toEqual(['a', 'b']);
   });
 
   it('falls back to the given label for a nameless ghost', () => {


### PR DESCRIPTION
Reported: "I have one person already assigned a phone number, and another is anonymous. I want to merge them. The merge screen doesn't show the person I already assigned a phone number, or who is already part of a group. The person with a phone number should be given preference — and if not, I should be able to change it."

Two separate client-side defects, both real.

## The candidate list had been deleted and never replaced

`friends/merge.tsx` computed a `guests` list and then rendered only `selectedRows`. The sole ways to get anyone onto the screen were the route params from the Friends tab, or a device contact whose name matched **exactly**. PR #547 removed the "add another person" sheet and nothing took its place — its i18n keys `mergePeople.addGuestTitle` / `noMoreGuests` have sat orphaned in the string table ever since, which is the fingerprint of the missing picker. Anyone outside the pre-picked cluster simply was not there to select.

## The screen was reading the wrong roster, and that roster had no identity in it

`merge.tsx:117` read `fetchPeopleBalances` → RPC `waves_people_i_owe`, whose body ends `HAVING sum(n.net) <> 0`. That is a list of **debts**, not of people: anyone you are square with is dropped before the screen ever sees them. It is also a network read, while the Friends tab you arrived from reads the local mirror — so a person pre-picked on Friends could resolve to nothing here. And `PersonBalanceRow` carries no phone or email at all, so no row could have shown that somebody was the identified one even if it had been listed.

The address was available locally the whole time: `group_members.invite_phone` / `invite_email` are mirrored.

The existing "only guests without a Waves account can be merged" rule was **not** the cause, and is untouched — that boundary still holds.

## What it does now

A new `buildMergeCandidates` builds one candidate per person from raw memberships (ghosts only, left-members dropped, prior merges folded under their `person_id` and carrying every member id), read from the mirror per ADR-005 and restricted to groups you are still in. The inline "add a person" list is back. Every row shows `phone-or-email · in N groups`, and a selected identified row wears a tick with a spoken label — so "this one is already somebody" is visible, which is what was asked for.

**The name preference ladder** (`defaultMergeName`): a pick with a non-blank phone or email wins, most-common name among those; failing that, the widest reach (`group_count > 1`), most-common name at that reach; failing that, the previous most-common-name rule. Ties break by pick order, blanks ignored. The field stays editable and shows a "suggested" caption — typing, or assigning a contact, takes over permanently. The default is a default, not a lock.

Two smaller correctness fixes fell out: `canMerge` now counts distinct `person_key` rather than member ids, so one person spread across three groups can no longer "merge" with themselves; and `memberIdsForMerge` flattens all memberships.

## No server change

`waves_merge_ghosts` already unions transitively across `ghost_merges`, so handing it the fuller member list is a no-op improvement, and its ghost-only + shared-group guard is unchanged. No migration.

## Verification

`pnpm lint` 0 errors (3 pre-existing `import/first` warnings in `phone.tsx`, untouched), typecheck clean, **81 files / 1057 tests pass**. `test/mergePeople.test.ts` grew from 20 to 32 cases: a phone-carrying guest with no debt is offered, an account-holder is refused, a left member is dropped, a prior merge folds with all its member ids, two same-named ghosts are never auto-folded, plus the whole preference ladder including "one group is not reach".

Needs a device: that the phone renders correctly per locale and in RTL, that the restored list scrolls clear of the tab bar, and an end-to-end merge against a real ghost with an `invite_phone`. Also worth confirming on hardware that a guest you are **square** with now appears — that path depends on real mirror data and could not be exercised here. JS only, OTA-shippable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jhzmZz5fkjnZZ14YxHGfS