### PR TITLE
The sign-out sheet says what is at risk, and ranks the doors

### DIFF
--- a/apps/mobile/src/components/SignOutSheet.tsx
+++ b/apps/mobile/src/components/SignOutSheet.tsx
@@ -17,6 +17,28 @@
  * holds somebody's account open until an upload succeeds is a worse failure
  * than a lost draft. The warning is honest and the door stays unlocked.
  *
+ * Three shape rules, each of them the fix for a way the first version misled:
+ *
+ * 1. **The alarm is proportional.** With nothing queued, signing out costs
+ *    nothing that does not come back, so the sheet says exactly that in one
+ *    line and shows two buttons. The warning language, the list and the two
+ *    precautions appear only when there is something on this phone the account
+ *    has never seen. A sheet that shouts at everybody teaches people to tap
+ *    through the shout.
+ * 2. **The list is never promised without being shown.** The lead line points
+ *    at the rows below it, so the rows have to be laid out where they can be
+ *    seen. They used to sit in a `ScrollView` nested one `View` deep, which
+ *    measured short and clipped: the warning said "listed below" over an empty
+ *    white gap. The scroll region is now a direct child of the sheet with a
+ *    definite `maxHeight` in points — the shape that hugs its content instead
+ *    of guessing at it — and its indicator is on, so a list that really is too
+ *    long to fit says so.
+ * 3. **Weight follows consequence.** Signing out is the destructive thing being
+ *    confirmed, so it is the filled red button; staying is the soft one right
+ *    under it, full width and impossible to miss; and the two ways to keep the
+ *    data are small and sit with the list they protect, because a precaution
+ *    drawn at full width above the decision reads as the recommended path.
+ *
  * The copy button writes a plain JSON snapshot of everything on the device
  * (`saveDeviceCopy`) — the unsent queue and the drafts included — and hands it
  * to the share sheet. It never touches the network, because the case it exists
@@ -27,9 +49,14 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { ScrollView, View } from 'react-native';
+import { ScrollView, useWindowDimensions, View } from 'react-native';
 
-import { unsentWork, type DeviceDraft } from '@waves/core';
+import {
+  materialiseArchivedGroups,
+  materialiseGroups,
+  unsentWork,
+  type DeviceDraft,
+} from '@waves/core';
 import { Button, Callout, iconSize, Row, Sheet, Text, useTheme } from '@waves/ui';
 
 import { plural, useStrings } from '@/i18n';
@@ -49,15 +76,73 @@ import { syncEngine, SyncStatus, useSync } from '@/sync';
 /** What the two work buttons are doing, so neither can be pressed twice. */
 type Busy = 'none' | 'sync' | 'copy';
 
-/** One "this is still only here" line: a warning glyph and the count in words. */
-function RiskRow({ icon, label }: { icon: keyof typeof Ionicons.glyphMap; label: string }) {
+/** How many group names the "changes to your groups" row will name before it
+ *  stops. Three is a line; a device holding work in eight groups wants a count,
+ *  not a paragraph, and the count is already the line above it. */
+const NAMED_GROUPS = 3;
+
+/** The round tinted mark this app puts at the head of a settings row, reused
+ *  here so the sheet is built out of the same parts as the screen behind it. */
+function Chip({
+  icon,
+  bg,
+  ink,
+  size,
+}: {
+  icon: keyof typeof Ionicons.glyphMap;
+  bg: string;
+  ink: string;
+  size: number;
+}) {
   const theme = useTheme();
   return (
-    <Row style={{ gap: theme.spacing.md, alignItems: 'center' }}>
-      <Ionicons name={icon} size={iconSize.md} color={theme.color.warning} />
-      <Text variant="body" style={{ flex: 1 }}>
-        {label}
-      </Text>
+    <View
+      style={{
+        width: size,
+        height: size,
+        borderRadius: theme.radius.pill,
+        backgroundColor: bg,
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <Ionicons name={icon} size={iconSize.md} color={ink} />
+    </View>
+  );
+}
+
+/**
+ * One "this is still only here" line.
+ *
+ * Read as a single item by a screen reader — the count and the detail under it
+ * are one fact, and hearing them as two lines loses which belongs to which when
+ * there are four of them.
+ */
+function RiskRow({
+  icon,
+  label,
+  hint,
+}: {
+  icon: keyof typeof Ionicons.glyphMap;
+  label: string;
+  hint?: string;
+}) {
+  const theme = useTheme();
+  return (
+    <Row
+      accessible
+      accessibilityLabel={hint ? `${label}. ${hint}` : label}
+      style={{ gap: theme.spacing.md, alignItems: 'center' }}
+    >
+      <Chip icon={icon} bg={theme.color.warningSoft} ink={theme.color.warning} size={36} />
+      <View style={{ flex: 1 }}>
+        <Text variant="body">{label}</Text>
+        {hint ? (
+          <Text variant="caption" tone="muted">
+            {hint}
+          </Text>
+        ) : null}
+      </View>
     </Row>
   );
 }
@@ -135,6 +220,7 @@ export function SignOutSheet({
   const { session, isGuest } = useAuth();
   const { mirror, queue, status, flush } = useSync();
   const receipts = usePendingReceipts();
+  const { height: screenHeight } = useWindowDimensions();
 
   const ownerId = session?.user?.id ?? '';
   const drafts = useDeviceDrafts(visible);
@@ -148,6 +234,37 @@ export function SignOutSheet({
   // their own queue, and leaving them out of this gated the button away from a
   // device whose only unsent thing was a photograph it could have sent.
   const sendable = work.personal + work.other + unsentReceipts > 0;
+
+  /**
+   * The names of the groups the unsent changes belong to.
+   *
+   * "3 changes to your groups" is a number somebody has to take on trust; "3
+   * changes to your groups / Goa trip · Flatmates" is one they can check
+   * against what they remember doing. The ids come off the queue and the names
+   * off the mirror, archived groups included, so an unsent change to a trip
+   * that has since been put away is still named rather than silently dropped.
+   * Ids with no group behind them — the personal scope, the capture inbox — do
+   * not resolve and fall out here, which is right: they have their own rows.
+   */
+  const groupNames = useMemo(() => {
+    if (work.other + work.refused === 0) return undefined;
+    const named = new Map<string, string>();
+    for (const group of [
+      ...materialiseGroups(mirror, queue),
+      ...materialiseArchivedGroups(mirror, queue),
+    ]) {
+      if (group.name) named.set(group.id, group.name);
+    }
+    const seen: string[] = [];
+    for (const item of queue) {
+      const name = named.get(item.groupId);
+      if (name !== undefined && !seen.includes(name)) seen.push(name);
+    }
+    if (seen.length === 0) return undefined;
+    return seen.length > NAMED_GROUPS
+      ? `${seen.slice(0, NAMED_GROUPS).join(' · ')} …`
+      : seen.join(' · ');
+  }, [mirror, queue, work.other, work.refused]);
 
   const [busy, setBusy] = useState<Busy>('none');
   const [error, setError] = useState<string | null>(null);
@@ -217,154 +334,183 @@ export function SignOutSheet({
     }
   }, [mirror, queue, drafts, ownerId, t]);
 
+  // Nothing queued and no key to lose is the ordinary case, and it is not a
+  // dangerous one — the head mark then says "safe", not "look out".
+  const alarmed = atRisk > 0 || backupKeyAtRisk;
+  const headTone = isGuest
+    ? { bg: theme.color.negativeSoft, ink: theme.color.negative }
+    : alarmed
+      ? { bg: theme.color.warningSoft, ink: theme.color.warning }
+      : { bg: theme.color.positiveSoft, ink: theme.color.positive };
+  const email = session?.user?.email ?? '';
+
+  // Points, not a percentage: a percentage max-height resolves against a parent
+  // with no height of its own here, and a scroll view with no real bound is the
+  // thing that clipped the list. Two fifths of the window leaves the title and
+  // both doors on screen on the shortest phone we support.
+  const bodyMax = Math.round(screenHeight * 0.42);
+
   return (
     <Sheet
       visible={visible}
       onClose={onClose}
       closeLabel={t.common.close}
-      style={{ maxHeight: '88%' }}
+      style={{ maxHeight: Math.round(screenHeight * 0.88) }}
     >
-      <View style={{ gap: theme.spacing.lg, flexShrink: 1 }}>
-        <Text variant="heading">{t.lock.signOutQuestion}</Text>
-
-        <ScrollView
-          showsVerticalScrollIndicator={false}
-          style={{ flexShrink: 1 }}
-          contentContainerStyle={{ gap: theme.spacing.md }}
-        >
-          {/* A guest has no way back into the account at all, which outranks
-              everything else on this sheet — so it is said first, and loudest. */}
-          {isGuest ? (
-            <Callout tone="negative" title={t.signOutSheet.guestTitle}>
-              {t.lock.signOutGuestWarning}
-            </Callout>
-          ) : null}
-
-          {/* Deliberately outside the two branches below. The recovery key is
-              not unsent work — it is lost on sign-out whether or not anything
-              is still queued — so it has to be sayable beside the green
-              callout as well as the warning one. That is also why `allSafeBody`
-              is scoped to the ledger: "everything comes back" with this
-              underneath it would be a contradiction on the same screen. */}
-          {backupKeyAtRisk ? (
-            <Callout tone="warning" title={t.signOutSheet.backupKeyTitle}>
-              {t.signOutSheet.backupKeyWarning}
-            </Callout>
-          ) : null}
-
-          {atRisk === 0 ? (
-            <Callout tone="positive" title={t.signOutSheet.allSafeTitle}>
-              {t.signOutSheet.allSafeBody}
-            </Callout>
-          ) : (
-            <>
-              <Callout tone="warning" title={t.signOutSheet.atRiskTitle}>
-                {t.signOutSheet.atRiskBody}
-              </Callout>
-
-              <View style={{ gap: theme.spacing.sm, paddingVertical: theme.spacing.xs }}>
-                {work.other > 0 ? (
-                  <RiskRow
-                    icon="people-outline"
-                    label={plural(locale, work.other, t.signOutSheet.otherUnsent)}
-                  />
-                ) : null}
-                {/* The private ledger gets its own line rather than being folded
-                    into the count above: it lives on the Me tab, it is the one
-                    part of the app nobody else holds a copy of, and somebody who
-                    keeps their money there deserves to be told by name. */}
-                {work.personal > 0 ? (
-                  <RiskRow
-                    icon="wallet-outline"
-                    label={plural(locale, work.personal, t.signOutSheet.personalUnsent)}
-                  />
-                ) : null}
-                {work.refused > 0 ? (
-                  <RiskRow
-                    icon="alert-circle-outline"
-                    label={plural(locale, work.refused, t.signOutSheet.refused)}
-                  />
-                ) : null}
-                {unsentReceipts > 0 ? (
-                  <RiskRow
-                    icon="receipt-outline"
-                    label={plural(locale, unsentReceipts, t.signOutSheet.receiptsUnsent)}
-                  />
-                ) : null}
-                {/* A draft was never submitted, so unlike everything above it
-                    there is no server copy waiting and no queue entry to send —
-                    only the file below can keep it. */}
-                {drafts.length > 0 ? (
-                  <RiskRow
-                    icon="document-text-outline"
-                    label={plural(locale, drafts.length, t.signOutSheet.draftsUnsent)}
-                  />
-                ) : null}
-              </View>
-
-              {/* Offline is why the copy button is not an afterthought: sending
-                  is not on the table, so "sync first" would be advice nobody in
-                  that moment can take. */}
-              {offline ? (
-                <Text variant="caption" tone="muted">
-                  {t.signOutSheet.offlineHint}
-                </Text>
-              ) : null}
-
-              {/* The snapshot is JSON: the records go in, the image bytes do
-                  not. Said here, next to the count of photos still on the
-                  phone, because "download a copy" one line above it otherwise
-                  reads as an offer to keep them. */}
-              {unsentReceipts > 0 ? (
-                <Text variant="caption" tone="muted">
-                  {t.signOutSheet.copyExcludesPhotos}
-                </Text>
-              ) : null}
-            </>
-          )}
-
-          {error ? (
-            <Text variant="caption" style={{ color: theme.color.negative }}>
-              {error}
+      <Row style={{ gap: theme.spacing.md, marginBottom: theme.spacing.lg }}>
+        <Chip
+          icon={alarmed || isGuest ? 'alert-circle' : 'shield-checkmark'}
+          bg={headTone.bg}
+          ink={headTone.ink}
+          size={44}
+        />
+        <View style={{ flex: 1 }}>
+          <Text variant="title">{t.lock.signOutQuestion}</Text>
+          {email ? (
+            <Text variant="caption" tone="muted" numberOfLines={1}>
+              {t.signOutSheet.signedInAs.replace('{email}', email)}
             </Text>
           ) : null}
-          {saved ? (
-            <Text variant="caption" tone="muted">
-              {t.signOutSheet.copySaved.replace('{file}', saved)}
-            </Text>
-          ) : null}
-        </ScrollView>
+        </View>
+      </Row>
 
-        {/* The two ways to keep the data, then the two doors. The order is
-            deliberate — safe first, destructive last — but nothing here is
-            gated on anything else: this sheet warns, it does not hold anybody
-            hostage. */}
-        <View style={{ gap: theme.spacing.sm }}>
+      <ScrollView
+        // `flexGrow: 0` with a definite `maxHeight` is the shape that sizes
+        // itself to its content and stops there. Left to grow it measures short
+        // inside a sheet that has no height of its own, which is how the list
+        // the copy above points at came to be drawn off the bottom of it.
+        style={{ flexGrow: 0, flexShrink: 1, maxHeight: bodyMax }}
+        contentContainerStyle={{ gap: theme.spacing.md, paddingBottom: theme.spacing.xs }}
+      >
+        {/* A guest has no way back into the account at all, which outranks
+            everything else on this sheet — so it is said first, and loudest.
+            It keeps the panel the rest of the sheet no longer needs: this is
+            the one case where the whole account ends, not a copy of it. */}
+        {isGuest ? (
+          <Callout tone="negative" title={t.signOutSheet.guestTitle}>
+            {t.lock.signOutGuestWarning}
+          </Callout>
+        ) : null}
+
+        <Text variant="body" tone="muted">
+          {atRisk === 0 ? t.signOutSheet.allSafeBody : t.signOutSheet.atRiskBody}
+        </Text>
+
+        {alarmed ? (
+          <View style={{ gap: theme.spacing.sm }}>
+            {work.other > 0 ? (
+              <RiskRow
+                icon="people-outline"
+                label={plural(locale, work.other, t.signOutSheet.otherUnsent)}
+                hint={groupNames}
+              />
+            ) : null}
+            {/* The private ledger gets its own line rather than being folded
+                into the count above: it lives on the Me tab, it is the one
+                part of the app nobody else holds a copy of, and somebody who
+                keeps their money there deserves to be told by name. */}
+            {work.personal > 0 ? (
+              <RiskRow
+                icon="wallet-outline"
+                label={plural(locale, work.personal, t.signOutSheet.personalUnsent)}
+              />
+            ) : null}
+            {work.refused > 0 ? (
+              <RiskRow
+                icon="alert-circle-outline"
+                label={plural(locale, work.refused, t.signOutSheet.refused)}
+                hint={t.signOutSheet.refusedHint}
+              />
+            ) : null}
+            {unsentReceipts > 0 ? (
+              <RiskRow
+                icon="receipt-outline"
+                label={plural(locale, unsentReceipts, t.signOutSheet.receiptsUnsent)}
+                // The snapshot is JSON: the records go in, the image bytes do
+                // not. Said on this row rather than beside the copy button,
+                // because it is a fact about the photographs and this is where
+                // somebody is already counting them.
+                hint={t.signOutSheet.copyExcludesPhotos}
+              />
+            ) : null}
+            {/* A draft was never submitted, so unlike everything above it there
+                is no server copy waiting and no queue entry to send — only the
+                file can keep it. */}
+            {drafts.length > 0 ? (
+              <RiskRow
+                icon="document-text-outline"
+                label={plural(locale, drafts.length, t.signOutSheet.draftsUnsent)}
+              />
+            ) : null}
+            {/* Not unsent work: the recovery key is lost on sign-out whether or
+                not anything is queued, which is why it is the one row that can
+                appear under an otherwise clear list. */}
+            {backupKeyAtRisk ? (
+              <RiskRow
+                icon="key-outline"
+                label={t.signOutSheet.backupKeyTitle}
+                hint={t.signOutSheet.backupKeyWarning}
+              />
+            ) : null}
+          </View>
+        ) : null}
+
+        {/* Offline is why the copy button is not an afterthought: sending is not
+            on the table, so "sync first" would be advice nobody in that moment
+            can take. */}
+        {atRisk > 0 && offline ? (
+          <Text variant="caption" tone="muted">
+            {t.signOutSheet.offlineHint}
+          </Text>
+        ) : null}
+
+        {/* The two ways to keep it, kept small and kept here — beside the list
+            they protect rather than above the decision, which is where a
+            precaution drawn at full width starts reading as the thing to do. */}
+        <Row style={{ gap: theme.spacing.sm }}>
           {sendable && !offline ? (
             <Button
               label={busy === 'sync' ? t.signOutSheet.syncing : t.signOutSheet.syncNow}
-              variant="primary"
-              fullWidth
+              variant="secondary"
+              size="sm"
               disabled={busy !== 'none'}
               onPress={() => void syncNow()}
             />
           ) : null}
           <Button
             label={busy === 'copy' ? t.signOutSheet.copying : t.signOutSheet.copyNow}
-            variant="secondary"
-            fullWidth
+            variant="ghost"
+            size="sm"
             disabled={busy !== 'none'}
             onPress={() => void download()}
           />
-          <Button
-            label={t.lock.signOut}
-            variant="ghostDanger"
-            fullWidth
-            disabled={busy !== 'none'}
-            onPress={onSignOut}
-          />
-          <Button label={t.lock.staySignedIn} variant="ghost" fullWidth onPress={onClose} />
-        </View>
+        </Row>
+
+        {error ? (
+          <Text variant="caption" style={{ color: theme.color.negative }}>
+            {error}
+          </Text>
+        ) : null}
+        {saved ? (
+          <Text variant="caption" tone="muted">
+            {t.signOutSheet.copySaved.replace('{file}', saved)}
+          </Text>
+        ) : null}
+      </ScrollView>
+
+      {/* The doors, in the order the consequence puts them: the destructive one
+          wears the destructive colour, and the way out of it is the wide soft
+          button directly under the thumb. Neither is gated on anything above —
+          this sheet warns, it does not hold anybody hostage. */}
+      <View style={{ gap: theme.spacing.sm, marginTop: theme.spacing.lg }}>
+        <Button
+          label={t.lock.signOut}
+          variant="danger"
+          fullWidth
+          disabled={busy !== 'none'}
+          onPress={onSignOut}
+        />
+        <Button label={t.lock.staySignedIn} variant="secondary" fullWidth onPress={onClose} />
       </View>
     </Sheet>
   );

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -773,29 +773,35 @@ export interface UiStrings {
   signOutSheet: {
     /** Callout title above the guest warning in `lock.signOutGuestWarning`. */
     guestTitle: string;
-    /** Callout when the queue is empty and every photo has been sent. Scoped to
-     *  the ledger on purpose: the backup-key warning below can appear beside
-     *  it, and a reassurance that claimed *everything* comes back would then
-     *  contradict the line right under it. */
-    allSafeTitle: string;
+    /** "Signed in as {email}" — the line under the sheet's title, so the
+     *  account being left is named rather than assumed. Omitted for a guest,
+     *  who has no address. */
+    signedInAs: string;
+    /** Said when the queue is empty and every photo has been sent. Scoped to
+     *  the ledger on purpose: the backup-key row can appear beside it, and a
+     *  reassurance that claimed *everything* comes back would then contradict
+     *  the line right under it. */
     allSafeBody: string;
-    /** Callout when something on this device has not reached the account. */
-    atRiskTitle: string;
+    /** Said when something on this device has not reached the account. It
+     *  points at the rows below it, so it must never be shown without them. */
     atRiskBody: string;
-    /** The lines under that callout. `otherUnsent` counts queued changes to
-     *  shared groups, `personalUnsent` the private records on the Personal
-     *  tab, `refused` the ones the server turned down, which will never go on
-     *  their own, `receiptsUnsent` the photos still only on the phone, and
-     *  `draftsUnsent` the forms somebody had started but never submitted —
-     *  those live in the drafts table, which the sign-out wipe deletes. */
+    /** The rows under that line. `otherUnsent` counts queued changes to shared
+     *  groups (its detail line names them), `personalUnsent` the private
+     *  records on the Personal tab, `refused` the ones the server turned down,
+     *  which will never go on their own, `receiptsUnsent` the photos still only
+     *  on the phone, and `draftsUnsent` the forms somebody had started but
+     *  never submitted — those live in the drafts table, which the sign-out
+     *  wipe deletes. */
     otherUnsent: PluralForms;
     personalUnsent: PluralForms;
     refused: PluralForms;
+    /** Why a refusal is not waiting for a better signal. */
+    refusedHint: string;
     receiptsUnsent: PluralForms;
     draftsUnsent: PluralForms;
     /** The backup recovery key, which this device holds and sign-out forgets.
-     *  Not part of the list above: it is lost even when everything has synced,
-     *  so it is shown whether or not anything is unsent. */
+     *  Not part of the unsent work: it is lost even when everything has synced,
+     *  so its row is shown whether or not anything is queued. */
     backupKeyTitle: string;
     backupKeyWarning: string;
     /** Shown when nothing can be sent right now — offline, or on a connection
@@ -3485,12 +3491,11 @@ const en: UiStrings = {
   },
   signOutSheet: {
     guestTitle: 'This account cannot be signed back into',
-    allSafeTitle: 'Everything is safe',
+    signedInAs: 'Signed in as {email}',
     allSafeBody:
-      'Every change on this device has reached your account. Sign back in and your ledger comes back.',
-    atRiskTitle: 'Some of this would be lost',
+      "Every change on this device has reached your account. Signing out clears this phone's copy — sign back in and your ledger comes back.",
     atRiskBody:
-      "Signing out erases this device's copy. What is listed below has not reached your account yet, so it goes with it.",
+      "Signing out clears this phone's copy. These have not reached your account yet, so they go with it:",
     otherUnsent: {
       one: '{n} change to your groups has not been sent',
       other: '{n} changes to your groups have not been sent',
@@ -3503,6 +3508,7 @@ const en: UiStrings = {
       one: '{n} change the server would not accept',
       other: '{n} changes the server would not accept',
     },
+    refusedHint: 'Waiting longer will not send these. Save a copy to keep them.',
     receiptsUnsent: {
       one: '{n} receipt photo is still only on this phone',
       other: '{n} receipt photos are still only on this phone',
@@ -3513,16 +3519,15 @@ const en: UiStrings = {
     },
     backupKeyTitle: 'Your backup key is only on this device',
     backupKeyWarning:
-      'Signing out forgets the recovery key for your backup. The file stays on Drive, but nothing can open it again without that key — not even you. Write it down before you go.',
-    offlineHint: 'Nothing can be sent right now. Download a copy before you go.',
+      'Write it down before you go — without it nothing can open the backup on Drive again, not even you.',
+    offlineHint: 'Nothing can be sent right now. Save a copy before you go.',
     syncNow: 'Sync now',
     syncing: 'Sending…',
-    syncFailed: 'Could not send everything. Try again, or download a copy.',
-    copyNow: 'Download a copy',
+    syncFailed: 'Could not send everything. Try again, or save a copy.',
+    copyNow: 'Save a copy',
     copying: 'Preparing…',
     copyFailed: 'Could not make the file.',
-    copyExcludesPhotos:
-      'The file holds your records, not the receipt photos. Send those first if you need them kept.',
+    copyExcludesPhotos: 'A saved copy holds your records, not the photos themselves.',
     copySaved: 'Saved {file}',
     copyShareTitle: 'Your Waves data',
   },
@@ -5990,12 +5995,11 @@ const ta: UiStrings = {
   },
   signOutSheet: {
     guestTitle: 'இந்தக் கணக்கில் மீண்டும் உள்நுழைய முடியாது',
-    allSafeTitle: 'எல்லாம் பாதுகாப்பாக உள்ளது',
+    signedInAs: '{email} என உள்நுழைந்துள்ளீர்கள்',
     allSafeBody:
-      'இந்தச் சாதனத்தில் செய்த ஒவ்வொரு மாற்றமும் உங்கள் கணக்கை அடைந்துவிட்டது. மீண்டும் உள்நுழைந்தால் உங்கள் கணக்குப் பதிவு திரும்பி வரும்.',
-    atRiskTitle: 'இவற்றில் சில தொலைந்துவிடும்',
+      'இந்தச் சாதனத்தில் செய்த ஒவ்வொரு மாற்றமும் உங்கள் கணக்கை அடைந்துவிட்டது. வெளியேறினால் இந்தத் தொலைபேசியில் உள்ள நகல் அழிக்கப்படும் — மீண்டும் உள்நுழைந்தால் உங்கள் கணக்குப் பதிவு திரும்பி வரும்.',
     atRiskBody:
-      'வெளியேறினால் இந்தச் சாதனத்தில் உள்ள நகல் அழிக்கப்படும். கீழே பட்டியலிட்டவை இன்னும் உங்கள் கணக்கை அடையவில்லை, எனவே அவையும் அதனுடன் போய்விடும்.',
+      'வெளியேறினால் இந்தத் தொலைபேசியில் உள்ள நகல் அழிக்கப்படும். இவை இன்னும் உங்கள் கணக்கை அடையவில்லை, எனவே அவையும் அதனுடன் போய்விடும்:',
     otherUnsent: {
       one: 'உங்கள் குழுக்களில் {n} மாற்றம் அனுப்பப்படவில்லை',
       other: 'உங்கள் குழுக்களில் {n} மாற்றங்கள் அனுப்பப்படவில்லை',
@@ -6008,6 +6012,7 @@ const ta: UiStrings = {
       one: 'சர்வர் ஏற்க மறுத்த {n} மாற்றம்',
       other: 'சர்வர் ஏற்க மறுத்த {n} மாற்றங்கள்',
     },
+    refusedHint: 'காத்திருந்தாலும் இவை அனுப்பப்படாது. வைத்திருக்க ஒரு நகலைச் சேமியுங்கள்.',
     receiptsUnsent: {
       one: '{n} ரசீதுப் படம் இன்னும் இந்தத் தொலைபேசியில் மட்டுமே உள்ளது',
       other: '{n} ரசீதுப் படங்கள் இன்னும் இந்தத் தொலைபேசியில் மட்டுமே உள்ளன',
@@ -6018,17 +6023,16 @@ const ta: UiStrings = {
     },
     backupKeyTitle: 'உங்கள் காப்புப்பிரதி விசை இந்தச் சாதனத்தில் மட்டுமே உள்ளது',
     backupKeyWarning:
-      'வெளியேறினால் உங்கள் காப்புப்பிரதியின் மீட்பு விசை மறக்கப்படும். கோப்பு Drive-இல் இருக்கும், ஆனால் அந்த விசை இல்லாமல் அதை யாராலும் — உங்களாலும் — திறக்க முடியாது. வெளியேறும் முன் அதை எழுதி வைத்துக்கொள்ளுங்கள்.',
-    offlineHint: 'இப்போது எதையும் அனுப்ப முடியாது. வெளியேறும் முன் ஒரு நகலைப் பதிவிறக்கவும்.',
+      'வெளியேறும் முன் அதை எழுதி வைத்துக்கொள்ளுங்கள் — அது இல்லாமல் Drive-இல் உள்ள காப்புப்பிரதியை யாராலும், உங்களாலும் கூட, மீண்டும் திறக்க முடியாது.',
+    offlineHint: 'இப்போது எதையும் அனுப்ப முடியாது. வெளியேறும் முன் ஒரு நகலைச் சேமியுங்கள்.',
     syncNow: 'இப்போது ஒத்திசை',
     syncing: 'அனுப்பப்படுகிறது…',
     syncFailed:
-      'எல்லாவற்றையும் அனுப்ப முடியவில்லை. மீண்டும் முயற்சிக்கவும், அல்லது ஒரு நகலைப் பதிவிறக்கவும்.',
-    copyNow: 'ஒரு நகலைப் பதிவிறக்கு',
+      'எல்லாவற்றையும் அனுப்ப முடியவில்லை. மீண்டும் முயற்சிக்கவும், அல்லது ஒரு நகலைச் சேமிக்கவும்.',
+    copyNow: 'ஒரு நகலைச் சேமி',
     copying: 'தயாராகிறது…',
     copyFailed: 'கோப்பை உருவாக்க முடியவில்லை.',
-    copyExcludesPhotos:
-      'இந்தக் கோப்பில் உங்கள் பதிவுகள் இருக்கும், ரசீதுப் படங்கள் இருக்காது. அவை தேவைப்பட்டால் முதலில் அவற்றை அனுப்பிவிடுங்கள்.',
+    copyExcludesPhotos: 'சேமித்த நகலில் உங்கள் பதிவுகள் இருக்கும், படங்கள் இருக்காது.',
     copySaved: '{file} சேமிக்கப்பட்டது',
     copyShareTitle: 'உங்கள் Waves தரவு',
   },
@@ -8589,12 +8593,11 @@ const hi: UiStrings = {
   },
   signOutSheet: {
     guestTitle: 'इस खाते में दोबारा साइन इन नहीं किया जा सकता',
-    allSafeTitle: 'सब कुछ सुरक्षित है',
+    signedInAs: '{email} के रूप में साइन इन हैं',
     allSafeBody:
-      'इस डिवाइस का हर बदलाव आपके खाते तक पहुँच चुका है। दोबारा साइन इन करने पर आपका पूरा हिसाब वापस आ जाएगा।',
-    atRiskTitle: 'इनमें से कुछ खो जाएगा',
+      'इस डिवाइस का हर बदलाव आपके खाते तक पहुँच चुका है। साइन आउट करने पर इस फ़ोन की कॉपी मिट जाएगी — दोबारा साइन इन करने पर आपका पूरा हिसाब वापस आ जाएगा।',
     atRiskBody:
-      'साइन आउट करने पर इस डिवाइस की कॉपी मिट जाती है। नीचे जो दिखाया है वह अभी आपके खाते तक नहीं पहुँचा है, इसलिए वह भी उसी के साथ चला जाएगा।',
+      'साइन आउट करने पर इस फ़ोन की कॉपी मिट जाती है। ये अभी आपके खाते तक नहीं पहुँचे हैं, इसलिए ये भी उसी के साथ चले जाएँगे:',
     otherUnsent: {
       one: 'आपके समूहों में {n} बदलाव नहीं भेजा गया',
       other: 'आपके समूहों में {n} बदलाव नहीं भेजे गए',
@@ -8607,6 +8610,7 @@ const hi: UiStrings = {
       one: '{n} बदलाव जिसे सर्वर ने स्वीकार नहीं किया',
       other: '{n} बदलाव जिन्हें सर्वर ने स्वीकार नहीं किया',
     },
+    refusedHint: 'और इंतज़ार करने से ये नहीं भेजे जाएँगे। रखना है तो एक कॉपी सहेज लें।',
     receiptsUnsent: {
       one: '{n} रसीद की फ़ोटो अब भी सिर्फ़ इसी फ़ोन पर है',
       other: '{n} रसीदों की फ़ोटो अब भी सिर्फ़ इसी फ़ोन पर हैं',
@@ -8617,16 +8621,15 @@ const hi: UiStrings = {
     },
     backupKeyTitle: 'आपकी बैकअप कुंजी सिर्फ़ इसी डिवाइस पर है',
     backupKeyWarning:
-      'साइन आउट करने पर आपके बैकअप की रिकवरी कुंजी भूल जाएगी। फ़ाइल Drive पर रहेगी, पर उस कुंजी के बिना उसे कोई नहीं खोल सकता — आप भी नहीं। जाने से पहले उसे लिख लें।',
-    offlineHint: 'अभी कुछ भी नहीं भेजा जा सकता। जाने से पहले एक कॉपी डाउनलोड कर लें।',
+      'जाने से पहले उसे लिख लें — उसके बिना Drive पर रखे बैकअप को कोई दोबारा नहीं खोल सकता, आप भी नहीं।',
+    offlineHint: 'अभी कुछ भी नहीं भेजा जा सकता। जाने से पहले एक कॉपी सहेज लें।',
     syncNow: 'अभी सिंक करें',
     syncing: 'भेजा जा रहा है…',
-    syncFailed: 'सब कुछ भेजा नहीं जा सका। फिर कोशिश करें, या एक कॉपी डाउनलोड कर लें।',
-    copyNow: 'एक कॉपी डाउनलोड करें',
+    syncFailed: 'सब कुछ भेजा नहीं जा सका। फिर कोशिश करें, या एक कॉपी सहेज लें।',
+    copyNow: 'एक कॉपी सहेजें',
     copying: 'तैयार हो रही है…',
     copyFailed: 'फ़ाइल नहीं बनाई जा सकी।',
-    copyExcludesPhotos:
-      'फ़ाइल में आपकी प्रविष्टियाँ होंगी, रसीदों की फ़ोटो नहीं। उन्हें रखना है तो पहले उन्हें भेज दें।',
+    copyExcludesPhotos: 'सहेजी गई कॉपी में आपकी प्रविष्टियाँ होंगी, फ़ोटो नहीं।',
     copySaved: '{file} सहेज लिया',
     copyShareTitle: 'आपका Waves डेटा',
   },
@@ -11132,11 +11135,10 @@ const ar: UiStrings = {
   },
   signOutSheet: {
     guestTitle: 'لا يمكن تسجيل الدخول إلى هذا الحساب مرة أخرى',
-    allSafeTitle: 'كل شيء بأمان',
-    allSafeBody: 'كل تغيير على هذا الجهاز وصل إلى حسابك. سجّل الدخول مرة أخرى وسيعود دفترك كما هو.',
-    atRiskTitle: 'بعض هذا سيُفقد',
-    atRiskBody:
-      'تسجيل الخروج يمحو نسخة هذا الجهاز. وما هو مذكور أدناه لم يصل إلى حسابك بعد، فسيذهب معها.',
+    signedInAs: 'مسجّل الدخول باسم {email}',
+    allSafeBody:
+      'كل تغيير على هذا الجهاز وصل إلى حسابك. تسجيل الخروج يمحو نسخة هذا الهاتف — سجّل الدخول مرة أخرى وسيعود دفترك كما هو.',
+    atRiskBody: 'تسجيل الخروج يمحو نسخة هذا الهاتف. وهذه لم تصل إلى حسابك بعد، فستذهب معها:',
     otherUnsent: {
       zero: 'لا تغييرات غير مُرسَلة في مجموعاتك',
       one: 'تغيير واحد في مجموعاتك لم يُرسَل',
@@ -11161,6 +11163,7 @@ const ar: UiStrings = {
       many: '{n} تغييرًا رفضه الخادم',
       other: '{n} تغيير رفضه الخادم',
     },
+    refusedHint: 'الانتظار أطول لن يُرسلها. احفظ نسخة إن أردت الاحتفاظ بها.',
     receiptsUnsent: {
       zero: 'لا صور إيصالات على هذا الهاتف وحده',
       one: 'صورة إيصال واحدة ما زالت على هذا الهاتف وحده',
@@ -11179,16 +11182,15 @@ const ar: UiStrings = {
     },
     backupKeyTitle: 'مفتاح نسختك الاحتياطية على هذا الجهاز وحده',
     backupKeyWarning:
-      'تسجيل الخروج ينسى مفتاح استرداد نسختك الاحتياطية. سيبقى الملف على Drive، لكن لا شيء يفتحه من دون ذلك المفتاح — ولا أنت. دوّنه قبل أن تخرج.',
-    offlineHint: 'لا يمكن إرسال أي شيء الآن. نزّل نسخة قبل أن تخرج.',
+      'دوّنه قبل أن تخرج — من دونه لا شيء يفتح النسخة الاحتياطية على Drive مرة أخرى، ولا أنت.',
+    offlineHint: 'لا يمكن إرسال أي شيء الآن. احفظ نسخة قبل أن تخرج.',
     syncNow: 'زامن الآن',
     syncing: 'جارٍ الإرسال…',
-    syncFailed: 'تعذّر إرسال كل شيء. حاول مرة أخرى، أو نزّل نسخة.',
-    copyNow: 'تنزيل نسخة',
+    syncFailed: 'تعذّر إرسال كل شيء. حاول مرة أخرى، أو احفظ نسخة.',
+    copyNow: 'حفظ نسخة',
     copying: 'جارٍ التجهيز…',
     copyFailed: 'تعذّر إنشاء الملف.',
-    copyExcludesPhotos:
-      'الملف يحمل سجلاتك، لا صور الإيصالات. أرسل الصور أولًا إن كنت تريد الاحتفاظ بها.',
+    copyExcludesPhotos: 'النسخة المحفوظة تحمل سجلاتك، لا الصور نفسها.',
     copySaved: 'تم حفظ {file}',
     copyShareTitle: 'بيانات Waves الخاصة بك',
   },


### PR DESCRIPTION
Reported from a screenshot: the sheet is not nice — and it also promised a list that was not on screen ("What is listed below has not reached your account yet") with nothing listed below it.

## The missing list was a clipped scroll view, not missing data

The rows rendered; they were drawn past the bottom edge of a `ScrollView` that had measured itself short. Proven from the screenshot's own pixels rather than assumed: at density 3.25 the warning `Callout` has a 16 dp top padding but ends 4 dp after its last line — cut off, 38 px short — and the scroll region is 99 dp tall for a callout that alone needs 110 dp. The list, the offline hint and the photo note all sat below that edge, and `showsVerticalScrollIndicator={false}` removed the only clue anything was down there.

The cause: the `ScrollView` sat one `View` deep inside a sheet card of auto height, bounded by `maxHeight: '88%'` — a percentage against a parent with no height of its own. Every working sheet in the app (`CoverEmojiPicker`, `TagEditorSheet`, `budgets`) makes the `ScrollView` a **direct child** of `Sheet`. It now is, with a definite `maxHeight` in points (42% of the window, computed in JS) and the scroll indicator back on.

## The doors are ranked by what they do

Researched against Mobbin — Chime "Delete splits?", Grab "Cancel this booking?", Duolingo delete-account, Linktree "Delete this link?", Manus log-out, GoPro Quik "Unsaved changes", Monzo "Bills in the mix". The consistent pattern: **the destructive act is the filled coloured button and comes first; the safe way out is a real full-width target directly beneath it, never plain text; a precaution is smaller and quieter.**

So: **Sign out** is `variant="danger"`, filled, full width — it crypto-erases the device copy, so it wears the destructive colour. **Stay signed in** is a full-width soft button beneath it. **Sync now / Save a copy** drop to `size="sm"` and move *inside* the risk section, beside the list they protect — a precaution drawn full-width above the decision reads as the recommended path, which is exactly what inverted the old sheet.

("Download a copy" → **"Save a copy"**: nothing is downloaded, it opens the share sheet.)

## No orange slab

The alarm now lives in a 44 pt round tinted chip beside a proper 24 pt title, tone carrying the state — brand-blue when nothing is at risk, amber when something is, red for a guest whose account itself ends. Each at-risk item is its own row: a 36 pt amber chip, a body line, and a detail line that says something useful — **which groups** have unsent changes (up to three, archived included), that waiting longer will not send refusals, that the saved copy holds records and not photos, that the recovery key should be written down. The key joins the list instead of owning a second panel.

**With nothing pending the sheet is chip + title + one sentence + two buttons.** Signing out fully synced is not dangerous and no longer dressed as if it were.

## Strings

Added `signedInAs`, `refusedHint`; removed `allSafeTitle`/`atRiskTitle` (callout titles with no callout left); reworded `allSafeBody`, `atRiskBody` (no longer promises a list it cannot point at), `backupKeyWarning`, `offlineHint`, `syncFailed`, `copyExcludesPhotos`, `copyNow`. All four locales hand-written; Arabic plurals untouched.

Sign-out behaviour is unchanged — crypto-erase, push-token revoke, personal-section lock all as before. Presentation only.

## Verification

`pnpm format:check` clean, `pnpm lint` pass across all 12 projects at `--max-warnings 0`, typecheck exit 0, **88 files / 1182 tests pass**.

## Two shared-primitive faults found and deliberately left alone

1. **`maxHeight: '82%'/'88%'/'90%'` on sheets is very likely a no-op** — the percentage resolves against an `Animated.View` with no height of its own; this sheet's card measured 393 dp against a supposed 744 dp cap and never clamped. Five call sites rely on it. Only this sheet was moved to points.
2. **The sheet does not reach the bottom edge and reserves its foot twice** — ~38 px of scrim below the card while `SheetCard` also pads `insets.bottom + 12 dp` *inside* it. That doubled ~53 dp is the dead space at the bottom of the screenshot, and it looks like `navigationBarTranslucent` not taking effect on this device — the exact failure the comment in `packages/ui/src/components/Overlay.tsx` anticipates. Fixing it moves every sheet in the app, so it wants its own PR.

Needs a device: that the list now renders and the cap behaves on a short phone and at 1.6× font scale, the red/soft button pair in dark mode, RTL mirroring of the header and risk rows, and group names on the unsent-changes row (needs a queue with real offline work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jhzmZz5fkjnZZ14YxHGfS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned the sign-out screen with clearer, tone-coded safety and risk indicators.
  - Shows which groups contain unsent changes and provides options to sync or copy information before signing out.
  - Displays backup and offline-sync warnings alongside other sign-out risks.
  - Improved sign-out actions, including clearer options to stay signed in or proceed.
  - Identifies the account currently signed in.

- **Localization**
  - Updated sign-out messaging in English, Tamil, Hindi, and Arabic for consistent guidance across languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->