### PR TITLE
Unlock Personal once, not on every screen inside it

### DIFF
--- a/apps/mobile/src/app/(tabs)/me.tsx
+++ b/apps/mobile/src/app/(tabs)/me.tsx
@@ -18,10 +18,10 @@
  * it was last open (idempotent — see `postDueRecurring`).
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
-import { ActivityIndicator, Pressable, ScrollView, StyleSheet, View } from 'react-native';
+import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import {
@@ -60,6 +60,7 @@ import {
 } from '@waves/ui';
 
 import { CategoryBadge } from '@/components/Category';
+import { PersonalLocked } from '@/components/PersonalGuard';
 import { useSourceLabel } from '@/components/IncomeSource';
 import {
   localIsoDate,
@@ -95,15 +96,14 @@ export default function MeScreen() {
   const ledger = usePersonalLedger();
   const upsert = useUpsertPersonalRecord();
 
-  // The Me tab is the private personal ledger — ask for biometrics on entry and
-  // keep the screen a blank shield until it succeeds (below), so the figures are
-  // never on show behind the prompt. It then stays quiet for the app-lock grace
-  // window. A failed or cancelled check leaves the tab rather than exposing data.
-  const leaveMe = useCallback(() => {
-    if (router.canGoBack()) router.back();
-    else router.replace('/');
-  }, []);
-  const gate = usePersonalGate(t.lock.personalPrompt, leaveMe);
+  // The Me tab is the home of the private personal ledger — ask for biometrics
+  // on entry and keep the screen a shield until it succeeds (below), so the
+  // figures are never on show behind the prompt. One unlock covers the whole
+  // section: the rooms under `personal/` mount the same gate and read the same
+  // state, so walking into "add income" and back never asks again. Only time
+  // spent away — out of the section, or with the app in the background — past
+  // the "Ask again after" window brings it back.
+  const gate = usePersonalGate(t.lock.personalPrompt);
 
   // Read the clock once, off render (the React Compiler forbids it inline).
   const [today] = useState(() => todayIso());
@@ -232,20 +232,10 @@ export default function MeScreen() {
     : null;
 
   // Private ledger: while the biometric gate is unresolved the whole screen is a
-  // blank shield — no hero, no figures — so nothing is on show behind the OS
-  // prompt. A failed check has already navigated away by the time this renders.
-  if (!gate.unlocked) {
-    return (
-      <Screen edges={[]}>
-        <View
-          style={{ flex: 1, alignItems: 'center', justifyContent: 'center', gap: theme.spacing.lg }}
-        >
-          <Ionicons name="lock-closed" size={iconSize.huge} color={theme.color.textFaint} />
-          {gate.checking ? <ActivityIndicator color={theme.color.textFaint} /> : null}
-        </View>
-      </Screen>
-    );
-  }
+  // shield — no hero, no figures — so nothing is on show behind the OS prompt.
+  // A refused check stays here with a way to try again, rather than sending the
+  // user backwards without a word.
+  if (!gate.unlocked) return <PersonalLocked gate={gate} />;
 
   return (
     <Screen edges={[]}>

--- a/apps/mobile/src/app/personal/budgets.tsx
+++ b/apps/mobile/src/app/personal/budgets.tsx
@@ -42,9 +42,10 @@ import {
 } from '@/data/personal';
 import { useDefaultCurrency } from '@/lib/currency';
 import { useStrings } from '@/i18n';
+import { PersonalGuard } from '@/components/PersonalGuard';
 import { useBottomClearance } from '@/lib/clearance';
 
-export default function BudgetsScreen() {
+function BudgetsScreenBody() {
   const theme = useTheme();
   const clearance = useBottomClearance();
   const { t, locale } = useStrings();
@@ -268,5 +269,17 @@ function BudgetEditor({
         ) : null}
       </ScrollView>
     </Sheet>
+  );
+}
+
+/**
+ * Behind the section shield: one unlock covers the Me tab and every room
+ * under `personal/`, so arriving here from the ledger never asks again.
+ */
+export default function BudgetsScreen() {
+  return (
+    <PersonalGuard>
+      <BudgetsScreenBody />
+    </PersonalGuard>
   );
 }

--- a/apps/mobile/src/app/personal/entry.tsx
+++ b/apps/mobile/src/app/personal/entry.tsx
@@ -45,9 +45,10 @@ import {
 import { useDefaultCurrency } from '@/lib/currency';
 import { useSync } from '@/sync';
 import { useStrings } from '@/i18n';
+import { PersonalGuard } from '@/components/PersonalGuard';
 import { useBottomClearance } from '@/lib/clearance';
 
-export default function PersonalEntryScreen() {
+function PersonalEntryScreenBody() {
   const theme = useTheme();
   const { t } = useStrings();
   const dc = useDefaultCurrency();
@@ -301,5 +302,17 @@ function EntryForm({
         <Button label={t.personal.save} size="lg" fullWidth onPress={onSave} disabled={!canSave} />
       </ScrollView>
     </Screen>
+  );
+}
+
+/**
+ * Behind the section shield: one unlock covers the Me tab and every room
+ * under `personal/`, so arriving here from the ledger never asks again.
+ */
+export default function PersonalEntryScreen() {
+  return (
+    <PersonalGuard>
+      <PersonalEntryScreenBody />
+    </PersonalGuard>
   );
 }

--- a/apps/mobile/src/app/personal/loans.tsx
+++ b/apps/mobile/src/app/personal/loans.tsx
@@ -45,9 +45,10 @@ import {
 } from '@/data/personal';
 import { useDefaultCurrency } from '@/lib/currency';
 import { useStrings } from '@/i18n';
+import { PersonalGuard } from '@/components/PersonalGuard';
 import { useBottomClearance } from '@/lib/clearance';
 
-export default function LoansScreen() {
+function LoansScreenBody() {
   const theme = useTheme();
   const clearance = useBottomClearance();
   const { t, locale } = useStrings();
@@ -358,5 +359,17 @@ function LoanEditor({
         ) : null}
       </ScrollView>
     </Sheet>
+  );
+}
+
+/**
+ * Behind the section shield: one unlock covers the Me tab and every room
+ * under `personal/`, so arriving here from the ledger never asks again.
+ */
+export default function LoansScreen() {
+  return (
+    <PersonalGuard>
+      <LoansScreenBody />
+    </PersonalGuard>
   );
 }

--- a/apps/mobile/src/app/personal/recurring.tsx
+++ b/apps/mobile/src/app/personal/recurring.tsx
@@ -57,6 +57,7 @@ import {
 } from '@/data/personal';
 import { useDefaultCurrency } from '@/lib/currency';
 import { fill, useStrings } from '@/i18n';
+import { PersonalGuard } from '@/components/PersonalGuard';
 import { useBottomClearance } from '@/lib/clearance';
 
 /** A repeat pattern in words. The open-ended one names its own interval, so
@@ -86,7 +87,7 @@ export function frequencyLabel(
   }
 }
 
-export default function RecurringScreen() {
+function RecurringScreenBody() {
   const theme = useTheme();
   const clearance = useBottomClearance();
   const { t, locale } = useStrings();
@@ -597,5 +598,17 @@ function RecurringEditor({
         ) : null}
       </ScrollView>
     </Sheet>
+  );
+}
+
+/**
+ * Behind the section shield: one unlock covers the Me tab and every room
+ * under `personal/`, so arriving here from the ledger never asks again.
+ */
+export default function RecurringScreen() {
+  return (
+    <PersonalGuard>
+      <RecurringScreenBody />
+    </PersonalGuard>
   );
 }

--- a/apps/mobile/src/app/personal/source/[id].tsx
+++ b/apps/mobile/src/app/personal/source/[id].tsx
@@ -58,6 +58,7 @@ import {
   useUpsertPersonalRecord,
 } from '@/data/personal';
 import { fill, useStrings } from '@/i18n';
+import { PersonalGuard } from '@/components/PersonalGuard';
 import { useBottomClearance } from '@/lib/clearance';
 
 /**
@@ -69,7 +70,7 @@ import { useBottomClearance } from '@/lib/clearance';
  */
 const LOOKBACK_YEARS = 5;
 
-export default function SourceTimelineScreen() {
+function SourceTimelineScreenBody() {
   const theme = useTheme();
   const clearance = useBottomClearance();
   const { t, locale } = useStrings();
@@ -406,5 +407,17 @@ function RecordSheet({
         />
       </View>
     </Sheet>
+  );
+}
+
+/**
+ * Behind the section shield: one unlock covers the Me tab and every room
+ * under `personal/`, so arriving here from the ledger never asks again.
+ */
+export default function SourceTimelineScreen() {
+  return (
+    <PersonalGuard>
+      <SourceTimelineScreenBody />
+    </PersonalGuard>
   );
 }

--- a/apps/mobile/src/app/personal/transactions.tsx
+++ b/apps/mobile/src/app/personal/transactions.tsx
@@ -23,9 +23,10 @@ import {
 import { CategoryBadge } from '@/components/Category';
 import { usePersonalLedger } from '@/data/personal';
 import { useStrings } from '@/i18n';
+import { PersonalGuard } from '@/components/PersonalGuard';
 import { useBottomClearance } from '@/lib/clearance';
 
-export default function PersonalTransactionsScreen() {
+function PersonalTransactionsScreenBody() {
   const theme = useTheme();
   const clearance = useBottomClearance();
   const { t, locale } = useStrings();
@@ -130,5 +131,17 @@ export default function PersonalTransactionsScreen() {
         }}
       />
     </Screen>
+  );
+}
+
+/**
+ * Behind the section shield: one unlock covers the Me tab and every room
+ * under `personal/`, so arriving here from the ledger never asks again.
+ */
+export default function PersonalTransactionsScreen() {
+  return (
+    <PersonalGuard>
+      <PersonalTransactionsScreenBody />
+    </PersonalGuard>
   );
 }

--- a/apps/mobile/src/app/settings/lock.tsx
+++ b/apps/mobile/src/app/settings/lock.tsx
@@ -82,7 +82,15 @@ export default function LockSettingsScreen() {
 
         {!supported ? <Badge label={t.lock.unsupported} /> : null}
 
-        {enabled ? (
+        {/* Shown whether or not the app lock is on, because the number governs
+            two locks and only one of them is behind that switch: the private
+            personal ledger asks again after this long away regardless. Hidden
+            behind `enabled`, somebody who tried "Straight away", disliked it
+            and turned the app lock off would be left with a zero-second window
+            on their ledger and no way back to the control that set it. Gated on
+            `supported` instead, since with nothing enrolled neither lock can
+            ask at all. */}
+        {supported ? (
           <Card style={{ gap: theme.spacing.md }}>
             <Text variant="subheading">{t.lock.askAgainAfter}</Text>
             <Text variant="caption" tone="muted">

--- a/apps/mobile/src/components/PersonalGuard.tsx
+++ b/apps/mobile/src/components/PersonalGuard.tsx
@@ -1,0 +1,84 @@
+/**
+ * The shield in front of the private personal ledger.
+ *
+ * Every screen in the section — the Me tab and each `personal/*` room — shows
+ * this, and they all read one unlock (`lib/personalLock`), so proving who you
+ * are once covers the whole section until you genuinely leave it or the app
+ * goes away for longer than the "Ask again after" window. Moving between the
+ * rooms costs nothing.
+ *
+ * While the check is in flight the shield stays up, so the figures are never on
+ * show behind the OS prompt, and a refusal leaves the user here with the two
+ * honest choices — try again, or go back — rather than being thrown backwards a
+ * few seconds later with nothing said.
+ */
+
+import type { ReactNode } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router } from 'expo-router';
+import { ActivityIndicator, View } from 'react-native';
+
+import { Button, iconSize, Screen, Text, useTheme } from '@waves/ui';
+
+import { useStrings } from '@/i18n';
+import { usePersonalGate, type PersonalGateValue } from '@/lib/lock';
+
+/** Wraps a personal screen so its body never mounts while the section is shut. */
+export function PersonalGuard({ children }: { children: ReactNode }) {
+  const { t } = useStrings();
+  const gate = usePersonalGate(t.lock.personalPrompt);
+  if (!gate.unlocked) return <PersonalLocked gate={gate} />;
+  return <>{children}</>;
+}
+
+/**
+ * The shield itself, also used directly by the Me tab (whose body is the
+ * section's home and computes its month before it can early-return).
+ */
+export function PersonalLocked({ gate }: { gate: PersonalGateValue }) {
+  const theme = useTheme();
+  const { t } = useStrings();
+
+  return (
+    <Screen edges={[]}>
+      <View
+        style={{
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: theme.spacing.lg,
+          paddingHorizontal: theme.spacing.xxxl,
+        }}
+      >
+        <Ionicons name="lock-closed" size={iconSize.huge} color={theme.color.textFaint} />
+        <Text variant="title" align="center">
+          {t.lock.personalLockedTitle}
+        </Text>
+        <Text variant="body" tone="muted" align="center">
+          {gate.failed ? t.lock.personalLockedRefused : t.lock.personalLockedBody}
+        </Text>
+        {/* Only one of the three: a spinner while the OS sheet is up, the way
+            back in once it has been refused, and nothing at all in the moment
+            before the prompt appears — a button that flashes past is a button
+            people press by accident. */}
+        {gate.checking ? (
+          <ActivityIndicator color={theme.color.textFaint} />
+        ) : gate.failed ? (
+          <View style={{ alignSelf: 'stretch', gap: theme.spacing.md }}>
+            <Button label={t.extras.unlock} size="lg" fullWidth onPress={gate.retry} />
+            <Button
+              label={t.common.back}
+              variant="secondary"
+              size="lg"
+              fullWidth
+              onPress={() => {
+                if (router.canGoBack()) router.back();
+                else router.replace('/');
+              }}
+            />
+          </View>
+        ) : null}
+      </View>
+    </Screen>
+  );
+}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -761,6 +761,12 @@ export interface UiStrings {
     footnote: string;
     /** Native biometric prompt shown on entering the private Me tab. */
     personalPrompt: string;
+    /** Heading on the shield in front of the private ledger. */
+    personalLockedTitle: string;
+    /** How to open it — shown while the prompt is up or about to be. */
+    personalLockedBody: string;
+    /** Shown instead, once a check has been refused or cancelled. */
+    personalLockedRefused: string;
   };
   /** The sheet behind Sign out: what leaves the phone with the account, and
    *  the two things you can do about it before you go. */
@@ -3414,6 +3420,9 @@ const en: UiStrings = {
     footnote:
       'This guards the screen, not the data — your ledger is protected by row-level security on the server whether the lock is on or not.',
     personalPrompt: 'Unlock your personal ledger',
+    personalLockedTitle: 'Your personal ledger is locked',
+    personalLockedBody: 'Unlock with the same face or fingerprint that opens this phone.',
+    personalLockedRefused: 'That did not unlock it. Try again, or go back.',
   },
   signOutSheet: {
     guestTitle: 'This account cannot be signed back into',
@@ -5886,6 +5895,9 @@ const ta: UiStrings = {
     footnote:
       'இது திரையைக் காக்கிறது, தரவை அல்ல — பூட்டு இருந்தாலும் இல்லாவிட்டாலும் உங்கள் கணக்கு சர்வரில் வரிசை அளவிலான பாதுகாப்பால் காக்கப்படுகிறது.',
     personalPrompt: 'உங்கள் தனிப்பட்ட கணக்கைத் திறக்கவும்',
+    personalLockedTitle: 'உங்கள் தனிப்பட்ட கணக்கு பூட்டப்பட்டுள்ளது',
+    personalLockedBody: 'இந்த ஃபோனைத் திறக்கும் அதே முகம் அல்லது கைரேகையால் திறக்கவும்.',
+    personalLockedRefused: 'அது திறக்கவில்லை. மீண்டும் முயலுங்கள், அல்லது திரும்பிச் செல்லுங்கள்.',
   },
   signOutSheet: {
     guestTitle: 'இந்தக் கணக்கில் மீண்டும் உள்நுழைய முடியாது',
@@ -8451,6 +8463,9 @@ const hi: UiStrings = {
     footnote:
       'यह स्क्रीन की रक्षा करता है, डेटा की नहीं — लॉक चालू हो या बंद, आपका हिसाब सर्वर पर रो-लेवल सुरक्षा से सुरक्षित है।',
     personalPrompt: 'अपना निजी हिसाब अनलॉक करें',
+    personalLockedTitle: 'आपका निजी हिसाब लॉक है',
+    personalLockedBody: 'उसी चेहरे या फ़िंगरप्रिंट से खोलें जिससे यह फ़ोन खुलता है।',
+    personalLockedRefused: 'इससे लॉक नहीं खुला। फिर से कोशिश करें, या वापस जाएँ।',
   },
   signOutSheet: {
     guestTitle: 'इस खाते में दोबारा साइन इन नहीं किया जा सकता',
@@ -10962,6 +10977,9 @@ const ar: UiStrings = {
     footnote:
       'هذا يحمي الشاشة لا البيانات — دفترك محمي على الخادم بأمان على مستوى الصفوف سواء كان القفل مفعّلًا أم لا.',
     personalPrompt: 'افتح قفل دفترك الشخصي',
+    personalLockedTitle: 'دفترك الشخصي مقفل',
+    personalLockedBody: 'افتحه بالوجه أو البصمة نفسها التي تفتح هذا الهاتف.',
+    personalLockedRefused: 'لم يُفتح القفل. حاول مرة أخرى، أو ارجع.',
   },
   signOutSheet: {
     guestTitle: 'لا يمكن تسجيل الدخول إلى هذا الحساب مرة أخرى',

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -3406,7 +3406,7 @@ const en: UiStrings = {
     unsupported: 'This device has no biometrics or passcode set up',
     askAgainAfter: 'Ask again after',
     askAgainExplain:
-      'Time in the background before Waves locks. Settling by UPI sends you to another app and back, so locking the instant you leave means unlocking every time you pay somebody.',
+      'Time away before Waves asks again — for the app lock, and for the private personal ledger, which uses the same window when you leave it. Settling by UPI sends you to another app and back, so asking the instant you leave means unlocking every time you pay somebody.',
     graceImmediate: 'Straight away',
     graceSeconds: { one: 'After {n} second', other: 'After {n} seconds' },
     graceMinutes: { one: 'After a minute', other: 'After {n} minutes' },
@@ -5881,7 +5881,7 @@ const ta: UiStrings = {
     unsupported: 'இந்தச் சாதனத்தில் கைரேகையோ கடவுக்குறியீடோ அமைக்கப்படவில்லை',
     askAgainAfter: 'மீண்டும் கேட்க',
     askAgainExplain:
-      'Waves பூட்டப்படுவதற்கு முன் பின்னணியில் இருக்கும் நேரம். UPI மூலம் தீர்ப்பது உங்களை வேறு ஆப்புக்கு அனுப்பி மீண்டும் கொண்டுவரும், எனவே வெளியேறியதுமே பூட்டினால் ஒவ்வொரு முறை பணம் கொடுக்கும்போதும் திறக்க வேண்டியிருக்கும்.',
+      'Waves மீண்டும் கேட்பதற்கு முன் நீங்கள் விலகி இருக்கும் நேரம் — ஆப் பூட்டுக்கும், தனிப்பட்ட கணக்குக்கும்; அதை விட்டு வெளியேறினாலும் இதே நேரம்தான். UPI மூலம் தீர்ப்பது உங்களை வேறு ஆப்புக்கு அனுப்பி மீண்டும் கொண்டுவரும், எனவே வெளியேறியதுமே கேட்டால் ஒவ்வொரு முறை பணம் கொடுக்கும்போதும் திறக்க வேண்டியிருக்கும்.',
     graceImmediate: 'உடனடியாக',
     graceSeconds: { one: '{n} வினாடி கழித்து', other: '{n} வினாடிகள் கழித்து' },
     graceMinutes: { one: 'ஒரு நிமிடம் கழித்து', other: '{n} நிமிடங்கள் கழித்து' },
@@ -8449,7 +8449,7 @@ const hi: UiStrings = {
     unsupported: 'इस डिवाइस पर बायोमेट्रिक या पासकोड सेट नहीं है',
     askAgainAfter: 'दोबारा पूछें',
     askAgainExplain:
-      'Waves के लॉक होने से पहले बैकग्राउंड में बीता समय। UPI से निपटाने पर आप दूसरे ऐप में जाकर लौटते हैं, इसलिए निकलते ही लॉक करने का मतलब है हर भुगतान पर दोबारा खोलना।',
+      'Waves के दोबारा पूछने से पहले आपके दूर रहने का समय — ऐप लॉक के लिए भी, और निजी हिसाब के लिए भी, जिसे छोड़ने पर यही समय लागू होता है। UPI से निपटाने पर आप दूसरे ऐप में जाकर लौटते हैं, इसलिए निकलते ही पूछने का मतलब है हर भुगतान पर दोबारा खोलना।',
     graceImmediate: 'तुरंत',
     graceSeconds: { one: '{n} सेकंड बाद', other: '{n} सेकंड बाद' },
     graceMinutes: { one: 'एक मिनट बाद', other: '{n} मिनट बाद' },
@@ -10949,7 +10949,7 @@ const ar: UiStrings = {
     unsupported: 'لا توجد بصمة أو رمز مرور مضبوط على هذا الجهاز',
     askAgainAfter: 'اسأل مرة أخرى بعد',
     askAgainExplain:
-      'المدة في الخلفية قبل أن يُقفل Waves. التسوية عبر UPI تنقلك إلى تطبيق آخر ثم تعيدك، فالقفل لحظة الخروج يعني فتح القفل مع كل دفعة.',
+      'المدة التي تقضيها بعيدًا قبل أن يسأل Waves مرة أخرى — لقفل التطبيق، ولدفترك الشخصي الذي يستخدم المدة نفسها عند مغادرته. التسوية عبر UPI تنقلك إلى تطبيق آخر ثم تعيدك، فالسؤال لحظة الخروج يعني فتح القفل مع كل دفعة.',
     graceImmediate: 'فورًا',
     graceSeconds: {
       zero: 'بعد {n} ثانية',

--- a/apps/mobile/src/lib/auth.tsx
+++ b/apps/mobile/src/lib/auth.tsx
@@ -18,7 +18,7 @@ import {
 import { appleNativeSignIn, googleNativeSignIn } from './nativeIdentity';
 import { identifyForReporting, reportHandled } from './observability';
 import { claimCode } from './oauthClaim';
-import { lockPersonal } from './personalLock';
+import { lockPersonal, syncPersonalAccount } from './personalLock';
 import { refreshPushToken, revokePushToken } from './push';
 import { backend } from './backend';
 
@@ -371,6 +371,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       .getSession()
       .then(({ data }) => {
         if (!active) return;
+        syncPersonalAccount(data.session?.user?.id ?? null);
         setSession(data.session);
       })
       .catch((caught) => {
@@ -381,6 +382,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       });
 
     const { data: subscription } = backend.auth.onAuthStateChange((_event, next) => {
+      // Whoever proved they were holding this phone proved it for one account.
+      // Most sign-outs never reach the `signOut` action below — a revoked
+      // refresh token, a remote sign-out from another device, an account
+      // deleted elsewhere, a refresh that simply fails — and the personal
+      // ledger's unlock is module-scoped, so it would outlive the unmounted
+      // tree and greet the next account with no check at all. Keyed on the user
+      // id, so a switch of account counts too and a token refresh does not.
+      syncPersonalAccount(next?.user?.id ?? null);
       setSession(next);
     });
 

--- a/apps/mobile/src/lib/auth.tsx
+++ b/apps/mobile/src/lib/auth.tsx
@@ -18,6 +18,7 @@ import {
 import { appleNativeSignIn, googleNativeSignIn } from './nativeIdentity';
 import { identifyForReporting, reportHandled } from './observability';
 import { claimCode } from './oauthClaim';
+import { lockPersonal } from './personalLock';
 import { refreshPushToken, revokePushToken } from './push';
 import { backend } from './backend';
 
@@ -650,6 +651,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         // the revocation to, and the token would keep receiving notifications
         // for an account nobody is signed in on.
         await revokePushToken();
+        // The private ledger's unlock belongs to whoever proved they were
+        // holding the phone, not to the phone. It does not survive the account
+        // it was granted under.
+        lockPersonal();
         await backend.auth.signOut();
       },
     }),

--- a/apps/mobile/src/lib/lock.tsx
+++ b/apps/mobile/src/lib/lock.tsx
@@ -5,6 +5,7 @@ import {
   useEffect,
   useRef,
   useState,
+  useSyncExternalStore,
   type ReactNode,
 } from 'react';
 import * as LocalAuthentication from 'expo-local-authentication';
@@ -14,6 +15,19 @@ import { AppState, Platform } from 'react-native';
 
 import { plural, type UiStrings } from '@/i18n';
 import { legacyKeysMigrated } from '@/lib/legacyKeys';
+import {
+  DEFAULT_IDLE_GRACE_SECONDS,
+  enterPersonalSection,
+  getPersonalLockState,
+  isPersonalUnlocked,
+  leavePersonalSection,
+  lockClockNow,
+  lockPersonal,
+  markPersonalUnlocked,
+  personalAppActive,
+  personalAppAway,
+  subscribePersonalLock,
+} from '@/lib/personalLock';
 
 const KEY = 'waves.app_lock_enabled';
 const GRACE_KEY = 'waves.app_lock_grace_seconds';
@@ -27,7 +41,14 @@ const GRACE_KEY = 'waves.app_lock_grace_seconds';
  * short enough that a phone left on a table is not an open ledger.
  */
 export const GRACE_CHOICES = [0, 15, 30, 60, 300] as const;
-export const DEFAULT_GRACE_SECONDS = 30;
+/**
+ * One window, two locks: the whole-app lock and the personal-ledger gate both
+ * ask again after this long away, so the single "Ask again after" setting
+ * cannot come to mean two different things. The number itself lives once, in
+ * `lib/personalLock` (the pure, testable half); this is the name the settings
+ * screens already import.
+ */
+export const DEFAULT_GRACE_SECONDS = DEFAULT_IDLE_GRACE_SECONDS;
 
 interface LockValue {
   /** Whether the user has turned the lock on. */
@@ -118,6 +139,19 @@ export function LockProvider({ children }: { children: ReactNode }) {
     return () => subscription.remove();
   }, [enabled, graceSeconds]);
 
+  // The personal ledger's own idle clock. Subscribed always, not only when the
+  // app lock is on: the two are independent gates, and the private section is
+  // guarded whether or not the whole app is. One subscription for the app, held
+  // above every screen, so no personal screen has to be mounted for a departure
+  // to be noticed.
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (state) => {
+      if (state === 'background' || state === 'inactive') personalAppAway();
+      else if (state === 'active') personalAppActive(graceSeconds);
+    });
+    return () => subscription.remove();
+  }, [graceSeconds]);
+
   const unlock = useCallback(async () => {
     const result = await LocalAuthentication.authenticateAsync({
       promptMessage: 'Unlock Waves',
@@ -170,96 +204,113 @@ export function useLock(): LockValue {
   return value;
 }
 
-/**
- * When the personal ("Me") ledger was last unlocked. Module-scoped so leaving
- * the tab and coming back within the grace window does not re-prompt — the same
- * intent the app lock's grace has, applied per-screen rather than per-app.
- */
-let personalAuthedAt: number | null = null;
-
-/**
- * Whether a recent personal unlock still counts, read off render through a
- * function call (the React Compiler forbids `Date.now()` inline in a component,
- * the same reason `todayIso()` is hoisted). Lets the gate open with no cover on
- * a within-grace re-entry instead of flashing the shield first.
- */
-export function personalGateFresh(graceSeconds: number): boolean {
-  return personalAuthedAt !== null && Date.now() - personalAuthedAt < graceSeconds * 1000;
+/** What a screen in the private section needs, to choose ledger or shield. */
+export interface PersonalGateValue {
+  /** Whether the private ledger may be drawn. */
+  unlocked: boolean;
+  /** Whether the OS prompt is up right now. */
+  checking: boolean;
+  /** Whether the last check was refused or cancelled, and is awaiting a retry. */
+  failed: boolean;
+  /** Ask again, after a refusal. */
+  retry: () => void;
 }
 
 /**
- * A biometric gate for the private personal ledger, independent of the whole-app
- * lock. On entering the Me tab it asks the device to prove who is holding it and
- * keeps the screen obscured until it succeeds, so the figures are never on show
- * behind the prompt. It then stays quiet for the same "ask again after" window
- * the app lock uses (so the two share one setting) — a within-grace re-entry
- * opens straight away. A failed or cancelled check calls `onFail` (navigate off
- * the tab) rather than revealing anything. With nothing enrolled to authenticate
- * against there is nothing to ask, so it opens; RLS still guards the data on the
- * server. `onFail` should be stable (wrap it in useCallback).
+ * The biometric gate on the private personal ledger, independent of the
+ * whole-app lock.
+ *
+ * Every screen in the section mounts this — the Me tab and each `personal/*`
+ * room — but they all read one state (`lib/personalLock`), so the first unlock
+ * covers the section and walking between its screens never asks again. What
+ * ages an unlock is time spent *away*: outside the section, or with the app in
+ * the background, for longer than the user's "Ask again after" window — the
+ * same setting the app lock uses, so the two can never disagree. Sign-out shuts
+ * it, and so does a cold start: the store begins locked.
+ *
+ * Until it opens the caller draws a shield rather than the figures, so nothing
+ * is ever on show behind the OS prompt. A refused or cancelled check leaves the
+ * shield up with a way to try again and a way out; it does not navigate on the
+ * user's behalf, because a screen that throws you backwards seconds after you
+ * arrived is indistinguishable from a bug.
+ *
+ * With nothing enrolled to authenticate against there is nothing to ask, so it
+ * opens — unchanged from before; RLS still guards the data on the server.
  */
-export function usePersonalGate(
-  promptMessage: string,
-  onFail: () => void,
-): { unlocked: boolean; checking: boolean } {
-  const { graceSeconds, supported } = useLock();
-  // Start open only when a prior unlock is still within grace; otherwise start
-  // covered so the first paint never shows the ledger.
-  const [unlocked, setUnlocked] = useState(() => personalGateFresh(graceSeconds));
+export function usePersonalGate(promptMessage: string): PersonalGateValue {
+  const { graceSeconds, supported, ready } = useLock();
+  const state = useSyncExternalStore(subscribePersonalLock, getPersonalLockState);
   const [checking, setChecking] = useState(false);
+  const [failed, setFailed] = useState(false);
+  const [focused, setFocused] = useState(false);
+  // One prompt at a time. The effect below can re-run while the OS sheet is
+  // still up (the grace window arrives asynchronously, and `supported` flips
+  // once the hardware check lands), and two stacked biometric prompts is how a
+  // device comes to refuse both.
+  const asking = useRef(false);
 
-  const run = useCallback(async (): Promise<void> => {
-    // Still inside the grace window from a recent success — open, no prompt.
-    if (personalGateFresh(graceSeconds)) {
-      setUnlocked(true);
-      return;
-    }
-    // Nothing to authenticate against (no hardware, nothing enrolled, or web):
-    // there is nothing to prompt for, so open. RLS still guards the data.
-    const canAsk =
-      Platform.OS !== 'web' && supported && (await LocalAuthentication.isEnrolledAsync());
-    if (!canAsk) {
-      personalAuthedAt = Date.now();
-      setUnlocked(true);
-      return;
-    }
-    // Keep it covered while the OS prompt is up so a cancel never flashes the
-    // figures.
-    setUnlocked(false);
-    setChecking(true);
-    const result = await LocalAuthentication.authenticateAsync({
-      promptMessage,
-      fallbackLabel: 'Use passcode',
-    });
-    setChecking(false);
-    if (result.success) {
-      personalAuthedAt = Date.now();
-      setUnlocked(true);
-    } else {
-      onFail();
-    }
-  }, [graceSeconds, supported, promptMessage, onFail]);
+  // The clock is read through a function call, not inline — the React Compiler
+  // forbids `Date.now()` in a component body, the same reason `todayIso()` is
+  // hoisted. `state` is an argument so this re-evaluates whenever the store moves.
+  const unlocked = isPersonalUnlocked(state, lockClockNow(), graceSeconds);
 
+  // Presence, not authentication: this is what tells the store whether the user
+  // is still in the section. A push inside it blurs one screen and focuses the
+  // next, and the store's settle window covers that gap.
   useFocusEffect(
     useCallback(() => {
-      let active = true;
-      // The check runs inside the async callback, not the effect body, so no
-      // state is set synchronously on the render path.
-      void (async () => {
-        if (active) await run();
-      })();
-      // On blur, always re-cover: the tab stays mounted, so without this a
-      // return after the grace lapsed would show the old figures for a frame
-      // before the next prompt resolves. A within-grace return re-opens on the
-      // next focus with no prompt, so the cost is at most a one-frame shield.
+      enterPersonalSection(graceSeconds);
+      setFocused(true);
       return () => {
-        active = false;
-        setUnlocked(false);
+        setFocused(false);
+        leavePersonalSection();
       };
-    }, [run]),
+    }, [graceSeconds]),
   );
 
-  return { unlocked, checking };
+  const ask = useCallback(async (): Promise<void> => {
+    if (asking.current) return;
+    asking.current = true;
+    try {
+      // Nothing to authenticate against (no hardware, nothing enrolled, or
+      // web): there is nothing to prompt for, so open. RLS still guards the data.
+      const canAsk =
+        Platform.OS !== 'web' && supported && (await LocalAuthentication.isEnrolledAsync());
+      if (!canAsk) {
+        markPersonalUnlocked();
+        return;
+      }
+      setChecking(true);
+      const result = await LocalAuthentication.authenticateAsync({
+        promptMessage,
+        fallbackLabel: 'Use passcode',
+      });
+      if (result.success) {
+        markPersonalUnlocked();
+      } else {
+        // Refused: stay shut, and wait to be asked again rather than looping the
+        // prompt or navigating away underneath whoever is holding the phone.
+        lockPersonal();
+        setFailed(true);
+      }
+    } finally {
+      setChecking(false);
+      asking.current = false;
+    }
+  }, [supported, promptMessage]);
+
+  useEffect(() => {
+    // `ready` first: whether this device can ask at all is read asynchronously,
+    // and `supported` is false until it lands. Deciding before then would open
+    // the ledger on a phone that could perfectly well have asked. The shield is
+    // up in the meantime, so the wait costs a spinner, not a leak.
+    if (!ready || !focused || unlocked || failed || checking) return;
+    void ask();
+  }, [ready, focused, unlocked, failed, checking, ask]);
+
+  const retry = useCallback(() => setFailed(false), []);
+
+  return { unlocked, checking, failed, retry };
 }
 
 /** "Straight away", "After 30 seconds" — the words the settings row uses too. */

--- a/apps/mobile/src/lib/lock.tsx
+++ b/apps/mobile/src/lib/lock.tsx
@@ -24,6 +24,7 @@ import {
   lockClockNow,
   lockPersonal,
   markPersonalUnlocked,
+  markPersonalUnlockedFromPrompt,
   personalAppActive,
   personalAppAway,
   subscribePersonalLock,
@@ -286,7 +287,7 @@ export function usePersonalGate(promptMessage: string): PersonalGateValue {
         fallbackLabel: 'Use passcode',
       });
       if (result.success) {
-        markPersonalUnlocked();
+        markPersonalUnlockedFromPrompt();
       } else {
         // Refused: stay shut, and wait to be asked again rather than looping the
         // prompt or navigating away underneath whoever is holding the phone.

--- a/apps/mobile/src/lib/lock.tsx
+++ b/apps/mobile/src/lib/lock.tsx
@@ -10,23 +10,24 @@ import {
 } from 'react';
 import * as LocalAuthentication from 'expo-local-authentication';
 import * as SecureStore from 'expo-secure-store';
-import { useFocusEffect } from 'expo-router';
+import { useFocusEffect, useSegments } from 'expo-router';
 import { AppState, Platform } from 'react-native';
 
 import { plural, type UiStrings } from '@/i18n';
 import { legacyKeysMigrated } from '@/lib/legacyKeys';
 import {
+  beginPersonalCheck,
   DEFAULT_IDLE_GRACE_SECONDS,
-  enterPersonalSection,
+  endPersonalCheck,
   getPersonalLockState,
+  isPersonalSection,
   isPersonalUnlocked,
-  leavePersonalSection,
   lockClockNow,
   lockPersonal,
   markPersonalUnlocked,
-  markPersonalUnlockedFromPrompt,
   personalAppActive,
   personalAppAway,
+  setPersonalPresence,
   subscribePersonalLock,
 } from '@/lib/personalLock';
 
@@ -144,10 +145,10 @@ export function LockProvider({ children }: { children: ReactNode }) {
   // app lock is on: the two are independent gates, and the private section is
   // guarded whether or not the whole app is. One subscription for the app, held
   // above every screen, so no personal screen has to be mounted for a departure
-  // to be noticed.
+  // to be noticed. `inactive` is not a departure here — see `personalAppAway`.
   useEffect(() => {
     const subscription = AppState.addEventListener('change', (state) => {
-      if (state === 'background' || state === 'inactive') personalAppAway();
+      if (state === 'background') personalAppAway();
       else if (state === 'active') personalAppActive(graceSeconds);
     });
     return () => subscription.remove();
@@ -194,9 +195,30 @@ export function LockProvider({ children }: { children: ReactNode }) {
         unlock,
       }}
     >
+      {/* Renders nothing; it is the one place that says whether the user is
+          inside the private section. A sibling of `children` rather than a hook
+          up here, so a route change re-renders this and nothing else. */}
+      <PersonalPresence graceSeconds={graceSeconds} />
       {children}
     </LockContext.Provider>
   );
+}
+
+/**
+ * Keeps the personal lock's idea of "the user is in the section" in step with
+ * the router.
+ *
+ * Presence is a property of where you are, not of which component happened to
+ * fire a focus event, and reading it off the path is what lets a push from the
+ * Me tab into `personal/entry` cost nothing: one personal route replaces
+ * another and presence never changes at all.
+ */
+function PersonalPresence({ graceSeconds }: { graceSeconds: number }) {
+  const segments = useSegments();
+  useEffect(() => {
+    setPersonalPresence(isPersonalSection(segments as string[]), graceSeconds);
+  }, [segments, graceSeconds]);
+  return null;
 }
 
 export function useLock(): LockValue {
@@ -224,10 +246,13 @@ export interface PersonalGateValue {
  * Every screen in the section mounts this — the Me tab and each `personal/*`
  * room — but they all read one state (`lib/personalLock`), so the first unlock
  * covers the section and walking between its screens never asks again. What
- * ages an unlock is time spent *away*: outside the section, or with the app in
- * the background, for longer than the user's "Ask again after" window — the
- * same setting the app lock uses, so the two can never disagree. Sign-out shuts
- * it, and so does a cold start: the store begins locked.
+ * ages an unlock is time spent *away*: on a route outside the section, or with
+ * the app in the background, for longer than the user's "Ask again after"
+ * window — the same setting the app lock uses, so the two can never disagree.
+ * Whether the user is in the section is read off the router, not off focus
+ * events, so a push has no gap in it to mistake for a departure. A cold start
+ * begins locked, and any change of account — signing out, a session revoked
+ * from elsewhere, somebody else signing in — shuts it.
  *
  * Until it opens the caller draws a shield rather than the figures, so nothing
  * is ever on show behind the OS prompt. A refused or cancelled check leaves the
@@ -240,10 +265,20 @@ export interface PersonalGateValue {
  */
 export function usePersonalGate(promptMessage: string): PersonalGateValue {
   const { graceSeconds, supported, ready } = useLock();
-  const state = useSyncExternalStore(subscribePersonalLock, getPersonalLockState);
+  // Third argument is the server snapshot: a static web export prerenders these
+  // routes, and the locked state is exactly what a render with no device should
+  // produce — the shield.
+  const state = useSyncExternalStore(
+    subscribePersonalLock,
+    getPersonalLockState,
+    getPersonalLockState,
+  );
   const [checking, setChecking] = useState(false);
   const [failed, setFailed] = useState(false);
   const [focused, setFocused] = useState(false);
+  // The same fact as `focused`, readable from inside an async check that
+  // started before the user walked off.
+  const onScreen = useRef(false);
   // One prompt at a time. The effect below can re-run while the OS sheet is
   // still up (the grace window arrives asynchronously, and `supported` flips
   // once the hardware check lands), and two stacked biometric prompts is how a
@@ -255,28 +290,41 @@ export function usePersonalGate(promptMessage: string): PersonalGateValue {
   // hoisted. `state` is an argument so this re-evaluates whenever the store moves.
   const unlocked = isPersonalUnlocked(state, lockClockNow(), graceSeconds);
 
-  // Presence, not authentication: this is what tells the store whether the user
-  // is still in the section. A push inside it blurs one screen and focuses the
-  // next, and the store's settle window covers that gap.
+  // Focus decides which screen does the asking — several personal screens can
+  // be mounted at once and only the visible one should raise a prompt. It says
+  // nothing about presence; that is the router's job (`PersonalPresence`).
+  // Leaving also clears a refusal, so coming back asks again rather than
+  // greeting the user with the last attempt's failure.
   useFocusEffect(
     useCallback(() => {
-      enterPersonalSection(graceSeconds);
+      onScreen.current = true;
       setFocused(true);
       return () => {
+        onScreen.current = false;
         setFocused(false);
-        leavePersonalSection();
+        setFailed(false);
       };
-    }, [graceSeconds]),
+    }, []),
   );
 
   const ask = useCallback(async (): Promise<void> => {
     if (asking.current) return;
     asking.current = true;
+    // From here until the result is applied, an OS transition is our own doing
+    // rather than the user leaving.
+    beginPersonalCheck();
     try {
       // Nothing to authenticate against (no hardware, nothing enrolled, or
       // web): there is nothing to prompt for, so open. RLS still guards the data.
       const canAsk =
         Platform.OS !== 'web' && supported && (await LocalAuthentication.isEnrolledAsync());
+      // Every result below is discarded if the screen that asked has gone. The
+      // OS sheet outlives its screen — back out of the section with Android's
+      // prompt up and the success lands on nothing — and an answer given to a
+      // question the user has walked away from is not consent to open the
+      // ledger. The store guards this too (`afterPersonalAuth`); this is the
+      // near end of the same rule.
+      if (!onScreen.current) return;
       if (!canAsk) {
         markPersonalUnlocked();
         return;
@@ -286,8 +334,9 @@ export function usePersonalGate(promptMessage: string): PersonalGateValue {
         promptMessage,
         fallbackLabel: 'Use passcode',
       });
+      if (!onScreen.current) return;
       if (result.success) {
-        markPersonalUnlockedFromPrompt();
+        markPersonalUnlocked();
       } else {
         // Refused: stay shut, and wait to be asked again rather than looping the
         // prompt or navigating away underneath whoever is holding the phone.
@@ -297,6 +346,7 @@ export function usePersonalGate(promptMessage: string): PersonalGateValue {
     } finally {
       setChecking(false);
       asking.current = false;
+      endPersonalCheck();
     }
   }, [supported, promptMessage]);
 

--- a/apps/mobile/src/lib/lock.tsx
+++ b/apps/mobile/src/lib/lock.tsx
@@ -22,12 +22,12 @@ import {
   getPersonalLockState,
   isPersonalSection,
   isPersonalUnlocked,
+  lockAwayTransition,
   lockClockNow,
   lockPersonal,
   markPersonalUnlocked,
   personalAppActive,
   personalAppAway,
-  personalAppTransition,
   setPersonalPresence,
   subscribePersonalLock,
 } from '@/lib/personalLock';
@@ -126,14 +126,19 @@ export function LockProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (!enabled) return;
     const subscription = AppState.addEventListener('change', (state) => {
-      if (state === 'background' || state === 'inactive') {
+      // Same reading of the same transitions as the personal gate below. One
+      // window governs both locks, so one function decides what starts it;
+      // two copies of the rule that merely happen to agree today is how the
+      // shared "Ask again after" setting would quietly come to mean two things.
+      const move = lockAwayTransition(state);
+      if (move === 'away') {
         // Only the first departure counts. iOS reports `inactive` on the way to
         // `background`, and treating the second as a fresh departure would
         // restart the clock at the moment the phone was put down.
         leftAt.current ??= Date.now();
         return;
       }
-      if (state !== 'active') return;
+      if (move !== 'back') return;
       const away = leftAt.current;
       leftAt.current = null;
       if (away === null) return;
@@ -146,11 +151,11 @@ export function LockProvider({ children }: { children: ReactNode }) {
   // app lock is on: the two are independent gates, and the private section is
   // guarded whether or not the whole app is. One subscription for the app, held
   // above every screen, so no personal screen has to be mounted for a departure
-  // to be noticed. Which transitions count is `personalAppTransition`'s to say,
+  // to be noticed. Which transitions count is `lockAwayTransition`'s to say,
   // so this gate and the app lock above cannot come to read them differently.
   useEffect(() => {
     const subscription = AppState.addEventListener('change', (state) => {
-      const move = personalAppTransition(state);
+      const move = lockAwayTransition(state);
       if (move === 'away') personalAppAway();
       else if (move === 'back') personalAppActive(graceSeconds);
     });

--- a/apps/mobile/src/lib/lock.tsx
+++ b/apps/mobile/src/lib/lock.tsx
@@ -27,6 +27,7 @@ import {
   markPersonalUnlocked,
   personalAppActive,
   personalAppAway,
+  personalAppTransition,
   setPersonalPresence,
   subscribePersonalLock,
 } from '@/lib/personalLock';
@@ -145,31 +146,50 @@ export function LockProvider({ children }: { children: ReactNode }) {
   // app lock is on: the two are independent gates, and the private section is
   // guarded whether or not the whole app is. One subscription for the app, held
   // above every screen, so no personal screen has to be mounted for a departure
-  // to be noticed. `inactive` is not a departure here — see `personalAppAway`.
+  // to be noticed. Which transitions count is `personalAppTransition`'s to say,
+  // so this gate and the app lock above cannot come to read them differently.
   useEffect(() => {
     const subscription = AppState.addEventListener('change', (state) => {
-      if (state === 'background') personalAppAway();
-      else if (state === 'active') personalAppActive(graceSeconds);
+      const move = personalAppTransition(state);
+      if (move === 'away') personalAppAway();
+      else if (move === 'back') personalAppActive(graceSeconds);
     });
     return () => subscription.remove();
   }, [graceSeconds]);
 
+  // Both prompts below are marked as ours for the personal clock's benefit.
+  // Any biometric sheet turns the app inactive, and one the app raised itself
+  // is not the user walking away — an app-lock unlock that stamped a personal
+  // departure would, at a zero-second window, cost a second prompt the instant
+  // the first was answered.
   const unlock = useCallback(async () => {
-    const result = await LocalAuthentication.authenticateAsync({
-      promptMessage: 'Unlock Waves',
-      fallbackLabel: 'Use passcode',
-    });
-    if (result.success) setLocked(false);
-    return result.success;
+    beginPersonalCheck();
+    try {
+      const result = await LocalAuthentication.authenticateAsync({
+        promptMessage: 'Unlock Waves',
+        fallbackLabel: 'Use passcode',
+      });
+      if (result.success) setLocked(false);
+      return result.success;
+    } finally {
+      endPersonalCheck();
+    }
   }, []);
 
   const setEnabled = useCallback(async (value: boolean) => {
     if (value) {
       // Prove the device can actually unlock before locking them out of it.
-      const result = await LocalAuthentication.authenticateAsync({
-        promptMessage: 'Confirm to turn on app lock',
-      });
-      if (!result.success) return;
+      beginPersonalCheck();
+      let confirmed = false;
+      try {
+        const result = await LocalAuthentication.authenticateAsync({
+          promptMessage: 'Confirm to turn on app lock',
+        });
+        confirmed = result.success;
+      } finally {
+        endPersonalCheck();
+      }
+      if (!confirmed) return;
     }
     // SecureStore has no web implementation, same as the read path above.
     if (Platform.OS !== 'web') await SecureStore.setItemAsync(KEY, value ? 'true' : 'false');

--- a/apps/mobile/src/lib/personalLock.ts
+++ b/apps/mobile/src/lib/personalLock.ts
@@ -159,6 +159,16 @@ export function markPersonalUnlocked(now = Date.now()): void {
 }
 
 /**
+ * A prompt proved who is holding the device. If the prompt resolved after the
+ * personal screen disappeared, start the away clock immediately instead of
+ * leaving a stale, indefinitely open section behind it.
+ */
+export function markPersonalUnlockedFromPrompt(now = Date.now()): void {
+  const unlocked = afterPersonalAuth(now);
+  commit(present > 0 ? unlocked : afterPersonalLeave(unlocked, now));
+}
+
+/**
  * Shut the section: sign-out, and a check that failed or was cancelled. A
  * refused check must never leave a half-open gate behind it.
  */

--- a/apps/mobile/src/lib/personalLock.ts
+++ b/apps/mobile/src/lib/personalLock.ts
@@ -1,0 +1,216 @@
+/**
+ * The unlock state of the private personal ("Me") ledger — one state for the
+ * whole section, held above every screen in it.
+ *
+ * The section is not one screen. Its home is the Me tab and its rooms are
+ * `app/personal/*` — add an entry, the recurring rules, the loans, the budgets,
+ * a source timeline. Walking between those rooms is not leaving the section, so
+ * it must never cost another fingerprint: a gate that re-authenticates on every
+ * push is a gate people route around, and the one before this did exactly that
+ * (the freshness stamp was "when you last touched the sensor", so a browse
+ * longer than the grace window meant the way back asked again).
+ *
+ * So the clock only runs while you are *away*: outside the section, or with the
+ * app in the background. Inside it, an unlock lasts as long as you stay.
+ *
+ * Deliberately free of React and of react-native: this is where the decision
+ * lives, and it is unit-tested as a plain reducer (see test/personalLock.test.ts).
+ * The wiring — biometrics, AppState, focus — is in `lib/lock.tsx`.
+ */
+
+/**
+ * How long the section may be left before it asks again, when the user has no
+ * "Ask again after" preference stored. The lock setting (`lock.askAgainAfter`)
+ * is the user's own auto-lock window and overrides this everywhere; this is
+ * only the value in force until it has been read back off the device.
+ *
+ * Thirty seconds: long enough to be sent to a UPI app and come back, short
+ * enough that a phone left on a table is not an open ledger.
+ */
+export const DEFAULT_IDLE_GRACE_SECONDS = 30;
+
+/**
+ * How long "no personal screen is focused" must hold before it counts as
+ * having left the section.
+ *
+ * A push inside the section blurs one screen and focuses the next, and for the
+ * instant between them nothing personal is focused. Without this settle that
+ * gap would read as a departure, and with the window set to "Straight away" it
+ * would re-lock on every single navigation — the very complaint this module
+ * exists to answer. The departure is timestamped when the blur happened, not
+ * when the timer fires, so the delay never lengthens anybody's grace.
+ */
+export const PERSONAL_LEAVE_SETTLE_MS = 50;
+
+export interface PersonalLockState {
+  /** When the device last proved who is holding it. `null` means locked. */
+  readonly unlockedAt: number | null;
+  /**
+   * When the section (or the whole app) was last left, or `null` while the
+   * user is still in it. Only this clock ages an unlock.
+   */
+  readonly awaySince: number | null;
+}
+
+/** Locked: nothing has been proved, so nothing is open. */
+export const PERSONAL_LOCKED: PersonalLockState = { unlockedAt: null, awaySince: null };
+
+/**
+ * The wall clock, behind a call. The gate has to read it while rendering to
+ * decide between ledger and shield, and the React Compiler forbids `Date.now()`
+ * inline in a component body — the same reason `todayIso()` is hoisted.
+ */
+export function lockClockNow(): number {
+  return Date.now();
+}
+
+/**
+ * Whether the section is open right now.
+ *
+ * Unlocked and still here — open, for as long as that lasts. Unlocked but away
+ * — open only until the idle window runs out. Never unlocked — shut.
+ */
+export function isPersonalUnlocked(
+  state: PersonalLockState,
+  now: number,
+  idleSeconds: number,
+): boolean {
+  if (state.unlockedAt === null) return false;
+  if (state.awaySince === null) return true;
+  return now - state.awaySince < idleSeconds * 1000;
+}
+
+/** A successful check: open, and the idle clock stops. */
+export function afterPersonalAuth(now: number): PersonalLockState {
+  return { unlockedAt: now, awaySince: null };
+}
+
+/**
+ * Leaving — the section blurred, or the app went to the background. The first
+ * departure is the one that counts: iOS reports `inactive` on the way to
+ * `background`, and treating the second as fresh would restart the clock at the
+ * moment the phone was put down.
+ */
+export function afterPersonalLeave(state: PersonalLockState, now: number): PersonalLockState {
+  if (state.awaySince !== null) return state;
+  return { ...state, awaySince: now };
+}
+
+/**
+ * Coming back. Within the window the clock simply stops again; past it the
+ * unlock is spent and the section closes.
+ */
+export function afterPersonalReturn(
+  state: PersonalLockState,
+  now: number,
+  idleSeconds: number,
+): PersonalLockState {
+  if (!isPersonalUnlocked(state, now, idleSeconds)) return PERSONAL_LOCKED;
+  if (state.awaySince === null) return state;
+  return { ...state, awaySince: null };
+}
+
+// --- The live store -------------------------------------------------------
+//
+// Module-scoped rather than React state on purpose: it has to outlive every
+// screen in the section, because the whole point is that unmounting one and
+// mounting the next changes nothing.
+
+let current: PersonalLockState = PERSONAL_LOCKED;
+const listeners = new Set<() => void>();
+
+/**
+ * How many personal screens are focused. In practice zero or one — a
+ * navigator focuses one screen at a time — but counting rather than flagging
+ * keeps the blur/focus pair of a push from ever losing track of itself.
+ */
+let present = 0;
+let settling: ReturnType<typeof setTimeout> | null = null;
+
+function commit(next: PersonalLockState): void {
+  if (next.unlockedAt === current.unlockedAt && next.awaySince === current.awaySince) return;
+  current = next;
+  for (const listener of listeners) listener();
+}
+
+export function getPersonalLockState(): PersonalLockState {
+  return current;
+}
+
+export function subscribePersonalLock(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/**
+ * Whether the section is open, read off the current state. A function call so
+ * the clock is read inside it — the React Compiler forbids `Date.now()` inline
+ * in a component, the same reason `todayIso()` is hoisted.
+ */
+export function personalUnlockedNow(idleSeconds: number, now = Date.now()): boolean {
+  return isPersonalUnlocked(current, now, idleSeconds);
+}
+
+/** The device proved who is holding it. */
+export function markPersonalUnlocked(now = Date.now()): void {
+  commit(afterPersonalAuth(now));
+}
+
+/**
+ * Shut the section: sign-out, and a check that failed or was cancelled. A
+ * refused check must never leave a half-open gate behind it.
+ */
+export function lockPersonal(): void {
+  commit(PERSONAL_LOCKED);
+}
+
+/** A personal screen took focus. */
+export function enterPersonalSection(idleSeconds: number, now = Date.now()): void {
+  if (settling !== null) {
+    clearTimeout(settling);
+    settling = null;
+  }
+  present += 1;
+  commit(afterPersonalReturn(current, now, idleSeconds));
+}
+
+/**
+ * A personal screen lost focus. Only the last one out closes the door, and only
+ * once the navigation has settled — see `PERSONAL_LEAVE_SETTLE_MS`.
+ */
+export function leavePersonalSection(now = Date.now()): void {
+  present = Math.max(0, present - 1);
+  if (present > 0) return;
+  if (settling !== null) clearTimeout(settling);
+  settling = setTimeout(() => {
+    settling = null;
+    if (present > 0) return;
+    commit(afterPersonalLeave(current, now));
+  }, PERSONAL_LEAVE_SETTLE_MS);
+}
+
+/** The app went to the background or turned inactive. */
+export function personalAppAway(now = Date.now()): void {
+  commit(afterPersonalLeave(current, now));
+}
+
+/**
+ * The app came back to the foreground. It only stops the clock when a personal
+ * screen is actually focused — coming back to the dashboard is still time spent
+ * away from the ledger.
+ */
+export function personalAppActive(idleSeconds: number, now = Date.now()): void {
+  if (present === 0) return;
+  commit(afterPersonalReturn(current, now, idleSeconds));
+}
+
+/** Test seam: forget everything, including who is on screen. */
+export function resetPersonalLockForTests(): void {
+  if (settling !== null) clearTimeout(settling);
+  settling = null;
+  present = 0;
+  current = PERSONAL_LOCKED;
+  listeners.clear();
+}

--- a/apps/mobile/src/lib/personalLock.ts
+++ b/apps/mobile/src/lib/personalLock.ts
@@ -30,17 +30,25 @@
 export const DEFAULT_IDLE_GRACE_SECONDS = 30;
 
 /**
- * How long "no personal screen is focused" must hold before it counts as
- * having left the section.
+ * Whether a route belongs to the private section.
  *
- * A push inside the section blurs one screen and focuses the next, and for the
- * instant between them nothing personal is focused. Without this settle that
- * gap would read as a departure, and with the window set to "Straight away" it
- * would re-lock on every single navigation — the very complaint this module
- * exists to answer. The departure is timestamped when the blur happened, not
- * when the timer fires, so the delay never lengthens anybody's grace.
+ * Presence is read off the router, not off focus events. Focus arrives as a
+ * blur and a focus with a gap between them, and every scheme for deciding
+ * whether that gap was a departure — a counter, a settle timer — is a race with
+ * a constant in it: too short and a slow focus re-locks mid-push, too long and
+ * a real departure is forgiven. The path has no gap. A push from the Me tab to
+ * `personal/entry` is one personal route replacing another, and presence never
+ * so much as flickers.
+ *
+ * Group segments are dropped, so this holds whether the router reports
+ * `['(tabs)', 'me']` or `['me']`.
  */
-export const PERSONAL_LEAVE_SETTLE_MS = 50;
+export function isPersonalSection(segments: readonly string[]): boolean {
+  const first = segments.find(
+    (part) => part !== '' && !(part.startsWith('(') && part.endsWith(')')),
+  );
+  return first === 'me' || first === 'personal';
+}
 
 export interface PersonalLockState {
   /** When the device last proved who is holding it. `null` means locked. */
@@ -80,9 +88,19 @@ export function isPersonalUnlocked(
   return now - state.awaySince < idleSeconds * 1000;
 }
 
-/** A successful check: open, and the idle clock stops. */
-export function afterPersonalAuth(now: number): PersonalLockState {
-  return { unlockedAt: now, awaySince: null };
+/**
+ * A successful check.
+ *
+ * `inside` is whether the user is actually in the section as the result lands.
+ * A biometric prompt is a system window that outlives the screen that asked:
+ * back out of the section with Android's sheet still up, then present a
+ * fingerprint, and the success arrives for a screen that has gone. Stopping the
+ * idle clock on that would open the ledger for good, so an unlock granted from
+ * outside starts its clock immediately — it is worth exactly the grace window,
+ * and nothing more.
+ */
+export function afterPersonalAuth(now: number, inside: boolean): PersonalLockState {
+  return { unlockedAt: now, awaySince: inside ? null : now };
 }
 
 /**
@@ -119,13 +137,20 @@ export function afterPersonalReturn(
 let current: PersonalLockState = PERSONAL_LOCKED;
 const listeners = new Set<() => void>();
 
+/** Whether the current route is in the section. Set from the router, once. */
+let inside = false;
+
 /**
- * How many personal screens are focused. In practice zero or one — a
- * navigator focuses one screen at a time — but counting rather than flagging
- * keeps the blur/focus pair of a push from ever losing track of itself.
+ * How many biometric checks are up right now.
+ *
+ * The OS sheet is not part of our app: iOS reports `inactive` behind Face ID
+ * and some Android builds pause the activity outright behind BiometricPrompt.
+ * Counting our own prompt as the user leaving would re-lock the section because
+ * we asked it to unlock — at a zero-second window, over and over. Suppressing
+ * the away-clock while a check is up is safe by construction: we only ever ask
+ * while the section is shut, so there is nothing open to protect.
  */
-let present = 0;
-let settling: ReturnType<typeof setTimeout> | null = null;
+let checks = 0;
 
 function commit(next: PersonalLockState): void {
   if (next.unlockedAt === current.unlockedAt && next.awaySince === current.awaySince) return;
@@ -149,60 +174,81 @@ export function subscribePersonalLock(listener: () => void): () => void {
  * the clock is read inside it — the React Compiler forbids `Date.now()` inline
  * in a component, the same reason `todayIso()` is hoisted.
  */
-export function personalUnlockedNow(idleSeconds: number, now = Date.now()): boolean {
+export function personalUnlockedNow(idleSeconds: number, now = lockClockNow()): boolean {
   return isPersonalUnlocked(current, now, idleSeconds);
 }
 
-/** The device proved who is holding it. */
-export function markPersonalUnlocked(now = Date.now()): void {
-  commit(afterPersonalAuth(now));
+/** The device proved who is holding it — see `afterPersonalAuth` on `inside`. */
+export function markPersonalUnlocked(now = lockClockNow()): void {
+  commit(afterPersonalAuth(now, inside));
 }
 
 /**
- * A prompt proved who is holding the device. If the prompt resolved after the
- * personal screen disappeared, start the away clock immediately instead of
- * leaving a stale, indefinitely open section behind it.
- */
-export function markPersonalUnlockedFromPrompt(now = Date.now()): void {
-  const unlocked = afterPersonalAuth(now);
-  commit(present > 0 ? unlocked : afterPersonalLeave(unlocked, now));
-}
-
-/**
- * Shut the section: sign-out, and a check that failed or was cancelled. A
- * refused check must never leave a half-open gate behind it.
+ * Shut the section: sign-out, a switch of account, and a check that failed or
+ * was cancelled. A refused check must never leave a half-open gate behind it.
  */
 export function lockPersonal(): void {
   commit(PERSONAL_LOCKED);
 }
 
-/** A personal screen took focus. */
-export function enterPersonalSection(idleSeconds: number, now = Date.now()): void {
-  if (settling !== null) {
-    clearTimeout(settling);
-    settling = null;
-  }
-  present += 1;
-  commit(afterPersonalReturn(current, now, idleSeconds));
+/** Whether the router currently has the user inside the section. */
+export function personalPresent(): boolean {
+  return inside;
 }
 
 /**
- * A personal screen lost focus. Only the last one out closes the door, and only
- * once the navigation has settled — see `PERSONAL_LEAVE_SETTLE_MS`.
+ * Which account is signed in, as far as this lock is concerned. Any change —
+ * signing out, a session revoked from another device, a refresh that failed, a
+ * different person signing in — shuts the section.
+ *
+ * Most sign-outs never pass through the app's own sign-out action, and this
+ * store is module-scoped by design, so it outlives the React tree that was
+ * unmounted around it. Without this, the next account signed in during the same
+ * process launch would find the ledger already open. The rule lives here rather
+ * than in the auth listener so it can be tested without a React tree.
  */
-export function leavePersonalSection(now = Date.now()): void {
-  present = Math.max(0, present - 1);
-  if (present > 0) return;
-  if (settling !== null) clearTimeout(settling);
-  settling = setTimeout(() => {
-    settling = null;
-    if (present > 0) return;
-    commit(afterPersonalLeave(current, now));
-  }, PERSONAL_LEAVE_SETTLE_MS);
+let account: string | null = null;
+
+export function syncPersonalAccount(userId: string | null): void {
+  if (userId === account) return;
+  account = userId;
+  lockPersonal();
 }
 
-/** The app went to the background or turned inactive. */
-export function personalAppAway(now = Date.now()): void {
+/**
+ * The route changed. One caller — the watcher in `LockProvider` — and it passes
+ * what `isPersonalSection` made of the current segments, so arriving and
+ * leaving are the same event seen from two sides.
+ */
+export function setPersonalPresence(
+  next: boolean,
+  idleSeconds: number,
+  now = lockClockNow(),
+): void {
+  if (next === inside) return;
+  inside = next;
+  commit(next ? afterPersonalReturn(current, now, idleSeconds) : afterPersonalLeave(current, now));
+}
+
+/** A biometric check is going up. Pair every call with `endPersonalCheck`. */
+export function beginPersonalCheck(): void {
+  checks += 1;
+}
+
+export function endPersonalCheck(): void {
+  checks = Math.max(0, checks - 1);
+}
+
+/**
+ * The app went to the background. `inactive` is deliberately not a departure:
+ * on iOS it is what a notification banner, a control-centre pull and our own
+ * Face ID sheet all report, and none of those is the user leaving. Genuinely
+ * leaving — the switcher, the home gesture, the screen locking — reports
+ * `background` right behind it, so nothing that matters is missed.
+ */
+export function personalAppAway(now = lockClockNow()): void {
+  // Our own prompt is not the user walking off; see `checks`.
+  if (checks > 0) return;
   commit(afterPersonalLeave(current, now));
 }
 
@@ -211,16 +257,16 @@ export function personalAppAway(now = Date.now()): void {
  * screen is actually focused — coming back to the dashboard is still time spent
  * away from the ledger.
  */
-export function personalAppActive(idleSeconds: number, now = Date.now()): void {
-  if (present === 0) return;
+export function personalAppActive(idleSeconds: number, now = lockClockNow()): void {
+  if (!inside) return;
   commit(afterPersonalReturn(current, now, idleSeconds));
 }
 
-/** Test seam: forget everything, including who is on screen. */
+/** Test seam: forget everything, including where the user is. */
 export function resetPersonalLockForTests(): void {
-  if (settling !== null) clearTimeout(settling);
-  settling = null;
-  present = 0;
+  inside = false;
+  checks = 0;
+  account = null;
   current = PERSONAL_LOCKED;
   listeners.clear();
 }

--- a/apps/mobile/src/lib/personalLock.ts
+++ b/apps/mobile/src/lib/personalLock.ts
@@ -240,14 +240,36 @@ export function endPersonalCheck(): void {
 }
 
 /**
- * The app went to the background. `inactive` is deliberately not a departure:
- * on iOS it is what a notification banner, a control-centre pull and our own
- * Face ID sheet all report, and none of those is the user leaving. Genuinely
- * leaving — the switcher, the home gesture, the screen locking — reports
- * `background` right behind it, so nothing that matters is missed.
+ * What an `AppState` value means to this lock. A function rather than a
+ * condition inlined in the listener, so the app lock and the personal gate
+ * cannot drift into reading the same transitions differently.
+ *
+ * `inactive` counts as leaving. On iOS it is what the app switcher reports —
+ * and `background` only follows once some other app actually takes over, so a
+ * switcher swipe alone would otherwise never start the clock. That is exactly
+ * the case the lock exists for: the phone gets handed over with the ledger
+ * still on screen. It costs a false positive on a notification banner and a
+ * control-centre pull, which every window above zero forgives anyway, and which
+ * at "Straight away" is arguably what was asked for. Our own biometric sheet
+ * also reports `inactive`, and that one is not a trade-off but a bug — it is
+ * excluded by name, in `personalAppAway`, not by ignoring the whole transition.
+ */
+export function personalAppTransition(state: string): 'away' | 'back' | 'ignore' {
+  if (state === 'background' || state === 'inactive') return 'away';
+  if (state === 'active') return 'back';
+  return 'ignore';
+}
+
+/**
+ * The app went away — see `personalAppTransition` for what counts.
+ *
+ * A check in flight means the prompt we raised is the reason the app went
+ * quiet, so this is a no-op until it resolves. Safe by construction: we only
+ * ever ask while the section is shut, so nothing is being held open. iOS
+ * reports `inactive` on the way *into* the sheet and `active` on the way out,
+ * so the suppression window covers the whole of it.
  */
 export function personalAppAway(now = lockClockNow()): void {
-  // Our own prompt is not the user walking off; see `checks`.
   if (checks > 0) return;
   commit(afterPersonalLeave(current, now));
 }

--- a/apps/mobile/src/lib/personalLock.ts
+++ b/apps/mobile/src/lib/personalLock.ts
@@ -240,9 +240,14 @@ export function endPersonalCheck(): void {
 }
 
 /**
- * What an `AppState` value means to this lock. A function rather than a
- * condition inlined in the listener, so the app lock and the personal gate
- * cannot drift into reading the same transitions differently.
+ * What an `AppState` value means to a lock: gone, back, or neither.
+ *
+ * Used by both listeners in `lib/lock.tsx` — the whole-app lock and this gate.
+ * One "Ask again after" window governs the two of them, so one function has to
+ * decide what starts it; two inline conditions that merely happen to agree
+ * today is how a shared setting quietly comes to mean two different things.
+ * Named for locks rather than for the personal ledger for that reason, even
+ * though it lives in this file with the rest of the pure decisions.
  *
  * `inactive` counts as leaving. On iOS it is what the app switcher reports —
  * and `background` only follows once some other app actually takes over, so a
@@ -254,14 +259,14 @@ export function endPersonalCheck(): void {
  * also reports `inactive`, and that one is not a trade-off but a bug — it is
  * excluded by name, in `personalAppAway`, not by ignoring the whole transition.
  */
-export function personalAppTransition(state: string): 'away' | 'back' | 'ignore' {
+export function lockAwayTransition(state: string): 'away' | 'back' | 'ignore' {
   if (state === 'background' || state === 'inactive') return 'away';
   if (state === 'active') return 'back';
   return 'ignore';
 }
 
 /**
- * The app went away — see `personalAppTransition` for what counts.
+ * The app went away — see `lockAwayTransition` for what counts.
  *
  * A check in flight means the prompt we raised is the reason the app went
  * quiet, so this is a no-op until it resolves. Safe by construction: we only

--- a/apps/mobile/test/personalLock.test.ts
+++ b/apps/mobile/test/personalLock.test.ts
@@ -21,6 +21,7 @@ import {
   leavePersonalSection,
   lockPersonal,
   markPersonalUnlocked,
+  markPersonalUnlockedFromPrompt,
   personalAppActive,
   personalAppAway,
   PERSONAL_LEAVE_SETTLE_MS,
@@ -154,6 +155,21 @@ describe('the live store', () => {
     enterPersonalSection(GRACE, T0);
     lockPersonal();
     expect(personalUnlockedNow(GRACE, T0)).toBe(false);
+  });
+
+  it('starts the away clock if a prompt success resolves after the section was left', () => {
+    markPersonalUnlockedFromPrompt(T0);
+
+    expect(getPersonalLockState()).toEqual({ unlockedAt: T0, awaySince: T0 });
+    expect(personalUnlockedNow(GRACE, T0 + (GRACE - 1) * 1000)).toBe(true);
+    expect(personalUnlockedNow(GRACE, T0 + GRACE * 1000)).toBe(false);
+  });
+
+  it('does not start the away clock when a prompt success resolves while the section is focused', () => {
+    enterPersonalSection(GRACE, T0);
+    markPersonalUnlockedFromPrompt(T0);
+
+    expect(getPersonalLockState()).toEqual({ unlockedAt: T0, awaySince: null });
   });
 
   it('is not opened by a refused check', () => {

--- a/apps/mobile/test/personalLock.test.ts
+++ b/apps/mobile/test/personalLock.test.ts
@@ -1,11 +1,16 @@
 /**
  * The personal ledger's unlock: one state for the whole section.
  *
- * The bug these cover: the gate used to time an unlock from the moment the
+ * The bug these started from: the gate timed an unlock from the moment the
  * sensor was touched, so browsing the Me tab for longer than the grace window
- * meant the walk into "add income" and back asked again — and a refused prompt
- * navigated the user backwards. Here the clock only runs while the user is
- * away, so staying inside the section costs nothing however long it takes.
+ * meant the walk into "add income" and back asked again, and a refused prompt
+ * navigated the user backwards. The clock now runs only while the user is
+ * away, and "away" is read off the router rather than off focus events — which
+ * is what makes the cases below decidable at all rather than races with a
+ * timing constant.
+ *
+ * Every case in the second half is a review probe against PR #742, kept as the
+ * spec it was written as.
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -14,21 +19,23 @@ import {
   afterPersonalAuth,
   afterPersonalLeave,
   afterPersonalReturn,
+  beginPersonalCheck,
   DEFAULT_IDLE_GRACE_SECONDS,
-  enterPersonalSection,
+  endPersonalCheck,
   getPersonalLockState,
+  isPersonalSection,
   isPersonalUnlocked,
-  leavePersonalSection,
   lockPersonal,
   markPersonalUnlocked,
-  markPersonalUnlockedFromPrompt,
   personalAppActive,
   personalAppAway,
-  PERSONAL_LEAVE_SETTLE_MS,
   PERSONAL_LOCKED,
+  personalPresent,
   personalUnlockedNow,
   resetPersonalLockForTests,
+  setPersonalPresence,
   subscribePersonalLock,
+  syncPersonalAccount,
 } from '@/lib/personalLock';
 
 const GRACE = DEFAULT_IDLE_GRACE_SECONDS;
@@ -39,58 +46,72 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
+describe('isPersonalSection', () => {
+  it('claims the Me tab and every room under personal/', () => {
+    expect(isPersonalSection(['(tabs)', 'me'])).toBe(true);
+    expect(isPersonalSection(['me'])).toBe(true);
+    expect(isPersonalSection(['personal', 'entry'])).toBe(true);
+    expect(isPersonalSection(['personal', 'source', '[id]'])).toBe(true);
+  });
+
+  it('claims nothing else', () => {
+    expect(isPersonalSection(['(tabs)', 'index'])).toBe(false);
+    expect(isPersonalSection(['group', '[id]', 'add-expense'])).toBe(false);
+    expect(isPersonalSection(['settings', 'lock'])).toBe(false);
+    expect(isPersonalSection([])).toBe(false);
+  });
+});
+
 describe('isPersonalUnlocked', () => {
   it('is shut until something has been proved', () => {
     expect(isPersonalUnlocked(PERSONAL_LOCKED, T0, GRACE)).toBe(false);
   });
 
   it('stays open indefinitely while the user is still in the section', () => {
-    const state = afterPersonalAuth(T0);
+    const state = afterPersonalAuth(T0, true);
     // An hour of reading the ledger is not a reason to ask again.
     expect(isPersonalUnlocked(state, T0 + 3_600_000, GRACE)).toBe(true);
   });
 
   it('opens on a return inside the idle window', () => {
-    const away = afterPersonalLeave(afterPersonalAuth(T0), T0 + 5_000);
+    const away = afterPersonalLeave(afterPersonalAuth(T0, true), T0 + 5_000);
     expect(isPersonalUnlocked(away, T0 + 5_000 + (GRACE - 1) * 1000, GRACE)).toBe(true);
   });
 
   it('shuts once the idle window has run out', () => {
-    const away = afterPersonalLeave(afterPersonalAuth(T0), T0 + 5_000);
+    const away = afterPersonalLeave(afterPersonalAuth(T0, true), T0 + 5_000);
     expect(isPersonalUnlocked(away, T0 + 5_000 + GRACE * 1000, GRACE)).toBe(false);
   });
 
-  it('counts only the first departure, so iOS inactive-then-background does not restart the clock', () => {
-    const inactive = afterPersonalLeave(afterPersonalAuth(T0), T0 + 1_000);
-    const background = afterPersonalLeave(inactive, T0 + 1_200);
-    expect(background.awaySince).toBe(T0 + 1_000);
+  it('counts only the first departure, so a second leave cannot extend the grace', () => {
+    const first = afterPersonalLeave(afterPersonalAuth(T0, true), T0 + 1_000);
+    const second = afterPersonalLeave(first, T0 + 9_000);
+    expect(second.awaySince).toBe(T0 + 1_000);
   });
 });
 
 describe('afterPersonalReturn', () => {
   it('stops the clock when the return is inside the window', () => {
-    const away = afterPersonalLeave(afterPersonalAuth(T0), T0 + 1_000);
+    const away = afterPersonalLeave(afterPersonalAuth(T0, true), T0 + 1_000);
     const back = afterPersonalReturn(away, T0 + 2_000, GRACE);
     expect(back.awaySince).toBe(null);
     expect(back.unlockedAt).toBe(T0);
   });
 
   it('spends the unlock when the return is past the window', () => {
-    const away = afterPersonalLeave(afterPersonalAuth(T0), T0 + 1_000);
+    const away = afterPersonalLeave(afterPersonalAuth(T0, true), T0 + 1_000);
     expect(afterPersonalReturn(away, T0 + 1_000 + GRACE * 1000, GRACE)).toEqual(PERSONAL_LOCKED);
   });
 });
 
 describe('the live store', () => {
   it('keeps one unlock across navigation inside the section', () => {
-    vi.useFakeTimers();
+    setPersonalPresence(true, GRACE, T0);
     markPersonalUnlocked(T0);
-    enterPersonalSection(GRACE, T0); // the Me tab takes focus
 
-    // Push into "add income": the tab blurs, then the new screen focuses.
-    leavePersonalSection(T0 + 60_000);
-    enterPersonalSection(GRACE, T0 + 60_000);
-    vi.advanceTimersByTime(PERSONAL_LEAVE_SETTLE_MS * 4);
+    // Push into "add income": one personal route replaces another, so the
+    // watcher reports the same answer and presence never moves.
+    setPersonalPresence(isPersonalSection(['personal', 'entry']), GRACE, T0 + 60_000);
 
     // A minute inside the section is well past the grace window, and it makes
     // no difference: nobody left.
@@ -98,39 +119,54 @@ describe('the live store', () => {
     expect(getPersonalLockState().awaySince).toBe(null);
   });
 
-  it('does not re-lock on an intra-section push even with the window set to "straight away"', () => {
-    vi.useFakeTimers();
+  it('survives a push however long the incoming screen takes, even at "straight away"', () => {
+    // The review probe that broke the focus-counter model: with a zero-second
+    // window, a departure of any length at all re-locked. There is no departure
+    // to time now — the path never left the section.
+    setPersonalPresence(true, 0, T0);
     markPersonalUnlocked(T0);
-    enterPersonalSection(0, T0);
-    leavePersonalSection(T0 + 10);
-    enterPersonalSection(0, T0 + 10);
-    vi.advanceTimersByTime(PERSONAL_LEAVE_SETTLE_MS * 4);
-    expect(personalUnlockedNow(0, T0 + 20)).toBe(true);
+    setPersonalPresence(isPersonalSection(['personal', 'entry']), 0, T0 + 120);
+    expect(personalUnlockedNow(0, T0 + 120)).toBe(true);
+    expect(personalUnlockedNow(0, T0 + 10_000)).toBe(true);
   });
 
-  it('starts the clock once the last personal screen is gone', () => {
-    vi.useFakeTimers();
+  it('starts the clock on leaving the section', () => {
+    setPersonalPresence(true, GRACE, T0);
     markPersonalUnlocked(T0);
-    enterPersonalSection(GRACE, T0);
-    leavePersonalSection(T0 + 1_000);
-    vi.advanceTimersByTime(PERSONAL_LEAVE_SETTLE_MS * 4);
+    setPersonalPresence(false, GRACE, T0 + 1_000);
 
     expect(getPersonalLockState().awaySince).toBe(T0 + 1_000);
     expect(personalUnlockedNow(GRACE, T0 + 1_000 + (GRACE - 1) * 1000)).toBe(true);
     expect(personalUnlockedNow(GRACE, T0 + 1_000 + GRACE * 1000)).toBe(false);
   });
 
-  it('re-locks after the app has been in the background beyond the window', () => {
+  it('at "straight away", leaving the section really does shut it', () => {
+    setPersonalPresence(true, 0, T0);
     markPersonalUnlocked(T0);
-    enterPersonalSection(GRACE, T0);
+    setPersonalPresence(false, 0, T0 + 1_000);
+    setPersonalPresence(true, 0, T0 + 2_000);
+    expect(personalUnlockedNow(0, T0 + 2_000)).toBe(false);
+  });
+
+  it('ignores a repeated presence report, so no departure can be re-stamped', () => {
+    setPersonalPresence(true, GRACE, T0);
+    markPersonalUnlocked(T0);
+    setPersonalPresence(false, GRACE, T0 + 1_000);
+    setPersonalPresence(false, GRACE, T0 + 9_000);
+    expect(getPersonalLockState().awaySince).toBe(T0 + 1_000);
+  });
+
+  it('re-locks after the app has been in the background beyond the window', () => {
+    setPersonalPresence(true, GRACE, T0);
+    markPersonalUnlocked(T0);
     personalAppAway(T0 + 1_000);
     personalAppActive(GRACE, T0 + 1_000 + GRACE * 1000);
     expect(getPersonalLockState()).toEqual(PERSONAL_LOCKED);
   });
 
   it('does not re-lock after a glance at a notification', () => {
+    setPersonalPresence(true, GRACE, T0);
     markPersonalUnlocked(T0);
-    enterPersonalSection(GRACE, T0);
     personalAppAway(T0 + 1_000);
     personalAppActive(GRACE, T0 + 6_000);
     expect(personalUnlockedNow(GRACE, T0 + 6_000)).toBe(true);
@@ -138,11 +174,14 @@ describe('the live store', () => {
   });
 
   it('leaves the clock running when the app comes back somewhere other than the section', () => {
+    setPersonalPresence(true, GRACE, T0);
     markPersonalUnlocked(T0);
+    setPersonalPresence(false, GRACE, T0 + 500); // off to the dashboard
     personalAppAway(T0 + 1_000);
     personalAppActive(GRACE, T0 + 2_000);
-    // Nothing personal is on screen, so the time away keeps counting.
-    expect(getPersonalLockState().awaySince).toBe(T0 + 1_000);
+    // Coming back to the dashboard is still time spent away from the ledger,
+    // and the clock started when the section was left, not when the app was.
+    expect(getPersonalLockState().awaySince).toBe(T0 + 500);
   });
 
   it('is shut on a cold start', () => {
@@ -151,40 +190,28 @@ describe('the live store', () => {
   });
 
   it('is shut by sign-out', () => {
+    setPersonalPresence(true, GRACE, T0);
     markPersonalUnlocked(T0);
-    enterPersonalSection(GRACE, T0);
     lockPersonal();
     expect(personalUnlockedNow(GRACE, T0)).toBe(false);
   });
 
-  it('starts the away clock if a prompt success resolves after the section was left', () => {
-    markPersonalUnlockedFromPrompt(T0);
-
-    expect(getPersonalLockState()).toEqual({ unlockedAt: T0, awaySince: T0 });
-    expect(personalUnlockedNow(GRACE, T0 + (GRACE - 1) * 1000)).toBe(true);
-    expect(personalUnlockedNow(GRACE, T0 + GRACE * 1000)).toBe(false);
-  });
-
-  it('does not start the away clock when a prompt success resolves while the section is focused', () => {
-    enterPersonalSection(GRACE, T0);
-    markPersonalUnlockedFromPrompt(T0);
-
-    expect(getPersonalLockState()).toEqual({ unlockedAt: T0, awaySince: null });
-  });
-
   it('is not opened by a refused check', () => {
+    setPersonalPresence(true, GRACE, T0);
     markPersonalUnlocked(T0);
     // What the gate does when authenticateAsync comes back unsuccessful.
     lockPersonal();
     expect(personalUnlockedNow(GRACE, T0)).toBe(false);
-    // And entering the section again does not resurrect the spent unlock.
-    enterPersonalSection(GRACE, T0);
-    expect(personalUnlockedNow(GRACE, T0)).toBe(false);
+    // And re-entering the section does not resurrect the spent unlock.
+    setPersonalPresence(false, GRACE, T0 + 1);
+    setPersonalPresence(true, GRACE, T0 + 2);
+    expect(personalUnlockedNow(GRACE, T0 + 2)).toBe(false);
   });
 
   it('tells its subscribers when the state moves, and only then', () => {
     const seen = vi.fn();
     const stop = subscribePersonalLock(seen);
+    setPersonalPresence(true, GRACE, T0);
     markPersonalUnlocked(T0);
     expect(seen).toHaveBeenCalledTimes(1);
     // Same state again: nothing to say.
@@ -193,5 +220,86 @@ describe('the live store', () => {
     stop();
     lockPersonal();
     expect(seen).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('an account change shuts the section', () => {
+  it('locks when the session goes without passing through sign-out', () => {
+    syncPersonalAccount('user-a');
+    setPersonalPresence(true, GRACE, T0);
+    markPersonalUnlocked(T0);
+
+    // A revoked refresh token, a remote sign-out, an account deleted
+    // elsewhere: the listener just sees the session go.
+    syncPersonalAccount(null);
+    expect(personalUnlockedNow(GRACE, T0)).toBe(false);
+  });
+
+  it('locks when a different account signs in during the same launch', () => {
+    syncPersonalAccount('user-a');
+    setPersonalPresence(true, GRACE, T0);
+    markPersonalUnlocked(T0);
+    syncPersonalAccount('user-b');
+    expect(personalUnlockedNow(GRACE, T0)).toBe(false);
+  });
+
+  it('costs nothing on a token refresh, which reports the same account', () => {
+    syncPersonalAccount('user-a');
+    setPersonalPresence(true, GRACE, T0);
+    markPersonalUnlocked(T0);
+    syncPersonalAccount('user-a');
+    expect(personalUnlockedNow(GRACE, T0 + 3_600_000)).toBe(true);
+  });
+});
+
+describe('a result that lands after the user has gone', () => {
+  it('does not open the section for good', () => {
+    // Android's biometric sheet outlives the screen that raised it: back out of
+    // the section, then present a fingerprint, and the success arrives for a
+    // screen that is no longer there.
+    setPersonalPresence(true, GRACE, T0);
+    setPersonalPresence(false, GRACE, T0 + 1_000);
+    expect(personalPresent()).toBe(false);
+
+    markPersonalUnlocked(T0 + 2_000);
+    // Worth the grace window and no more — not for ever.
+    expect(personalUnlockedNow(GRACE, T0 + 2_000)).toBe(true);
+    expect(personalUnlockedNow(GRACE, T0 + 2_000 + GRACE * 1000)).toBe(false);
+    expect(personalUnlockedNow(GRACE, T0 + 10_000_000)).toBe(false);
+  });
+
+  it('opens without a clock when the user is still there', () => {
+    setPersonalPresence(true, GRACE, T0);
+    markPersonalUnlocked(T0);
+    expect(getPersonalLockState().awaySince).toBe(null);
+  });
+});
+
+describe("the app's own biometric prompt is not a departure", () => {
+  it('survives a background reported from behind our own sheet', () => {
+    // Some Android builds pause the activity behind BiometricPrompt, and iOS
+    // reports inactive behind Face ID. At a zero-second window, counting that
+    // as leaving would re-lock the section because we asked it to unlock —
+    // and then ask again, and again.
+    setPersonalPresence(true, 0, T0);
+    markPersonalUnlocked(T0);
+
+    beginPersonalCheck();
+    personalAppAway(T0 + 5);
+    endPersonalCheck();
+    personalAppActive(0, T0 + 10);
+
+    expect(personalUnlockedNow(0, T0 + 10)).toBe(true);
+    expect(getPersonalLockState().awaySince).toBe(null);
+  });
+
+  it('still notices a real departure once the check is over', () => {
+    setPersonalPresence(true, 0, T0);
+    markPersonalUnlocked(T0);
+    beginPersonalCheck();
+    endPersonalCheck();
+    personalAppAway(T0 + 5);
+    personalAppActive(0, T0 + 10);
+    expect(personalUnlockedNow(0, T0 + 10)).toBe(false);
   });
 });

--- a/apps/mobile/test/personalLock.test.ts
+++ b/apps/mobile/test/personalLock.test.ts
@@ -29,6 +29,7 @@ import {
   markPersonalUnlocked,
   personalAppActive,
   personalAppAway,
+  personalAppTransition,
   PERSONAL_LOCKED,
   personalPresent,
   personalUnlockedNow,
@@ -275,12 +276,43 @@ describe('a result that lands after the user has gone', () => {
   });
 });
 
+describe('personalAppTransition', () => {
+  it('counts the app switcher, which iOS reports as inactive and nothing else', () => {
+    // `background` only arrives once another app actually takes the foreground,
+    // so a switcher swipe and a hand-over would never start the clock without
+    // this — the exact case the lock is for.
+    expect(personalAppTransition('inactive')).toBe('away');
+    expect(personalAppTransition('background')).toBe('away');
+  });
+
+  it('counts coming back, and nothing else at all', () => {
+    expect(personalAppTransition('active')).toBe('back');
+    expect(personalAppTransition('extension')).toBe('ignore');
+    expect(personalAppTransition('unknown')).toBe('ignore');
+  });
+});
+
+describe('the app switcher shuts the section', () => {
+  it('starts the clock on inactive alone, with no background behind it', () => {
+    setPersonalPresence(true, GRACE, T0);
+    markPersonalUnlocked(T0);
+
+    // Swipe into the switcher and hand the phone over. No `background` ever
+    // arrives, because no other app takes over.
+    if (personalAppTransition('inactive') === 'away') personalAppAway(T0 + 1_000);
+
+    expect(getPersonalLockState().awaySince).toBe(T0 + 1_000);
+    expect(personalUnlockedNow(GRACE, T0 + 1_000 + GRACE * 1000)).toBe(false);
+  });
+});
+
 describe("the app's own biometric prompt is not a departure", () => {
-  it('survives a background reported from behind our own sheet', () => {
-    // Some Android builds pause the activity behind BiometricPrompt, and iOS
-    // reports inactive behind Face ID. At a zero-second window, counting that
-    // as leaving would re-lock the section because we asked it to unlock —
-    // and then ask again, and again.
+  it('survives the away reported from behind our own sheet', () => {
+    // iOS turns inactive behind Face ID and some Android builds pause the
+    // activity outright behind BiometricPrompt. Now that `inactive` counts as
+    // leaving, this exclusion is what keeps a zero-second window from
+    // re-locking the section because we asked it to unlock — and then asking
+    // again, and again.
     setPersonalPresence(true, 0, T0);
     markPersonalUnlocked(T0);
 
@@ -291,6 +323,31 @@ describe("the app's own biometric prompt is not a departure", () => {
 
     expect(personalUnlockedNow(0, T0 + 10)).toBe(true);
     expect(getPersonalLockState().awaySince).toBe(null);
+  });
+
+  it('covers the app lock raising its own prompt, which is also not a departure', () => {
+    // `unlock()` and the confirm inside `setEnabled` wrap themselves the same
+    // way; without it, answering the app lock at a zero-second window would
+    // stamp a personal departure and cost a second prompt straight after.
+    setPersonalPresence(true, 0, T0);
+    markPersonalUnlocked(T0);
+
+    beginPersonalCheck();
+    personalAppAway(T0 + 5); // inactive, behind the app lock's sheet
+    personalAppActive(0, T0 + 20);
+    endPersonalCheck();
+
+    expect(personalUnlockedNow(0, T0 + 20)).toBe(true);
+  });
+
+  it('cannot leak the exclusion past a check that threw', () => {
+    // The gate pairs these in a `finally`; this is the property that relies on.
+    beginPersonalCheck();
+    endPersonalCheck();
+    setPersonalPresence(true, 0, T0);
+    markPersonalUnlocked(T0);
+    personalAppAway(T0 + 5);
+    expect(getPersonalLockState().awaySince).toBe(T0 + 5);
   });
 
   it('still notices a real departure once the check is over', () => {

--- a/apps/mobile/test/personalLock.test.ts
+++ b/apps/mobile/test/personalLock.test.ts
@@ -25,11 +25,11 @@ import {
   getPersonalLockState,
   isPersonalSection,
   isPersonalUnlocked,
+  lockAwayTransition,
   lockPersonal,
   markPersonalUnlocked,
   personalAppActive,
   personalAppAway,
-  personalAppTransition,
   PERSONAL_LOCKED,
   personalPresent,
   personalUnlockedNow,
@@ -276,19 +276,22 @@ describe('a result that lands after the user has gone', () => {
   });
 });
 
-describe('personalAppTransition', () => {
+describe('lockAwayTransition', () => {
+  // Both listeners in lib/lock.tsx read transitions through this — the app lock
+  // and the personal gate — so the one "Ask again after" window they share
+  // cannot come to mean two different things.
   it('counts the app switcher, which iOS reports as inactive and nothing else', () => {
     // `background` only arrives once another app actually takes the foreground,
     // so a switcher swipe and a hand-over would never start the clock without
     // this — the exact case the lock is for.
-    expect(personalAppTransition('inactive')).toBe('away');
-    expect(personalAppTransition('background')).toBe('away');
+    expect(lockAwayTransition('inactive')).toBe('away');
+    expect(lockAwayTransition('background')).toBe('away');
   });
 
   it('counts coming back, and nothing else at all', () => {
-    expect(personalAppTransition('active')).toBe('back');
-    expect(personalAppTransition('extension')).toBe('ignore');
-    expect(personalAppTransition('unknown')).toBe('ignore');
+    expect(lockAwayTransition('active')).toBe('back');
+    expect(lockAwayTransition('extension')).toBe('ignore');
+    expect(lockAwayTransition('unknown')).toBe('ignore');
   });
 });
 
@@ -299,7 +302,7 @@ describe('the app switcher shuts the section', () => {
 
     // Swipe into the switcher and hand the phone over. No `background` ever
     // arrives, because no other app takes over.
-    if (personalAppTransition('inactive') === 'away') personalAppAway(T0 + 1_000);
+    if (lockAwayTransition('inactive') === 'away') personalAppAway(T0 + 1_000);
 
     expect(getPersonalLockState().awaySince).toBe(T0 + 1_000);
     expect(personalUnlockedNow(GRACE, T0 + 1_000 + GRACE * 1000)).toBe(false);

--- a/apps/mobile/test/personalLock.test.ts
+++ b/apps/mobile/test/personalLock.test.ts
@@ -1,0 +1,181 @@
+/**
+ * The personal ledger's unlock: one state for the whole section.
+ *
+ * The bug these cover: the gate used to time an unlock from the moment the
+ * sensor was touched, so browsing the Me tab for longer than the grace window
+ * meant the walk into "add income" and back asked again — and a refused prompt
+ * navigated the user backwards. Here the clock only runs while the user is
+ * away, so staying inside the section costs nothing however long it takes.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  afterPersonalAuth,
+  afterPersonalLeave,
+  afterPersonalReturn,
+  DEFAULT_IDLE_GRACE_SECONDS,
+  enterPersonalSection,
+  getPersonalLockState,
+  isPersonalUnlocked,
+  leavePersonalSection,
+  lockPersonal,
+  markPersonalUnlocked,
+  personalAppActive,
+  personalAppAway,
+  PERSONAL_LEAVE_SETTLE_MS,
+  PERSONAL_LOCKED,
+  personalUnlockedNow,
+  resetPersonalLockForTests,
+  subscribePersonalLock,
+} from '@/lib/personalLock';
+
+const GRACE = DEFAULT_IDLE_GRACE_SECONDS;
+const T0 = 1_700_000_000_000;
+
+afterEach(() => {
+  resetPersonalLockForTests();
+  vi.useRealTimers();
+});
+
+describe('isPersonalUnlocked', () => {
+  it('is shut until something has been proved', () => {
+    expect(isPersonalUnlocked(PERSONAL_LOCKED, T0, GRACE)).toBe(false);
+  });
+
+  it('stays open indefinitely while the user is still in the section', () => {
+    const state = afterPersonalAuth(T0);
+    // An hour of reading the ledger is not a reason to ask again.
+    expect(isPersonalUnlocked(state, T0 + 3_600_000, GRACE)).toBe(true);
+  });
+
+  it('opens on a return inside the idle window', () => {
+    const away = afterPersonalLeave(afterPersonalAuth(T0), T0 + 5_000);
+    expect(isPersonalUnlocked(away, T0 + 5_000 + (GRACE - 1) * 1000, GRACE)).toBe(true);
+  });
+
+  it('shuts once the idle window has run out', () => {
+    const away = afterPersonalLeave(afterPersonalAuth(T0), T0 + 5_000);
+    expect(isPersonalUnlocked(away, T0 + 5_000 + GRACE * 1000, GRACE)).toBe(false);
+  });
+
+  it('counts only the first departure, so iOS inactive-then-background does not restart the clock', () => {
+    const inactive = afterPersonalLeave(afterPersonalAuth(T0), T0 + 1_000);
+    const background = afterPersonalLeave(inactive, T0 + 1_200);
+    expect(background.awaySince).toBe(T0 + 1_000);
+  });
+});
+
+describe('afterPersonalReturn', () => {
+  it('stops the clock when the return is inside the window', () => {
+    const away = afterPersonalLeave(afterPersonalAuth(T0), T0 + 1_000);
+    const back = afterPersonalReturn(away, T0 + 2_000, GRACE);
+    expect(back.awaySince).toBe(null);
+    expect(back.unlockedAt).toBe(T0);
+  });
+
+  it('spends the unlock when the return is past the window', () => {
+    const away = afterPersonalLeave(afterPersonalAuth(T0), T0 + 1_000);
+    expect(afterPersonalReturn(away, T0 + 1_000 + GRACE * 1000, GRACE)).toEqual(PERSONAL_LOCKED);
+  });
+});
+
+describe('the live store', () => {
+  it('keeps one unlock across navigation inside the section', () => {
+    vi.useFakeTimers();
+    markPersonalUnlocked(T0);
+    enterPersonalSection(GRACE, T0); // the Me tab takes focus
+
+    // Push into "add income": the tab blurs, then the new screen focuses.
+    leavePersonalSection(T0 + 60_000);
+    enterPersonalSection(GRACE, T0 + 60_000);
+    vi.advanceTimersByTime(PERSONAL_LEAVE_SETTLE_MS * 4);
+
+    // A minute inside the section is well past the grace window, and it makes
+    // no difference: nobody left.
+    expect(personalUnlockedNow(GRACE, T0 + 60_000)).toBe(true);
+    expect(getPersonalLockState().awaySince).toBe(null);
+  });
+
+  it('does not re-lock on an intra-section push even with the window set to "straight away"', () => {
+    vi.useFakeTimers();
+    markPersonalUnlocked(T0);
+    enterPersonalSection(0, T0);
+    leavePersonalSection(T0 + 10);
+    enterPersonalSection(0, T0 + 10);
+    vi.advanceTimersByTime(PERSONAL_LEAVE_SETTLE_MS * 4);
+    expect(personalUnlockedNow(0, T0 + 20)).toBe(true);
+  });
+
+  it('starts the clock once the last personal screen is gone', () => {
+    vi.useFakeTimers();
+    markPersonalUnlocked(T0);
+    enterPersonalSection(GRACE, T0);
+    leavePersonalSection(T0 + 1_000);
+    vi.advanceTimersByTime(PERSONAL_LEAVE_SETTLE_MS * 4);
+
+    expect(getPersonalLockState().awaySince).toBe(T0 + 1_000);
+    expect(personalUnlockedNow(GRACE, T0 + 1_000 + (GRACE - 1) * 1000)).toBe(true);
+    expect(personalUnlockedNow(GRACE, T0 + 1_000 + GRACE * 1000)).toBe(false);
+  });
+
+  it('re-locks after the app has been in the background beyond the window', () => {
+    markPersonalUnlocked(T0);
+    enterPersonalSection(GRACE, T0);
+    personalAppAway(T0 + 1_000);
+    personalAppActive(GRACE, T0 + 1_000 + GRACE * 1000);
+    expect(getPersonalLockState()).toEqual(PERSONAL_LOCKED);
+  });
+
+  it('does not re-lock after a glance at a notification', () => {
+    markPersonalUnlocked(T0);
+    enterPersonalSection(GRACE, T0);
+    personalAppAway(T0 + 1_000);
+    personalAppActive(GRACE, T0 + 6_000);
+    expect(personalUnlockedNow(GRACE, T0 + 6_000)).toBe(true);
+    expect(getPersonalLockState().awaySince).toBe(null);
+  });
+
+  it('leaves the clock running when the app comes back somewhere other than the section', () => {
+    markPersonalUnlocked(T0);
+    personalAppAway(T0 + 1_000);
+    personalAppActive(GRACE, T0 + 2_000);
+    // Nothing personal is on screen, so the time away keeps counting.
+    expect(getPersonalLockState().awaySince).toBe(T0 + 1_000);
+  });
+
+  it('is shut on a cold start', () => {
+    expect(getPersonalLockState()).toEqual(PERSONAL_LOCKED);
+    expect(personalUnlockedNow(GRACE, T0)).toBe(false);
+  });
+
+  it('is shut by sign-out', () => {
+    markPersonalUnlocked(T0);
+    enterPersonalSection(GRACE, T0);
+    lockPersonal();
+    expect(personalUnlockedNow(GRACE, T0)).toBe(false);
+  });
+
+  it('is not opened by a refused check', () => {
+    markPersonalUnlocked(T0);
+    // What the gate does when authenticateAsync comes back unsuccessful.
+    lockPersonal();
+    expect(personalUnlockedNow(GRACE, T0)).toBe(false);
+    // And entering the section again does not resurrect the spent unlock.
+    enterPersonalSection(GRACE, T0);
+    expect(personalUnlockedNow(GRACE, T0)).toBe(false);
+  });
+
+  it('tells its subscribers when the state moves, and only then', () => {
+    const seen = vi.fn();
+    const stop = subscribePersonalLock(seen);
+    markPersonalUnlocked(T0);
+    expect(seen).toHaveBeenCalledTimes(1);
+    // Same state again: nothing to say.
+    markPersonalUnlocked(T0);
+    expect(seen).toHaveBeenCalledTimes(1);
+    stop();
+    lockPersonal();
+    expect(seen).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Reported: "I'm in Personal. When I go to add income, recurring, or a loan, after a few seconds I'm back on that same screen. Those tabs should not keep asking me for bio-authentication — I already unlocked those screens."

Both halves of that — the repeated prompt and the bounce — plus a hole neither of us was looking for.

## The gate was per-screen, and timed from the sensor rather than from presence

`personalAuthedAt` was stamped **only** on a successful `authenticateAsync` and never refreshed while you were inside the section, so `personalGateFresh(graceSeconds)` meant "30 seconds since you last touched the sensor", not "you are still in Personal". The gate's `useFocusEffect` then re-covered on blur and re-ran the whole check on focus — and `/personal/entry|recurring|loans|budgets` are plain root-stack pushes that blur the Me tab. So any round trip lasting longer than the grace re-prompted. With "Ask again after" set to **Straight away** (a real choice in the picker, value `0`), it re-prompted on *every* navigation.

**The bounce** was a separate bug in the same function: `onFail()` was called after the await with no check that the gate was still focused, and `onFail` was `router.back()` / `router.replace('/')`. A prompt resolving refused, cancelled, or timed-out *after* you had moved on popped whatever screen you were then on — "after a few seconds I'm back on that same screen".

**The hole:** `usePersonalGate` was mounted only on `(tabs)/me.tsx`. Nothing under `app/personal/` was gated at all, so a deep link walked straight into the private ledger with no check.

## What it does now

A new pure `lib/personalLock.ts` — no React, no react-native — holds `{ unlockedAt, awaySince }` at module scope with a subscribe/notify store, so mounting and unmounting screens cannot disturb it. `usePersonalGate` reads it through `useSyncExternalStore` and uses `useFocusEffect` only for **presence**. The `onFail` argument is gone entirely; a failed check can no longer navigate.

All six `personal/*` screens now render behind a new `PersonalGuard`, which closes the deep-link hole **at zero extra prompts**, because the unlock is section-wide.

Re-locks on: background beyond the window, leaving the section beyond the window, sign-out, cold start, and a refused check. Never on intra-section navigation — a push's blur/focus pair is absorbed by a 50ms settle, and the departure is timestamped at blur so the settle cannot quietly extend anyone's grace. Time spent inside the section never ages the unlock.

The window is your existing **"Ask again after"** setting, so the app lock and this gate share one preference rather than inventing a second. Its default is one named constant, `DEFAULT_IDLE_GRACE_SECONDS = 30`, which `lock.tsx` now aliases — one literal in the codebase.

## Security is stricter, not looser

No hardware / nothing enrolled / web still opens with no prompt, byte-identical to before, with RLS still guarding the data. It is **strengthened** in two places: the check now waits for the async hardware answer before deciding, so it can no longer open because `supported` was still `false` mid-hydration; and the six previously ungated screens are now gated. A cancelled or failed check forces the locked state — shield stays up, no content flash, no navigation, and an explicit "That did not unlock it. Try again, or go back."

## Verification

`pnpm lint` 0 errors, typecheck clean, **82 files / 1058 tests pass**, including a new `test/personalLock.test.ts` (17 cases: unlocked survives intra-section navigation *including with the window set to 0*; background beyond the window re-locks and under it does not; a foreground return outside the section keeps the clock running; sign-out clears; a refused auth never marks unlocked; cold start shut).

Needs a device — this is the fix's whole point and only hardware shows it: one prompt entering Personal, then none walking into income/recurring/loans/budgets/transactions and back. Also the 50ms settle on a real Android push with "Straight away" selected (the harshest case), and iOS Face ID driving `AppState` to `inactive` without reading as a departure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jhzmZz5fkjnZZ14YxHGfS