### PR TITLE
Put the expense date where somebody looking for it will find it

### DIFF
--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -1661,6 +1661,40 @@ export default function AddExpenseScreen() {
             multiline
           />
 
+          {/* When it happened, on the common path rather than behind the fold.
+            The day is not an advanced setting: an expense filed on the wrong one
+            lands in the wrong month, the wrong trip and the wrong place in the
+            feed, and somebody correcting a date should not have to guess that it
+            lives under "More details" — which is exactly what happened when it
+            did. It sits beside the note rather than above the fold for the same
+            reason: split, payers and participants fill the first screenful, so
+            anything after them is still a scroll away. What, when, then who.
+            Untouched it still inherits the day it always had, so editing a note
+            never moves a three-week-old dinner. */}
+          <Card style={{ paddingVertical: theme.spacing.xs, gap: 0 }}>
+            <SettingRow
+              label={t.captures.date}
+              value={showDate(expenseDate, locale)}
+              leading={
+                <Ionicons
+                  name="calendar-outline"
+                  size={iconSize.md}
+                  color={theme.color.textMuted}
+                />
+              }
+              onPress={() => setEditingDate(true)}
+            />
+          </Card>
+
+          {editingDate ? (
+            <DateTimePicker
+              value={dateFrom(expenseDate)}
+              mode="date"
+              display={Platform.OS === 'ios' ? 'inline' : 'default'}
+              onChange={applyDate}
+            />
+          ) : null}
+
           {/* The bill is a shortcut, not the screen: two small actions rather
             than a card that makes this look like a receipt scanner. Scan is
             metered and gives way when the group is capped; Add photo keeps an
@@ -2197,37 +2231,6 @@ export default function AddExpenseScreen() {
               }
             />
           </Card>
-
-          {/* When it happened, on the common path rather than behind the fold.
-            The day is not an advanced setting: an expense filed on the wrong one
-            lands in the wrong month, the wrong trip and the wrong place in the
-            feed, and somebody correcting a date should not have to guess that it
-            lives under "More details" — which is exactly what happened when it
-            did. Untouched it still inherits the day it always had, so editing a
-            note never moves a three-week-old dinner. */}
-          <Card style={{ paddingVertical: theme.spacing.xs, gap: 0 }}>
-            <SettingRow
-              label={t.captures.date}
-              value={showDate(expenseDate, locale)}
-              leading={
-                <Ionicons
-                  name="calendar-outline"
-                  size={iconSize.md}
-                  color={theme.color.textMuted}
-                />
-              }
-              onPress={() => setEditingDate(true)}
-            />
-          </Card>
-
-          {editingDate ? (
-            <DateTimePicker
-              value={dateFrom(expenseDate)}
-              mode="date"
-              display={Platform.OS === 'ios' ? 'inline' : 'default'}
-              onChange={applyDate}
-            />
-          ) : null}
 
           {/* Everything most expenses never need — the category (already guessed
             from the note), how it was paid, where, and a foreign rate — folded

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -2198,6 +2198,37 @@ export default function AddExpenseScreen() {
             />
           </Card>
 
+          {/* When it happened, on the common path rather than behind the fold.
+            The day is not an advanced setting: an expense filed on the wrong one
+            lands in the wrong month, the wrong trip and the wrong place in the
+            feed, and somebody correcting a date should not have to guess that it
+            lives under "More details" — which is exactly what happened when it
+            did. Untouched it still inherits the day it always had, so editing a
+            note never moves a three-week-old dinner. */}
+          <Card style={{ paddingVertical: theme.spacing.xs, gap: 0 }}>
+            <SettingRow
+              label={t.captures.date}
+              value={showDate(expenseDate, locale)}
+              leading={
+                <Ionicons
+                  name="calendar-outline"
+                  size={iconSize.md}
+                  color={theme.color.textMuted}
+                />
+              }
+              onPress={() => setEditingDate(true)}
+            />
+          </Card>
+
+          {editingDate ? (
+            <DateTimePicker
+              value={dateFrom(expenseDate)}
+              mode="date"
+              display={Platform.OS === 'ios' ? 'inline' : 'default'}
+              onChange={applyDate}
+            />
+          ) : null}
+
           {/* Everything most expenses never need — the category (already guessed
             from the note), how it was paid, where, and a foreign rate — folded
             off the common path. It opens itself the moment one of them carries a
@@ -2241,34 +2272,7 @@ export default function AddExpenseScreen() {
               />
               <Divider />
               <PaymentMethodRow value={paymentMethod} onPress={() => setPickingPayment(true)} />
-              <Divider />
-              {/* When it happened. An expense filed on the wrong day lands in
-                the wrong month, the wrong trip and the wrong place in the feed,
-                and until now the only way to correct one was to delete it and
-                type it again. Untouched it still inherits the day it always
-                did, so editing a note never moves a three-week-old dinner. */}
-              <SettingRow
-                label={t.captures.date}
-                value={showDate(expenseDate, locale)}
-                leading={
-                  <Ionicons
-                    name="calendar-outline"
-                    size={iconSize.md}
-                    color={theme.color.textMuted}
-                  />
-                }
-                onPress={() => setEditingDate(true)}
-              />
             </Card>
-
-            {editingDate ? (
-              <DateTimePicker
-                value={dateFrom(expenseDate)}
-                mode="date"
-                display={Platform.OS === 'ios' ? 'inline' : 'default'}
-                onChange={applyDate}
-              />
-            ) : null}
 
             {/* Where it happened (A43) — optional, opt-in, never a background track. */}
             <LocationField value={location} onChange={setLocation} />

--- a/apps/mobile/src/lib/expenseMemberRows.ts
+++ b/apps/mobile/src/lib/expenseMemberRows.ts
@@ -6,10 +6,19 @@
  * same member page as the group member list. If it no longer exists, leave it
  * inert instead of sending someone to a known "member not found" dead-end.
  */
+/**
+ * Kept as a template-literal type rather than a plain `string`: expo-router's
+ * typed routes accept an inline `` `/group/${id}/member/${id}` `` because it
+ * matches one of the generated route patterns, and a widened `string` does not.
+ * The guarded router in `lib/navigation` keeps that signature, so returning
+ * `string` here fails to typecheck at every call site.
+ */
+export type ExpenseMemberHref = `/group/${string}/member/${string}`;
+
 export function expenseMemberHref(
   groupId: string,
   memberId: string,
   memberExists: boolean,
-): string | null {
+): ExpenseMemberHref | null {
   return memberExists ? `/group/${groupId}/member/${memberId}` : null;
 }


### PR DESCRIPTION
Reported, after #745 shipped: "I'm not able to change the date of that expense. Can you add that? At the bottom we have that list — there you need to add it."

The picker *was* added in #745. It landed inside the **More details** fold, beside the category and the payment rail, so it was invisible until you expanded a collapsed row. Being told it isn't there is the honest verdict on a control nobody can see.

The day an expense happened is not an advanced setting. Filed on the wrong one it lands in the wrong month, the wrong trip and the wrong place in the feed — and somebody correcting a date should not have to guess where it lives. It now sits on the common path, in its own card directly above the fold, with the picker beneath it.

Nothing else moves, and the inherited-day behaviour from #745 is untouched: left alone, an edit still keeps the day the expense already had, so fixing a typo does not re-file a three-week-old dinner.

## It also fixes a typecheck failure already on main

`pnpm --filter @waves/mobile typecheck` fails on `dce539c0` — two errors in `app/group/[id]/expense/[expenseId].tsx`, both `TS2345`. `expenseMemberHref` (added in #738) returned a widened `string`. expo-router's typed routes accept an inline `` `/group/${id}/member/${id}` `` because it matches a generated route pattern; a `string` does not, and the guarded router from #741 keeps that signature. Neither PR was wrong alone — the failure only exists once both are in.

The helper now returns the template-literal type `` `/group/${string}/member/${string}` `` with the reason recorded above it.

Worth asking separately why CI went green on both: the `typecheck + lint` job passed on #741 with #738 already in its base. Expo's generated route types are the likely culprit (this repo has hit stale `.expo` typed-route caches before), so CI may be typechecking against different generated types than a local checkout.

## Verification

`pnpm format` clean, `pnpm lint` 0 errors across all five projects, `pnpm --filter @waves/mobile typecheck` exit 0 — **which it was not before this change** — and 88 files / 1182 tests pass.

Not run on a device: that the row reads well above the fold and the picker opens where expected on a real Android dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jhzmZz5fkjnZZ14YxHGfS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expense dates are now displayed in a dedicated, always-visible card after the participant split section.
* **Improvements**
  * The additional details section now focuses exclusively on category and payment method.
  * Expense date editing continues to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->