### PR TITLE
Let the expense say which day it happened

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -3,7 +3,6 @@
 import '@/lib/intlPolyfill';
 
 import { useEffect, useState } from 'react';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import Constants from 'expo-constants';
 import * as Notifications from 'expo-notifications';
@@ -50,7 +49,7 @@ import { isRtl, isRtlLanguage, useStrings } from '@/i18n';
 import { LanguageProvider, useLanguage } from '@/i18n/language';
 import { LocaleSync } from '@/i18n/localeSync';
 import { LockProvider, useLock } from '@/lib/lock';
-import { legacyKeysMigrated } from '@/lib/legacyKeys';
+import { onboardingSeen, rememberOnboardingSeen } from '@/lib/onboardingSeen';
 import { isRouteAllowed } from '@/lib/routeAccess';
 import { ReducedMotionProvider, useReducedMotion } from '@/lib/reducedMotion';
 import { RecentCountProvider } from '@/lib/recentCount';
@@ -102,11 +101,6 @@ if (pushSupported) {
     }),
   });
 }
-
-// The device-local flag that the intro tour has been seen. Shared verbatim with
-// the value AuthFlow wrote before the tour moved here, so anybody who already
-// saw it pre-move is not shown it again.
-const TOUR_KEY = 'waves.onboarding_seen';
 
 // How long a forward push runs. A touch longer than a plain slide because the
 // iOS-style transition has two layers to read — the incoming page arriving and
@@ -516,27 +510,35 @@ function AuthGate() {
     else router.replace('/');
   }, [session, loading, routeAllowed, router]);
 
-  // The intro tour now comes *after* sign-in, not in front of it: the first
-  // authenticated launch on this device shows the three cards once, over the
-  // app, then never again. `null` until storage answers, so it neither flashes
-  // for a returning account nor holds a first-timer at a blank screen.
-  const [tourSeen, setTourSeen] = useState<boolean | null>(null);
+  // The intro tour comes *after* sign-in, not in front of it: the first launch
+  // of an account shows the three cards once, over the app, then never again.
+  // Asked per account rather than per phone — the flag used to be one
+  // device-wide key, so the first person to finish the tour on a handset
+  // silently cancelled it for every account that signed in there afterwards
+  // (see `lib/onboardingSeen`).
+  //
+  // The answer is stored *with the account it is about*, the way the profile is,
+  // rather than as a bare boolean that a change of account has to reset: an
+  // answer left behind by whoever was signed in before must not decide this
+  // person's tour, and clearing it from the effect body is a cascading render.
+  // So `tourSeen` is derived — `null` until storage has answered for the current
+  // account, which neither flashes the tour at a returning one nor holds a
+  // first-timer at a blank screen.
+  const ownerId = session?.user.id ?? null;
+  const [tourAnswer, setTourAnswer] = useState<{ owner: string; seen: boolean } | null>(null);
   useEffect(() => {
+    if (!ownerId) return;
     let cancelled = false;
-    void legacyKeysMigrated
-      .then(() => AsyncStorage.getItem(TOUR_KEY))
-      .then((value) => {
-        if (!cancelled) setTourSeen(value === 'yes');
-      })
-      // Storage failing is not a reason to trap somebody on the tour forever;
-      // worst case they miss it, which costs nothing they cannot find later.
-      .catch(() => {
-        if (!cancelled) setTourSeen(true);
-      });
+    // Never rejects — a phone whose storage refuses to answer reports "seen"
+    // rather than trapping somebody behind an intro they cannot dismiss.
+    void onboardingSeen(ownerId).then((seen) => {
+      if (!cancelled) setTourAnswer({ owner: ownerId, seen });
+    });
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [ownerId]);
+  const tourSeen = tourAnswer && tourAnswer.owner === ownerId ? tourAnswer.seen : null;
 
   if (loading || needsRedirect) {
     return (
@@ -556,7 +558,7 @@ function AuthGate() {
   // A signed-in person who has not seen the tour meets it here, once, before
   // the app proper. Held while storage is still answering so the app tree does
   // not paint under it for a frame.
-  if (session && tourSeen !== true) {
+  if (session && ownerId && tourSeen !== true) {
     if (tourSeen === null) {
       return (
         <View
@@ -574,10 +576,10 @@ function AuthGate() {
     return (
       <Onboarding
         onDone={() => {
-          setTourSeen(true);
+          setTourAnswer({ owner: ownerId, seen: true });
           // Not awaited: the tour is over the moment they say so, and a write
           // that fails costs them one repeat, not a stuck screen.
-          void AsyncStorage.setItem(TOUR_KEY, 'yes').catch(() => {});
+          void rememberOnboardingSeen(ownerId);
           // One onboarding, not two: mark the coach tour seen as well so it does
           // not autostart on the Home screen the intro just handed them to.
           tour.finish();

--- a/apps/mobile/src/app/capture.tsx
+++ b/apps/mobile/src/app/capture.tsx
@@ -49,6 +49,7 @@ import { groupLabel, GroupType, type GroupRow, type MemberRow } from '@/data/typ
 import { useAuth } from '@/lib/auth';
 import { useDefaultCurrency } from '@/lib/currency';
 import { plural, useStrings, type UiStrings } from '@/i18n';
+import { dateFrom, isoDate, showDate } from '@/lib/expenseDay';
 import { captureReceipt, type PickedImage } from '@/lib/image';
 import { recogniseReceipt } from '@/lib/ocr';
 import { uploadCapturePhoto } from '@/data/api';
@@ -121,30 +122,6 @@ function todayIn(timeZone: string): string {
 function isCurrentTrip(group: GroupRow): boolean {
   if (group.type !== GroupType.Trip) return false;
   return dayNumber(todayIn(group.time_zone), group.start_date, group.end_date) !== null;
-}
-
-/**
- * Parsed as local noon rather than midnight: a date-only string turned into
- * midnight UTC lands on the previous day west of Greenwich (the same trap
- * TripDates avoids).
- */
-function dateFrom(iso: string): Date {
-  const [year, month, day] = iso.split('-').map(Number);
-  return new Date(year ?? 2026, (month ?? 1) - 1, day ?? 1, 12);
-}
-
-function isoDate(value: Date): string {
-  const month = String(value.getMonth() + 1).padStart(2, '0');
-  const day = String(value.getDate()).padStart(2, '0');
-  return `${value.getFullYear()}-${month}-${day}`;
-}
-
-function showDate(iso: string, locale: string): string {
-  return dateFrom(iso).toLocaleDateString(locale, {
-    weekday: 'short',
-    day: 'numeric',
-    month: 'short',
-  });
 }
 
 /**

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import DateTimePicker, { type DateTimePickerEvent } from '@react-native-community/datetimepicker';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { randomUUID } from 'expo-crypto';
 import { router, useLocalSearchParams } from 'expo-router';
@@ -71,7 +72,7 @@ import { COMMON_CURRENCIES, CurrencyRate } from '@/components/CurrencyRate';
 import { DescriptionField } from '@/components/expense/DescriptionField';
 import { ExpenseHero } from '@/components/expense/ExpenseHero';
 import { splitIcon } from '@/components/expense/splitIcon';
-import { ChoiceRow, SheetOverlay } from '@/components/expense/SheetOverlay';
+import { ChoiceRow, SettingRow, SheetOverlay } from '@/components/expense/SheetOverlay';
 import {
   canAddReceipt,
   expenseReceiptPath,
@@ -89,6 +90,7 @@ import { useAuth } from '@/lib/auth';
 import { useGuestGuard } from '@/lib/guestGuard';
 import { handoverKey } from '@/lib/handover';
 import { resolveDraftCurrency, resolveDraftFx } from '@/lib/expenseDraft';
+import { dateFrom, isoDate, showDate } from '@/lib/expenseDay';
 import {
   expenseDateFor,
   planCollapseToOne,
@@ -440,6 +442,13 @@ export default function AddExpenseScreen() {
   // How it was paid — a free-text tag on the expense. Defaults to cash; the
   // picker offers UPI only where the region settles over it.
   const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>('cash');
+  // The day the expense is filed under. It opens on the answer `expenseDateFor`
+  // has always computed — a capture's own day, a saved expense's own day, or
+  // today for a new one — and, now that there is a picker, the person can move
+  // it. `null` means "nobody has touched it", which is what keeps an edit from
+  // re-filing an expense it did not mean to move.
+  const [pickedDate, setPickedDate] = useState<string | null>(null);
+  const [editingDate, setEditingDate] = useState(false);
   const [participants, setParticipants] = useState<MemberId[]>([]);
   // What was typed into each member's field, as text. Two maps, not one: the
   // same person is "2 shares" and "40%", and switching between the two must not
@@ -839,6 +848,21 @@ export default function AddExpenseScreen() {
   // moment a second person is added, the figures have to add up to the total —
   // the ledger has always allowed several payer rows, and both edge functions
   // reject a write whose rows do not sum to the amount.
+  // The day this expense is filed under, picked or inherited (expenseDateFor).
+  const expenseDate = expenseDateFor({
+    picked: pickedDate,
+    captureDate: captureId ? captureExpenseDate : null,
+    savedDate: editing?.currentVersion?.expense_date,
+    today: todayIso(),
+  });
+
+  const applyDate = (event: DateTimePickerEvent, picked?: Date): void => {
+    // Android's dialog dismisses itself; iOS keeps the spinner on the screen.
+    if (Platform.OS === 'android') setEditingDate(false);
+    if (event.type === 'dismissed' || !picked) return;
+    setPickedDate(isoDate(picked));
+  };
+
   const payerIds = [...payers.keys()];
   // With one payer there is nothing to hold constant: that person carries the
   // whole bill by definition, so a lock left over from a moment when there were
@@ -1185,13 +1209,10 @@ export default function AddExpenseScreen() {
         description: description.trim(),
         category,
         categoryMeta,
-        // A capture keeps the day it was caught, a saved expense keeps the day
-        // it has, and only a new one is today's (expenseDateFor).
-        expenseDate: expenseDateFor({
-          captureDate: captureId ? captureExpenseDate : null,
-          savedDate: editing?.currentVersion?.expense_date,
-          today: todayIso(),
-        }),
+        // A chosen day wins outright. Untouched, a capture keeps the day it was
+        // caught, a saved expense keeps the day it has, and only a new one is
+        // today's (expenseDateFor).
+        expenseDate: expenseDate,
         currency,
         amount: amount.toString(),
         fx,
@@ -2210,7 +2231,34 @@ export default function AddExpenseScreen() {
               />
               <Divider />
               <PaymentMethodRow value={paymentMethod} onPress={() => setPickingPayment(true)} />
+              <Divider />
+              {/* When it happened. An expense filed on the wrong day lands in
+                the wrong month, the wrong trip and the wrong place in the feed,
+                and until now the only way to correct one was to delete it and
+                type it again. Untouched it still inherits the day it always
+                did, so editing a note never moves a three-week-old dinner. */}
+              <SettingRow
+                label={t.captures.date}
+                value={showDate(expenseDate, locale)}
+                leading={
+                  <Ionicons
+                    name="calendar-outline"
+                    size={iconSize.md}
+                    color={theme.color.textMuted}
+                  />
+                }
+                onPress={() => setEditingDate(true)}
+              />
             </Card>
+
+            {editingDate ? (
+              <DateTimePicker
+                value={dateFrom(expenseDate)}
+                mode="date"
+                display={Platform.OS === 'ios' ? 'inline' : 'default'}
+                onChange={applyDate}
+              />
+            ) : null}
 
             {/* Where it happened (A43) — optional, opt-in, never a background track. */}
             <LocationField value={location} onChange={setLocation} />

--- a/apps/mobile/src/app/settings/delete-account.tsx
+++ b/apps/mobile/src/app/settings/delete-account.tsx
@@ -22,6 +22,7 @@ import { deleteMyAccount, erasurePreview } from '@/data/api';
 import { fill, plural, useStrings } from '@/i18n';
 import { friendlyError } from '@/lib/errors';
 import { useAuth } from '@/lib/auth';
+import { forgetTours } from '@/lib/onboardingSeen';
 
 /**
  * Leaving, with the consequence in view before the button.
@@ -40,7 +41,7 @@ export default function DeleteAccountScreen() {
   const theme = useTheme();
   const clearance = useTabBarClearance();
   const { t, locale } = useStrings();
-  const { signOut } = useAuth();
+  const { session, signOut } = useAuth();
 
   const [reason, setReason] = useState('');
   const [confirm, setConfirm] = useState('');
@@ -57,6 +58,13 @@ export default function DeleteAccountScreen() {
     setError(null);
     try {
       const result = await deleteMyAccount(reason.trim() || null);
+      // The device's own note of which tours this account had seen. Erasure is
+      // the one moment it is meaningless — there is no account left to have
+      // seen anything — and the last moment we still know the id to look it up
+      // by. It never rejects, so it cannot come between the deletion and the
+      // sign-out below.
+      const ownerId = session?.user.id;
+      if (ownerId) await forgetTours(ownerId);
       // Signing out is the last thing, and only after the data is gone: the
       // reverse order would leave somebody signed out of an account that still
       // holds everything, with no way back in to try again.

--- a/apps/mobile/src/lib/expenseDay.ts
+++ b/apps/mobile/src/lib/expenseDay.ts
@@ -1,0 +1,35 @@
+/**
+ * The day an expense is filed under, as the three conversions a form needs.
+ *
+ * The ledger stores a plain UTC day with no time (`YYYY-MM-DD`), a date picker
+ * wants a `Date`, and a person wants to read "Tue, 9 Sep". These lived inside
+ * the capture screen until the expense form grew a date picker of its own; a
+ * second copy is how the two screens would have drifted into disagreeing about
+ * what "the same day" means.
+ */
+
+/**
+ * Parsed as local noon rather than midnight: a date-only string turned into
+ * midnight UTC lands on the previous day west of Greenwich (the same trap
+ * TripDates avoids).
+ */
+export function dateFrom(iso: string): Date {
+  const [year, month, day] = iso.split('-').map(Number);
+  return new Date(year ?? 2026, (month ?? 1) - 1, day ?? 1, 12);
+}
+
+/** The picker's answer, back as the day the ledger stores. */
+export function isoDate(value: Date): string {
+  const month = String(value.getMonth() + 1).padStart(2, '0');
+  const day = String(value.getDate()).padStart(2, '0');
+  return `${value.getFullYear()}-${month}-${day}`;
+}
+
+/** The same day, said in the reader's language. */
+export function showDate(iso: string, locale: string): string {
+  return dateFrom(iso).toLocaleDateString(locale, {
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+  });
+}

--- a/apps/mobile/src/lib/expenseForm.ts
+++ b/apps/mobile/src/lib/expenseForm.ts
@@ -27,21 +27,24 @@ export function todayIso(now: Date = new Date()): string {
 /**
  * The day the expense is filed under.
  *
- * An edit must not move it. The form has no date picker, so it used to send
- * today's date on every write — which meant opening a three-week-old dinner to
- * fix a spelling silently re-filed it as today's, reordered the feed, moved it
- * between months and trips, and (now that an expense keeps a visible history)
- * wrote a date change into the audit trail that nobody made.
+ * An edit must not move it *by itself*. The form used to send today's date on
+ * every write — which meant opening a three-week-old dinner to fix a spelling
+ * silently re-filed it as today's, reordered the feed, moved it between months
+ * and trips, and (now that an expense keeps a visible history) wrote a date
+ * change into the audit trail that nobody made.
  *
- * A capture keeps the day it was caught; a saved expense keeps the day it has;
- * only a genuinely new expense is today's.
+ * So the order is: a day the person actually picked; else the day a capture was
+ * caught; else the day a saved expense already has; else today. `picked` is
+ * null until somebody opens the picker, which is what keeps "I edited the note"
+ * distinct from "I moved this to Tuesday".
  */
 export function expenseDateFor(input: {
+  readonly picked?: string | null;
   readonly captureDate: string | null | undefined;
   readonly savedDate: string | null | undefined;
   readonly today: string;
 }): string {
-  return input.captureDate ?? input.savedDate ?? input.today;
+  return input.picked ?? input.captureDate ?? input.savedDate ?? input.today;
 }
 
 /**

--- a/apps/mobile/src/lib/legacyKeys.ts
+++ b/apps/mobile/src/lib/legacyKeys.ts
@@ -16,6 +16,9 @@
  * overwrite. That makes the whole pass idempotent and safe to run at every
  * launch, which is what it does.
  *
+ * A few keys are swept away here instead of moved — see `RETIRED` below. They
+ * are the ones whose meaning has gone, not just their name.
+ *
  * `legacyKeysMigrated` is the promise every reader of a moved key awaits. It is
  * created at import time and settles once per process; awaiting it a dozen
  * times costs nothing after the first. It never rejects — a device whose
@@ -49,7 +52,6 @@ const MOVES: readonly Move[] = [
   { from: 'baaki.session_replay_consent', to: 'waves.session_replay_consent' },
   { from: 'baaki.release_policy', to: 'waves.release_policy' },
   { from: 'baaki.update_dismissed', to: 'waves.update_dismissed' },
-  { from: 'baaki.onboarding_seen', to: 'waves.onboarding_seen' },
   // The web driver's whole local store, including writes that have not synced.
   { from: 'baaki:mirror', to: 'waves:mirror' },
   { from: 'baaki:cursors', to: 'waves:cursors' },
@@ -58,6 +60,32 @@ const MOVES: readonly Move[] = [
   { from: 'baaki.device.id', to: 'waves.device.id', secure: true },
   { from: 'baaki.app_lock_enabled', to: 'waves.app_lock_enabled', secure: true },
   { from: 'baaki.app_lock_grace_seconds', to: 'waves.app_lock_grace_seconds', secure: true },
+];
+
+/**
+ * Keys that are deleted rather than moved, because nothing reads them any more.
+ *
+ * All three held "somebody on this handset has already been shown the intro"
+ * (or the coach-marks) — one device-wide answer, given on behalf of every
+ * account that would ever sign in here. That is the bug `lib/onboardingSeen`
+ * exists to end: the answer belongs to an account now, and a phone does not get
+ * to give it. So the old values are not migrated, not claimed and not
+ * consulted; they are swept up, and every account is asked once for itself.
+ *
+ * Sweeping is what makes it safe. A retired key is never read again, so a
+ * delete that fails is an orphaned string and nothing more — it cannot come
+ * back as an answer, and it cannot be re-created by the moves above, because
+ * `baaki.onboarding_seen` is no longer one of them. (Leaving it a move and
+ * deleting the destination elsewhere would have resurrected it: `apply` rewrites
+ * the destination whenever it finds it empty, so a source whose `forget` had
+ * failed would re-answer on the next launch, and every launch after that.)
+ */
+const RETIRED: readonly string[] = [
+  'baaki.onboarding_seen',
+  'waves.onboarding_seen',
+  // Never had a `baaki.` spelling — it was born after the rename — so the one
+  // name is the whole of it.
+  'waves.tour_seen_v1',
 ];
 
 const onWeb = typeof document !== 'undefined';
@@ -121,9 +149,24 @@ async function apply(move: Move): Promise<void> {
   await forget(move, move.from);
 }
 
-async function migrate(): Promise<void> {
-  await Promise.all(MOVES.map((move) => apply(move).catch(() => {})));
+async function retire(key: string): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(key);
+  } catch {
+    // Nothing reads it, so a key that will not delete is wasted bytes rather
+    // than a wrong answer. The next launch tries again.
+  }
 }
 
-/** Settles once the device's pre-rename keys have been moved. Never rejects. */
+async function migrate(): Promise<void> {
+  await Promise.all([
+    ...MOVES.map((move) => apply(move).catch(() => {})),
+    ...RETIRED.map((key) => retire(key)),
+  ]);
+}
+
+/**
+ * Settles once the device's pre-rename keys have been moved and its retired
+ * ones swept. Never rejects.
+ */
 export const legacyKeysMigrated: Promise<void> = migrate();

--- a/apps/mobile/src/lib/onboardingSeen.ts
+++ b/apps/mobile/src/lib/onboardingSeen.ts
@@ -23,6 +23,13 @@
  * missing their onboarding would have carried on missing it. So existing
  * accounts see the intro once more after this ships. It is three cards.
  *
+ * Deliberately no `await legacyKeysMigrated` here, unlike every other reader of
+ * a renamed key. A per-account slot never existed before the rename, so no
+ * migration can touch one, and awaiting would hold the gate's spinner behind a
+ * dozen storage reads to answer a question that does not depend on them. The
+ * sweep still runs at boot — half a dozen modules the root layout mounts import
+ * `legacyKeys` and start it — it simply is not on this path.
+ *
  * Nothing in here rejects. Storage refusing to answer must not decide anything
  * dramatic, so each reader states its own safe direction below.
  */

--- a/apps/mobile/src/lib/onboardingSeen.ts
+++ b/apps/mobile/src/lib/onboardingSeen.ts
@@ -34,8 +34,11 @@
  * a renamed key. A per-account slot never existed before the rename, so no
  * migration can touch one, and awaiting would hold the gate's spinner behind a
  * dozen storage reads to answer a question that does not depend on them. The
- * sweep still runs at boot — half a dozen modules the root layout mounts import
- * `legacyKeys` and start it — it simply is not on this path.
+ * sweep still runs at boot, and not merely because some provider happens to
+ * mount: the root layout calls `applyStoredSessionReplayConsent()` at module
+ * scope, and `lib/sessionReplay` imports `legacyKeys`, so importing the layout
+ * starts the migration. (Half a dozen other modules import it too, but that one
+ * is the guarantee — it is the one a refactor would have to break on purpose.)
  *
  * Nothing in here rejects. Storage refusing to answer must not decide anything
  * dramatic, so each reader states its own safe direction below.

--- a/apps/mobile/src/lib/onboardingSeen.ts
+++ b/apps/mobile/src/lib/onboardingSeen.ts
@@ -23,6 +23,13 @@
  * missing their onboarding would have carried on missing it. So existing
  * accounts see the intro once more after this ships. It is three cards.
  *
+ * The coach-marks are re-armed by the same sweep, and that is intended too,
+ * though almost nobody will meet them: the intro's `onDone` marks them seen, so
+ * a returning account gets the three cards and then Home as usual. Only somebody
+ * who reaches Home without passing through the intro — dismissing it is passing
+ * through it — sees the coach-marks again, and one more pass over the balance
+ * deck is not worth a mechanism to prevent.
+ *
  * Deliberately no `await legacyKeysMigrated` here, unlike every other reader of
  * a renamed key. A per-account slot never existed before the rename, so no
  * migration can touch one, and awaiting would hold the gate's spinner behind a
@@ -85,3 +92,23 @@ export const tourSeen = (ownerId: string): Promise<boolean> => readFlag(tourSlot
 
 /** Remember that this account is done with the coach-marks. Never rejects. */
 export const rememberTourSeen = (ownerId: string): Promise<void> => writeFlag(tourSlot(ownerId));
+
+/**
+ * Drop both answers for an account that no longer exists. Never rejects.
+ *
+ * Only for erasure, and deliberately not for signing out: an account that signs
+ * out has still seen the tour, and would be entitled to be annoyed at meeting it
+ * again on the way back in. A deleted account has not — there is no it. Left
+ * alone the two slots are about sixty bytes of a phone that will never read them
+ * again, since every read is keyed by the live session's id; sweeping them is
+ * hygiene rather than a fix.
+ */
+export async function forgetTours(ownerId: string): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(introSlot(ownerId));
+    await AsyncStorage.removeItem(tourSlot(ownerId));
+  } catch {
+    // Sixty bytes that outlive the account they describe. Not worth a word to
+    // the person who is in the middle of deleting everything they own.
+  }
+}

--- a/apps/mobile/src/lib/onboardingSeen.ts
+++ b/apps/mobile/src/lib/onboardingSeen.ts
@@ -45,7 +45,12 @@ export async function onboardingSeen(ownerId: string): Promise<boolean> {
     // before that has landed would call a returning phone a new one.
     await legacyKeysMigrated;
 
-    if ((await AsyncStorage.getItem(slotFor(ownerId))) === 'yes') return true;
+    if ((await AsyncStorage.getItem(slotFor(ownerId))) === 'yes') {
+      // If a legacy device-wide answer survived beside this account's own slot,
+      // it is stale now. Do not let it answer for the next person on the phone.
+      await AsyncStorage.removeItem(DEVICE_KEY);
+      return true;
+    }
     if ((await AsyncStorage.getItem(DEVICE_KEY)) !== 'yes') return false;
 
     // Claimed: this account inherits the phone's old answer, and the phone

--- a/apps/mobile/src/lib/onboardingSeen.ts
+++ b/apps/mobile/src/lib/onboardingSeen.ts
@@ -1,0 +1,68 @@
+/**
+ * Who has already met the three intro cards.
+ *
+ * The flag used to be a single device-wide key: whoever finished — or skipped —
+ * the tour on this phone answered for every account that would ever sign in
+ * here afterwards. That is why the tour stopped appearing after login. The
+ * screen never went anywhere and the gate never changed; the phone had simply
+ * already said "seen" on behalf of everybody, and nothing clears that, not even
+ * signing out.
+ *
+ * A tour is shown to a *person* meeting the app, not to a handset, so the flag
+ * is filed per account id — the same shape the backup recovery key and the
+ * cloud tokens already use.
+ *
+ * The old device-wide key is still read, once, and claimed by the first account
+ * that asks: that account is the one that saw the tour, so it keeps not seeing
+ * it, and the key is then removed so a second, genuinely new account on the
+ * same phone is treated as new. A phone that already had two accounts signed in
+ * pays for that with one repeat of the tour on the second of them — three
+ * swipes, and only ever once.
+ *
+ * Nothing in here rejects. Storage refusing a read is not a reason to trap
+ * somebody behind an intro, so a failure reports "seen" and they miss a tour
+ * rather than meeting a wall.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { legacyKeysMigrated } from '@/lib/legacyKeys';
+
+/**
+ * The pre-account key: one phone, one answer. Read until an account claims it,
+ * never written again. Kept verbatim so a device that saw the tour under the
+ * old scheme is recognised rather than re-toured.
+ */
+const DEVICE_KEY = 'waves.onboarding_seen';
+
+/** Where the answer lives now — one slot per signed-in account. */
+const slotFor = (ownerId: string): string => `${DEVICE_KEY}.${ownerId}`;
+
+/** Has this account already been shown the intro? Never rejects. */
+export async function onboardingSeen(ownerId: string): Promise<boolean> {
+  try {
+    // The rename moved `baaki.onboarding_seen` onto the device key. Reading
+    // before that has landed would call a returning phone a new one.
+    await legacyKeysMigrated;
+
+    if ((await AsyncStorage.getItem(slotFor(ownerId))) === 'yes') return true;
+    if ((await AsyncStorage.getItem(DEVICE_KEY)) !== 'yes') return false;
+
+    // Claimed: this account inherits the phone's old answer, and the phone
+    // stops answering for anybody else.
+    await AsyncStorage.setItem(slotFor(ownerId), 'yes');
+    await AsyncStorage.removeItem(DEVICE_KEY);
+    return true;
+  } catch {
+    return true;
+  }
+}
+
+/** Remember that this account is done with the intro. Never rejects. */
+export async function rememberOnboardingSeen(ownerId: string): Promise<void> {
+  try {
+    await AsyncStorage.setItem(slotFor(ownerId), 'yes');
+  } catch {
+    // A write that fails costs them one repeat of the tour, not a stuck screen.
+  }
+}

--- a/apps/mobile/src/lib/onboardingSeen.ts
+++ b/apps/mobile/src/lib/onboardingSeen.ts
@@ -1,73 +1,80 @@
 /**
- * Who has already met the three intro cards.
+ * Who has already met the intro cards, and who has already had the coach-marks.
  *
- * The flag used to be a single device-wide key: whoever finished — or skipped —
- * the tour on this phone answered for every account that would ever sign in
- * here afterwards. That is why the tour stopped appearing after login. The
- * screen never went anywhere and the gate never changed; the phone had simply
- * already said "seen" on behalf of everybody, and nothing clears that, not even
- * signing out.
+ * Both flags used to be a single device-wide key. Whoever first finished — or
+ * skipped — the tour on a handset answered on behalf of every account that
+ * would ever sign in there afterwards, and nothing cleared it, not signing out
+ * and not signing in as somebody else. That is why the intro stopped appearing
+ * after login: the screen never went anywhere and the gate never changed, the
+ * phone had simply already said "seen" for everybody.
  *
- * A tour is shown to a *person* meeting the app, not to a handset, so the flag
- * is filed per account id — the same shape the backup recovery key and the
- * cloud tokens already use.
+ * A tour is shown to a person meeting the app, not to a handset, so each flag is
+ * filed per account id — the same shape the backup recovery key and the cloud
+ * tokens already use.
  *
- * The old device-wide key is still read, once, and claimed by the first account
- * that asks: that account is the one that saw the tour, so it keeps not seeing
- * it, and the key is then removed so a second, genuinely new account on the
- * same phone is treated as new. A phone that already had two accounts signed in
- * pays for that with one repeat of the tour on the second of them — three
- * swipes, and only ever once.
+ * The old device-wide values are not migrated, not claimed and not consulted.
+ * They are swept away by `legacyKeys` (see its `RETIRED` list) and every account
+ * is asked once for itself. That is deliberate, and it is the point of the
+ * change rather than a cost of it: on any handset that ran the app before the
+ * intro moved behind sign-in, the device key says "yes" because somebody swiped
+ * past the cards on the *login screen*, before there was an account to attribute
+ * it to. Honouring that would have handed the first account to sign in the very
+ * answer this module exists to stop trusting — the people most likely to be
+ * missing their onboarding would have carried on missing it. So existing
+ * accounts see the intro once more after this ships. It is three cards.
  *
- * Nothing in here rejects. Storage refusing a read is not a reason to trap
- * somebody behind an intro, so a failure reports "seen" and they miss a tour
- * rather than meeting a wall.
+ * Nothing in here rejects. Storage refusing to answer must not decide anything
+ * dramatic, so each reader states its own safe direction below.
  */
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-import { legacyKeysMigrated } from '@/lib/legacyKeys';
+/**
+ * One slot per account, per flag. The suffix is the account id; the stems are
+ * the old device-wide key names, which are retired and can never collide with
+ * a suffixed one.
+ */
+const introSlot = (ownerId: string): string => `waves.onboarding_seen.${ownerId}`;
+/** Bumping the `v1` re-shows the coach-marks to everyone after they change shape. */
+const tourSlot = (ownerId: string): string => `waves.tour_seen_v1.${ownerId}`;
+
+async function readFlag(key: string, whenUnreadable: boolean): Promise<boolean> {
+  try {
+    return (await AsyncStorage.getItem(key)) === 'yes';
+  } catch {
+    return whenUnreadable;
+  }
+}
+
+async function writeFlag(key: string): Promise<void> {
+  try {
+    await AsyncStorage.setItem(key, 'yes');
+  } catch {
+    // A write that fails costs one repeat of a tour, not a stuck screen.
+  }
+}
 
 /**
- * The pre-account key: one phone, one answer. Read until an account claims it,
- * never written again. Kept verbatim so a device that saw the tour under the
- * old scheme is recognised rather than re-toured.
+ * Has this account already been shown the three intro cards? Never rejects.
+ *
+ * Unreadable storage reports "seen": the intro is a full-screen gate in front
+ * of the app, and a phone that cannot answer must not trap somebody behind it.
  */
-const DEVICE_KEY = 'waves.onboarding_seen';
-
-/** Where the answer lives now — one slot per signed-in account. */
-const slotFor = (ownerId: string): string => `${DEVICE_KEY}.${ownerId}`;
-
-/** Has this account already been shown the intro? Never rejects. */
-export async function onboardingSeen(ownerId: string): Promise<boolean> {
-  try {
-    // The rename moved `baaki.onboarding_seen` onto the device key. Reading
-    // before that has landed would call a returning phone a new one.
-    await legacyKeysMigrated;
-
-    if ((await AsyncStorage.getItem(slotFor(ownerId))) === 'yes') {
-      // If a legacy device-wide answer survived beside this account's own slot,
-      // it is stale now. Do not let it answer for the next person on the phone.
-      await AsyncStorage.removeItem(DEVICE_KEY);
-      return true;
-    }
-    if ((await AsyncStorage.getItem(DEVICE_KEY)) !== 'yes') return false;
-
-    // Claimed: this account inherits the phone's old answer, and the phone
-    // stops answering for anybody else.
-    await AsyncStorage.setItem(slotFor(ownerId), 'yes');
-    await AsyncStorage.removeItem(DEVICE_KEY);
-    return true;
-  } catch {
-    return true;
-  }
-}
+export const onboardingSeen = (ownerId: string): Promise<boolean> =>
+  readFlag(introSlot(ownerId), true);
 
 /** Remember that this account is done with the intro. Never rejects. */
-export async function rememberOnboardingSeen(ownerId: string): Promise<void> {
-  try {
-    await AsyncStorage.setItem(slotFor(ownerId), 'yes');
-  } catch {
-    // A write that fails costs them one repeat of the tour, not a stuck screen.
-  }
-}
+export const rememberOnboardingSeen = (ownerId: string): Promise<void> =>
+  writeFlag(introSlot(ownerId));
+
+/**
+ * Has this account already had the Home coach-marks? Never rejects.
+ *
+ * Unreadable storage reports "not seen", the opposite of the intro and for the
+ * same reason: the coach-marks are a dismissable overlay on a screen that works
+ * without them, so the cost of a spurious one is a tap on the X.
+ */
+export const tourSeen = (ownerId: string): Promise<boolean> => readFlag(tourSlot(ownerId), false);
+
+/** Remember that this account is done with the coach-marks. Never rejects. */
+export const rememberTourSeen = (ownerId: string): Promise<void> => writeFlag(tourSlot(ownerId));

--- a/apps/mobile/src/lib/tour.tsx
+++ b/apps/mobile/src/lib/tour.tsx
@@ -14,7 +14,8 @@
  * target has not measured yet) is shown centred, as a plain card.
  *
  * State lives here so the overlay, the Home autostart and the replay item all
- * read the same thing; the "seen" flag is the only thing that persists.
+ * read the same thing; the "seen" flag is the only thing that persists, and it
+ * persists per account rather than per handset (see `lib/onboardingSeen`).
  */
 
 import {
@@ -27,13 +28,11 @@ import {
   useState,
   type ReactNode,
 } from 'react';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { View, type ViewStyle } from 'react-native';
 
 import type { UiStrings } from '@/i18n';
-
-/** Bumping the suffix re-shows the tour to everyone after it changes shape. */
-const SEEN_KEY = 'waves.tour_seen_v1';
+import { useAuth } from '@/lib/auth';
+import { rememberTourSeen, tourSeen } from '@/lib/onboardingSeen';
 
 /** A measured target, in window (screen) coordinates. */
 export interface TourRect {
@@ -107,10 +106,14 @@ interface TourValue {
 const TourContext = createContext<TourValue | null>(null);
 
 export function TourProvider({ children }: { children: ReactNode }) {
+  // Whose coach-marks these are. The "seen" flag used to be one device-wide key,
+  // so the first person to finish the tour on a handset silently cancelled it
+  // for every account that signed in there afterwards — the same bug the intro
+  // cards had, one line further on (`lib/onboardingSeen` tells the whole story).
+  const { session } = useAuth();
+  const ownerId = session?.user.id ?? null;
   const [active, setActive] = useState(false);
   const [step, setStep] = useState(0);
-  const [seen, setSeen] = useState(false);
-  const [ready, setReady] = useState(false);
   // Bumped when a target re-measures while the tour is up, so the overlay
   // re-renders and reads the fresh rectangle (see `register`). Carried in the
   // value's deps so the context identity changes and consumers re-render.
@@ -125,21 +128,28 @@ export function TourProvider({ children }: { children: ReactNode }) {
     activeRef.current = active;
   }, [active]);
 
+  // The answer is held *with the account it is about*, the way the profile is,
+  // rather than as a bare boolean an account change has to reset: an answer left
+  // behind by whoever was signed in before must not start (or suppress) this
+  // person's tour, and clearing it from the effect body is a cascading render.
+  // So `ready` and `seen` are derived, and a sign-in stands them back down until
+  // storage has answered for the new account.
+  const [answer, setAnswer] = useState<{ owner: string; seen: boolean } | null>(null);
   useEffect(() => {
-    let active2 = true;
-    void AsyncStorage.getItem(SEEN_KEY)
-      .then((value) => {
-        if (!active2) return;
-        setSeen(value === 'yes');
-      })
-      .catch(() => {})
-      .finally(() => {
-        if (active2) setReady(true);
-      });
+    if (!ownerId) return;
+    let live = true;
+    // Never rejects; a phone that cannot answer reports "not seen", so the worst
+    // case is a dismissable overlay rather than a tour nobody can ever get.
+    void tourSeen(ownerId).then((value) => {
+      if (live) setAnswer({ owner: ownerId, seen: value });
+    });
     return () => {
-      active2 = false;
+      live = false;
     };
-  }, []);
+  }, [ownerId]);
+  const current = answer && answer.owner === ownerId ? answer : null;
+  const ready = current !== null;
+  const seen = current?.seen ?? false;
 
   const register = useCallback((id: string, rect: TourRect | null) => {
     if (rect) rects.current.set(id, rect);
@@ -161,9 +171,12 @@ export function TourProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const remember = useCallback(() => {
-    setSeen(true);
-    void AsyncStorage.setItem(SEEN_KEY, 'yes').catch(() => {});
-  }, []);
+    // Signed out there is nobody to remember it for — and nobody can be looking
+    // at the tour either, since Home is behind the door.
+    if (!ownerId) return;
+    setAnswer({ owner: ownerId, seen: true });
+    void rememberTourSeen(ownerId);
+  }, [ownerId]);
 
   const finish = useCallback(() => {
     setActive(false);

--- a/apps/mobile/test/expenseForm.test.ts
+++ b/apps/mobile/test/expenseForm.test.ts
@@ -63,6 +63,25 @@ describe('expenseDateFor', () => {
     ).toBe('2026-07-04');
   });
 
+  it('lets a picked day beat every day it would have inherited', () => {
+    expect(
+      expenseDateFor({
+        picked: '2026-06-20',
+        captureDate: '2026-07-04',
+        savedDate: '2026-08-11',
+        today: TODAY,
+      }),
+    ).toBe('2026-06-20');
+  });
+
+  it('inherits while the picker has not been touched', () => {
+    // `null` is "nobody moved this", which is what keeps editing a note from
+    // re-filing a three-week-old expense under today.
+    expect(
+      expenseDateFor({ picked: null, captureDate: null, savedDate: '2026-08-11', today: TODAY }),
+    ).toBe('2026-08-11');
+  });
+
   it('writes a plain UTC day, never a timestamp', () => {
     expect(todayIso(new Date('2026-09-01T22:45:00.000Z'))).toBe('2026-09-01');
   });

--- a/apps/mobile/test/onboardingSeen.test.ts
+++ b/apps/mobile/test/onboardingSeen.test.ts
@@ -1,7 +1,8 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  forgetTours,
   onboardingSeen,
   rememberOnboardingSeen,
   rememberTourSeen,
@@ -88,6 +89,63 @@ describe('the coach-mark flag', () => {
 
     expect(await onboardingSeen(ALICE)).toBe(true);
     expect(await tourSeen(ALICE)).toBe(false);
+  });
+});
+
+/**
+ * The module's one behavioural asymmetry, and the only thing its header spends a
+ * paragraph arguing: a phone that cannot answer sends the two flags in opposite
+ * directions. Worth pinning, because both directions look arbitrary until you
+ * remember which of the two is a full-screen gate.
+ */
+describe('when storage will not answer', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+    // Seeded so neither assertion below can pass by accident: Alice has had the
+    // coach-marks and has *not* had the intro, so a working read would answer
+    // false then true, and the failing reads have to answer true then false to
+    // prove the catch is what spoke.
+    await rememberTourSeen(ALICE);
+
+    vi.spyOn(AsyncStorage, 'getItem').mockRejectedValue(new Error('storage unavailable'));
+    vi.spyOn(AsyncStorage, 'setItem').mockRejectedValue(new Error('storage unavailable'));
+    vi.spyOn(AsyncStorage, 'removeItem').mockRejectedValue(new Error('storage unavailable'));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('lets the intro through rather than trapping somebody behind it', async () => {
+    expect(await onboardingSeen(ALICE)).toBe(true);
+  });
+
+  it('offers the coach-marks, because the worst case is a tap on the X', async () => {
+    expect(await tourSeen(ALICE)).toBe(false);
+  });
+
+  it('reports rather than throws, so a gate is never left waiting', async () => {
+    await expect(rememberOnboardingSeen(ALICE)).resolves.toBeUndefined();
+    await expect(rememberTourSeen(ALICE)).resolves.toBeUndefined();
+    await expect(forgetTours(ALICE)).resolves.toBeUndefined();
+  });
+});
+
+describe('forgetting a deleted account', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+  });
+
+  it('drops both of its answers and nobody else’s', async () => {
+    await rememberOnboardingSeen(ALICE);
+    await rememberTourSeen(ALICE);
+    await rememberOnboardingSeen(BOB);
+
+    await forgetTours(ALICE);
+
+    expect(await onboardingSeen(ALICE)).toBe(false);
+    expect(await tourSeen(ALICE)).toBe(false);
+    expect(await onboardingSeen(BOB)).toBe(true);
   });
 });
 

--- a/apps/mobile/test/onboardingSeen.test.ts
+++ b/apps/mobile/test/onboardingSeen.test.ts
@@ -42,6 +42,15 @@ describe('onboardingSeen', () => {
     expect(await onboardingSeen(ALICE)).toBe(true);
   });
 
+  it('clears a stale device flag when this account already has its own answer', async () => {
+    await rememberOnboardingSeen(ALICE);
+    await AsyncStorage.setItem(DEVICE_KEY, 'yes');
+
+    expect(await onboardingSeen(ALICE)).toBe(true);
+    expect(await AsyncStorage.getItem(DEVICE_KEY)).toBeNull();
+    expect(await onboardingSeen(BOB)).toBe(false);
+  });
+
   it('leaves an untouched device flag alone for a first-run phone', async () => {
     expect(await onboardingSeen(ALICE)).toBe(false);
     expect(await AsyncStorage.getItem(`${DEVICE_KEY}.${ALICE}`)).toBeNull();

--- a/apps/mobile/test/onboardingSeen.test.ts
+++ b/apps/mobile/test/onboardingSeen.test.ts
@@ -1,13 +1,22 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { onboardingSeen, rememberOnboardingSeen } from '@/lib/onboardingSeen';
+import {
+  onboardingSeen,
+  rememberOnboardingSeen,
+  rememberTourSeen,
+  tourSeen,
+} from '@/lib/onboardingSeen';
 
-const DEVICE_KEY = 'waves.onboarding_seen';
+/** The device-wide keys that used to answer on everybody's behalf. */
+const OLD_INTRO_KEY = 'waves.onboarding_seen';
+const OLDER_INTRO_KEY = 'baaki.onboarding_seen';
+const OLD_TOUR_KEY = 'waves.tour_seen_v1';
+
 const ALICE = 'user-alice';
 const BOB = 'user-bob';
 
-describe('onboardingSeen', () => {
+describe('the intro flag', () => {
   beforeEach(async () => {
     await AsyncStorage.clear();
   });
@@ -24,38 +33,95 @@ describe('onboardingSeen', () => {
     expect(await onboardingSeen(BOB)).toBe(false);
   });
 
-  it('lets the first account claim the old device-wide flag', async () => {
-    await AsyncStorage.setItem(DEVICE_KEY, 'yes');
+  it('ignores the old device-wide answer, so an existing account is asked once more', async () => {
+    // What a handset that ran the app before the intro moved behind sign-in
+    // looks like: somebody swiped past the cards on the login screen, before
+    // there was an account to attribute it to.
+    await AsyncStorage.setItem(OLD_INTRO_KEY, 'yes');
 
-    // Alice was the one who saw it, so she is not toured again...
-    expect(await onboardingSeen(ALICE)).toBe(true);
-    expect(await AsyncStorage.getItem(`${DEVICE_KEY}.${ALICE}`)).toBe('yes');
-    // ...and the phone stops answering on everybody else's behalf.
-    expect(await AsyncStorage.getItem(DEVICE_KEY)).toBeNull();
-    expect(await onboardingSeen(BOB)).toBe(false);
-  });
-
-  it('keeps the claim across a re-read', async () => {
-    await AsyncStorage.setItem(DEVICE_KEY, 'yes');
-    await onboardingSeen(ALICE);
-
-    expect(await onboardingSeen(ALICE)).toBe(true);
-  });
-
-  it('clears a stale device flag when this account already has its own answer', async () => {
-    await rememberOnboardingSeen(ALICE);
-    await AsyncStorage.setItem(DEVICE_KEY, 'yes');
-
-    expect(await onboardingSeen(ALICE)).toBe(true);
-    expect(await AsyncStorage.getItem(DEVICE_KEY)).toBeNull();
-    expect(await onboardingSeen(BOB)).toBe(false);
-  });
-
-  it('leaves an untouched device flag alone for a first-run phone', async () => {
     expect(await onboardingSeen(ALICE)).toBe(false);
-    expect(await AsyncStorage.getItem(`${DEVICE_KEY}.${ALICE}`)).toBeNull();
+    // And it is not quietly claimed on the way past, so the account after
+    // Alice is asked for itself too.
+    expect(await onboardingSeen(BOB)).toBe(false);
+  });
 
+  it('does not let the old key back in once an account has answered', async () => {
+    await AsyncStorage.setItem(OLD_INTRO_KEY, 'yes');
     await rememberOnboardingSeen(ALICE);
-    expect(await AsyncStorage.getItem(DEVICE_KEY)).toBeNull();
+
+    expect(await onboardingSeen(ALICE)).toBe(true);
+    expect(await onboardingSeen(BOB)).toBe(false);
+  });
+
+  it('writes nowhere but its own account slot', async () => {
+    await rememberOnboardingSeen(ALICE);
+
+    expect(await AsyncStorage.getItem(`${OLD_INTRO_KEY}.${ALICE}`)).toBe('yes');
+    expect(await AsyncStorage.getItem(OLD_INTRO_KEY)).toBeNull();
+  });
+});
+
+describe('the coach-mark flag', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+  });
+
+  it('runs the coach-marks for an account that has never had them', async () => {
+    expect(await tourSeen(ALICE)).toBe(false);
+  });
+
+  it('remembers per account, not per phone', async () => {
+    await rememberTourSeen(ALICE);
+
+    expect(await tourSeen(ALICE)).toBe(true);
+    expect(await tourSeen(BOB)).toBe(false);
+  });
+
+  it('ignores the old device-wide answer', async () => {
+    await AsyncStorage.setItem(OLD_TOUR_KEY, 'yes');
+
+    expect(await tourSeen(ALICE)).toBe(false);
+  });
+
+  it('is a separate answer from the intro', async () => {
+    await rememberOnboardingSeen(ALICE);
+
+    expect(await onboardingSeen(ALICE)).toBe(true);
+    expect(await tourSeen(ALICE)).toBe(false);
+  });
+});
+
+/**
+ * One test, not several: `legacyKeys` runs its migration once, at import, so a
+ * second case would be asserting against a sweep that had already happened. The
+ * seeding therefore covers every shape at once, and the import is the last thing
+ * to run.
+ */
+describe('retiring the device-wide flags', () => {
+  it('sweeps them away, and cannot resurrect an answer from the pre-rename key', async () => {
+    await AsyncStorage.clear();
+    // The `baaki.` source surviving next to an empty `waves.` destination is
+    // exactly the shape that used to bring the answer back: a source whose
+    // delete failed on an earlier launch was re-migrated on the next one, and
+    // the next new account inherited "seen" from it. It is no longer a move.
+    await AsyncStorage.setItem(OLDER_INTRO_KEY, 'yes');
+    await AsyncStorage.setItem(OLD_INTRO_KEY, 'yes');
+    await AsyncStorage.setItem(OLD_TOUR_KEY, 'yes');
+    // Something that IS still moved, to prove the sweep did not eat the rest.
+    await AsyncStorage.setItem('baaki.theme_scheme', 'dark');
+
+    // Imported here rather than at the top of the file so the keys above are in
+    // place before the module runs its one-shot migration on import.
+    const { legacyKeysMigrated } = await import('@/lib/legacyKeys');
+    await legacyKeysMigrated;
+
+    expect(await AsyncStorage.getItem(OLDER_INTRO_KEY)).toBeNull();
+    expect(await AsyncStorage.getItem(OLD_INTRO_KEY)).toBeNull();
+    expect(await AsyncStorage.getItem(OLD_TOUR_KEY)).toBeNull();
+    expect(await AsyncStorage.getItem('waves.theme_scheme')).toBe('dark');
+
+    // And nobody inherits anything from any of it.
+    expect(await onboardingSeen(ALICE)).toBe(false);
+    expect(await tourSeen(ALICE)).toBe(false);
   });
 });

--- a/apps/mobile/test/onboardingSeen.test.ts
+++ b/apps/mobile/test/onboardingSeen.test.ts
@@ -1,0 +1,52 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { onboardingSeen, rememberOnboardingSeen } from '@/lib/onboardingSeen';
+
+const DEVICE_KEY = 'waves.onboarding_seen';
+const ALICE = 'user-alice';
+const BOB = 'user-bob';
+
+describe('onboardingSeen', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+  });
+
+  it('shows the intro to an account that has never seen it', async () => {
+    expect(await onboardingSeen(ALICE)).toBe(false);
+  });
+
+  it('remembers per account, not per phone', async () => {
+    await rememberOnboardingSeen(ALICE);
+
+    expect(await onboardingSeen(ALICE)).toBe(true);
+    // The bug this replaces: Bob signing in on Alice's phone never met the tour.
+    expect(await onboardingSeen(BOB)).toBe(false);
+  });
+
+  it('lets the first account claim the old device-wide flag', async () => {
+    await AsyncStorage.setItem(DEVICE_KEY, 'yes');
+
+    // Alice was the one who saw it, so she is not toured again...
+    expect(await onboardingSeen(ALICE)).toBe(true);
+    expect(await AsyncStorage.getItem(`${DEVICE_KEY}.${ALICE}`)).toBe('yes');
+    // ...and the phone stops answering on everybody else's behalf.
+    expect(await AsyncStorage.getItem(DEVICE_KEY)).toBeNull();
+    expect(await onboardingSeen(BOB)).toBe(false);
+  });
+
+  it('keeps the claim across a re-read', async () => {
+    await AsyncStorage.setItem(DEVICE_KEY, 'yes');
+    await onboardingSeen(ALICE);
+
+    expect(await onboardingSeen(ALICE)).toBe(true);
+  });
+
+  it('leaves an untouched device flag alone for a first-run phone', async () => {
+    expect(await onboardingSeen(ALICE)).toBe(false);
+    expect(await AsyncStorage.getItem(`${DEVICE_KEY}.${ALICE}`)).toBeNull();
+
+    await rememberOnboardingSeen(ALICE);
+    expect(await AsyncStorage.getItem(DEVICE_KEY)).toBeNull();
+  });
+});


### PR DESCRIPTION
Reported: "In edit expense I don't see a way to change the expense date."

There wasn't one. `expenseForm.ts` said so in as many words — *"The form has no date picker"* — and an expense filed on the wrong day lands in the wrong month, the wrong trip and the wrong place in the feed, with deleting and retyping it as the only correction.

## The tier that was missing

`expenseDateFor` already had three tiers and no way to say "I mean this day". It now has four: **a day the person actually picked**, else the day a capture was caught, else the day a saved expense already has, else today.

`picked` stays `null` until somebody opens the picker. That is the whole safety property, and it preserves the regression the function was written for: editing a three-week-old dinner's description still does not re-file it under today, still does not move it between months and trips, and still writes no date change into its visible history. Two tests pin both directions — a picked day beating everything it would have inherited, and an untouched picker inheriting as before.

## Where it sits

With the other two one-answer fields (category, paid with) behind **More details**, as a third `SettingRow` in the same card, using the same `DateTimePicker` the capture screen uses — `inline` on iOS, the platform dialog on Android, dismissal handled the same way.

It reuses the existing `captures.date` key, so there are no new strings and no locale work.

## One thing extracted rather than copied

The three conversions this needs — ISO to `Date` at **local noon** (midnight UTC lands on the previous day west of Greenwich, the trap `TripDates` already avoids), `Date` back to ISO, and the day said in the reader's language — lived inside `capture.tsx`. They move to `lib/expenseDay.ts` and both screens import them. A second copy is how the two screens would have drifted about what "the same day" means.

## Verification

`pnpm lint` 0 errors (3 pre-existing `import/first` warnings in `phone.tsx`, untouched), `pnpm --filter @waves/mobile typecheck` clean, **82 files / 1057 tests pass**.

Not run on a device: that the picker opens and commits on a real Android dialog, and the iOS `inline` presentation inside the More-details fold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jhzmZz5fkjnZZ14YxHGfS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added expense-date selection when creating or editing expenses, with platform-appropriate date pickers.
  - Expense dates now display consistently in localized formats.

- **Improvements**
  - Intro tours and coach marks are tracked separately for each account.
  - Account deletion now clears the associated onboarding and tour history.
  - Existing device-wide onboarding records are no longer reused, so each account completes onboarding independently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->