### PR TITLE
Add a whole saved-for-later batch to a group in one go

### DIFF
--- a/apps/mobile/src/app/captures.tsx
+++ b/apps/mobile/src/app/captures.tsx
@@ -7,10 +7,12 @@
  * real group expense and drops it from this list. Everything here is personal
  * and offline-first: a row still queued wears a faint cloud glyph rather than
  * hiding until the server has seen it (ADR-005). Expenses spoken in one breath
- * fold into a single collapsible "N expenses" row with the running total.
+ * fold into a single collapsible "N expenses" row with the running total, and
+ * that row's ⋯ can place the whole cluster in one group at once — one answer to
+ * "where does this go?" instead of the same answer once per row.
  */
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { FlashList } from '@shopify/flash-list';
 import { randomUUID } from 'expo-crypto';
@@ -24,7 +26,7 @@ import {
   View,
 } from 'react-native';
 
-import { peopleSignatureKey } from '@waves/core';
+import { MutationKind, peopleSignatureKey } from '@waves/core';
 import {
   Button,
   directionalIcon,
@@ -52,6 +54,7 @@ import { InboxSkeleton } from '@/components/Skeletons';
 import { dayHeading } from '@/data/activity';
 import {
   useAddGhostMember,
+  useAssignCapture,
   useCaptures,
   useCreateGroup,
   useDeleteCapture,
@@ -66,16 +69,34 @@ import { plural, useStrings, type UiStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { assignCaptureHref } from '@/lib/captureAssign';
 import { foldedCaptureCount } from '@/lib/captureBatch';
+import { planCaptureAssign, stillWaiting, type AssignMember } from '@/lib/captureBulkAssign';
 import { buildCaptureFeedItems, type CaptureFeedItem } from '@/lib/captureFeed';
 import { friendlyError } from '@/lib/errors';
+import { useGuestGuard } from '@/lib/guestGuard';
 import { usePullRefresh } from '@/lib/pullRefresh';
+import { useToast } from '@/lib/toast';
+import { useSync } from '@/sync';
 
 /**
  * What the ⋯ overflow sheet is open on: a single capture (add to group / edit /
- * delete) or a whole spoken batch (delete them all). Null when nothing is open.
+ * delete) or a whole spoken batch (add them all to one group / delete them all).
+ * Null when nothing is open.
  */
 type CaptureMenu =
   { kind: 'capture'; capture: CaptureRow } | { kind: 'batch'; items: CaptureRow[] } | null;
+
+/**
+ * What the destination sheet is placing: one draft, or a whole spoken batch at
+ * once. One picker serves both, so "where does this go?" is the same control and
+ * the same list of groups however many drafts are riding on the answer.
+ *
+ * The two differ only in what happens after the tap. A single draft opens the
+ * add-expense form prefilled — the unchanged path, where a person says who split
+ * what. A batch is written straight onto the queue with the form's own defaults,
+ * which is the whole point of asking once for several.
+ */
+type AssignTarget =
+  { kind: 'capture'; capture: CaptureRow } | { kind: 'batch'; items: CaptureRow[] };
 
 /**
  * One capture, in the card grammar this screen now speaks (Mobbin: Phantom
@@ -464,6 +485,18 @@ export default function CapturesScreen() {
 
   const captures = useCaptures();
   const deleteCapture = useDeleteCapture();
+  // Closing a draft against the expense it became. The single-draft path reaches
+  // this from inside the add-expense form; the batch path calls it here, right
+  // after queueing each expense.
+  const assignCapture = useAssignCapture();
+  // The batch path writes the expenses itself rather than opening a form per
+  // draft, so it queues them the way the form does (ADR-005).
+  const { mutate } = useSync();
+  const toast = useToast();
+  // A guest past their trial may read but not write. The single-draft path is
+  // stopped by the same guard inside add-expense; a batch write never reaches
+  // that screen, so it asks here.
+  const guard = useGuestGuard();
   const groups = useGroups();
   const summary = useHomeSummary(profile?.id ?? null);
   // The people the picker can point a draft at, and the raw material for
@@ -474,8 +507,15 @@ export default function CapturesScreen() {
   const signatures = useGroupPeopleSignatures(profile?.id ?? null);
   const createGroup = useCreateGroup();
 
-  // Which capture is being assigned, if any — drives the destination sheet.
-  const [assigning, setAssigning] = useState<CaptureRow | null>(null);
+  // What is being assigned, if anything — drives the destination sheet: one
+  // draft, or a whole spoken batch.
+  const [assigning, setAssigning] = useState<AssignTarget | null>(null);
+  // The one draft under the picker, when it is a single one. The batch case has
+  // no single capture to preview or pre-aim from.
+  const assigningCapture = assigning?.kind === 'capture' ? assigning.capture : null;
+  // A batch write is several queue writes behind one tap; the lock keeps a
+  // second tap (or a re-entrant people-tab resolve) from filing them twice.
+  const placing = useRef(false);
   // The id a group made from picked people will take, minted before the create
   // so the ghosts and the expense behind it can already name it — the
   // offline-first pattern the voice review and "add a person" both use. Retired
@@ -540,17 +580,32 @@ export default function CapturesScreen() {
   // pre-aim used to be spelled out on the row itself and skip the picker
   // entirely; it is now a suggestion the picker shows and a tap confirms.
   const pickerSelection: DestinationSelection = useMemo(() => {
-    const targetId = assigning?.target_group_id;
+    const targetId = assigningCapture?.target_group_id;
     return targetId && assignableGroups.some((group) => group.id === targetId)
       ? { kind: 'existing', groupId: targetId }
       : { kind: 'none' };
-  }, [assigning?.target_group_id, assignableGroups]);
+  }, [assigningCapture?.target_group_id, assignableGroups]);
   // How tall the picker sheet is ever allowed to get. A ceiling, not a height:
   // the sheet hugs its rows and only starts scrolling here. In points off the
   // window rather than the '80%' it used to pass, because a percentage height
   // needs an ancestor with a definite one to resolve against and this card is
   // sized by its own content — points can't be quietly dropped.
   const pickerMaxHeight = height * 0.8;
+
+  // What the picker says it is placing when a whole batch is riding on the
+  // answer: the running total (absent when the drafts are not one currency, as
+  // on the batch card itself) and how many drafts it stands for.
+  const batchPreview = useMemo(() => {
+    if (assigning?.kind !== 'batch') return null;
+    const items = assigning.items;
+    const currency = items[0]!.currency;
+    const sameCurrency = items.every((item) => item.currency === currency);
+    return {
+      count: items.length,
+      currency,
+      total: sameCurrency ? items.reduce((sum, item) => sum + BigInt(item.amount), 0n) : null,
+    };
+  }, [assigning]);
 
   const rows = useMemo(() => captures.data ?? [], [captures.data]);
   const feedItems = useMemo(() => buildCaptureFeedItems(rows), [rows]);
@@ -559,7 +614,13 @@ export default function CapturesScreen() {
   const waitingCount = useMemo(() => foldedCaptureCount(rows), [rows]);
 
   const openAssign = useCallback((capture: CaptureRow): void => {
-    setAssigning(capture);
+    setAssigning({ kind: 'capture', capture });
+  }, []);
+
+  // The batch card's ⋯ → "Add these to a group": the same picker, opened on the
+  // whole cluster instead of one row of it.
+  const openAssignBatch = useCallback((items: CaptureRow[]): void => {
+    setAssigning({ kind: 'batch', items });
   }, []);
 
   // Open the draft in the capture form to fix its fields — the same screen that
@@ -636,16 +697,132 @@ export default function CapturesScreen() {
 
   const closeAssign = useCallback((): void => setAssigning(null), []);
 
-  // Hand the capture's own values to the add-expense form as prefill, and carry
-  // its id so that saving there can close the capture (useAssignCapture). The
-  // href is built by the shared helper so the "New group" flow, which routes to
-  // the very same form, hands it identical params.
-  const assignTo = useCallback(
-    (capture: CaptureRow, groupId: string): void => {
-      closeAssign();
-      router.push(assignCaptureHref(capture, groupId));
+  /**
+   * A whole spoken batch into one group, in one go.
+   *
+   * This is the batch's answer to the same question the single row asks, and it
+   * ends differently on purpose: opening the add-expense form four times to
+   * accept its defaults four times is exactly the work the ⋯ item exists to
+   * remove. So the expenses are written here, with the form's own defaults —
+   * everyone in the group, split equally, the person assigning down as having
+   * paid — and each draft is closed against the expense it became.
+   *
+   * Both writes ride the ordinary offline queue (ADR-005), so this works with no
+   * network and survives being killed mid-run. Each draft is its own attempt:
+   * one that refuses does not take the others down, and it is left in the inbox
+   * (nothing closes it) rather than vanishing into a success message that would
+   * be a lie. What actually happened is then said out loud — the count that
+   * landed, and, when anything did not, the count still waiting.
+   */
+  const placeBatch = useCallback(
+    async (input: {
+      items: readonly CaptureRow[];
+      groupId: string;
+      /** What to call the group in the confirmation. */
+      label: string;
+      members: readonly AssignMember[];
+      currency: string;
+    }): Promise<void> => {
+      if (placing.current) return;
+      if (guard.blockWrite()) return;
+      placing.current = true;
+      try {
+        // Another device may have placed one of these while the sheet was open;
+        // the inbox read already knows, and writing it again would file the same
+        // dinner twice.
+        const waiting = stillWaiting(input.items, rows);
+        const plan = planCaptureAssign({
+          captures: waiting,
+          members: input.members,
+          myProfileId: profile?.id ?? null,
+          currency: input.currency,
+        });
+
+        let placed = 0;
+        // A draft whose amount the ledger cannot take never had a write to try.
+        let failed = plan.unusable.length;
+        for (const write of plan.writes) {
+          try {
+            await mutate(MutationKind.ExpenseCreate, input.groupId, write.payload);
+            // Only once the expense is on the queue: a draft closed before its
+            // expense exists is a spend that quietly disappeared.
+            await assignCapture.mutateAsync({
+              captureId: write.captureId,
+              groupId: input.groupId,
+              expenseId: write.expenseId,
+            });
+            placed += 1;
+          } catch {
+            failed += 1;
+          }
+        }
+
+        if (failed === 0) {
+          if (placed > 0) {
+            toast.show(
+              plural(locale, placed, t.captures.assignedBatch).replaceAll('{name}', input.label),
+            );
+          }
+          return;
+        }
+        // Something did not land, so this is said in a dialog rather than a
+        // toast that fades: it names how many are still waiting, and (when some
+        // did land) how many did, so neither half of a partial run is implied.
+        const lines: string[] = [];
+        if (placed > 0) {
+          lines.push(
+            plural(locale, placed, t.captures.assignedBatch).replaceAll('{name}', input.label),
+          );
+        }
+        lines.push(plural(locale, failed, t.captures.assignBatchSomeFailed));
+        Alert.alert(t.captures.title, lines.join('\n\n'));
+      } finally {
+        placing.current = false;
+      }
     },
-    [closeAssign],
+    [
+      assignCapture,
+      guard,
+      locale,
+      mutate,
+      profile?.id,
+      rows,
+      t.captures.assignBatchSomeFailed,
+      t.captures.assignedBatch,
+      t.captures.title,
+      toast,
+    ],
+  );
+
+  /**
+   * A chosen existing group, for whichever the picker is open on.
+   *
+   * One draft is unchanged: its own values are handed to the add-expense form as
+   * prefill, carrying its id so that saving there closes the capture
+   * (`useAssignCapture`). The href is built by the shared helper so the "New
+   * group" flow, which routes to the very same form, hands it identical params.
+   * A batch skips the form — that is the whole point of the batch item.
+   */
+  const chooseExistingGroup = useCallback(
+    (target: AssignTarget, groupId: string): void => {
+      closeAssign();
+      if (target.kind === 'capture') {
+        router.push(assignCaptureHref(target.capture, groupId));
+        return;
+      }
+      const members = summary.membersFor(groupId);
+      const group = assignableGroups.find((row) => row.id === groupId);
+      void placeBatch({
+        items: target.items,
+        groupId,
+        label: group ? groupLabel(group, members, profile?.id) : '',
+        members,
+        // A draft assigned through the form takes the group's currency too
+        // (the href carries no currency of its own), so the batch does the same.
+        currency: group?.default_currency ?? target.items[0]!.currency,
+      });
+    },
+    [assignableGroups, closeAssign, placeBatch, profile?.id, summary],
   );
 
   // The People tab, confirmed: this draft is with these people. If they already
@@ -659,30 +836,34 @@ export default function CapturesScreen() {
   // the group and the members before the server has ever heard of them.
   const assignToPeople = useCallback(
     async (names: string[]): Promise<void> => {
-      const capture = assigning;
-      if (!capture) return;
+      const target = assigning;
+      if (!target) return;
       const clean = [...new Set(names.map((name) => name.trim()).filter(Boolean))];
       if (clean.length === 0) return;
 
       const shared = groupBySignature.get(peopleSignatureKey(clean));
       if (shared) {
-        assignTo(capture, shared);
+        chooseExistingGroup(target, shared);
         return;
       }
 
       const groupId = newGroupId;
+      // The draft's own currency: it is the money actually spent with these
+      // people, and a fresh group has nothing better to go on. A batch is one
+      // utterance, so its first draft speaks for the lot.
+      const currency =
+        target.kind === 'capture' ? target.capture.currency : target.items[0]!.currency;
       closeAssign();
+      const ghostIds: string[] = [];
       try {
         await createGroup.mutateAsync({
           groupId,
           creatorMemberId: newMemberId,
           name: clean.join(', '),
           type: GroupType.Other,
-          // The draft's own currency: it is the money actually spent with these
-          // people, and a fresh group has nothing better to go on.
-          currency: capture.currency,
+          currency,
         });
-        for (const name of clean) await addGhost.mutateAsync(name);
+        for (const name of clean) ghostIds.push(await addGhost.mutateAsync(name));
       } catch (caught) {
         // With no group to assign into there is nowhere to push, so say why and
         // leave the draft exactly where it was rather than opening a form over a
@@ -696,17 +877,35 @@ export default function CapturesScreen() {
       // Spent — the next new group needs its own pair of ids.
       setNewGroupId(randomUUID());
       setNewMemberId(randomUUID());
-      router.push(assignCaptureHref(capture, groupId));
+      if (target.kind === 'capture') {
+        router.push(assignCaptureHref(target.capture, groupId));
+        return;
+      }
+      // The group and its people exist only on the queue so far, so the mirror
+      // cannot list its members yet. Their ids were minted here, so the batch
+      // names them itself rather than waiting for a read that has not happened.
+      void placeBatch({
+        items: target.items,
+        groupId,
+        label: clean.join(', '),
+        members: [
+          { id: newMemberId, profile_id: profile?.id ?? null },
+          ...ghostIds.map((id) => ({ id, profile_id: null })),
+        ],
+        currency,
+      });
     },
     [
       addGhost,
       assigning,
-      assignTo,
+      chooseExistingGroup,
       closeAssign,
       createGroup,
       groupBySignature,
       newGroupId,
       newMemberId,
+      placeBatch,
+      profile?.id,
       t.captures.couldNotSave,
       t.captures.title,
     ],
@@ -905,26 +1104,57 @@ export default function CapturesScreen() {
                 glyph. The title says what this sheet is for; a line under this
                 repeating "choose where to add this expense" only said it again,
                 so the summary is the whole of the preamble now. */}
-        {assigning ? (
+        {assigningCapture ? (
           <Row style={{ gap: theme.spacing.md, alignItems: 'center' }}>
             <CategoryBadge
-              category={assigning.category}
-              meta={assigning.category_meta}
-              description={assigning.description}
+              category={assigningCapture.category}
+              meta={assigningCapture.category_meta}
+              description={assigningCapture.description}
               size={38}
             />
             <View style={{ flex: 1, minWidth: 0 }}>
               <MoneyText
-                amount={BigInt(assigning.amount)}
-                currency={assigning.currency}
+                amount={BigInt(assigningCapture.amount)}
+                currency={assigningCapture.currency}
                 locale={locale}
                 variant="subheading"
               />
-              {assigning.description ? (
+              {assigningCapture.description ? (
                 <Text variant="caption" tone="muted" numberOfLines={1}>
-                  {assigning.description}
+                  {assigningCapture.description}
                 </Text>
               ) : null}
+            </View>
+          </Row>
+        ) : batchPreview ? (
+          /* A whole cluster is being placed: the batch card's own glyph and
+             running total, so the sheet says how much money the next tap moves
+             and how many drafts it clears. */
+          <Row style={{ gap: theme.spacing.md, alignItems: 'center' }}>
+            <View
+              style={{
+                width: 38,
+                height: 38,
+                borderRadius: 12,
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: theme.color.brandSoft,
+              }}
+            >
+              <Ionicons name="layers-outline" size={iconSize.md} color={theme.color.brand} />
+            </View>
+            <View style={{ flex: 1, minWidth: 0 }}>
+              {batchPreview.total !== null ? (
+                <MoneyText
+                  amount={batchPreview.total}
+                  currency={batchPreview.currency}
+                  locale={locale}
+                  variant="subheading"
+                />
+              ) : null}
+              <Text variant="caption" tone="muted" numberOfLines={1}>
+                {plural(locale, batchPreview.count, t.captures.batchExpenses)}
+              </Text>
             </View>
           </Row>
         ) : null}
@@ -948,9 +1178,16 @@ export default function CapturesScreen() {
           style={{ flexShrink: 1 }}
         >
           <DestinationPicker
-            // Remount per capture, so the tab and any half-made people selection
-            // start fresh on each open rather than carrying over from the last.
-            key={assigning?.id ?? 'closed'}
+            // Remount per draft (or per batch), so the tab and any half-made
+            // people selection start fresh on each open rather than carrying
+            // over from the last.
+            key={
+              assigning
+                ? assigning.kind === 'capture'
+                  ? assigning.capture.id
+                  : assigning.items[0]!.id
+                : 'closed'
+            }
             selection={pickerSelection}
             // The sheet's own heading already says what this is; a second
             // "SAVE TO" line under it would only say it again.
@@ -959,7 +1196,11 @@ export default function CapturesScreen() {
             // unassigned, and "just me" writes to the personal ledger, which
             // this screen has no path to.
             pinned={[]}
-            createRow={{ label: t.captures.assignNew }}
+            // "New group" routes away to /new-group, which carries one draft
+            // back to the form; a batch stays here, so the row is not offered
+            // for one. Naming the people it was with still makes a group —
+            // that path (the People tab) places the whole batch into it.
+            createRow={assigning?.kind === 'batch' ? null : { label: t.captures.assignNew }}
             emptyGroups={t.captures.noGroups}
             // A group with no name of its own reads as its members here, which
             // needs the membership only the home summary holds.
@@ -970,15 +1211,18 @@ export default function CapturesScreen() {
             onChoose={(choice) => {
               // The Sheet stays mounted through its fade-out, so this can fire a
               // frame after the backdrop cleared `assigning`.
-              const capture = assigning;
-              if (!capture) return;
+              const target = assigning;
+              if (!target) return;
               if (choice.kind === 'existing') {
-                assignTo(capture, choice.groupId);
-              } else if (choice.kind === 'create') {
+                chooseExistingGroup(target, choice.groupId);
+              } else if (choice.kind === 'create' && target.kind === 'capture') {
                 // Carry the capture through group creation so new-group can hand
                 // it back and finish the assignment.
                 closeAssign();
-                router.push({ pathname: '/new-group', params: { assignCaptureId: capture.id } });
+                router.push({
+                  pathname: '/new-group',
+                  params: { assignCaptureId: target.capture.id },
+                });
               }
             }}
             onResolvePeople={(names) => void assignToPeople(names)}
@@ -1044,6 +1288,21 @@ export default function CapturesScreen() {
             <Text variant="heading" numberOfLines={1} style={{ marginBottom: theme.spacing.xs }}>
               {plural(locale, menu.items.length, t.captures.batchExpenses)}
             </Text>
+            {/* The whole cluster into one group, in one tap — the alternative
+                to expanding it and answering the same question once per row.
+                Opens the very same picker a single draft opens, so the choice
+                is made the same way whichever is riding on it. */}
+            <ActionSheetRow
+              icon="people-outline"
+              label={t.captures.assignBatch}
+              tone="brand"
+              onPress={() => {
+                const items = menu.items;
+                setMenu(null);
+                openAssignBatch(items);
+              }}
+            />
+            <Divider />
             <ActionSheetRow
               icon="trash-outline"
               label={t.captures.deleteBatch}

--- a/apps/mobile/src/app/captures.tsx
+++ b/apps/mobile/src/app/captures.tsx
@@ -514,7 +514,10 @@ export default function CapturesScreen() {
   // no single capture to preview or pre-aim from.
   const assigningCapture = assigning?.kind === 'capture' ? assigning.capture : null;
   // A batch write is several queue writes behind one tap; the lock keeps a
-  // second tap (or a re-entrant people-tab resolve) from filing them twice.
+  // second tap from filing them twice. It guards the write itself — the group a
+  // People-tab confirm creates is made before this is taken, and a double tap
+  // there can still make two groups (as it could before this screen wrote
+  // anything in batch).
   const placing = useRef(false);
   // The id a group made from picked people will take, minted before the create
   // so the ghosts and the expense behind it can already name it — the
@@ -721,6 +724,8 @@ export default function CapturesScreen() {
       /** What to call the group in the confirmation. */
       label: string;
       members: readonly AssignMember[];
+      /** Who the viewer is in that group — the payer. Resolved by the caller. */
+      myMemberId: string | null;
       currency: string;
     }): Promise<void> => {
       if (placing.current) return;
@@ -731,10 +736,16 @@ export default function CapturesScreen() {
         // the inbox read already knows, and writing it again would file the same
         // dinner twice.
         const waiting = stillWaiting(input.items, rows);
+        if (waiting.length === 0) {
+          // There is nothing left to do, and a sheet that simply closes would
+          // read as "done" for work this device never did. Say what happened.
+          toast.show(t.captures.assignBatchAlreadyDone);
+          return;
+        }
         const plan = planCaptureAssign({
           captures: waiting,
           members: input.members,
-          myProfileId: profile?.id ?? null,
+          myMemberId: input.myMemberId,
           currency: input.currency,
         });
 
@@ -776,6 +787,14 @@ export default function CapturesScreen() {
         }
         lines.push(plural(locale, failed, t.captures.assignBatchSomeFailed));
         Alert.alert(t.captures.title, lines.join('\n\n'));
+      } catch (caught) {
+        // The callers fire this without awaiting it, so anything the planning
+        // step throws would otherwise leave with no word to the person whose
+        // drafts are still sitting there.
+        Alert.alert(
+          t.captures.title,
+          friendlyError(caught, t.captures.couldNotSave, 'captures.assignBatch'),
+        );
       } finally {
         placing.current = false;
       }
@@ -785,10 +804,11 @@ export default function CapturesScreen() {
       guard,
       locale,
       mutate,
-      profile?.id,
       rows,
+      t.captures.assignBatchAlreadyDone,
       t.captures.assignBatchSomeFailed,
       t.captures.assignedBatch,
+      t.captures.couldNotSave,
       t.captures.title,
       toast,
     ],
@@ -817,6 +837,10 @@ export default function CapturesScreen() {
         groupId,
         label: group ? groupLabel(group, members, profile?.id) : '',
         members,
+        // Compared against `profile?.id` — undefined, never null — exactly as
+        // the add-expense form resolves the same thing. A ghost's null
+        // `profile_id` can therefore never answer to an unloaded profile.
+        myMemberId: members.find((member) => member.profile_id === profile?.id)?.id ?? null,
         // A draft assigned through the form takes the group's currency too
         // (the href carries no currency of its own), so the batch does the same.
         currency: group?.default_currency ?? target.items[0]!.currency,
@@ -888,10 +912,10 @@ export default function CapturesScreen() {
         items: target.items,
         groupId,
         label: clean.join(', '),
-        members: [
-          { id: newMemberId, profile_id: profile?.id ?? null },
-          ...ghostIds.map((id) => ({ id, profile_id: null })),
-        ],
+        members: [{ id: newMemberId }, ...ghostIds.map((id) => ({ id }))],
+        // Not looked up but minted: this group's creator membership is the one
+        // this screen just chose an id for, so who paid is known outright.
+        myMemberId: newMemberId,
         currency,
       });
     },
@@ -905,7 +929,6 @@ export default function CapturesScreen() {
       newGroupId,
       newMemberId,
       placeBatch,
-      profile?.id,
       t.captures.couldNotSave,
       t.captures.title,
     ],

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -100,6 +100,7 @@ import {
 } from '@/lib/expenseForm';
 import { captureReceipt, pickReceiptImage, type PickedImage } from '@/lib/image';
 import { recogniseReceipt } from '@/lib/ocr';
+import { capturePaymentMethod } from '@/lib/captureAssign';
 import { matchMemberNames, stripMemberNames } from '@/lib/voiceExpense';
 import {
   entryValues,
@@ -360,6 +361,7 @@ export default function AddExpenseScreen() {
     category: captureCategory,
     categoryMeta: captureCategoryMeta,
     location: captureLocation,
+    paymentMethod: capturePayment,
     expenseDate: captureExpenseDate,
     focus,
   } = useLocalSearchParams<{
@@ -379,6 +381,9 @@ export default function AddExpenseScreen() {
     /** The capture's {lat,lng,name} place, JSON-encoded, carried onto the
      *  assigned expense (A43). Absent when the capture had no location. */
     location?: string;
+    /** How the capture says it was paid, so assigning keeps it. Absent when the
+     *  draft never named one, and on a voice hand-off. */
+    paymentMethod?: string;
     expenseDate?: string;
     /** 'amount' when the editor was opened by tapping the total on the expense
      *  screen — the amount field takes focus and raises the keyboard on arrival. */
@@ -655,6 +660,10 @@ export default function AddExpenseScreen() {
       setCategoryChosen(Boolean(captureCategory));
       // Carry the capture's place onto the expense it becomes (A43).
       setLocation(parseLocationParam(captureLocation));
+      // And how the draft says it was paid, so assigning does not quietly turn a
+      // card payment into cash. A voice hand-off carries none and keeps the
+      // default; anything the ledger does not know falls back to it too.
+      setPaymentMethod(capturePaymentMethod(capturePayment));
       seedSolePayer(myMemberId, safeBigInt(captureAmount));
     } else if (draft) {
       // A draft outranks the saved version: it is what the user was in the

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1527,6 +1527,12 @@ export interface UiStrings {
     /** Confirm body when deleting a whole voice batch at once. */
     deleteBatch: string;
     deleteBatchConfirm: PluralForms;
+    /** The batch ⋯ can also place the whole cluster in one group at once: the
+     *  menu item, the confirmation once they land, and — because a queued write
+     *  can refuse — what is said when only some of them made it. */
+    assignBatch: string;
+    assignedBatch: PluralForms;
+    assignBatchSomeFailed: PluralForms;
     assign: string;
     /** Chip label on a pre-aimed row: "Add to {name}" (the group it was tagged for). */
     addTo: string;
@@ -4053,6 +4059,15 @@ const en: UiStrings = {
       one: 'Delete this expense?',
       other: 'Delete all {n} expenses in this batch?',
     },
+    assignBatch: 'Add these to a group',
+    assignedBatch: {
+      one: '{n} expense added to {name}',
+      other: '{n} expenses added to {name}',
+    },
+    assignBatchSomeFailed: {
+      one: '{n} could not be added, and is still saved for later.',
+      other: '{n} could not be added, and are still saved for later.',
+    },
     assign: 'Add to group',
     addTo: 'Add to {name}',
     assignTitle: 'Add to a group',
@@ -6550,6 +6565,15 @@ const ta: UiStrings = {
     deleteBatchConfirm: {
       one: 'இந்தச் செலவை நீக்கவா?',
       other: 'இந்த தொகுப்பில் உள்ள {n} செலவுகளையும் நீக்கவா?',
+    },
+    assignBatch: 'இவற்றை ஒரு குழுவில் சேர்',
+    assignedBatch: {
+      one: '{n} செலவு {name} இல் சேர்க்கப்பட்டது',
+      other: '{n} செலவுகள் {name} இல் சேர்க்கப்பட்டன',
+    },
+    assignBatchSomeFailed: {
+      one: '{n} சேர்க்க முடியவில்லை; அது இன்னும் பிறகுக்காகச் சேமித்திருக்கிறது.',
+      other: '{n} சேர்க்க முடியவில்லை; அவை இன்னும் பிறகுக்காகச் சேமித்திருக்கின்றன.',
     },
     assign: 'குழுவில் சேர்',
     addTo: '{name} இல் சேர்',
@@ -9090,6 +9114,15 @@ const hi: UiStrings = {
     batchHint: 'एक साथ असाइन करें, या हर एक को खोलकर संभालें',
     deleteBatch: 'ये खर्च हटाएँ',
     deleteBatchConfirm: { one: 'यह खर्च हटाएँ?', other: 'इस बैच के सभी {n} खर्च हटाएँ?' },
+    assignBatch: 'इन्हें किसी समूह में जोड़ें',
+    assignedBatch: {
+      one: '{n} खर्च {name} में जोड़ा गया',
+      other: '{n} खर्च {name} में जोड़े गए',
+    },
+    assignBatchSomeFailed: {
+      one: '{n} जोड़ा नहीं जा सका, वह अब भी बाद के लिए सहेजा है।',
+      other: '{n} जोड़े नहीं जा सके, वे अब भी बाद के लिए सहेजे हैं।',
+    },
     assign: 'समूह में जोड़ें',
     addTo: '{name} में जोड़ें',
     assignTitle: 'किसी समूह में जोड़ें',
@@ -11638,6 +11671,21 @@ const ar: UiStrings = {
     deleteBatchConfirm: {
       one: 'حذف هذا المصروف؟',
       other: 'حذف كل المصاريف الـ {n} في هذه المجموعة؟',
+    },
+    assignBatch: 'أضِف هذه إلى مجموعة',
+    assignedBatch: {
+      one: 'أُضيف مصروف واحد إلى {name}',
+      two: 'أُضيف مصروفان إلى {name}',
+      few: 'أُضيفت {n} مصاريف إلى {name}',
+      many: 'أُضيف {n} مصروفًا إلى {name}',
+      other: 'أُضيف {n} مصروف إلى {name}',
+    },
+    assignBatchSomeFailed: {
+      one: 'تعذّرت إضافة مصروف واحد، وما زال محفوظًا لوقت لاحق.',
+      two: 'تعذّرت إضافة مصروفين، وما زالا محفوظين لوقت لاحق.',
+      few: 'تعذّرت إضافة {n} مصاريف، وما زالت محفوظة لوقت لاحق.',
+      many: 'تعذّرت إضافة {n} مصروفًا، وما زالت محفوظة لوقت لاحق.',
+      other: 'تعذّرت إضافة {n} مصروف، وما زالت محفوظة لوقت لاحق.',
     },
     assign: 'أضِف إلى مجموعة',
     addTo: 'أضِف إلى {name}',

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1533,6 +1533,8 @@ export interface UiStrings {
     assignBatch: string;
     assignedBatch: PluralForms;
     assignBatchSomeFailed: PluralForms;
+    /** Nothing was left to place — another device had already placed them. */
+    assignBatchAlreadyDone: string;
     assign: string;
     /** Chip label on a pre-aimed row: "Add to {name}" (the group it was tagged for). */
     addTo: string;
@@ -4068,6 +4070,7 @@ const en: UiStrings = {
       one: '{n} could not be added, and is still saved for later.',
       other: '{n} could not be added, and are still saved for later.',
     },
+    assignBatchAlreadyDone: 'These were already added somewhere else',
     assign: 'Add to group',
     addTo: 'Add to {name}',
     assignTitle: 'Add to a group',
@@ -6575,6 +6578,7 @@ const ta: UiStrings = {
       one: '{n} சேர்க்க முடியவில்லை; அது இன்னும் பிறகுக்காகச் சேமித்திருக்கிறது.',
       other: '{n} சேர்க்க முடியவில்லை; அவை இன்னும் பிறகுக்காகச் சேமித்திருக்கின்றன.',
     },
+    assignBatchAlreadyDone: 'இவை ஏற்கனவே வேறு சாதனத்தில் சேர்க்கப்பட்டுவிட்டன',
     assign: 'குழுவில் சேர்',
     addTo: '{name} இல் சேர்',
     assignTitle: 'ஒரு குழுவில் சேர்க்கவும்',
@@ -9123,6 +9127,7 @@ const hi: UiStrings = {
       one: '{n} जोड़ा नहीं जा सका, वह अब भी बाद के लिए सहेजा है।',
       other: '{n} जोड़े नहीं जा सके, वे अब भी बाद के लिए सहेजे हैं।',
     },
+    assignBatchAlreadyDone: 'ये पहले ही कहीं और जोड़े जा चुके हैं',
     assign: 'समूह में जोड़ें',
     addTo: '{name} में जोड़ें',
     assignTitle: 'किसी समूह में जोड़ें',
@@ -11687,6 +11692,7 @@ const ar: UiStrings = {
       many: 'تعذّرت إضافة {n} مصروفًا، وما زالت محفوظة لوقت لاحق.',
       other: 'تعذّرت إضافة {n} مصروف، وما زالت محفوظة لوقت لاحق.',
     },
+    assignBatchAlreadyDone: 'أُضيفت هذه من جهاز آخر بالفعل',
     assign: 'أضِف إلى مجموعة',
     addTo: 'أضِف إلى {name}',
     assignTitle: 'أضِف إلى مجموعة',

--- a/apps/mobile/src/lib/captureAssign.ts
+++ b/apps/mobile/src/lib/captureAssign.ts
@@ -10,7 +10,25 @@
  * replaces (back must not return to the half-made group screen).
  */
 
+import type { PaymentMethod } from '@waves/core';
+
 import { type CaptureRow } from '@/data/types';
+
+/** The methods the ledger knows (`PaymentMethod`), as a runtime guard. */
+const PAYMENT_METHODS: readonly string[] = ['cash', 'upi', 'credit', 'debit', 'forex'];
+
+/**
+ * How a draft says it was paid, as the expense form's own value.
+ *
+ * A capture stores this as free text from an older build's picker, so it is
+ * narrowed here rather than cast: anything the ledger does not know falls back
+ * to the form's default. One place answers it, because both routes out of the
+ * inbox — the form and the batch write — must agree, or the same draft would
+ * become a different expense depending on which one a person took.
+ */
+export function capturePaymentMethod(value: string | null | undefined): PaymentMethod {
+  return PAYMENT_METHODS.includes(value ?? '') ? (value as PaymentMethod) : 'cash';
+}
 
 function fold(value: string): string {
   return value
@@ -39,6 +57,12 @@ export function assignCaptureHref(capture: CaptureRow, groupId: string) {
       ...(capture.category_meta ? { categoryMeta: JSON.stringify(capture.category_meta) } : {}),
       // The place the capture recorded, so the assigned expense keeps it (A43).
       ...(capture.location ? { location: JSON.stringify(capture.location) } : {}),
+      // How the draft says it was paid. It used not to travel at all, so a
+      // draft recorded as "credit card" became a cash expense the moment it was
+      // assigned — a field the person had filled in, dropped in the handoff.
+      ...(capture.payment_method
+        ? { paymentMethod: capturePaymentMethod(capture.payment_method) }
+        : {}),
       expenseDate: capture.expense_date,
     },
   };

--- a/apps/mobile/src/lib/captureBulkAssign.ts
+++ b/apps/mobile/src/lib/captureBulkAssign.ts
@@ -54,9 +54,9 @@ export interface CaptureAssignWrite {
 export interface CaptureAssignPlan {
   readonly writes: readonly CaptureAssignWrite[];
   /**
-   * Drafts that cannot become an expense at all — an amount that is not a whole
-   * number of minor units. They are counted as failures and left in the inbox
-   * rather than quietly skipped.
+   * Drafts that cannot become an expense at all — an amount that is not a
+   * positive whole number of minor units. They are counted as failures and left
+   * in the inbox rather than quietly skipped.
    */
   readonly unusable: readonly CaptureRow[];
   /** Set when the group itself cannot take an expense; then `writes` is empty. */
@@ -68,7 +68,7 @@ function minorAmount(value: string): bigint | null {
   if (!/^-?\d+$/.test(value.trim())) return null;
   try {
     const amount = BigInt(value.trim());
-    return amount < 0n ? null : amount;
+    return amount <= 0n ? null : amount;
   } catch {
     return null;
   }

--- a/apps/mobile/src/lib/captureBulkAssign.ts
+++ b/apps/mobile/src/lib/captureBulkAssign.ts
@@ -25,20 +25,27 @@
  * (mobile's vitest renders nothing; see vitest.config.ts).
  */
 
-import { computeShares, type PaymentMethod, type SplitParams } from '@waves/core';
+import { computeShares, type SplitParams } from '@waves/core';
 
 import type { CaptureRow } from '@/data/types';
+import { capturePaymentMethod } from '@/lib/captureAssign';
 
 /** Everyone in, divided evenly — the add-expense form's own default. */
 const EQUAL: SplitParams = { kind: 'equal' };
 
-/** The methods the ledger knows; anything else on a draft is not sent. */
-const PAYMENT_METHODS: readonly string[] = ['cash', 'upi', 'credit', 'debit', 'forex'];
-
-/** The member fields a plan reads. `summary.membersFor(groupId)` satisfies it. */
+/**
+ * The member fields a plan reads: an id, and nothing else.
+ *
+ * Deliberately not the profile id. Working out "which of these is me" from a
+ * profile id is identity resolution, and a plan is the wrong place for it: a
+ * ghost carries `profile_id: null`, so a comparison against an unloaded profile
+ * (`null`) matches the first ghost and makes them sole payer of every expense in
+ * the cluster. The caller knows who it is — the form resolves the same thing
+ * against `profile?.id`, and the new-people path mints the id outright — so it
+ * passes the answer in rather than leaving it to be guessed here.
+ */
 export interface AssignMember {
   readonly id: string;
-  readonly profile_id: string | null;
 }
 
 /** One draft's expense, ready to be queued as an `expense.create` on the group. */
@@ -95,23 +102,23 @@ export function stillWaiting(
 /**
  * What to write so a whole cluster lands in one group.
  *
- * `myProfileId` decides who is down as having paid: the viewer's own membership
- * when they are in the group, and otherwise the first member, which is the same
- * fallback the voice save uses — an expense with no payer is not a state the
- * ledger has.
+ * `myMemberId` is the viewer's membership in that group, already resolved by
+ * the caller; it is who goes down as having paid. It falls back to the first
+ * member — the same fallback the voice save uses — because an expense nobody
+ * paid is not a state the ledger has.
  */
 export function planCaptureAssign(input: {
   readonly captures: readonly CaptureRow[];
   readonly members: readonly AssignMember[];
-  readonly myProfileId: string | null;
+  /** The viewer's own member id in this group, or null when they have none. */
+  readonly myMemberId: string | null;
   /** The group's own currency — a capture assigned through the form takes it too. */
   readonly currency: string;
 }): CaptureAssignPlan {
   const participants = input.members.map((member) => member.id);
-  const payer =
-    input.members.find((member) => member.profile_id === input.myProfileId)?.id ??
-    participants[0] ??
-    null;
+  const mine =
+    input.myMemberId && participants.includes(input.myMemberId) ? input.myMemberId : null;
+  const payer = mine ?? participants[0] ?? null;
   if (!payer || participants.length === 0) {
     return { writes: [], unusable: [...input.captures], problem: 'no-members' };
   }
@@ -151,11 +158,9 @@ export function planCaptureAssign(input: {
         splitParams: EQUAL,
         participants,
         payers: { [payer]: amount.toString() },
-        // How the draft says it was paid, when it says something the ledger
-        // knows; the form's own default otherwise.
-        paymentMethod: (PAYMENT_METHODS.includes(capture.payment_method ?? '')
-          ? capture.payment_method
-          : 'cash') as PaymentMethod,
+        // How the draft says it was paid — read through the same helper the
+        // form's own handoff uses, so both routes produce the same expense.
+        paymentMethod: capturePaymentMethod(capture.payment_method),
         // The place the draft recorded (A43), kept the way the form keeps it.
         location: capture.location,
         expectedShares: Object.fromEntries(

--- a/apps/mobile/src/lib/captureBulkAssign.ts
+++ b/apps/mobile/src/lib/captureBulkAssign.ts
@@ -1,0 +1,171 @@
+/**
+ * Emptying a whole "saved for later" cluster into one group, in one go.
+ *
+ * The drafts inbox folds expenses caught in one breath into a single
+ * collapsible card, and that card's ⋯ can place the lot at once. Assigning them
+ * one at a time still exists and is untouched — that path opens the add-expense
+ * form per draft, which is where a person goes to say who split what. This is
+ * the other half of the same intent: several drafts, one destination, the
+ * ordinary defaults.
+ *
+ * Those defaults are exactly the ones the form itself opens with for a capture:
+ * everybody still in the group is in the split, it is split equally, and the
+ * person assigning is down as having paid. Nothing here invents a figure the
+ * form would not have shown, and every field the form carries over from a
+ * capture (`assignCaptureHref`) is carried over here too.
+ *
+ * The expense takes the capture's own id. It is a uuid, it is unique, and a
+ * capture becomes exactly one expense — so a retry after a half-finished run
+ * writes the same ledger row again rather than a second copy of the same
+ * dinner.
+ *
+ * Pure on purpose: the screen owns the queue, the sheet and the toast, and this
+ * only decides what to write. That is what lets "all of them go, none goes
+ * missing, nothing outside the cluster is touched" be tested with no device
+ * (mobile's vitest renders nothing; see vitest.config.ts).
+ */
+
+import { computeShares, type PaymentMethod, type SplitParams } from '@waves/core';
+
+import type { CaptureRow } from '@/data/types';
+
+/** Everyone in, divided evenly — the add-expense form's own default. */
+const EQUAL: SplitParams = { kind: 'equal' };
+
+/** The methods the ledger knows; anything else on a draft is not sent. */
+const PAYMENT_METHODS: readonly string[] = ['cash', 'upi', 'credit', 'debit', 'forex'];
+
+/** The member fields a plan reads. `summary.membersFor(groupId)` satisfies it. */
+export interface AssignMember {
+  readonly id: string;
+  readonly profile_id: string | null;
+}
+
+/** One draft's expense, ready to be queued as an `expense.create` on the group. */
+export interface CaptureAssignWrite {
+  /** The draft this closes once the expense is on the queue. */
+  readonly captureId: string;
+  /** The expense it becomes — the draft's own id, so a retry appends nothing. */
+  readonly expenseId: string;
+  /** The `/sync` envelope, amounts already decimal strings (bigint is not JSON). */
+  readonly payload: Record<string, unknown>;
+}
+
+export interface CaptureAssignPlan {
+  readonly writes: readonly CaptureAssignWrite[];
+  /**
+   * Drafts that cannot become an expense at all — an amount that is not a whole
+   * number of minor units. They are counted as failures and left in the inbox
+   * rather than quietly skipped.
+   */
+  readonly unusable: readonly CaptureRow[];
+  /** Set when the group itself cannot take an expense; then `writes` is empty. */
+  readonly problem: 'no-members' | null;
+}
+
+/** A stored minor-unit amount, or null when the row carries something else. */
+function minorAmount(value: string): bigint | null {
+  if (!/^-?\d+$/.test(value.trim())) return null;
+  try {
+    const amount = BigInt(value.trim());
+    return amount < 0n ? null : amount;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The drafts of a cluster that are still waiting.
+ *
+ * The ⋯ sheet holds the cluster as it looked when it opened; by the time a
+ * group is chosen another device may have assigned one of them, and the inbox
+ * read (`useCaptures`, open drafts only) will already know. Writing the
+ * disappeared one would file the same dinner twice, so the run is narrowed to
+ * whatever the inbox still shows — order kept, so the person sees the same list
+ * they picked from.
+ */
+export function stillWaiting(
+  items: readonly CaptureRow[],
+  open: readonly CaptureRow[],
+): CaptureRow[] {
+  const ids = new Set(open.map((row) => row.id));
+  return items.filter((item) => ids.has(item.id));
+}
+
+/**
+ * What to write so a whole cluster lands in one group.
+ *
+ * `myProfileId` decides who is down as having paid: the viewer's own membership
+ * when they are in the group, and otherwise the first member, which is the same
+ * fallback the voice save uses — an expense with no payer is not a state the
+ * ledger has.
+ */
+export function planCaptureAssign(input: {
+  readonly captures: readonly CaptureRow[];
+  readonly members: readonly AssignMember[];
+  readonly myProfileId: string | null;
+  /** The group's own currency — a capture assigned through the form takes it too. */
+  readonly currency: string;
+}): CaptureAssignPlan {
+  const participants = input.members.map((member) => member.id);
+  const payer =
+    input.members.find((member) => member.profile_id === input.myProfileId)?.id ??
+    participants[0] ??
+    null;
+  if (!payer || participants.length === 0) {
+    return { writes: [], unusable: [...input.captures], problem: 'no-members' };
+  }
+
+  const writes: CaptureAssignWrite[] = [];
+  const unusable: CaptureRow[] = [];
+
+  for (const capture of input.captures) {
+    const amount = minorAmount(capture.amount);
+    if (amount === null) {
+      unusable.push(capture);
+      continue;
+    }
+    const expenseId = capture.id;
+    const shares = computeShares({
+      amount,
+      currency: input.currency,
+      params: EQUAL,
+      participants,
+      seed: expenseId,
+    });
+    writes.push({
+      captureId: capture.id,
+      expenseId,
+      payload: {
+        expenseId,
+        // Blank stays blank, exactly as the form leaves it: an undescribed row
+        // must not be handed an English word nobody typed.
+        description: capture.description.trim(),
+        category: capture.category,
+        categoryMeta: capture.category_meta,
+        // A capture keeps the day it was caught (`expenseDateFor`).
+        expenseDate: capture.expense_date,
+        currency: input.currency,
+        amount: amount.toString(),
+        fx: null,
+        splitParams: EQUAL,
+        participants,
+        payers: { [payer]: amount.toString() },
+        // How the draft says it was paid, when it says something the ledger
+        // knows; the form's own default otherwise.
+        paymentMethod: (PAYMENT_METHODS.includes(capture.payment_method ?? '')
+          ? capture.payment_method
+          : 'cash') as PaymentMethod,
+        // The place the draft recorded (A43), kept the way the form keeps it.
+        location: capture.location,
+        expectedShares: Object.fromEntries(
+          [...shares].map(([member, share]) => [member, share.toString()]),
+        ),
+        // A create, never an edit — there is no earlier version to be based on.
+        baseVersionNo: null,
+      },
+    });
+  }
+
+  return { writes, unusable, problem: null };
+}

--- a/apps/mobile/src/sync/engine.ts
+++ b/apps/mobile/src/sync/engine.ts
@@ -16,6 +16,7 @@ import * as Network from 'expo-network';
 import {
   applyOutcomes,
   dialingCodeForCountry,
+  discard as discardMutation,
   emptyMirror,
   enqueue as enqueueMutation,
   markFailed,
@@ -305,9 +306,15 @@ export class SyncEngine {
    * This is the only path that removes it, and it is deliberately a person's
    * decision: dropping a rejected `group.create` takes the group off the phone,
    * because the queue overlay is the only place that group has ever existed.
+   *
+   * The rule that decides what "whatever it made" means lives in the queue
+   * itself (`discard` in @waves/core), where it can be tested — abandoning an
+   * expense also abandons the `capture.assign` that was waiting to close a draft
+   * against it, so the draft comes back into the inbox rather than being closed
+   * against an expense nobody will ever write.
    */
   async discard(clientMutationId: string): Promise<void> {
-    const queue = this.state.queue.filter((item) => item.clientMutationId !== clientMutationId);
+    const queue = discardMutation(this.state.queue, clientMutationId);
     this.set({
       queue,
       rejected: describeRejections(queue),

--- a/apps/mobile/test/captureAssign.test.ts
+++ b/apps/mobile/test/captureAssign.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import { CaptureStatus, type CaptureRow } from '../src/data/types';
-import { assignCaptureHref, matchesAssignGroupQuery } from '../src/lib/captureAssign';
+import {
+  assignCaptureHref,
+  capturePaymentMethod,
+  matchesAssignGroupQuery,
+} from '../src/lib/captureAssign';
 
 function capture(overrides: Partial<CaptureRow> = {}): CaptureRow {
   const base: CaptureRow = {
@@ -43,6 +47,32 @@ describe('assignCaptureHref', () => {
         expenseDate: '2026-09-08',
       },
     });
+  });
+
+  it('carries how the draft was paid, so assigning does not turn a card into cash', () => {
+    const href = assignCaptureHref(capture({ payment_method: 'credit' }), 'group-1');
+    expect(href.params).toMatchObject({ paymentMethod: 'credit' });
+  });
+
+  it('says nothing about payment when the draft named none', () => {
+    const href = assignCaptureHref(capture({ payment_method: null }), 'group-1');
+    expect(href.params).not.toHaveProperty('paymentMethod');
+  });
+});
+
+describe('capturePaymentMethod', () => {
+  it('keeps every method the ledger knows', () => {
+    for (const method of ['cash', 'upi', 'credit', 'debit', 'forex'] as const) {
+      expect(capturePaymentMethod(method)).toBe(method);
+    }
+  });
+
+  it('falls back to the form default for anything it does not know', () => {
+    // A draft's column is plain text, so an older build's value — or none at
+    // all — must land on something the ledger accepts rather than be cast.
+    expect(capturePaymentMethod(null)).toBe('cash');
+    expect(capturePaymentMethod(undefined)).toBe('cash');
+    expect(capturePaymentMethod('crypto')).toBe('cash');
   });
 });
 

--- a/apps/mobile/test/captureBulkAssign.test.ts
+++ b/apps/mobile/test/captureBulkAssign.test.ts
@@ -38,10 +38,8 @@ function capture(overrides: Partial<CaptureRow> = {}): CaptureRow {
   return { ...base, ...overrides };
 }
 
-const MEMBERS = [
-  { id: 'member-me', profile_id: 'user-1' },
-  { id: 'member-ravi', profile_id: null },
-];
+const MEMBERS = [{ id: 'member-me' }, { id: 'member-ravi' }];
+const ME = 'member-me';
 
 describe('planCaptureAssign', () => {
   it('turns every draft in the cluster into an expense for the chosen group', () => {
@@ -52,7 +50,7 @@ describe('planCaptureAssign', () => {
         capture({ id: 'c', amount: '4000' }),
       ],
       members: MEMBERS,
-      myProfileId: 'user-1',
+      myMemberId: ME,
       currency: 'INR',
     });
 
@@ -68,7 +66,7 @@ describe('planCaptureAssign', () => {
     const plan = planCaptureAssign({
       captures: [capture({ id: 'a', amount: '9000' })],
       members: MEMBERS,
-      myProfileId: 'user-1',
+      myMemberId: ME,
       currency: 'INR',
     });
 
@@ -105,7 +103,7 @@ describe('planCaptureAssign', () => {
         }),
       ],
       members: MEMBERS,
-      myProfileId: 'user-1',
+      myMemberId: ME,
       currency: 'INR',
     });
 
@@ -119,8 +117,36 @@ describe('planCaptureAssign', () => {
   it('files a draft nobody else can pay under whoever is in the group', () => {
     const plan = planCaptureAssign({
       captures: [capture({ id: 'a' })],
-      members: [{ id: 'member-ravi', profile_id: 'user-9' }],
-      myProfileId: 'user-1',
+      members: [{ id: 'member-ravi' }],
+      myMemberId: ME,
+      currency: 'INR',
+    });
+
+    expect(plan.writes[0]!.payload).toMatchObject({ payers: { 'member-ravi': '9000' } });
+  });
+
+  it('never makes a ghost the payer when the viewer is unknown', () => {
+    // A ghost has no profile of their own. When identity resolution lived in
+    // here it compared profile ids, and an unloaded profile (null) matched the
+    // first ghost — making them sole payer of every expense in the cluster.
+    // The plan is handed the answer now, so there is nothing to mismatch: with
+    // no viewer it falls to the group's first member, never to whoever happens
+    // to carry a null profile.
+    const plan = planCaptureAssign({
+      captures: [capture({ id: 'a' })],
+      members: [{ id: 'member-me' }, { id: 'ghost-ravi' }],
+      myMemberId: null,
+      currency: 'INR',
+    });
+
+    expect(plan.writes[0]!.payload).toMatchObject({ payers: { 'member-me': '9000' } });
+  });
+
+  it('ignores a viewer who is not in the chosen group', () => {
+    const plan = planCaptureAssign({
+      captures: [capture({ id: 'a' })],
+      members: [{ id: 'member-ravi' }, { id: 'member-asha' }],
+      myMemberId: 'member-from-another-group',
       currency: 'INR',
     });
 
@@ -136,7 +162,7 @@ describe('planCaptureAssign', () => {
         capture({ id: 'c' }),
       ],
       members: MEMBERS,
-      myProfileId: 'user-1',
+      myMemberId: ME,
       currency: 'INR',
     });
 
@@ -151,7 +177,7 @@ describe('planCaptureAssign', () => {
     const plan = planCaptureAssign({
       captures: [capture({ id: 'a' }), capture({ id: 'b' })],
       members: [],
-      myProfileId: 'user-1',
+      myMemberId: ME,
       currency: 'INR',
     });
 
@@ -164,7 +190,7 @@ describe('planCaptureAssign', () => {
     const plan = planCaptureAssign({
       captures: [capture({ id: 'only' })],
       members: MEMBERS,
-      myProfileId: 'user-1',
+      myMemberId: ME,
       currency: 'INR',
     });
 

--- a/apps/mobile/test/captureBulkAssign.test.ts
+++ b/apps/mobile/test/captureBulkAssign.test.ts
@@ -132,6 +132,7 @@ describe('planCaptureAssign', () => {
       captures: [
         capture({ id: 'a' }),
         capture({ id: 'broken', amount: 'not-a-number' }),
+        capture({ id: 'zero', amount: '0' }),
         capture({ id: 'c' }),
       ],
       members: MEMBERS,
@@ -141,8 +142,9 @@ describe('planCaptureAssign', () => {
 
     expect(plan.writes.map((write) => write.captureId)).toEqual(['a', 'c']);
     // Named, not dropped: the screen counts it as a failure and it stays in the
-    // inbox rather than disappearing into a success message.
-    expect(plan.unusable.map((row) => row.id)).toEqual(['broken']);
+    // inbox rather than disappearing into a success message. Zero matches the
+    // single add-expense form, whose Save is blocked until there is an amount.
+    expect(plan.unusable.map((row) => row.id)).toEqual(['broken', 'zero']);
   });
 
   it('writes nothing into a group with nobody left in it', () => {

--- a/apps/mobile/test/captureBulkAssign.test.ts
+++ b/apps/mobile/test/captureBulkAssign.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Placing a whole "saved for later" cluster in one group.
+ *
+ * The point of these is the promise the inbox makes when somebody taps "Add
+ * these to a group": every draft in the cluster goes, in the group they picked,
+ * with the same figures the add-expense form would have shown — and nothing
+ * outside the cluster is touched by it.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { CaptureStatus, type CaptureRow } from '../src/data/types';
+import { planCaptureAssign, stillWaiting } from '../src/lib/captureBulkAssign';
+
+function capture(overrides: Partial<CaptureRow> = {}): CaptureRow {
+  const base: CaptureRow = {
+    id: 'capture-1',
+    owner_user_id: 'user-1',
+    description: 'chai',
+    amount: '9000',
+    currency: 'INR',
+    expense_date: '2026-09-08',
+    category: 'food',
+    category_meta: null,
+    payment_method: null,
+    target_group_id: null,
+    location: null,
+    status: CaptureStatus.Open,
+    assigned_expense_id: null,
+    assigned_group_id: null,
+    created_at: '2026-09-08T08:00:00Z',
+    pending: false,
+    notes: null,
+    photo_path: null,
+    raw_text: null,
+    parsed: null,
+  };
+  return { ...base, ...overrides };
+}
+
+const MEMBERS = [
+  { id: 'member-me', profile_id: 'user-1' },
+  { id: 'member-ravi', profile_id: null },
+];
+
+describe('planCaptureAssign', () => {
+  it('turns every draft in the cluster into an expense for the chosen group', () => {
+    const plan = planCaptureAssign({
+      captures: [
+        capture({ id: 'a', amount: '9000' }),
+        capture({ id: 'b', amount: '15000', description: 'samosas' }),
+        capture({ id: 'c', amount: '4000' }),
+      ],
+      members: MEMBERS,
+      myProfileId: 'user-1',
+      currency: 'INR',
+    });
+
+    expect(plan.problem).toBeNull();
+    expect(plan.unusable).toEqual([]);
+    expect(plan.writes.map((write) => write.captureId)).toEqual(['a', 'b', 'c']);
+    // The draft's own id becomes the expense id, so a retry after a half-run
+    // rewrites the same row rather than filing the dinner twice.
+    expect(plan.writes.map((write) => write.expenseId)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('writes the form defaults: everyone in, split equally, the assigner paid', () => {
+    const plan = planCaptureAssign({
+      captures: [capture({ id: 'a', amount: '9000' })],
+      members: MEMBERS,
+      myProfileId: 'user-1',
+      currency: 'INR',
+    });
+
+    expect(plan.writes[0]!.payload).toMatchObject({
+      expenseId: 'a',
+      description: 'chai',
+      category: 'food',
+      expenseDate: '2026-09-08',
+      currency: 'INR',
+      amount: '9000',
+      splitParams: { kind: 'equal' },
+      participants: ['member-me', 'member-ravi'],
+      payers: { 'member-me': '9000' },
+      paymentMethod: 'cash',
+      baseVersionNo: null,
+    });
+    // Our own division, sent so the server can contradict it rather than
+    // silently disagree.
+    expect(plan.writes[0]!.payload.expectedShares).toEqual({
+      'member-me': '4500',
+      'member-ravi': '4500',
+    });
+  });
+
+  it('keeps what the draft recorded: its tag, its place and how it was paid', () => {
+    const meta = { label: 'Chai runs', icon: 'cafe', tint: 'peach' } as const;
+    const plan = planCaptureAssign({
+      captures: [
+        capture({
+          id: 'a',
+          category_meta: meta,
+          location: { name: 'Marine Drive', lat: 18.94, lng: 72.82 },
+          payment_method: 'credit',
+        }),
+      ],
+      members: MEMBERS,
+      myProfileId: 'user-1',
+      currency: 'INR',
+    });
+
+    expect(plan.writes[0]!.payload).toMatchObject({
+      categoryMeta: meta,
+      location: { name: 'Marine Drive', lat: 18.94, lng: 72.82 },
+      paymentMethod: 'credit',
+    });
+  });
+
+  it('files a draft nobody else can pay under whoever is in the group', () => {
+    const plan = planCaptureAssign({
+      captures: [capture({ id: 'a' })],
+      members: [{ id: 'member-ravi', profile_id: 'user-9' }],
+      myProfileId: 'user-1',
+      currency: 'INR',
+    });
+
+    expect(plan.writes[0]!.payload).toMatchObject({ payers: { 'member-ravi': '9000' } });
+  });
+
+  it('loses none of the others when one draft cannot be written', () => {
+    const plan = planCaptureAssign({
+      captures: [
+        capture({ id: 'a' }),
+        capture({ id: 'broken', amount: 'not-a-number' }),
+        capture({ id: 'c' }),
+      ],
+      members: MEMBERS,
+      myProfileId: 'user-1',
+      currency: 'INR',
+    });
+
+    expect(plan.writes.map((write) => write.captureId)).toEqual(['a', 'c']);
+    // Named, not dropped: the screen counts it as a failure and it stays in the
+    // inbox rather than disappearing into a success message.
+    expect(plan.unusable.map((row) => row.id)).toEqual(['broken']);
+  });
+
+  it('writes nothing into a group with nobody left in it', () => {
+    const plan = planCaptureAssign({
+      captures: [capture({ id: 'a' }), capture({ id: 'b' })],
+      members: [],
+      myProfileId: 'user-1',
+      currency: 'INR',
+    });
+
+    expect(plan.problem).toBe('no-members');
+    expect(plan.writes).toEqual([]);
+    expect(plan.unusable.map((row) => row.id)).toEqual(['a', 'b']);
+  });
+
+  it('places a cluster of one, the same as a cluster of five', () => {
+    const plan = planCaptureAssign({
+      captures: [capture({ id: 'only' })],
+      members: MEMBERS,
+      myProfileId: 'user-1',
+      currency: 'INR',
+    });
+
+    expect(plan.writes).toHaveLength(1);
+    expect(plan.writes[0]!.captureId).toBe('only');
+  });
+});
+
+describe('stillWaiting', () => {
+  it('drops a draft another device assigned while the sheet was open', () => {
+    const a = capture({ id: 'a' });
+    const b = capture({ id: 'b' });
+    const c = capture({ id: 'c' });
+
+    expect(stillWaiting([a, b, c], [a, c]).map((row) => row.id)).toEqual(['a', 'c']);
+  });
+
+  it('never reaches past the cluster into the rest of the inbox', () => {
+    const a = capture({ id: 'a' });
+    const other = capture({ id: 'elsewhere' });
+
+    expect(stillWaiting([a], [a, other]).map((row) => row.id)).toEqual(['a']);
+  });
+
+  it('has nothing to place when the whole cluster went in the meantime', () => {
+    expect(stillWaiting([capture({ id: 'a' })], [])).toEqual([]);
+  });
+});

--- a/packages/core/src/sync/queue.ts
+++ b/packages/core/src/sync/queue.ts
@@ -414,6 +414,26 @@ function expenseIdOf(mutation: MutationEnvelope): string | undefined {
   return stringPayloadField(mutation.payload, 'expenseId') ?? undefined;
 }
 
+/**
+ * The expenses this queue is still carrying — the ones the server has not
+ * confirmed, refusals included (a refusal stays in the queue, rule 3).
+ *
+ * Only the two kinds that *write* an expense count. `capture.assign` names an
+ * expense id too, so counting every payload that mentions one would have an
+ * assign hold itself forever.
+ */
+export function unwrittenExpenseIds(queue: readonly QueuedMutation[]): Set<string> {
+  const ids = new Set<string>();
+  for (const item of queue) {
+    if (item.kind !== MutationKind.ExpenseCreate && item.kind !== MutationKind.ExpenseUpdate) {
+      continue;
+    }
+    const id = expenseIdOf(item);
+    if (id) ids.add(id);
+  }
+  return ids;
+}
+
 export interface BatchOptions {
   readonly now: number;
   readonly limit?: number;
@@ -427,6 +447,18 @@ export interface BatchOptions {
  * all this round — sending its later mutations would apply an edit before the
  * create it depends on. Other groups are unaffected, so one poisoned expense
  * cannot stop the rest of the app from syncing.
+ *
+ * The one dependency that crosses scopes gets the same treatment. Closing a
+ * draft (`capture.assign`, personal scope) records that it became a particular
+ * expense in some group — but that expense is written under the *group's* scope,
+ * and per-group blocking says nothing about a personal one. So a refused
+ * expense left the draft free to close against an expense that does not exist:
+ * the draft leaves the inbox, the money sits refused behind the banner, and
+ * discarding the banner loses it with nothing to fall back on. An assign is
+ * therefore held while the expense it names is still anywhere in the queue —
+ * sent only once the server has confirmed the expense, never merely enqueued
+ * it. Held, not dropped: it goes out on a later round, and if the expense is
+ * refused it waits behind that refusal until a person retries or discards.
  */
 export function nextBatch(
   queue: readonly QueuedMutation[],
@@ -435,9 +467,20 @@ export function nextBatch(
   const { now, limit = 50, maxAttempts = MAX_ATTEMPTS } = options;
   const blocked = new Set<string>();
   const batch: QueuedMutation[] = [];
+  const unwrittenExpenses = unwrittenExpenseIds(queue);
 
   for (const item of [...queue].sort((a, b) => a.seq - b.seq)) {
     if (blocked.has(item.groupId)) continue;
+    // The cross-scope dependency above. It blocks its own scope for the reason
+    // every other hold does: what a person queued after this expects it to have
+    // happened.
+    if (item.kind === MutationKind.CaptureAssign) {
+      const expenseId = expenseIdOf(item);
+      if (expenseId && unwrittenExpenses.has(expenseId)) {
+        blocked.add(item.groupId);
+        continue;
+      }
+    }
     // A refusal is the server's settled answer, so this is not a backoff to
     // wait out — resending would fail identically, forever. It blocks its group
     // for the same reason a stalled mutation does: what is queued behind it

--- a/packages/core/src/sync/queue.ts
+++ b/packages/core/src/sync/queue.ts
@@ -583,12 +583,37 @@ export function markFailed(
   });
 }
 
-/** Drop a dead-lettered mutation the user has chosen to abandon. */
+/**
+ * Drop a mutation the user has chosen to abandon — and anything that was only
+ * ever a claim about it.
+ *
+ * Discarding a refused `expense.create` is a person saying "let that spend go".
+ * A `capture.assign` waiting on it (see `nextBatch`) exists for one purpose: to
+ * record which expense a draft became. With the expense abandoned it is a claim
+ * about something that will now never exist, and sending it would close the
+ * draft against nothing — which is how a refusal turns into a deletion, the one
+ * thing rule 3 is here to prevent. So it goes too, and the draft simply stays in
+ * the inbox for the person to place again.
+ *
+ * Only a discarded *create* cascades. An `expense.update` being abandoned leaves
+ * an expense that already exists on the server, and the assign is still true.
+ * And if another write for the same expense is still queued, the expense is
+ * still coming, so the assign keeps waiting for it instead.
+ */
 export function discard(
   queue: readonly QueuedMutation[],
   clientMutationId: string,
 ): QueuedMutation[] {
-  return queue.filter((item) => item.clientMutationId !== clientMutationId);
+  const dropped = queue.find((item) => item.clientMutationId === clientMutationId);
+  const remaining = queue.filter((item) => item.clientMutationId !== clientMutationId);
+  if (!dropped || dropped.kind !== MutationKind.ExpenseCreate) return remaining;
+
+  const expenseId = expenseIdOf(dropped);
+  if (!expenseId || unwrittenExpenseIds(remaining).has(expenseId)) return remaining;
+
+  return remaining.filter(
+    (item) => !(item.kind === MutationKind.CaptureAssign && expenseIdOf(item) === expenseId),
+  );
 }
 
 /**

--- a/packages/core/test/sync.property.test.ts
+++ b/packages/core/test/sync.property.test.ts
@@ -1031,6 +1031,88 @@ describe('the mutation queue', () => {
     expect(discard(queue, 'a')).toHaveLength(0);
   });
 
+  it('abandoning an expense abandons the draft-closing assign waiting on it', () => {
+    // The action a person actually takes when staring at a refused expense.
+    // Without this the hold simply lifts and the assign goes out — closing the
+    // draft against an expense that was discarded and will never be written,
+    // which is finding #1 arriving by another door. The draft must come back.
+    const OWNER = 'owner-1';
+    let queue: QueuedMutation[] = [];
+    queue = enqueue(queue, {
+      clientMutationId: 'x1',
+      kind: MutationKind.ExpenseCreate,
+      groupId: GROUP,
+      clientCreatedAt: '2026-03-01T00:00:00Z',
+      payload: { expenseId: 'e-1' },
+    });
+    queue = enqueue(queue, {
+      clientMutationId: 'x2',
+      kind: MutationKind.CaptureAssign,
+      groupId: OWNER,
+      clientCreatedAt: '2026-03-01T00:00:01Z',
+      payload: { captureId: 'c-1', groupId: GROUP, expenseId: 'e-1' },
+    });
+    // A second draft's assign, for an expense that synced long ago: untouched.
+    queue = enqueue(queue, {
+      clientMutationId: 'x3',
+      kind: MutationKind.CaptureAssign,
+      groupId: OWNER,
+      clientCreatedAt: '2026-03-01T00:00:02Z',
+      payload: { captureId: 'c-2', groupId: GROUP, expenseId: 'e-other' },
+    });
+
+    expect(discard(queue, 'x1').map((item) => item.clientMutationId)).toEqual(['x3']);
+  });
+
+  it('keeps the assign when the expense is still coming', () => {
+    // Two writes of the same expense (a re-run after a half-finished batch):
+    // dropping one leaves the other, so the expense is still on its way and the
+    // assign must go on waiting rather than be thrown away with it.
+    const OWNER = 'owner-1';
+    let queue: QueuedMutation[] = [];
+    for (const id of ['x1', 'x1b']) {
+      queue = enqueue(queue, {
+        clientMutationId: id,
+        kind: MutationKind.ExpenseCreate,
+        groupId: id === 'x1' ? GROUP : 'g-other',
+        clientCreatedAt: '2026-03-01T00:00:00Z',
+        payload: { expenseId: 'e-1' },
+      });
+    }
+    queue = enqueue(queue, {
+      clientMutationId: 'x2',
+      kind: MutationKind.CaptureAssign,
+      groupId: OWNER,
+      clientCreatedAt: '2026-03-01T00:00:01Z',
+      payload: { captureId: 'c-1', groupId: GROUP, expenseId: 'e-1' },
+    });
+
+    expect(discard(queue, 'x1').map((item) => item.clientMutationId)).toEqual(['x1b', 'x2']);
+  });
+
+  it('leaves the assign alone when an edit is abandoned, not the expense itself', () => {
+    // An `expense.update` that is given up on leaves an expense that already
+    // exists on the server, so the draft's claim about it is still true.
+    const OWNER = 'owner-1';
+    let queue: QueuedMutation[] = [];
+    queue = enqueue(queue, {
+      clientMutationId: 'x1',
+      kind: MutationKind.ExpenseUpdate,
+      groupId: GROUP,
+      clientCreatedAt: '2026-03-01T00:00:00Z',
+      payload: { expenseId: 'e-1' },
+    });
+    queue = enqueue(queue, {
+      clientMutationId: 'x2',
+      kind: MutationKind.CaptureAssign,
+      groupId: OWNER,
+      clientCreatedAt: '2026-03-01T00:00:01Z',
+      payload: { captureId: 'c-1', groupId: GROUP, expenseId: 'e-1' },
+    });
+
+    expect(discard(queue, 'x1').map((item) => item.clientMutationId)).toEqual(['x2']);
+  });
+
   it('collapses un-sent consecutive edits of the same expense', () => {
     const edit = (id: string, description: string): MutationEnvelope => ({
       clientMutationId: id,

--- a/packages/core/test/sync.property.test.ts
+++ b/packages/core/test/sync.property.test.ts
@@ -435,6 +435,95 @@ describe('the mutation queue', () => {
     ).toEqual(['a1', 'a2', 'b1']);
   });
 
+  it('holds a draft-closing assign until the expense it names is confirmed', () => {
+    // The one dependency that crosses scopes: the expense is written under the
+    // group, the `capture.assign` that closes the draft under the owner. Per-
+    // group blocking says nothing about a personal scope, so without this rule
+    // a refused expense still let its draft close against an expense that does
+    // not exist — the draft leaves the inbox and the money sits refused.
+    const OWNER = 'owner-1';
+    let queue: QueuedMutation[] = [];
+    queue = enqueue(queue, {
+      clientMutationId: 'x1',
+      kind: MutationKind.ExpenseCreate,
+      groupId: GROUP,
+      clientCreatedAt: '2026-03-01T00:00:00Z',
+      payload: { expenseId: 'e-1' },
+    });
+    queue = enqueue(queue, {
+      clientMutationId: 'x2',
+      kind: MutationKind.CaptureAssign,
+      groupId: OWNER,
+      clientCreatedAt: '2026-03-01T00:00:01Z',
+      payload: { captureId: 'c-1', groupId: GROUP, expenseId: 'e-1' },
+    });
+
+    // The expense goes; the assign waits, even though its own scope is clear.
+    expect(nextBatch(queue, { now: 0 }).map((item) => item.clientMutationId)).toEqual(['x1']);
+
+    // Confirmed — and only now is the draft closed.
+    const settled = applyOutcomes(queue, [{ clientMutationId: 'x1', status: 'applied' }]).queue;
+    expect(nextBatch(settled, { now: 0 }).map((item) => item.clientMutationId)).toEqual(['x2']);
+  });
+
+  it('keeps the assign waiting while its expense sits refused', () => {
+    const OWNER = 'owner-1';
+    let queue: QueuedMutation[] = [];
+    queue = enqueue(queue, {
+      clientMutationId: 'x1',
+      kind: MutationKind.ExpenseCreate,
+      groupId: GROUP,
+      clientCreatedAt: '2026-03-01T00:00:00Z',
+      payload: { expenseId: 'e-1' },
+    });
+    queue = enqueue(queue, {
+      clientMutationId: 'x2',
+      kind: MutationKind.CaptureAssign,
+      groupId: OWNER,
+      clientCreatedAt: '2026-03-01T00:00:01Z',
+      payload: { captureId: 'c-1', groupId: GROUP, expenseId: 'e-1' },
+    });
+    // A capture create in the same personal scope, queued after the assign.
+    queue = enqueue(queue, {
+      clientMutationId: 'x3',
+      kind: MutationKind.CaptureCreate,
+      groupId: OWNER,
+      clientCreatedAt: '2026-03-01T00:00:02Z',
+      payload: { captureId: 'c-2' },
+    });
+
+    const refused = applyOutcomes(queue, [
+      {
+        clientMutationId: 'x1',
+        status: 'rejected',
+        code: SyncRejectionCode.ValidationFailed,
+        message: 'Unknown member',
+      },
+    ]).queue;
+
+    // Nothing goes: the refusal blocks its group (rule 3) and the assign is
+    // still waiting on it, which holds its own scope behind it in turn.
+    expect(nextBatch(refused, { now: 0 })).toEqual([]);
+    // The refusal is kept, not dropped — it is what the banner offers to retry.
+    expect(refused.map((item) => item.clientMutationId)).toEqual(['x1', 'x2', 'x3']);
+  });
+
+  it('lets an assign through when no expense of that id is queued', () => {
+    // The ordinary case after a restart: the expense synced in an earlier
+    // session, so only the assign is left and it must not wait forever.
+    const OWNER = 'owner-1';
+    let queue: QueuedMutation[] = [];
+    queue = enqueue(queue, {
+      clientMutationId: 'x2',
+      kind: MutationKind.CaptureAssign,
+      groupId: OWNER,
+      clientCreatedAt: '2026-03-01T00:00:01Z',
+      payload: { captureId: 'c-1', groupId: GROUP, expenseId: 'e-1' },
+    });
+
+    expect(nextBatch(queue, { now: 0 }).map((item) => item.clientMutationId)).toEqual(['x2']);
+  });
+
   it('treats applied and duplicate identically — both mean the server has it', () => {
     let queue: QueuedMutation[] = [];
     queue = enqueue(queue, envelope('a', GROUP, MutationKind.ExpenseCreate));

--- a/supabase/functions/sync/captures.test.ts
+++ b/supabase/functions/sync/captures.test.ts
@@ -32,6 +32,9 @@ const DUPLICATE_KEY = {
   message: 'duplicate key value violates unique constraint "captures_pkey"',
 };
 
+const GROUP_ID = '66666666-7777-8888-9999-000000000000';
+const EXPENSE_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
 interface CallerOptions {
   /** The error `insert` reports, or null for a clean first write. */
   insertError?: { code: string; message: string } | null;
@@ -132,5 +135,94 @@ describe('capture.create arriving twice', () => {
 
     expect(outcome).toMatchObject({ status: 'rejected' });
     expect(scoped.maybeSingle).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Closing a draft is what takes a spend out of somebody's inbox, and the expense
+ * it closes against is a *different mutation in a different scope* — written
+ * under the group, while this is written under the owner. Per-group ordering on
+ * the client therefore says nothing about this one: a refused expense used to
+ * leave its assign free to apply, and the draft left the inbox for good while
+ * the money sat refused behind the sync banner. The client now holds an assign
+ * until its expense is confirmed; this is the guarantee underneath it.
+ */
+function assignCaller() {
+  const update = vi.fn(() => {
+    const builder: Record<string, unknown> = {};
+    builder.eq = () => builder;
+    return builder;
+  });
+  const from = vi.fn(() => ({ update }));
+  return { client: { from } as never, update };
+}
+
+/** Service-role client: the replay table, plus the expense existence question. */
+function assignService(expense: { id: string; group_id: string } | null) {
+  const insert = vi.fn(() => Promise.resolve({ error: null }));
+  const from = vi.fn((table: string) => {
+    const builder: Record<string, unknown> = { insert };
+    builder.select = () => builder;
+    builder.eq = () => builder;
+    builder.maybeSingle = () =>
+      Promise.resolve({ data: table === 'expenses' ? expense : null, error: null });
+    return builder;
+  });
+  return { client: { from } as never, insert };
+}
+
+function assignCapture(clientMutationId: string, expenseId = EXPENSE_ID) {
+  return {
+    clientMutationId,
+    kind: 'capture.assign',
+    groupId: OWNER,
+    seq: 1,
+    clientCreatedAt: '2026-09-09T10:00:00.000Z',
+    payload: { captureId: CAPTURE_ID, groupId: GROUP_ID, expenseId },
+  } as never;
+}
+
+describe('capture.assign against the expense it names', () => {
+  it('closes the draft when the expense really is in that group', async () => {
+    const scoped = assignCaller();
+    const session = new SyncSession(
+      scoped.client,
+      assignService({ id: EXPENSE_ID, group_id: GROUP_ID }).client,
+      OWNER,
+    );
+
+    const outcome = await session.apply(assignCapture('mutation-5'));
+
+    expect(outcome).toMatchObject({
+      status: 'applied',
+      result: { captureId: CAPTURE_ID, expenseId: EXPENSE_ID, groupId: GROUP_ID },
+    });
+    expect(scoped.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses to close a draft against an expense that was never written', async () => {
+    // The refused-expense case. Answering "fine" here is what loses the money:
+    // the draft would leave the inbox with nothing to fall back on.
+    const scoped = assignCaller();
+    const session = new SyncSession(scoped.client, assignService(null).client, OWNER);
+
+    const outcome = await session.apply(assignCapture('mutation-6'));
+
+    expect(outcome).toMatchObject({ status: 'rejected', code: 'EXPENSE_MISSING' });
+    expect(scoped.update).not.toHaveBeenCalled();
+  });
+
+  it('refuses an expense that exists but belongs to another group', async () => {
+    const scoped = assignCaller();
+    const session = new SyncSession(
+      scoped.client,
+      assignService({ id: EXPENSE_ID, group_id: 'some-other-group' }).client,
+      OWNER,
+    );
+
+    const outcome = await session.apply(assignCapture('mutation-7'));
+
+    expect(outcome).toMatchObject({ status: 'rejected', code: 'EXPENSE_MISSING' });
+    expect(scoped.update).not.toHaveBeenCalled();
   });
 });

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -934,6 +934,37 @@ export class SyncSession {
     const captureId = requireString(mutation.payload.captureId, 'captureId');
     const groupId = requireString(mutation.payload.groupId, 'groupId');
     const expenseId = requireString(mutation.payload.expenseId, 'expenseId');
+
+    // A draft may only be closed against an expense that actually exists.
+    //
+    // This flip is what takes a spend out of somebody's inbox, and it used to
+    // be taken on the client's word alone. The two writes are separate
+    // mutations in separate scopes — the expense under the group, this under
+    // the owner — so a refused expense (an unknown member, a share mismatch)
+    // did not stop its assign: the draft left the inbox for good while the
+    // money sat refused behind the sync banner, and discarding that banner lost
+    // it with nothing to fall back on. The client now holds an assign until its
+    // expense is confirmed (`nextBatch`), and this is the guarantee underneath:
+    // no expense, no close. Read with the service client because this is a bare
+    // existence question — RLS not seeing the row is not the same as it not
+    // being there, and a false refusal here would strand a real draft.
+    const { data: expense, error: lookupError } = await this.service
+      .from('expenses')
+      .select('id, group_id')
+      .eq('id', expenseId)
+      .maybeSingle();
+    if (lookupError) throw new HttpError(500, 'INTERNAL', lookupError.message);
+    if (!expense || expense.group_id !== groupId) {
+      // Refused, not quietly ignored: a draft the server would not close is a
+      // thing the person has to see, and rule 3 keeps this in the queue where
+      // the banner can offer a retry once the expense lands.
+      throw new HttpError(
+        409,
+        'EXPENSE_MISSING',
+        'That expense has not been saved to this group, so the draft stays in the inbox',
+      );
+    }
+
     // Idempotent and one-way: only an open capture flips, so a replay after the
     // expense already exists is a no-op rather than a second assignment.
     const { error } = await this.caller


### PR DESCRIPTION
Reported: "When I expand [a Saved for later cluster] it makes me click each and every one and assign a group. There's a ••• on the cluster itself — right now it only shows 'Delete these expenses'. It should also give me 'Assign these to a group', so it happens in one go. If the user wants to do them individually, that already exists — don't change that."

The cluster in question is a **voice batch** (`BatchGroupCard`, folded by `foldCaptureBatches`). Its header ••• had exactly one item: delete. It now has "Add these to a group" above a divider and the existing delete.

## How it is wired

The menu item sets the **same** picker state the single-draft flow uses. `assigning` became `AssignTarget = {kind:'capture'} | {kind:'batch'}`, so one `DestinationPicker` in one `Sheet` serves both — same group list, same People tab, same search. Choosing a group runs `chooseExistingGroup`: a single draft takes the old `assignCaptureHref` path byte-for-byte; a batch calls `placeBatch`.

`placeBatch` plans the writes with a new pure `planCaptureAssign`, then per draft does `mutate(MutationKind.ExpenseCreate, …)` — the exact call `add-expense.tsx:1179` makes — followed by the same `useAssignCapture()` mutation the form uses to close a capture. **Both are queue writes, so it rides the offline queue** (ADR-005); no direct RPC.

Defaults are what the form would have shown for that capture: all active members, equal split, you as sole payer, `expectedShares` via `computeShares`, the group's default currency, and the draft's date/category/tag/location carried over. **The expense id is the draft's id**, so a retry after a half-finished run rewrites the same ledger row instead of creating a duplicate.

## Partial failure is told, not swallowed

Each draft has its own try/catch. A failure closes nothing, so that draft stays in the inbox. An unusable draft (amount not in minor units, or a group with no members) counts as failed rather than being skipped quietly. All-success shows a toast; any failure shows an alert carrying both what landed and what did not ("1 could not be added, and is still saved for later"), with no toast racing it. No raw error text reaches the UI.

`stillWaiting()` intersects the sheet's snapshot with the live open-captures read, so a draft another device assigned while the sheet was open is not filed twice.

Guest ceilings: the single path is stopped by `guard.blockWrite()` inside `add-expense.submit`, which a batch never reaches — so `placeBatch` calls `blockWrite()` itself first. Plus a busy-lock ref against double taps.

**The single-capture flow is untouched:** row tap, the row's own ••• items, the pre-aimed picker selection, `assignCaptureHref`, and the `/new-group` carry-through all behave identically.

## Verification

`pnpm lint` 0 errors, typecheck clean, **82 files / 1051 tests pass**, including a new `test/captureBulkAssign.test.ts` (11 cases: whole cluster placed, form defaults and `expectedShares`, tag/place/payment carried, payer fallback, one bad draft not losing the others, empty group, cluster of one, and `stillWaiting` not reaching past the cluster). Three new `captures` keys hand-written in all four locales, Arabic with the full plural set.

Needs a device: the two-row ••• sheet and its RTL mirroring, the toast clearing the tab bar on this route, the guest-trial redirect from the batch path, a real airplane-mode run (assign a batch, kill the app, confirm the queue replays and the drafts stay gone), and the multi-currency batch, where the picker preview intentionally shows no total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jhzmZz5fkjnZZ14YxHGfS