### PR TITLE
The phone not answering is not a connection problem

### DIFF
--- a/apps/mobile/src/app/settings/offline-voice.tsx
+++ b/apps/mobile/src/app/settings/offline-voice.tsx
@@ -54,12 +54,12 @@
  * different sentences, because they are different problems.
  */
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { FlashList } from '@shopify/flash-list';
 import { useQuery } from '@tanstack/react-query';
-import { router } from 'expo-router';
-import { Platform, Pressable, View } from 'react-native';
+import { router, useFocusEffect } from 'expo-router';
+import { Pressable, View } from 'react-native';
 
 import {
   Avatar,
@@ -82,7 +82,10 @@ import {
 import { deviceLocale, LANGUAGE_NAMES, LANGUAGES, plural, useStrings } from '@/i18n';
 import {
   offlineDownloadReason,
+  offlineVoiceKnowledge,
   offlineVoiceModels,
+  offlineVoiceRead,
+  withConfirmedInstalls,
   type OfflineDownloadReason,
   type OfflineVoiceModel,
 } from '@/lib/dictation';
@@ -197,12 +200,59 @@ export default function OfflineVoiceScreen() {
     enabled: speechModels !== null && reportsInstalled,
   });
 
-  const models = offlineVoiceModels(
-    LANGUAGES,
-    deviceLocale(),
-    locales.data?.locales,
-    locales.data?.installedLocales,
-    reportsInstalled ? 'reported' : 'unknowable',
+  // A model can land while this screen is not the one in front — the Android 13
+  // dialog finishes, a queued download completes on Wi-Fi, somebody adds one in
+  // Android's own settings — and nothing tells us when. Coming back is the moment
+  // to ask again, so the tick appears on its own rather than only after somebody
+  // thinks to pull or tap refresh.
+  //
+  // Gated on the same condition the query is enabled by rather than trusting a
+  // disabled query to ignore a refetch — the screen should not depend on which
+  // way the data library happens to read `enabled` this major version.
+  const canRead = speechModels !== null && reportsInstalled;
+  const refetch = locales.refetch;
+  useFocusEffect(
+    useCallback(() => {
+      if (canRead) void refetch();
+    }, [canRead, refetch]),
+  );
+
+  // What this screen actually knows, as one word (see `offlineVoiceRead`). Every
+  // notice, the error card, and whether the installed list may be believed all
+  // come from here, so they cannot disagree with one another.
+  const read = offlineVoiceRead({
+    hasModule: speechModels !== null,
+    supportsOnDevice,
+    reportsInstalled,
+    canDownload,
+    query: locales.isError
+      ? 'error'
+      : locales.isSuccess
+        ? 'success'
+        : locales.isPending && locales.fetchStatus === 'idle'
+          ? 'idle'
+          : 'loading',
+    namedAnything:
+      (locales.data?.locales.length ?? 0) > 0 || (locales.data?.installedLocales.length ?? 0) > 0,
+  });
+
+  // The tags this screen watched land. Stronger evidence than the inventory,
+  // which under-reports on many phones and on some cannot be read at all —
+  // without it, a finished download on such a phone leaves the row still
+  // offering Download with "Downloaded. The mic can use it now." underneath.
+  const confirmed = Object.entries(progress)
+    .filter(([, row]) => row.phase === 'done')
+    .map(([tag]) => tag);
+
+  const models = withConfirmedInstalls(
+    offlineVoiceModels(
+      LANGUAGES,
+      deviceLocale(),
+      locales.data?.locales,
+      locales.data?.installedLocales,
+      offlineVoiceKnowledge(read),
+    ),
+    confirmed,
   );
 
   const setRow = (tag: string, row: RowProgress): void => {
@@ -229,6 +279,8 @@ export default function OfflineVoiceScreen() {
         return t.offlineVoice.notDownloaded;
       case 'network':
         return t.offlineVoice.networkFailed;
+      case 'permission':
+        return t.offlineVoice.permissionNeeded;
       case 'busy':
         return t.offlineVoice.serviceBusy;
       case 'started':
@@ -291,27 +343,21 @@ export default function OfflineVoiceScreen() {
   };
 
   const showList = speechModels !== null && supportsOnDevice;
-  // A phone that answered, and named nothing at all. Worth saying out loud: the
-  // app rows below are then the only ones on the screen, and their absence of
-  // company is the phone's doing rather than a list still loading.
-  const namedNothing =
-    locales.isSuccess &&
-    (locales.data?.locales.length ?? 0) === 0 &&
-    (locales.data?.installedLocales.length ?? 0) === 0;
 
-  // One notice at a time, most disqualifying first. Each says what this
-  // particular phone can do, and none of them promises a download that will not
-  // happen.
+  // One notice at a time, in the order `offlineVoiceRead` settled — most
+  // disqualifying fact first, and each of them something about this phone rather
+  // than about the app. `unreadable` is deliberately absent: it is not a notice
+  // but the card below, because it is the one state with something to press.
   const notice: { tone: 'warning' | 'info'; text: string } | null =
-    speechModels === null
+    read === 'no-module'
       ? { tone: 'warning', text: t.offlineVoice.unavailable }
-      : !supportsOnDevice
+      : read === 'no-on-device'
         ? { tone: 'warning', text: t.offlineVoice.noOnDevice }
-        : Platform.OS === 'ios'
+        : read === 'unknowable'
           ? { tone: 'info', text: t.offlineVoice.iosNote }
-          : !canDownload
+          : read === 'too-old'
             ? { tone: 'warning', text: t.offlineVoice.tooOld }
-            : namedNothing
+            : read === 'empty'
               ? { tone: 'info', text: t.offlineVoice.empty }
               : null;
 
@@ -411,19 +457,32 @@ export default function OfflineVoiceScreen() {
           paddingBottom: clearance,
         }}
         showsVerticalScrollIndicator={false}
+        // The gesture the old copy promised and the screen never had. Offered
+        // only where there is a list to re-read, exactly as the header glyph is.
+        refreshing={reportsInstalled && locales.isFetching}
+        onRefresh={reportsInstalled ? () => void locales.refetch() : undefined}
         ListHeaderComponent={
           <View style={{ gap: theme.spacing.md, paddingVertical: theme.spacing.lg }}>
             <Text variant="body" tone="muted">
               {t.offlineVoice.intro}
             </Text>
             {notice ? <Callout tone={notice.tone}>{notice.text}</Callout> : null}
-            {locales.isError ? (
+            {/* The phone's own words, never the network's. Nothing in this read
+                leaves the device, so the app's generic "check your connection"
+                was naming a fault that cannot be the cause — and sending somebody
+                on full signal off to look at their Wi-Fi. */}
+            {read === 'unreadable' ? (
               <Card style={{ gap: theme.spacing.sm }}>
-                <Text variant="subheading">{t.loadError}</Text>
+                <Text variant="subheading">{t.offlineVoice.unreadable}</Text>
                 <Text variant="body" tone="muted">
-                  {t.loadErrorBody}
+                  {t.offlineVoice.unreadableBody}
                 </Text>
-                <Button label={t.retry} fullWidth onPress={() => void locales.refetch()} />
+                <Button
+                  label={t.retry}
+                  fullWidth
+                  disabled={locales.isFetching}
+                  onPress={() => void locales.refetch()}
+                />
               </Card>
             ) : null}
           </View>
@@ -673,11 +732,13 @@ function ModelRow({
             </Text>
           ) : null}
         </View>
-        {/* `unknown` gets a question mark and says so. It used to draw nothing,
-            which read as an answer of its own — a row with no tick looks
-            uninstalled. "Can't tell" is the true statement, and the notice in
-            the header explains why iPhone cannot be asked. What it still does
-            not get is a button, because there is nothing here to press. */}
+        {/* Three answers, and only one of them is a shrug. A tick is a fact. A
+            Download button is offered wherever a download is actually possible —
+            including when the phone would not say what it holds, because there
+            the tap *is* the probe (see `offlineDownloadReason`), and refusing to
+            offer it would strand the reader on the one screen built to help
+            them. "Can't tell" is left for the phones with nothing to press:
+            iPhone, which cannot be asked, and Android 12, which cannot fetch. */}
         {model.state === 'installed' ? (
           <StateMark
             icon="checkmark-circle"
@@ -685,30 +746,28 @@ function ModelRow({
             label={t.offlineVoice.installed}
             tone="positive"
           />
+        ) : canDownload ? (
+          <Button
+            label={t.offlineVoice.download}
+            size="sm"
+            variant="secondary"
+            icon={
+              <Ionicons
+                name="cloud-download-outline"
+                size={iconSize.md}
+                color={theme.color.brand}
+              />
+            }
+            disabled={working}
+            onPress={onDownload}
+          />
         ) : model.state === 'missing' ? (
-          canDownload ? (
-            <Button
-              label={t.offlineVoice.download}
-              size="sm"
-              variant="secondary"
-              icon={
-                <Ionicons
-                  name="cloud-download-outline"
-                  size={iconSize.md}
-                  color={theme.color.brand}
-                />
-              }
-              disabled={working}
-              onPress={onDownload}
-            />
-          ) : (
-            <StateMark
-              icon="cloud-offline-outline"
-              color={theme.color.textMuted}
-              label={t.offlineVoice.notInstalled}
-              tone="neutral"
-            />
-          )
+          <StateMark
+            icon="cloud-offline-outline"
+            color={theme.color.textMuted}
+            label={t.offlineVoice.notInstalled}
+            tone="neutral"
+          />
         ) : (
           <StateMark
             icon="help-circle-outline"

--- a/apps/mobile/src/app/settings/offline-voice.tsx
+++ b/apps/mobile/src/app/settings/offline-voice.tsx
@@ -88,6 +88,7 @@ import {
   withConfirmedInstalls,
   type OfflineDownloadReason,
   type OfflineVoiceModel,
+  type OfflineVoiceReadInput,
 } from '@/lib/dictation';
 import { useReducedMotion } from '@/lib/reducedMotion';
 import { speechModels } from '@/lib/speechModels';
@@ -217,24 +218,28 @@ export default function OfflineVoiceScreen() {
     }, [canRead, refetch]),
   );
 
-  // What this screen actually knows, as one word (see `offlineVoiceRead`). Every
-  // notice, the error card, and whether the installed list may be believed all
-  // come from here, so they cannot disagree with one another.
-  const read = offlineVoiceRead({
+  // Everything the screen knows about this phone, gathered once and then asked
+  // two separate questions — what to say, and what may be believed. They are not
+  // the same question and must not be derived from one another; see
+  // `offlineVoiceKnowledge`.
+  //
+  // `hasData` is the one that has to be read carefully. React Query keeps a
+  // query's answer when a later refetch fails — `status` goes to `error` while
+  // `data` stays exactly where it was — so "the last fetch failed" and "we know
+  // nothing" are different facts, and this screen refetches on every visit now.
+  // Conflating them would mean a briefly busy speech service, on the visit after
+  // a good one, wiped every tick off the screen.
+  const inventory: OfflineVoiceReadInput = {
     hasModule: speechModels !== null,
     supportsOnDevice,
     reportsInstalled,
     canDownload,
-    query: locales.isError
-      ? 'error'
-      : locales.isSuccess
-        ? 'success'
-        : locales.isPending && locales.fetchStatus === 'idle'
-          ? 'idle'
-          : 'loading',
+    query: locales.isError ? 'error' : locales.isSuccess ? 'success' : 'loading',
+    hasData: locales.data != null,
     namedAnything:
       (locales.data?.locales.length ?? 0) > 0 || (locales.data?.installedLocales.length ?? 0) > 0,
-  });
+  };
+  const read = offlineVoiceRead(inventory);
 
   // The tags this screen watched land. Stronger evidence than the inventory,
   // which under-reports on many phones and on some cannot be read at all —
@@ -250,7 +255,7 @@ export default function OfflineVoiceScreen() {
       deviceLocale(),
       locales.data?.locales,
       locales.data?.installedLocales,
-      offlineVoiceKnowledge(read),
+      offlineVoiceKnowledge(inventory),
     ),
     confirmed,
   );
@@ -343,11 +348,16 @@ export default function OfflineVoiceScreen() {
   };
 
   const showList = speechModels !== null && supportsOnDevice;
+  // There is a list, and it can be re-read. Both refresh affordances answer to
+  // this one condition rather than each judging it for itself.
+  const canRefresh = showList && reportsInstalled;
 
   // One notice at a time, in the order `offlineVoiceRead` settled — most
   // disqualifying fact first, and each of them something about this phone rather
   // than about the app. `unreadable` is deliberately absent: it is not a notice
   // but the card below, because it is the one state with something to press.
+  // `stale` is a notice and not that card, which is the whole difference between
+  // them — the list is still standing, so there is nothing here to recover from.
   const notice: { tone: 'warning' | 'info'; text: string } | null =
     read === 'no-module'
       ? { tone: 'warning', text: t.offlineVoice.unavailable }
@@ -357,9 +367,11 @@ export default function OfflineVoiceScreen() {
           ? { tone: 'info', text: t.offlineVoice.iosNote }
           : read === 'too-old'
             ? { tone: 'warning', text: t.offlineVoice.tooOld }
-            : read === 'empty'
-              ? { tone: 'info', text: t.offlineVoice.empty }
-              : null;
+            : read === 'stale'
+              ? { tone: 'info', text: t.offlineVoice.staleNote }
+              : read === 'empty'
+                ? { tone: 'info', text: t.offlineVoice.empty }
+                : null;
 
   /**
    * A group that folds: its header always, its rows only when open.
@@ -434,7 +446,7 @@ export default function OfflineVoiceScreen() {
             where there is a list to re-read: on a phone that reports nothing,
             refreshing would redraw the same four rows and mean nothing. The
             spacer keeps the title centred in its absence. */}
-        {reportsInstalled ? (
+        {canRefresh ? (
           <IconButton label={t.offlineVoice.refresh} onPress={() => void locales.refetch()}>
             <Ionicons name="refresh" size={iconSize.md} color={theme.color.text} />
           </IconButton>
@@ -458,9 +470,12 @@ export default function OfflineVoiceScreen() {
         }}
         showsVerticalScrollIndicator={false}
         // The gesture the old copy promised and the screen never had. Offered
-        // only where there is a list to re-read, exactly as the header glyph is.
-        refreshing={reportsInstalled && locales.isFetching}
-        onRefresh={reportsInstalled ? () => void locales.refetch() : undefined}
+        // wherever there is actually a list to re-read — which is `showList` and
+        // not merely "this phone reports installed models": an Android build that
+        // cannot recognise on-device at all draws no rows, and a pull that
+        // re-reads nothing is a control with no referent.
+        refreshing={canRefresh && locales.isFetching}
+        onRefresh={canRefresh ? () => void locales.refetch() : undefined}
         ListHeaderComponent={
           <View style={{ gap: theme.spacing.md, paddingVertical: theme.spacing.lg }}>
             <Text variant="body" tone="muted">

--- a/apps/mobile/src/app/voice.tsx
+++ b/apps/mobile/src/app/voice.tsx
@@ -54,7 +54,6 @@ import {
   Row,
   Screen,
   Text,
-  useScreenClearance,
   useTheme,
 } from '@waves/ui';
 
@@ -76,6 +75,7 @@ import { useUpsertPersonalRecord } from '@/data/personal';
 import { displayName, groupLabel, GroupType, type GroupRow } from '@/data/types';
 import { isRtl, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
+import { useBottomClearance } from '@/lib/clearance';
 import { useDefaultCurrency } from '@/lib/currency';
 import { friendlyError } from '@/lib/errors';
 import {
@@ -191,7 +191,9 @@ function toMinor(amount: string, currency: string): bigint | null {
 
 export default function VoiceScreen() {
   const theme = useTheme();
-  const clearance = useScreenClearance();
+  // The one canonical foot. `Screen` below takes only the top edge, so nothing
+  // else has added the bottom inset — this is where it comes from, once.
+  const clearance = useBottomClearance();
   const insets = useSafeAreaInsets();
   const { height: windowHeight } = useWindowDimensions();
   // The keyboard's height, measured — used to lift the destination sheet above
@@ -1387,6 +1389,13 @@ export default function VoiceScreen() {
           paddingHorizontal: theme.spacing.xl,
           paddingBottom: phase === 'review' ? theme.spacing.xl : clearance,
           gap: theme.spacing.xl,
+          // Fill the viewport when the capture surface is shorter than it, so the
+          // mic panel's own footer (the offline-voice offer) can sit at the foot of
+          // the screen rather than tucked under the mic. `flexGrow` only ever sets a
+          // *minimum* — a panel taller than the window still scrolls, where `flex`
+          // would have squeezed it. The review lays itself out and keeps its own
+          // pinned action bar, so it is left alone.
+          ...(phase === 'review' ? null : { flexGrow: 1 }),
         }}
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
@@ -1579,7 +1588,7 @@ export default function VoiceScreen() {
           // included. A heard-but-amountless try comes back as `missed`; the mic
           // is the retry, and tapping it (via `onListen`) clears the miss. No
           // warning banner and no separate button stacked around it.
-          <View style={{ gap: theme.spacing.lg, paddingTop: theme.spacing.xxl }}>
+          <View style={{ flexGrow: 1, gap: theme.spacing.lg, paddingTop: theme.spacing.xxl }}>
             <VoiceMicPanel
               key={attempt}
               onDone={handleTranscript}

--- a/apps/mobile/src/components/VoiceCapture.tsx
+++ b/apps/mobile/src/components/VoiceCapture.tsx
@@ -15,6 +15,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
+import { useFocusEffect } from 'expo-router';
 import { ExpoSpeechRecognitionModule, useSpeechRecognitionEvent } from 'expo-speech-recognition';
 import { Animated, Easing, Linking, Pressable, View } from 'react-native';
 import Reanimated, {
@@ -193,6 +194,75 @@ function PulseRings({ active, theme }: { active: boolean; theme: Theme }) {
       ))}
     </>
   );
+}
+
+/**
+ * The resting breath: how long one half of it takes, how far it swells, and how
+ * long it takes to let go.
+ *
+ * Slow and shallow on purpose. This is an invitation to tap, not a notification,
+ * so there is no bounce, no jitter and no colour in it — a four-and-a-bit-percent
+ * swell over two and a half seconds, which the eye reads as alive and never as
+ * urgent.
+ *
+ * It is also deliberately a *different gesture* from listening, not a weaker one.
+ * While the mic listens, the button holds perfectly still and the space around it
+ * comes alive — the halo swells, rings break outward. At rest the opposite: the
+ * button itself breathes and nothing surrounds it. Because the two states are
+ * made of different parts, idle can never read as a half-broken listening.
+ */
+const IDLE_BREATH_MS = 2500;
+const IDLE_BREATH_SCALE = 1.045;
+const IDLE_SETTLE_MS = 320;
+
+/**
+ * The mic's breath while nobody is speaking, as a 0…1 driver.
+ *
+ * `active` is the entire gate, and every reason to be still goes through it: the
+ * reduce-motion preference, a screen that is no longer in front, and a live
+ * recogniser. Switching it off does not snap the button back to size — a jump at
+ * the exact moment the mic opens reads as a glitch — it eases home over
+ * {@link IDLE_SETTLE_MS}, so idle → listening → idle is one continuous gesture.
+ *
+ * Nothing outlives the effect: every path stops its own animation on the way out,
+ * so a re-render, a blur, or a Fast Refresh cannot leave a loop running behind
+ * the screen.
+ */
+function useIdleBreath(active: boolean): Animated.Value {
+  const [breath] = useState(() => new Animated.Value(0));
+
+  useEffect(() => {
+    if (!active) {
+      const settle = Animated.timing(breath, {
+        toValue: 0,
+        duration: IDLE_SETTLE_MS,
+        easing: Easing.out(Easing.ease),
+        useNativeDriver: true,
+      });
+      settle.start();
+      return () => settle.stop();
+    }
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(breath, {
+          toValue: 1,
+          duration: IDLE_BREATH_MS,
+          easing: Easing.inOut(Easing.ease),
+          useNativeDriver: true,
+        }),
+        Animated.timing(breath, {
+          toValue: 0,
+          duration: IDLE_BREATH_MS,
+          easing: Easing.inOut(Easing.ease),
+          useNativeDriver: true,
+        }),
+      ]),
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [active, breath]);
+
+  return breath;
 }
 
 /** The waveform's drawing box. Fixed and centred — the status area centres it. */
@@ -533,6 +603,23 @@ export function VoiceCapture({
   const [downloading, setDownloading] = useState(false);
   const [downloadMsg, setDownloadMsg] = useState<string | null>(null);
 
+  // Whether this screen is the one in front. The resting breath below must not
+  // run behind another screen — an animation nobody can see is battery and
+  // nothing else — and the panel is not always unmounted when it is left.
+  const [focused, setFocused] = useState(true);
+  useFocusEffect(
+    useCallback(() => {
+      setFocused(true);
+      return () => setFocused(false);
+    }, []),
+  );
+
+  // The mic breathes only while it is genuinely waiting to be tapped: not while
+  // it listens (that state has motion of its own), not behind another screen,
+  // not on a build that has no microphone to offer, and never when the reader
+  // has asked the OS for less motion.
+  const breath = useIdleBreath(available && focused && !listening && !reduceMotion);
+
   useSpeechRecognitionEvent('start', () => {
     if (!speechMic.owns(session)) return;
     clearStall();
@@ -808,6 +895,21 @@ export function VoiceCapture({
     speechMic.stop(session);
   }, [session]);
 
+  /**
+   * The one act this screen offers: open the mic, or close it.
+   *
+   * It is a named function rather than a lambda on the button because it now has
+   * two ways in — the mic itself, and the line of copy under it, which somebody
+   * reading "Tap to speak" will very reasonably tap. Two entrances must not mean
+   * two implementations: every guard `start` keeps (the claim on the single
+   * recogniser, a permission call already in flight, the installed-model probe)
+   * and everything `stop` is careful about belong to both taps or to neither.
+   */
+  const toggle = useCallback((): void => {
+    if (listening) stop();
+    else void start();
+  }, [listening, start, stop]);
+
   // A push-to-talk hold has ended (see `endSignal`). Lifting the finger is the
   // same act as tapping the stop button, so it takes the same path; sliding away
   // is the one that has to differ, because it must not deliver a transcript.
@@ -945,40 +1047,57 @@ export function VoiceCapture({
       >
         <Halo active={listening && !reduceMotion} theme={theme} />
         <PulseRings active={listening && !reduceMotion} theme={theme} />
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel={
-            listening ? t.misc.stopDictating : showMiss ? t.voice.tapToRetry : t.voice.tapToSpeak
-          }
-          accessibilityState={{ busy: listening }}
-          onPress={() => (listening ? stop() : void start())}
-          hitSlop={8}
-          style={({ pressed }) => ({
-            width: MIC_SIZE,
-            height: MIC_SIZE,
-            borderRadius: MIC_SIZE / 2,
-            alignItems: 'center',
-            justifyContent: 'center',
-            backgroundColor: theme.color.buttonPrimary,
-            opacity: pressed ? 0.9 : 1,
-            // A soft glow lifts the black mic off the surface while it is live.
-            ...(listening
-              ? {
-                  shadowColor: theme.color.buttonPrimary,
-                  shadowOpacity: 0.45,
-                  shadowRadius: 20,
-                  shadowOffset: { width: 0, height: 6 },
-                  elevation: 10,
-                }
-              : null),
-          })}
+        {/* The resting breath scales the button and only the button. It lives
+            inside the fixed square, so the swell never moves a single thing
+            around it — and it is a wrapper rather than a style on the Pressable
+            so the press feedback and the breath cannot overwrite each other. */}
+        <Animated.View
+          style={{
+            transform: [
+              {
+                scale: breath.interpolate({
+                  inputRange: [0, 1],
+                  outputRange: [1, IDLE_BREATH_SCALE],
+                }),
+              },
+            ],
+          }}
         >
-          <Ionicons
-            name={listening ? 'stop' : 'mic'}
-            size={iconSize.xxl}
-            color={theme.color.onButtonPrimary}
-          />
-        </Pressable>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={
+              listening ? t.misc.stopDictating : showMiss ? t.voice.tapToRetry : t.voice.tapToSpeak
+            }
+            accessibilityState={{ busy: listening }}
+            onPress={toggle}
+            hitSlop={8}
+            style={({ pressed }) => ({
+              width: MIC_SIZE,
+              height: MIC_SIZE,
+              borderRadius: MIC_SIZE / 2,
+              alignItems: 'center',
+              justifyContent: 'center',
+              backgroundColor: theme.color.buttonPrimary,
+              opacity: pressed ? 0.9 : 1,
+              // A soft glow lifts the black mic off the surface while it is live.
+              ...(listening
+                ? {
+                    shadowColor: theme.color.buttonPrimary,
+                    shadowOpacity: 0.45,
+                    shadowRadius: 20,
+                    shadowOffset: { width: 0, height: 6 },
+                    elevation: 10,
+                  }
+                : null),
+            })}
+          >
+            <Ionicons
+              name={listening ? 'stop' : 'mic'}
+              size={iconSize.xxl}
+              color={theme.color.onButtonPrimary}
+            />
+          </Pressable>
+        </Animated.View>
       </View>
 
       {/* Listening: the status word over a live waveform. Recovering: the title
@@ -987,9 +1106,28 @@ export function VoiceCapture({
           The miss is stated once (the title), never a warning stacked on a
           warning. */}
       <View style={{ alignItems: 'center', gap: theme.spacing.md }}>
-        <Text tone={listening || showMiss ? 'brand' : 'muted'}>
-          {listening ? t.misc.listening : showMiss ? t.voice.tapToRetry : t.voice.tapToSpeak}
-        </Text>
+        {/* The line that says "Tap to speak" is a thing to tap. It was copy and
+            nothing else, which meant the most literal reading of the screen —
+            tap the words telling you to tap — did nothing at all. It runs the
+            same `toggle` the mic runs, so it can never drift out of step with
+            it: whatever the mic would do in this state, this does.
+
+            Deliberately not a second entry in the accessibility tree. The mic
+            two rows up is already a button carrying this exact label and this
+            exact action, and a screen reader that meets the same command twice
+            in a row has learned nothing the second time. This is that control's
+            own copy, widened into a target for the eye and the thumb. */}
+        <Pressable
+          onPress={toggle}
+          hitSlop={8}
+          accessibilityElementsHidden
+          importantForAccessibility="no-hide-descendants"
+          style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+        >
+          <Text tone={listening || showMiss ? 'brand' : 'muted'}>
+            {listening ? t.misc.listening : showMiss ? t.voice.tapToRetry : t.voice.tapToSpeak}
+          </Text>
+        </Pressable>
         {listening && !reduceMotion ? (
           <Waveform active={listening} level={level} />
         ) : !listening && !showMiss && !live ? (

--- a/apps/mobile/src/components/VoiceCapture.tsx
+++ b/apps/mobile/src/components/VoiceCapture.tsx
@@ -908,8 +908,24 @@ export function VoiceCapture({
   const showMiss = !listening && (missed || emptyMiss);
   const missHeadline = missed ? t.voice.noAmount : t.voice.missedNothing;
 
+  // The on-device setup offer, in one place instead of two.
+  //
+  // It used to be drawn twice — once crammed under the worked example at rest,
+  // once after a miss the network engine caused — and the first of those put a
+  // one-off piece of housekeeping in the middle of the capture surface, a line
+  // under the sentence somebody is being invited to speak. The *when* is
+  // unchanged (this is exactly the union of the two old conditions); only the
+  // *where* moved, to the foot of the panel, where an aside belongs.
+  const offerOffline =
+    (!listening && !showMiss && !live && offlineEligible) ||
+    (showMiss && (engine === 'network' || offlineEligible));
+
   return (
-    <View style={{ alignItems: 'center', gap: theme.spacing.xl }}>
+    // `flexGrow` (never `flex`) so the panel fills a tall screen — letting the
+    // offer below settle on the bottom edge — without being squeezed on a short
+    // one, where the screen scrolls instead. See the matching note on the route's
+    // scroll container.
+    <View style={{ flexGrow: 1, alignItems: 'center', gap: theme.spacing.xl }}>
       {/* One headline, whatever most needs saying: the sentence forming while
           listening, a calm recovery line after a miss, or the opening prompt at
           rest. Never a warning stacked on top of it. */}
@@ -977,24 +993,9 @@ export function VoiceCapture({
         {listening && !reduceMotion ? (
           <Waveform active={listening} level={level} />
         ) : !listening && !showMiss && !live ? (
-          <View style={{ alignItems: 'center', gap: theme.spacing.xs }}>
-            <Text variant="caption" tone="faint" align="center">
-              {t.voice.example}
-            </Text>
-            {offlineEligible ? (
-              <Pressable
-                accessibilityRole="button"
-                disabled={downloading}
-                onPress={() => void setupOffline()}
-                hitSlop={8}
-                style={({ pressed }) => ({ opacity: downloading ? 0.5 : pressed ? 0.6 : 1 })}
-              >
-                <Text variant="caption" tone="brand" style={{ fontWeight: '600' }}>
-                  {t.voice.setupOffline}
-                </Text>
-              </Pressable>
-            ) : null}
-          </View>
+          <Text variant="caption" tone="faint" align="center">
+            {t.voice.example}
+          </Text>
         ) : null}
       </View>
 
@@ -1006,17 +1007,31 @@ export function VoiceCapture({
         </Pressable>
       ) : null}
 
-      {/* A one-line failure diagnostic, shown only on a miss — which engine ran,
-          whether audio reached it, whether any words returned. Lets a device
-          where voice silently does nothing be told apart from a cable. */}
-      {/* When the network engine heard audio but returned nothing, its recogniser
-          is broken on this device — offer the on-device model, which recognises
-          without the network path at all. */}
-      {showMiss && (engine === 'network' || offlineEligible) ? (
-        <View style={{ alignItems: 'center', gap: theme.spacing.xs }}>
+      {/* The panel's footer: the on-device setup offer, at the foot of the screen.
+          Either it is the standing offer (on-device is supported here but the
+          English model is not installed) or it is the way out of a miss the
+          network engine caused — when that recogniser hears audio and returns
+          nothing, it is broken on this device and the on-device model is the only
+          path that works.
+
+          `marginTop: 'auto'` is what carries it down: the panel grows to the
+          window, so the free space collects above this block instead of below it.
+          The padding above is its own breathing room, and the room below it comes
+          from the route's `clearance` — the system navigation bar's inset plus a
+          breath — applied once, on the scroll container. */}
+      {offerOffline ? (
+        <View
+          style={{
+            marginTop: 'auto',
+            paddingTop: theme.spacing.xxl,
+            alignItems: 'center',
+            gap: theme.spacing.xs,
+          }}
+        >
           <Pressable
             accessibilityRole="button"
             disabled={downloading}
+            accessibilityState={{ disabled: downloading }}
             onPress={() => void setupOffline()}
             hitSlop={8}
             style={({ pressed }) => ({ opacity: downloading ? 0.5 : pressed ? 0.6 : 1 })}

--- a/apps/mobile/src/components/VoiceCapture.tsx
+++ b/apps/mobile/src/components/VoiceCapture.tsx
@@ -1113,13 +1113,24 @@ export function VoiceCapture({
             it: whatever the mic would do in this state, this does.
 
             Deliberately not a second entry in the accessibility tree. The mic
-            two rows up is already a button carrying this exact label and this
-            exact action, and a screen reader that meets the same command twice
-            in a row has learned nothing the second time. This is that control's
-            own copy, widened into a target for the eye and the thumb. */}
+            two rows up is already a button carrying this exact label — the same
+            expression, character for character — and this exact action, so a
+            screen reader that meets the same command twice in a row has learned
+            nothing the second time. This is that control's own copy, widened
+            into a target for the eye and the thumb.
+
+            It takes all three props, and `accessible={false}` is the one doing
+            the work on iOS. A `Pressable` defaults to `accessible`, which makes
+            it an accessibility *element* — and `accessibilityElementsHidden`
+            hides what an element contains, not the element itself, so on its own
+            it would have left VoiceOver announcing this button after the mic's.
+            (Everywhere else in the app this pair sits on a plain `View`, which
+            is not an element, which is why two props are enough there.)
+            `importantForAccessibility` is the Android half. */}
         <Pressable
           onPress={toggle}
           hitSlop={8}
+          accessible={false}
           accessibilityElementsHidden
           importantForAccessibility="no-hide-descendants"
           style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1124,6 +1124,17 @@ export interface UiStrings {
      */
     unreadable: string;
     unreadableBody: string;
+    /**
+     * The phone was asked again and refused, but its earlier answer still
+     * stands.
+     *
+     * A quieter thing than {@link unreadable}, and kept apart from it because
+     * the difference is the whole point: there the screen knows nothing and
+     * offers a way to recover, here the list is still on the page and is merely
+     * not fresh. Saying "couldn't load" over a list somebody can see is how a
+     * screen teaches people to disbelieve it.
+     */
+    staleNote: string;
     /** The speech service will not fetch a model for an app it cannot hear
      *  through — a switch in Settings, not a fault of the phone or the language. */
     permissionNeeded: string;
@@ -3702,7 +3713,9 @@ const en: UiStrings = {
     refresh: 'Refresh',
     unreadable: 'This phone wouldn’t say what it has',
     unreadableBody:
-      'Its own speech service didn’t answer, so the ticks below may be out of date. Nothing here needs a connection — try again, or just download the language you want.',
+      'Its own speech service didn’t answer, so there’s no telling which languages are already here. Nothing on this screen needs a connection — try again, or just download the language you want.',
+    staleNote:
+      'Couldn’t check with the phone again just now, so the ticks below may be out of date.',
     permissionNeeded:
       'Your phone’s speech service needs the microphone before it will fetch a model. Allow it in Settings, then try again.',
     empty:
@@ -6189,7 +6202,9 @@ const ta: UiStrings = {
     refresh: 'புதுப்பி',
     unreadable: 'இந்தத் தொலைபேசி தன்னிடம் என்ன இருக்கிறது எனச் சொல்லவில்லை',
     unreadableBody:
-      'அதன் சொந்தப் பேச்சுச் சேவை பதிலளிக்கவில்லை, எனவே கீழுள்ள குறிகள் பழையவையாக இருக்கலாம். இதற்கு இணைய இணைப்பு எதுவும் தேவையில்லை — மீண்டும் முயலுங்கள், அல்லது வேண்டிய மொழியை நேரடியாகப் பதிவிறக்குங்கள்.',
+      'அதன் சொந்தப் பேச்சுச் சேவை பதிலளிக்கவில்லை, எனவே எந்த மொழிகள் ஏற்கெனவே இங்கு உள்ளன எனத் தெரியவில்லை. இந்தத் திரையில் எதற்கும் இணைய இணைப்பு தேவையில்லை — மீண்டும் முயலுங்கள், அல்லது வேண்டிய மொழியை நேரடியாகப் பதிவிறக்குங்கள்.',
+    staleNote:
+      'இப்போது தொலைபேசியிடம் மீண்டும் சரிபார்க்க முடியவில்லை, எனவே கீழுள்ள குறிகள் பழையவையாக இருக்கலாம்.',
     permissionNeeded:
       'மாதிரியைப் பெறுவதற்கு முன் உங்கள் தொலைபேசியின் பேச்சுச் சேவைக்கு ஒலிவாங்கி அனுமதி தேவை. அமைப்புகளில் அனுமதித்துவிட்டு மீண்டும் முயலுங்கள்.',
     empty:
@@ -8750,7 +8765,8 @@ const hi: UiStrings = {
     refresh: 'ताज़ा करें',
     unreadable: 'यह फ़ोन नहीं बता रहा कि उसके पास क्या है',
     unreadableBody:
-      'इसकी अपनी स्पीच सेवा ने जवाब नहीं दिया, इसलिए नीचे के निशान पुराने हो सकते हैं। इसमें कनेक्शन की कोई ज़रूरत नहीं है — फिर कोशिश करें, या जो भाषा चाहिए उसे सीधे डाउनलोड कर लें।',
+      'इसकी अपनी स्पीच सेवा ने जवाब नहीं दिया, इसलिए पता नहीं चल रहा कि कौन-सी भाषाएँ पहले से मौजूद हैं। इस स्क्रीन पर किसी चीज़ को कनेक्शन की ज़रूरत नहीं है — फिर कोशिश करें, या जो भाषा चाहिए उसे सीधे डाउनलोड कर लें।',
+    staleNote: 'अभी फ़ोन से दोबारा पूछा नहीं जा सका, इसलिए नीचे के निशान पुराने हो सकते हैं।',
     permissionNeeded:
       'मॉडल लाने से पहले आपके फ़ोन की स्पीच सेवा को माइक्रोफ़ोन चाहिए। सेटिंग्स में अनुमति दें, फिर कोशिश करें।',
     empty:
@@ -11305,7 +11321,8 @@ const ar: UiStrings = {
     refresh: 'تحديث',
     unreadable: 'لم يخبرنا هذا الهاتف بما لديه',
     unreadableBody:
-      'لم تُجب خدمة الكلام في الهاتف نفسه، لذا قد تكون العلامات أدناه قديمة. لا شيء هنا يحتاج إلى اتصال — أعد المحاولة، أو نزّل اللغة التي تريدها مباشرةً.',
+      'لم تُجب خدمة الكلام في الهاتف نفسه، لذا لا سبيل لمعرفة اللغات الموجودة هنا بالفعل. لا شيء في هذه الشاشة يحتاج إلى اتصال — أعد المحاولة، أو نزّل اللغة التي تريدها مباشرةً.',
+    staleNote: 'تعذّرت مراجعة الهاتف مرة أخرى الآن، لذا قد تكون العلامات أدناه قديمة.',
     permissionNeeded:
       'تحتاج خدمة الكلام في هاتفك إلى إذن الميكروفون قبل جلب النموذج. اسمح به في الإعدادات ثم أعد المحاولة.',
     empty:

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1112,6 +1112,21 @@ export interface UiStrings {
     noOnDevice: string;
     /** Re-reads the phone's lists, so a download finished elsewhere shows up. */
     refresh: string;
+    /**
+     * The phone was asked what models it holds and would not say.
+     *
+     * Its own words, deliberately, and never the network's: reading the
+     * inventory is a local call into the recogniser service on the device, so
+     * the app's generic "check your connection" was naming a fault that cannot
+     * be the cause. It also must not claim the rows are missing — a failed read
+     * is not an empty one, and saying otherwise is what put a Download button
+     * next to a model somebody had just watched arrive.
+     */
+    unreadable: string;
+    unreadableBody: string;
+    /** The speech service will not fetch a model for an app it cannot hear
+     *  through — a switch in Settings, not a fault of the phone or the language. */
+    permissionNeeded: string;
     /** The phone answered, and named no languages at all — so the app's own are
      *  the only rows on the screen. */
     empty: string;
@@ -3685,6 +3700,11 @@ const en: UiStrings = {
     noOnDevice:
       'This phone can’t recognise speech without a connection, so there’s nothing to download.',
     refresh: 'Refresh',
+    unreadable: 'This phone wouldn’t say what it has',
+    unreadableBody:
+      'Its own speech service didn’t answer, so the ticks below may be out of date. Nothing here needs a connection — try again, or just download the language you want.',
+    permissionNeeded:
+      'Your phone’s speech service needs the microphone before it will fetch a model. Allow it in Settings, then try again.',
     empty:
       'Your phone didn’t name any languages it can recognise, so only the ones Waves asks for are listed. A download may still work.',
     footnote:
@@ -6167,6 +6187,11 @@ const ta: UiStrings = {
     noOnDevice:
       'இணைப்பு இல்லாமல் பேச்சை இந்த ஃபோனால் அடையாளம் காண முடியாது, எனவே பதிவிறக்க எதுவும் இல்லை.',
     refresh: 'புதுப்பி',
+    unreadable: 'இந்தத் தொலைபேசி தன்னிடம் என்ன இருக்கிறது எனச் சொல்லவில்லை',
+    unreadableBody:
+      'அதன் சொந்தப் பேச்சுச் சேவை பதிலளிக்கவில்லை, எனவே கீழுள்ள குறிகள் பழையவையாக இருக்கலாம். இதற்கு இணைய இணைப்பு எதுவும் தேவையில்லை — மீண்டும் முயலுங்கள், அல்லது வேண்டிய மொழியை நேரடியாகப் பதிவிறக்குங்கள்.',
+    permissionNeeded:
+      'மாதிரியைப் பெறுவதற்கு முன் உங்கள் தொலைபேசியின் பேச்சுச் சேவைக்கு ஒலிவாங்கி அனுமதி தேவை. அமைப்புகளில் அனுமதித்துவிட்டு மீண்டும் முயலுங்கள்.',
     empty:
       'தான் அடையாளம் காணக்கூடிய மொழிகள் எதையும் உங்கள் ஃபோன் சொல்லவில்லை, எனவே Waves கேட்பவை மட்டுமே பட்டியலில் உள்ளன. பதிவிறக்கம் இன்னும் வேலை செய்யக்கூடும்.',
     footnote:
@@ -8723,6 +8748,11 @@ const hi: UiStrings = {
     unavailable: 'यह बिल्ड स्पीच मॉडल तक नहीं पहुँच सकता।',
     noOnDevice: 'यह फ़ोन बिना कनेक्शन के बोली नहीं पहचान सकता, इसलिए डाउनलोड करने को कुछ नहीं है।',
     refresh: 'ताज़ा करें',
+    unreadable: 'यह फ़ोन नहीं बता रहा कि उसके पास क्या है',
+    unreadableBody:
+      'इसकी अपनी स्पीच सेवा ने जवाब नहीं दिया, इसलिए नीचे के निशान पुराने हो सकते हैं। इसमें कनेक्शन की कोई ज़रूरत नहीं है — फिर कोशिश करें, या जो भाषा चाहिए उसे सीधे डाउनलोड कर लें।',
+    permissionNeeded:
+      'मॉडल लाने से पहले आपके फ़ोन की स्पीच सेवा को माइक्रोफ़ोन चाहिए। सेटिंग्स में अनुमति दें, फिर कोशिश करें।',
     empty:
       'आपके फ़ोन ने ऐसी कोई भाषा नहीं बताई जिसे वह पहचान सके, इसलिए सिर्फ़ वही सूचीबद्ध हैं जो Waves माँगता है। डाउनलोड फिर भी काम कर सकता है।',
     footnote:
@@ -11273,6 +11303,11 @@ const ar: UiStrings = {
     unavailable: 'لا يستطيع هذا الإصدار الوصول إلى نماذج الكلام.',
     noOnDevice: 'لا يستطيع هذا الهاتف التعرّف على الكلام دون اتصال، فلا شيء لتنزيله.',
     refresh: 'تحديث',
+    unreadable: 'لم يخبرنا هذا الهاتف بما لديه',
+    unreadableBody:
+      'لم تُجب خدمة الكلام في الهاتف نفسه، لذا قد تكون العلامات أدناه قديمة. لا شيء هنا يحتاج إلى اتصال — أعد المحاولة، أو نزّل اللغة التي تريدها مباشرةً.',
+    permissionNeeded:
+      'تحتاج خدمة الكلام في هاتفك إلى إذن الميكروفون قبل جلب النموذج. اسمح به في الإعدادات ثم أعد المحاولة.',
     empty:
       'لم يذكر هاتفك أي لغة يستطيع التعرّف عليها، لذا لا تظهر سوى اللغات التي يطلبها Waves. وقد ينجح التنزيل رغم ذلك.',
     footnote:

--- a/apps/mobile/src/lib/dictation.ts
+++ b/apps/mobile/src/lib/dictation.ts
@@ -232,7 +232,7 @@ export function offlineVoiceModels(
 }
 
 /**
- * What the offline-voice screen actually knows about this phone.
+ * What the offline-voice screen has to say about this phone.
  *
  * This exists because the screen used to have no name for its own most common
  * failure, and borrowed the app's generic one instead: any rejection from the
@@ -244,23 +244,29 @@ export function offlineVoiceModels(
  * implement the query — which is the OEM-ROM case this whole screen exists for —
  * the reader was told to go and look at their Wi-Fi.
  *
- * The second half of the same mistake was quieter and worse. A failed read left
- * the inventory undefined, which {@link offlineVoiceModels} could only read as
- * "nothing is installed" — so every row offered a Download, including one the
- * reader had just watched succeed, with the confirmation still under it. A
- * failed read is not an empty one, and these states keep them apart.
+ * This answers exactly one question — *what should the screen say* — and it is
+ * deliberately not asked the other one. Whether the installed list may be
+ * believed is {@link offlineVoiceKnowledge}. Deriving that from this cost two
+ * separate bugs, because a ranking of what most needs saying is the wrong
+ * instrument for a question of evidence: a phone too old to *fetch* a model was
+ * told it could not be *asked* what it holds (it can, and it just had), and a
+ * refresh that failed on top of a perfectly good answer threw that answer away.
  *
  *  - `no-module` — an older binary with no native speech module at all.
  *  - `no-on-device` — a recogniser that only ever works over the network.
  *  - `unknowable` — iPhone, which returns its supported list under both names,
  *    so its answer about what is installed means nothing (see
  *    {@link InstalledKnowledge}).
- *  - `too-old` — Android 12 and below: nothing to list and nothing to fetch.
- *  - `unreadable` — the phone was asked and would not say. Its own words, never
- *    the connection's.
- *  - `loading` — asked, still waiting.
+ *  - `too-old` — Android 12 and below: nothing to *fetch*. It may still be asked
+ *    what it holds, and on this path it usually answers.
+ *  - `unreadable` — asked, refused, and nothing held from before. Its own words,
+ *    never the connection's.
+ *  - `stale` — asked again and refused, but an earlier answer is still in hand.
+ *    A quieter thing entirely: the ticks stand, they are merely not fresh.
+ *  - `loading` — asked, still waiting, nothing yet. A refresh *over* an answer is
+ *    not this: the list stays on screen and keeps its own state.
  *  - `empty` — answered, and named nothing at all.
- *  - `ready` — answered with a list that can be trusted.
+ *  - `ready` — answered with a list.
  */
 export type OfflineVoiceRead =
   | 'no-module'
@@ -268,11 +274,12 @@ export type OfflineVoiceRead =
   | 'unknowable'
   | 'too-old'
   | 'unreadable'
+  | 'stale'
   | 'loading'
   | 'empty'
   | 'ready';
 
-/** Everything the read state is decided from — no React, no native module. */
+/** Everything both answers are decided from — no React, no native module. */
 export interface OfflineVoiceReadInput {
   /** The native speech module imported on this build. */
   readonly hasModule: boolean;
@@ -282,39 +289,70 @@ export interface OfflineVoiceReadInput {
   readonly reportsInstalled: boolean;
   /** A model can be fetched from inside the app — Android 13 and up. */
   readonly canDownload: boolean;
-  /** How the inventory read is going. */
-  readonly query: 'idle' | 'loading' | 'error' | 'success';
+  /** How the newest read went. */
+  readonly query: 'loading' | 'error' | 'success';
+  /**
+   * An answer is in hand — from this read or an earlier one.
+   *
+   * The distinction the data layer draws, and this file has to draw too: a query
+   * that answered and *then* failed a refresh is still holding its answer, and is
+   * a different thing from one that has never answered at all. Reading only "did
+   * the last fetch fail" turned a momentarily busy speech service into a screen
+   * that forgot everything it knew — on a surface whose single best-known failure
+   * mode is a momentarily busy speech service.
+   */
+  readonly hasData: boolean;
   /** The answer named at least one locale, supported or installed. */
   readonly namedAnything: boolean;
 }
 
 /**
- * The one state the screen draws from, most disqualifying fact first.
+ * The one sentence the screen leads with, most disqualifying fact first.
  *
- * The order is the point. A device that cannot do on-device recognition at all
+ * The order is the point. A device that cannot recognise speech offline at all
  * is not also "still loading", and a phone too old to fetch a model is told that
  * rather than told its read failed — the older fact is the truer sentence, and
- * the one with something to do about it.
+ * the one with something to do about it. What the order must never decide is
+ * whether the rows below may be trusted; that is not a sentence, and it is not
+ * here.
  */
 export function offlineVoiceRead(input: OfflineVoiceReadInput): OfflineVoiceRead {
   if (!input.hasModule) return 'no-module';
   if (!input.supportsOnDevice) return 'no-on-device';
   if (!input.reportsInstalled) return 'unknowable';
   if (!input.canDownload) return 'too-old';
-  if (input.query === 'error') return 'unreadable';
-  if (input.query !== 'success') return 'loading';
+  // A refusal on top of an answer is not the same event as a refusal instead of
+  // one, and must not wear the same words: the first costs freshness, the second
+  // costs everything.
+  if (input.query === 'error') return input.hasData ? 'stale' : 'unreadable';
+  // Likewise a refresh in flight over an answer, which is not a blank screen
+  // waiting to be filled — it is a list, being checked.
+  if (input.query === 'loading' && !input.hasData) return 'loading';
   return input.namedAnything ? 'ready' : 'empty';
 }
 
 /**
- * Whether the installed list may be believed in this state.
+ * Whether the installed list may be believed.
  *
- * Only an answer counts. `unreadable` and `loading` are emphatically not
- * `reported`: treating either as a trustworthy empty list is exactly how a row
- * came to offer a download for a model that was already there.
+ * Its own function over the same input, and emphatically not a reading of
+ * {@link OfflineVoiceRead}. Deriving it from that answered "can this phone be
+ * asked what it holds?" with "can this phone download?", and an Android 12
+ * reader who had installed English through system settings — the one person the
+ * screen exists to answer — was told the phone could not say, immediately after
+ * it did.
+ *
+ * Three things make an answer trustworthy, and `canDownload` is not among them:
+ * the module is here, the phone recognises on-device at all, and it reports
+ * installed models as fact rather than echoing its supported list (iPhone does
+ * the latter — see {@link InstalledKnowledge}). Then there must actually be an
+ * answer in hand. That is `hasData`, never "the last fetch succeeded", so a
+ * failed refresh over a good list keeps the list instead of blanking every row;
+ * and never "the answer named something", because a phone that answers with
+ * nothing has still answered, and an empty inventory is a fact like any other.
  */
-export function offlineVoiceKnowledge(read: OfflineVoiceRead): InstalledKnowledge {
-  return read === 'ready' || read === 'empty' ? 'reported' : 'unknowable';
+export function offlineVoiceKnowledge(input: OfflineVoiceReadInput): InstalledKnowledge {
+  if (!input.hasModule || !input.supportsOnDevice || !input.reportsInstalled) return 'unknowable';
+  return input.hasData ? 'reported' : 'unknowable';
 }
 
 /**

--- a/apps/mobile/src/lib/dictation.ts
+++ b/apps/mobile/src/lib/dictation.ts
@@ -78,20 +78,26 @@ export function onDeviceLocaleInstalled(
   langTag: string,
   installedLocales: readonly string[] | null | undefined,
 ): boolean {
-  const norm = (tag: string): string => tag.trim().replace(/_/g, '-').toLowerCase();
-  const want = norm(langTag);
+  const parse = (tag: string): { language: string; region: string | null } | null => {
+    const parts = tag.trim().replace(/_/g, '-').toLowerCase().split('-').filter(Boolean);
+    const language = parts[0];
+    if (!language) return null;
+    const region = parts
+      .slice(1)
+      .find((part) => /^[a-z]{2}$/.test(part) || /^\d{3}$/.test(part));
+    return { language, region: region ?? null };
+  };
+
+  const want = parse(langTag);
   if (!want) return false;
-  const wantLang = want.split('-')[0];
-  const wantHasRegion = want.includes('-');
   return (installedLocales ?? []).some((raw) => {
-    const tag = norm(raw);
+    const tag = parse(raw);
     if (!tag) return false;
-    if (tag.split('-')[0] !== wantLang) return false;
-    const tagHasRegion = tag.includes('-');
+    if (tag.language !== want.language) return false;
     // A language-only entry on either side is the generic model: it covers the
-    // whole language. Only when both carry a region must the regions match.
-    if (!tagHasRegion || !wantHasRegion) return true;
-    return tag === want;
+    // whole language. Only when both carry a region must those regions match.
+    if (!tag.region || !want.region) return true;
+    return tag.region === want.region;
   });
 }
 

--- a/apps/mobile/src/lib/dictation.ts
+++ b/apps/mobile/src/lib/dictation.ts
@@ -226,6 +226,119 @@ export function offlineVoiceModels(
 }
 
 /**
+ * What the offline-voice screen actually knows about this phone.
+ *
+ * This exists because the screen used to have no name for its own most common
+ * failure, and borrowed the app's generic one instead: any rejection from the
+ * inventory read drew "Couldn't load this — check your connection". That
+ * sentence is not merely unhelpful here, it is false. Reading the phone's speech
+ * models is a local call into the recogniser service on the device; there is no
+ * server anywhere in it, so a connection cannot be the cause and checking one
+ * cannot be the cure. On a phone whose service is slow, busy, or simply does not
+ * implement the query — which is the OEM-ROM case this whole screen exists for —
+ * the reader was told to go and look at their Wi-Fi.
+ *
+ * The second half of the same mistake was quieter and worse. A failed read left
+ * the inventory undefined, which {@link offlineVoiceModels} could only read as
+ * "nothing is installed" — so every row offered a Download, including one the
+ * reader had just watched succeed, with the confirmation still under it. A
+ * failed read is not an empty one, and these states keep them apart.
+ *
+ *  - `no-module` — an older binary with no native speech module at all.
+ *  - `no-on-device` — a recogniser that only ever works over the network.
+ *  - `unknowable` — iPhone, which returns its supported list under both names,
+ *    so its answer about what is installed means nothing (see
+ *    {@link InstalledKnowledge}).
+ *  - `too-old` — Android 12 and below: nothing to list and nothing to fetch.
+ *  - `unreadable` — the phone was asked and would not say. Its own words, never
+ *    the connection's.
+ *  - `loading` — asked, still waiting.
+ *  - `empty` — answered, and named nothing at all.
+ *  - `ready` — answered with a list that can be trusted.
+ */
+export type OfflineVoiceRead =
+  | 'no-module'
+  | 'no-on-device'
+  | 'unknowable'
+  | 'too-old'
+  | 'unreadable'
+  | 'loading'
+  | 'empty'
+  | 'ready';
+
+/** Everything the read state is decided from — no React, no native module. */
+export interface OfflineVoiceReadInput {
+  /** The native speech module imported on this build. */
+  readonly hasModule: boolean;
+  /** This phone can recognise speech with no connection. */
+  readonly supportsOnDevice: boolean;
+  /** The installed list is a fact rather than an echo — Android only. */
+  readonly reportsInstalled: boolean;
+  /** A model can be fetched from inside the app — Android 13 and up. */
+  readonly canDownload: boolean;
+  /** How the inventory read is going. */
+  readonly query: 'idle' | 'loading' | 'error' | 'success';
+  /** The answer named at least one locale, supported or installed. */
+  readonly namedAnything: boolean;
+}
+
+/**
+ * The one state the screen draws from, most disqualifying fact first.
+ *
+ * The order is the point. A device that cannot do on-device recognition at all
+ * is not also "still loading", and a phone too old to fetch a model is told that
+ * rather than told its read failed — the older fact is the truer sentence, and
+ * the one with something to do about it.
+ */
+export function offlineVoiceRead(input: OfflineVoiceReadInput): OfflineVoiceRead {
+  if (!input.hasModule) return 'no-module';
+  if (!input.supportsOnDevice) return 'no-on-device';
+  if (!input.reportsInstalled) return 'unknowable';
+  if (!input.canDownload) return 'too-old';
+  if (input.query === 'error') return 'unreadable';
+  if (input.query !== 'success') return 'loading';
+  return input.namedAnything ? 'ready' : 'empty';
+}
+
+/**
+ * Whether the installed list may be believed in this state.
+ *
+ * Only an answer counts. `unreadable` and `loading` are emphatically not
+ * `reported`: treating either as a trustworthy empty list is exactly how a row
+ * came to offer a download for a model that was already there.
+ */
+export function offlineVoiceKnowledge(read: OfflineVoiceRead): InstalledKnowledge {
+  return read === 'ready' || read === 'empty' ? 'reported' : 'unknowable';
+}
+
+/**
+ * Tick the models this screen watched land, whatever the phone will say.
+ *
+ * A download that resolved `download_success` is the strongest evidence there
+ * is — stronger than the inventory, which on many phones under-reports and on
+ * some cannot be read at all. Without this, finishing a download on a phone
+ * whose service will not answer leaves the row exactly as it was, still offering
+ * the Download that just worked.
+ *
+ * It only ever adds: a row already installed stays installed, and nothing here
+ * can turn a tick off.
+ */
+export function withConfirmedInstalls(
+  models: OfflineVoiceModels,
+  confirmed: readonly string[],
+): OfflineVoiceModels {
+  if (confirmed.length === 0) return models;
+  const tags = new Set(confirmed.map(normaliseTag));
+  const tick = (model: OfflineVoiceModel): OfflineVoiceModel =>
+    tags.has(normaliseTag(model.tag)) ? { ...model, state: 'installed' } : model;
+  return {
+    app: models.app.map(tick),
+    alsoInstalled: models.alsoInstalled.map(tick),
+    downloadable: models.downloadable.map(tick),
+  };
+}
+
+/**
  * Why a request to fetch an on-device model ended the way it did.
  *
  * This exists because the honest answer to "why did Tamil fail?" was being
@@ -257,14 +370,28 @@ export function offlineVoiceModels(
  *    all. The service took the request and cannot report on it. Calling that
  *    "couldn't download" is simply false.
  *  - `network` (1, 2, 4, 11), `busy` (8) — ordinary, retryable, and each has a
- *    different thing for a person to go and do.
+ *    different thing for a person to go and do. `network` is the *only* reason
+ *    on this screen that may mention a connection, because it is the only one
+ *    that is about one.
+ *  - `permission` (9, ERROR_INSUFFICIENT_PERMISSIONS) — the service will not act
+ *    for an app that has not been given the microphone. Nothing about the phone,
+ *    the language or the network; a switch in Settings, and previously filed
+ *    under "refused without saying why", which was a dead end for a fixable
+ *    thing.
  *  - `too-old` — the module's own pre-API-33 refusal, which the screen already
  *    prevents by not drawing a button; kept because a rejection is a rejection.
  *  - `refused` — everything else, including a code that is not a code. A future
  *    Android constant lands here and gets a sentence that is still true.
  */
 export type OfflineDownloadReason =
-  'too-old' | 'language-missing' | 'not-downloaded' | 'started' | 'network' | 'busy' | 'refused';
+  | 'too-old'
+  | 'language-missing'
+  | 'not-downloaded'
+  | 'started'
+  | 'network'
+  | 'busy'
+  | 'permission'
+  | 'refused';
 
 /**
  * The reason behind a rejected download, read off the thrown value.
@@ -298,8 +425,11 @@ export function offlineDownloadReason(caught: unknown): OfflineDownloadReason {
     // ERROR_CANNOT_LISTEN_TO_DOWNLOAD_EVENTS.
     case 15:
       return 'started';
-    // ERROR_CLIENT (5), ERROR_INSUFFICIENT_PERMISSIONS (9),
-    // ERROR_CANNOT_CHECK_SUPPORT (14), and whatever a later Android adds.
+    // ERROR_INSUFFICIENT_PERMISSIONS.
+    case 9:
+      return 'permission';
+    // ERROR_CLIENT (5), ERROR_CANNOT_CHECK_SUPPORT (14), and whatever a later
+    // Android adds.
     default:
       return 'refused';
   }

--- a/apps/mobile/src/lib/dictation.ts
+++ b/apps/mobile/src/lib/dictation.ts
@@ -82,9 +82,7 @@ export function onDeviceLocaleInstalled(
     const parts = tag.trim().replace(/_/g, '-').toLowerCase().split('-').filter(Boolean);
     const language = parts[0];
     if (!language) return null;
-    const region = parts
-      .slice(1)
-      .find((part) => /^[a-z]{2}$/.test(part) || /^\d{3}$/.test(part));
+    const region = parts.slice(1).find((part) => /^[a-z]{2}$/.test(part) || /^\d{3}$/.test(part));
     return { language, region: region ?? null };
   };
 

--- a/apps/mobile/test/dictation.test.ts
+++ b/apps/mobile/test/dictation.test.ts
@@ -173,6 +173,12 @@ describe('onDeviceLocaleInstalled', () => {
     expect(onDeviceLocaleInstalled('en-IN', null)).toBe(false);
     expect(onDeviceLocaleInstalled('', ['en'])).toBe(false);
   });
+
+  it('ignores script subtags when language and region match', () => {
+    expect(onDeviceLocaleInstalled('ar-SA', ['ar-Arab-SA'])).toBe(true);
+    expect(onDeviceLocaleInstalled('hi-IN', ['hi-Deva-IN'])).toBe(true);
+    expect(onDeviceLocaleInstalled('en-IN', ['en-Latn-US'])).toBe(false);
+  });
 });
 
 describe('offlineVoiceModels', () => {

--- a/apps/mobile/test/dictation.test.ts
+++ b/apps/mobile/test/dictation.test.ts
@@ -13,9 +13,13 @@ import {
   englishSpeechLocale,
   mergeTranscript,
   offlineDownloadReason,
+  offlineVoiceKnowledge,
   offlineVoiceModels,
+  offlineVoiceRead,
   onDeviceLocaleInstalled,
   speechLocale,
+  withConfirmedInstalls,
+  type OfflineVoiceReadInput,
 } from '@/lib/dictation';
 import { Language, STRINGS_BY_LANGUAGE } from '@/i18n';
 
@@ -288,6 +292,10 @@ describe('offlineDownloadReason', () => {
     }
     // ERROR_RECOGNIZER_BUSY.
     expect(offlineDownloadReason(rejected('error_8'))).toBe('busy');
+    // ERROR_INSUFFICIENT_PERMISSIONS — a switch in Settings, and nothing to do
+    // with the phone, the language or the connection. It used to land in
+    // `refused`, which is the sentence for a phone that would not say why.
+    expect(offlineDownloadReason(rejected('error_9'))).toBe('permission');
   });
 
   it('keeps the platform’s own pre-Android-13 refusal', () => {
@@ -305,5 +313,113 @@ describe('offlineDownloadReason', () => {
     expect(offlineDownloadReason(new Error('boom'))).toBe('refused');
     expect(offlineDownloadReason(null)).toBe('refused');
     expect(offlineDownloadReason(undefined)).toBe('refused');
+  });
+});
+
+/**
+ * The one question this screen kept getting wrong, now asked of a pure function.
+ *
+ * The bug in the field: a phone with working 5G, an English model already
+ * downloaded, and a card reading "Couldn't load this — check your connection".
+ * Reading the phone's models never touches a network, so that sentence could not
+ * have been true; what had actually happened was that the recogniser service
+ * refused the query, and every rejection was being poured into the app's generic
+ * network empty-state. The same undefined answer then told the row below that
+ * nothing was installed, so English offered a Download directly above its own
+ * "Downloaded. The mic can use it now."
+ */
+describe('offlineVoiceRead', () => {
+  // A modern Android that answers: the case everything else is a deviation from.
+  const android: OfflineVoiceReadInput = {
+    hasModule: true,
+    supportsOnDevice: true,
+    reportsInstalled: true,
+    canDownload: true,
+    query: 'success',
+    namedAnything: true,
+  };
+
+  it('trusts a phone that answered with a list', () => {
+    expect(offlineVoiceRead(android)).toBe('ready');
+    expect(offlineVoiceKnowledge(offlineVoiceRead(android))).toBe('reported');
+  });
+
+  it('separates an answer of nothing from no answer at all', () => {
+    // Answered, named nothing: an empty inventory is a fact, and believable.
+    const empty = offlineVoiceRead({ ...android, namedAnything: false });
+    expect(empty).toBe('empty');
+    expect(offlineVoiceKnowledge(empty)).toBe('reported');
+
+    // Refused: not an empty inventory, and emphatically not the connection.
+    const refused = offlineVoiceRead({ ...android, query: 'error', namedAnything: false });
+    expect(refused).toBe('unreadable');
+    expect(offlineVoiceKnowledge(refused)).toBe('unknowable');
+  });
+
+  it('never calls a read still in flight an answer', () => {
+    for (const query of ['idle', 'loading'] as const) {
+      const state = offlineVoiceRead({ ...android, query, namedAnything: false });
+      expect(state).toBe('loading');
+      // The whole of the row bug: believing a not-yet-answered read is what drew
+      // a Download button beside a model that was already there.
+      expect(offlineVoiceKnowledge(state)).toBe('unknowable');
+    }
+  });
+
+  it('puts the device facts ahead of the read, most disqualifying first', () => {
+    // Each of these is true whatever the query does, so each outranks it.
+    const broken = { query: 'error', namedAnything: false } as const;
+    expect(offlineVoiceRead({ ...android, ...broken, hasModule: false })).toBe('no-module');
+    expect(offlineVoiceRead({ ...android, ...broken, supportsOnDevice: false })).toBe(
+      'no-on-device',
+    );
+    // iPhone answers, and its answer means nothing — see InstalledKnowledge.
+    expect(offlineVoiceRead({ ...android, reportsInstalled: false })).toBe('unknowable');
+    // Android 12: nothing to fetch, which is a truer sentence than a failed read.
+    expect(offlineVoiceRead({ ...android, ...broken, canDownload: false })).toBe('too-old');
+  });
+
+  it('never lets iPhone’s echo be read as an inventory', () => {
+    expect(offlineVoiceKnowledge(offlineVoiceRead({ ...android, reportsInstalled: false }))).toBe(
+      'unknowable',
+    );
+  });
+});
+
+describe('withConfirmedInstalls', () => {
+  const model = (tag: string, state: 'installed' | 'missing' | 'unknown') => ({
+    tag,
+    language: null,
+    state,
+  });
+
+  it('ticks a model this screen watched land, whatever the phone says', () => {
+    // The screenshot, exactly: the read failed, so every row reads `unknown`,
+    // but English arrived a moment ago and we saw it arrive.
+    const models = {
+      app: [model('en-IN', 'unknown'), model('ta-IN', 'unknown')],
+      alsoInstalled: [],
+      downloadable: [],
+    };
+    const ticked = withConfirmedInstalls(models, ['en-IN']);
+    expect(ticked.app.map((row) => row.state)).toEqual(['installed', 'unknown']);
+  });
+
+  it('matches the way tags are written, not the way they are typed', () => {
+    const models = { app: [model('en-IN', 'missing')], alsoInstalled: [], downloadable: [] };
+    expect(withConfirmedInstalls(models, ['EN_in']).app[0]?.state).toBe('installed');
+  });
+
+  it('only ever adds — it cannot untick anything', () => {
+    const models = {
+      app: [model('en-IN', 'installed')],
+      alsoInstalled: [model('de-DE', 'installed')],
+      downloadable: [model('fr-FR', 'missing')],
+    };
+    const same = withConfirmedInstalls(models, []);
+    expect(same).toEqual(models);
+    const one = withConfirmedInstalls(models, ['en-IN']);
+    expect(one.alsoInstalled[0]?.state).toBe('installed');
+    expect(one.downloadable[0]?.state).toBe('missing');
   });
 });

--- a/apps/mobile/test/dictation.test.ts
+++ b/apps/mobile/test/dictation.test.ts
@@ -323,7 +323,7 @@ describe('offlineDownloadReason', () => {
 });
 
 /**
- * The one question this screen kept getting wrong, now asked of a pure function.
+ * The two questions this screen kept getting wrong, now asked separately.
  *
  * The bug in the field: a phone with working 5G, an English model already
  * downloaded, and a card reading "Couldn't load this — check your connection".
@@ -333,6 +333,12 @@ describe('offlineDownloadReason', () => {
  * network empty-state. The same undefined answer then told the row below that
  * nothing was installed, so English offered a Download directly above its own
  * "Downloaded. The mic can use it now."
+ *
+ * The deeper mistake, and the reason these are two functions: one value was
+ * being asked both "what should the screen say?" and "may the list be
+ * believed?". The first is a ranking of what most needs saying; the second is a
+ * question of evidence. Ranking the second produced two more bugs of its own,
+ * both pinned below — Android 12 and the failed refresh.
  */
 describe('offlineVoiceRead', () => {
   // A modern Android that answers: the case everything else is a deviation from.
@@ -342,39 +348,59 @@ describe('offlineVoiceRead', () => {
     reportsInstalled: true,
     canDownload: true,
     query: 'success',
+    hasData: true,
     namedAnything: true,
   };
 
   it('trusts a phone that answered with a list', () => {
     expect(offlineVoiceRead(android)).toBe('ready');
-    expect(offlineVoiceKnowledge(offlineVoiceRead(android))).toBe('reported');
+    expect(offlineVoiceKnowledge(android)).toBe('reported');
   });
 
   it('separates an answer of nothing from no answer at all', () => {
     // Answered, named nothing: an empty inventory is a fact, and believable.
-    const empty = offlineVoiceRead({ ...android, namedAnything: false });
-    expect(empty).toBe('empty');
+    const empty = { ...android, namedAnything: false };
+    expect(offlineVoiceRead(empty)).toBe('empty');
     expect(offlineVoiceKnowledge(empty)).toBe('reported');
 
-    // Refused: not an empty inventory, and emphatically not the connection.
-    const refused = offlineVoiceRead({ ...android, query: 'error', namedAnything: false });
-    expect(refused).toBe('unreadable');
+    // Refused with nothing held: not an empty inventory, and not the connection.
+    const refused = { ...android, query: 'error', hasData: false, namedAnything: false } as const;
+    expect(offlineVoiceRead(refused)).toBe('unreadable');
     expect(offlineVoiceKnowledge(refused)).toBe('unknowable');
   });
 
-  it('never calls a read still in flight an answer', () => {
-    for (const query of ['idle', 'loading'] as const) {
-      const state = offlineVoiceRead({ ...android, query, namedAnything: false });
-      expect(state).toBe('loading');
-      // The whole of the row bug: believing a not-yet-answered read is what drew
-      // a Download button beside a model that was already there.
-      expect(offlineVoiceKnowledge(state)).toBe('unknowable');
-    }
+  it('keeps the answer it already has when a refresh fails on top of it', () => {
+    // React Query keeps `data` and flips `status` to error when a *refetch*
+    // fails. Reading only "the last fetch failed" made the screen forget a good
+    // list — and since it now refetches on every visit, a briefly busy speech
+    // service (the known failure mode here) would wipe the ticks on the visit
+    // after a good one. The ticks must survive; only their freshness is in doubt.
+    const refreshFailed = { ...android, query: 'error' } as const;
+    expect(offlineVoiceRead(refreshFailed)).toBe('stale');
+    expect(offlineVoiceKnowledge(refreshFailed)).toBe('reported');
+
+    // Both error shapes, side by side, so neither can quietly take the other's
+    // words: one is a list that is merely not fresh, the other is no list.
+    expect(offlineVoiceRead({ ...refreshFailed, hasData: false })).toBe('unreadable');
+  });
+
+  it('does not blank the list while it is being re-read', () => {
+    // A refresh in flight over an answer is a list being checked, not an empty
+    // screen waiting to be filled.
+    const refreshing = { ...android, query: 'loading' } as const;
+    expect(offlineVoiceRead(refreshing)).toBe('ready');
+    expect(offlineVoiceKnowledge(refreshing)).toBe('reported');
+
+    // The first read, with nothing behind it, really is loading — and must not
+    // be believed as an empty inventory while it waits.
+    const first = { ...refreshing, hasData: false, namedAnything: false };
+    expect(offlineVoiceRead(first)).toBe('loading');
+    expect(offlineVoiceKnowledge(first)).toBe('unknowable');
   });
 
   it('puts the device facts ahead of the read, most disqualifying first', () => {
     // Each of these is true whatever the query does, so each outranks it.
-    const broken = { query: 'error', namedAnything: false } as const;
+    const broken = { query: 'error', hasData: false, namedAnything: false } as const;
     expect(offlineVoiceRead({ ...android, ...broken, hasModule: false })).toBe('no-module');
     expect(offlineVoiceRead({ ...android, ...broken, supportsOnDevice: false })).toBe(
       'no-on-device',
@@ -385,10 +411,30 @@ describe('offlineVoiceRead', () => {
     expect(offlineVoiceRead({ ...android, ...broken, canDownload: false })).toBe('too-old');
   });
 
-  it('never lets iPhone’s echo be read as an inventory', () => {
-    expect(offlineVoiceKnowledge(offlineVoiceRead({ ...android, reportsInstalled: false }))).toBe(
+  it('lets Android 12 be told it cannot fetch without being told it cannot be asked', () => {
+    // The regression this pins. `canDownload` is `android && API >= 33`, but
+    // `reportsInstalled` is merely `android` — so an Android 12 phone runs the
+    // query and answers it correctly. Ranking `too-old` above the read and then
+    // reading knowledge off that rank told somebody who had installed English
+    // through system settings that the phone could not say, immediately after it
+    // had. "Cannot fetch" is the right notice; it is not an answer about
+    // evidence, and the two must not be derived from one another.
+    const android12 = { ...android, canDownload: false } as const;
+    expect(offlineVoiceRead(android12)).toBe('too-old');
+    expect(offlineVoiceKnowledge(android12)).toBe('reported');
+
+    // Still nothing to believe when there is genuinely no answer in hand.
+    expect(offlineVoiceKnowledge({ ...android12, query: 'error', hasData: false })).toBe(
       'unknowable',
     );
+  });
+
+  it('never lets iPhone’s echo be read as an inventory', () => {
+    // The one refusal that survives a perfectly good-looking answer: iOS returns
+    // its supported list under both names, so `hasData` is true and worthless.
+    expect(offlineVoiceKnowledge({ ...android, reportsInstalled: false })).toBe('unknowable');
+    expect(offlineVoiceKnowledge({ ...android, supportsOnDevice: false })).toBe('unknowable');
+    expect(offlineVoiceKnowledge({ ...android, hasModule: false })).toBe('unknowable');
   });
 });
 


### PR DESCRIPTION
Four voice items reported in one sitting: move the offline-voice offer to the bottom, let the hint text start listening, give the idle mic some life, and explain the "Couldn't load this" card that appears on a phone with working internet.

## "Couldn't load this — check your connection"

**One bug, both symptoms.** `settings/offline-voice.tsx:420-428` rendered the app-wide network empty state for `locales.isError` — that is, for **any** rejection from `speechModels.listLocales()` → `ExpoSpeechRecognitionModule.getSupportedLocales()`. That call is local IPC into the device's own recogniser service. There is no network in it, so "check your connection" can never be the cause. On the reporter's ROM, the service simply refused the query.

The English row showing **Download** *and* "Downloaded. The mic can use it now." at the same time is the same failure: with the query in error `locales.data` is undefined, which `offlineVoiceModels` read as "nothing installed" → `state: 'missing'` → a Download button, while the `progress` entry from the download that had actually succeeded still printed the confirmation underneath. It never self-corrected because the post-download `refetch()` failed the same way every time.

A new pure `offlineVoiceRead` is now the single source for the notice, the card, and whether the installed list may be believed at all. The states it distinguishes: `ready`/`loading` · `empty` (the phone answered and named nothing) · **`unreadable`** — new, "This phone wouldn't say what it has… **Nothing here needs a connection** — try again, or just download the language you want" · `no-on-device` · `unknowable` (iPhone) · `too-old` (Android ≤12) · `no-module` · **permission** — new, `ERROR_INSUFFICIENT_PERMISSIONS` was previously falling into "refused without saying why" · and genuine **network failure**, which is now the only string that mentions a connection, on the download, which is the only thing on the screen that uses one.

`withConfirmedInstalls` also ticks any model this screen watched land, regardless of what the phone will admit to, and the Download button stays live under `unreadable` — the tap *is* the probe — so a phone that won't answer is never stranded. And pull-to-refresh, which the old copy promised and the screen never actually had, is now wired; the new copy no longer promises it.

## Placement, hint, and idle motion

`t.voice.setupOffline` was drawn **twice** in `VoiceCapture.tsx` — a standing offer crammed mid-screen under the worked example, and an after-a-miss offer already at the bottom. Now one block, last child, `marginTop: 'auto'` + `flexGrow`, so free space collects above it on a tall screen and it settles on the bottom edge, while a short screen scrolls rather than squeezing. The *when* is unchanged: literally the union of the two old conditions. A pinned footer was rejected because the state it needs lives inside the launch-guarded native panel and cannot be lifted into the route. `voice.tsx` also moves from the raw `useScreenClearance()` to the canonical `useBottomClearance()` — same number today, but it now asks the one authority instead of deciding for itself.

**The hint text starts listening**, calling the same `toggle` handler as the mic, so every guard in `start`/`stop` applies to both with no duplicated logic. One deliberate a11y deviation: the hint is *not* a second button — it is `accessibilityElementsHidden`, because the mic two rows up already announces the identical label and action, and a second one would be the same action announced twice. Wrapping mic and hint in a single pressable was not possible; the waveform and example sit between them.

**The idle mic breathes** — `1 → 1.045` over 2500ms each way, native driver, deliberately the *inverse* gesture of listening (where the disc holds still and the halo animates around it), so idle cannot read as broken listening. Gated on `available && focused && !listening && !reduceMotion`, with every effect path stopping its own animation on the way out, so nothing survives a blur or a Fast Refresh.

## Verification

`pnpm lint` 0 errors, typecheck clean, **81 files / 1049 tests pass** (+8 new in `test/dictation.test.ts`: answer-of-nothing vs no-answer, in-flight never trusted, device facts outranking the read, the iPhone echo never read as inventory, `withConfirmedInstalls` only ever adding, and `error_9 → permission`).

**Stated plainly: this does not prove the offline-voice screen is fixed on the reporter's ROM.** The mis-diagnosis and the contradictory row are proven from the code, and the honest states are in place, but *why* that phone's `getSupportedLocales` rejects is device-specific and could not be reproduced here. What should be visible next build: the card reads "This phone wouldn't say what it has" instead of blaming the connection, the English row shows ✓ once downloaded, and the tick appears by itself on returning to the screen. If the read still fails, the Download buttons remain live and usable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jhzmZz5fkjnZZ14YxHGfS