### PR TITLE
Say what the backup screen is waiting for, instead of greying out the answer

### DIFF
--- a/apps/mobile/src/app/settings/backup.tsx
+++ b/apps/mobile/src/app/settings/backup.tsx
@@ -14,11 +14,14 @@
  *
  * So the screen now has two modes and one anchor.
  *
- * The anchor is the card at the top, which always says the same three things in
- * the same place: whether the ledger is protected, when it last was, and that
- * the lock is a key only this person holds. That is WhatsApp's own status card
- * (Chat backup: last backup, total size, "End-to-end encrypted"), and it is
- * first because "am I safe" is the question somebody opened this screen with.
+ * The anchor is the card at the top. It always answers "is this protected",
+ * in the same place, in one line: still reading / not yet / ready / backed up.
+ * The other two things WhatsApp's chat-backup card carries — when the last one
+ * landed, and that the lock is a key only this person holds — appear once
+ * there is a truthful answer to give, which is once the setup is done; a
+ * "Locked with your key" line over a phone with no key would be the same lie
+ * this redesign is here to remove. It is first because "am I safe" is the
+ * question somebody opened this screen with.
  *
  * Below the fold of that card the screen forks. **Until a backup can run**, the
  * card continues into a three-step checklist and the outstanding step — and
@@ -35,20 +38,34 @@
  * 1. Status + the one thing to do. Both answers within a thumb of the top.
  * 2. The promise ("nothing legible leaves the phone"), because *what to do*
  *    outranks *why* on a screen somebody came to with a problem.
- * 3. Account, and then the key — but each only once it is no longer a step.
- *    While a step is outstanding the checklist owns its buttons, so the two are
- *    never on screen at the same time offering the same tap.
+ * 3. Account, and then the key — each rendered once the thing it manages
+ *    exists (a link; a key on this phone) *and* the checklist is not itself
+ *    asking for that same thing. So the two never offer the same tap. Note it
+ *    is not gated on the setup being finished: `configured` is a runtime
+ *    conjunction and can go false under a phone that already holds a key, and
+ *    hiding "Show my key" there would strand the Drive file for good.
  * 4. The schedule, which now refuses to lie. "Daily" with no key backs nothing
  *    up, so when the steps are unfinished the schedule says so directly under
- *    the picker rather than sitting there looking live.
+ *    the picker rather than sitting there looking live. Not in a build that
+ *    cannot back up at all, where the card has already said why and "the steps
+ *    above" would point at nothing.
  * 5. Which networks.
  * 6. Restore, last: it is the half people need once, at the worst moment, and
  *    burying it would be cruel — but putting it near "Back up now" invites the
- *    wrong tap. Unchanged, and deliberately so.
+ *    wrong tap. Its position is unchanged and deliberately so; what changed is
+ *    that when it is blocked for want of a key it now says which key and
+ *    carries the button that takes it. That is the one place the screen shows
+ *    a tap the checklist also offers, and it is worth it: the alternative was
+ *    a person on a new phone reading "Create your backup key first", doing it,
+ *    and having the next run overwrite the backup they came to recover.
  *
- * THE RULE THE WHOLE FILE OBEYS: no control is ever disabled and silent. Either
- * the reason is written next to it, or the control is not rendered at all and
- * the step that unblocks it stands in its place.
+ * THE RULE THE WHOLE FILE OBEYS, stated exactly. A control that *cannot* run
+ * either carries its reason beside it or is not rendered at all, with the step
+ * that unblocks it standing in its place. A control merely waiting on work
+ * already in flight is a different thing and gets a different treatment: the
+ * button that was pressed wears a spinner, and the rest go quiet for as long as
+ * that takes. What is ruled out is the third case, which is what was here
+ * before — a grey button, nothing running, and no reason anywhere on screen.
  *
  * The one promise this screen makes, and must keep: nothing legible leaves the
  * phone. What goes to Drive is a sealed blob; the key that opens it is shown to
@@ -101,6 +118,18 @@ const PROVIDER_LABEL = 'Google Drive';
 const STEP_MARK = 26;
 
 /**
+ * Which action is in flight, rather than a bare `busy` flag.
+ *
+ * A screen-wide boolean greys every button at once and says nothing about any
+ * of them, which is indistinguishable from the refusal this whole redesign
+ * exists to remove — worst of all on "Link your Google Drive", which holds the
+ * flag for the entire Google consent sheet plus a Drive round trip. Naming the
+ * action lets the pressed button carry a spinner and read as *working*, while
+ * the rest go quiet for a second or two beside something visibly running.
+ */
+type PendingAction = 'connect' | 'disconnect' | 'key' | 'backup' | 'scan' | 'restore';
+
+/**
  * The disc at the head of a checklist row: a tick once the step is taken, its
  * number in the brand colour while it is the one being asked for, and a hollow
  * outline for the steps still ahead.
@@ -143,13 +172,14 @@ export default function BackupSettingsScreen() {
   const { t, locale } = useStrings();
   const backup = useBackup();
 
-  const [busy, setBusy] = useState(false);
+  const [pending, setPending] = useState<PendingAction | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [shownKey, setShownKey] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const [entering, setEntering] = useState(false);
   const [typedKey, setTypedKey] = useState('');
-  const [typedInvalid, setTypedInvalid] = useState(false);
+  /** What went wrong with the key just typed — not a key, or the keystore. */
+  const [typedProblem, setTypedProblem] = useState<string | null>(null);
   const [unlinking, setUnlinking] = useState(false);
   const [found, setFound] = useState<FoundBackup | null>(null);
   const [restored, setRestored] = useState<number | null>(null);
@@ -224,65 +254,97 @@ export default function BackupSettingsScreen() {
   };
 
   const onConnect = async (): Promise<void> => {
-    setBusy(true);
+    setPending('connect');
     setError(null);
     try {
       await backup.connect();
     } catch (caught) {
       setError(connectFailure(caught));
     } finally {
-      setBusy(false);
+      setPending(null);
     }
   };
 
   const onBackUpNow = async (): Promise<void> => {
-    setBusy(true);
+    setPending('backup');
     setError(null);
     try {
       await backup.backupNow();
     } catch (caught) {
       setError(friendlyError(caught, t.backup.backupFailed, 'backup.run'));
     } finally {
-      setBusy(false);
+      setPending(null);
     }
   };
 
   const onCreateKey = async (): Promise<void> => {
-    setBusy(true);
+    setPending('key');
     setError(null);
     try {
       setCopied(false);
       setShownKey(await backup.createKey());
     } catch (caught) {
-      setError(friendlyError(caught, t.backup.backupFailed, 'backup.createKey'));
+      setError(friendlyError(caught, t.backup.keySaveFailed, 'backup.createKey'));
     } finally {
-      setBusy(false);
+      setPending(null);
     }
   };
 
+  /**
+   * Show the key again — and say so when it cannot.
+   *
+   * `loadRecoveryKey` swallows a SecureStore failure to null, so this used to
+   * be able to do nothing at all: no sheet, no sentence, and no way to finish
+   * the step that "Show my key" is the only exit from. It was survivable while
+   * this was a small chip beside other controls; it is not now that the
+   * checklist hangs a step on it.
+   */
   const onShowKey = async (): Promise<void> => {
-    setCopied(false);
-    setShownKey(await backup.revealKey());
+    setPending('key');
+    setError(null);
+    try {
+      setCopied(false);
+      const key = await backup.revealKey();
+      if (!key) {
+        setError(t.backup.keyUnreadable);
+        return;
+      }
+      setShownKey(key);
+    } catch (caught) {
+      setError(friendlyError(caught, t.backup.keyUnreadable, 'backup.revealKey'));
+    } finally {
+      setPending(null);
+    }
   };
 
   const onEnterKey = (): void => {
     setTypedKey('');
-    setTypedInvalid(false);
+    setTypedProblem(null);
     setEntering(true);
   };
 
+  /**
+   * Take a key typed in from another phone. The keystore write can reject, and
+   * an unhandled rejection would leave the sheet open saying nothing, so both
+   * kinds of "no" get the same treatment: a sentence inside the sheet, where
+   * the person still has what they typed.
+   */
   const onAcceptKey = async (): Promise<void> => {
-    if (!(await backup.acceptKey(typedKey))) {
-      setTypedInvalid(true);
-      return;
+    setTypedProblem(null);
+    try {
+      if (!(await backup.acceptKey(typedKey))) {
+        setTypedProblem(t.backup.keyEnterInvalid);
+        return;
+      }
+      setEntering(false);
+      setTypedKey('');
+    } catch (caught) {
+      setTypedProblem(friendlyError(caught, t.backup.keySaveFailed, 'backup.acceptKey'));
     }
-    setEntering(false);
-    setTypedKey('');
-    setTypedInvalid(false);
   };
 
   const onCheckForBackup = async (): Promise<void> => {
-    setBusy(true);
+    setPending('scan');
     setError(null);
     setRestored(null);
     try {
@@ -301,13 +363,13 @@ export default function BackupSettingsScreen() {
           : friendlyError(caught, t.backup.restoreFailed, 'backup.scan'),
       );
     } finally {
-      setBusy(false);
+      setPending(null);
     }
   };
 
   const onRestore = async (): Promise<void> => {
     if (!found) return;
-    setBusy(true);
+    setPending('restore');
     try {
       setRestored(await backup.applyRestore(found));
       setFound(null);
@@ -315,19 +377,19 @@ export default function BackupSettingsScreen() {
       setFound(null);
       setError(friendlyError(caught, t.backup.restoreFailed, 'backup.restore'));
     } finally {
-      setBusy(false);
+      setPending(null);
     }
   };
 
   const onUnlink = async (): Promise<void> => {
     setUnlinking(false);
-    setBusy(true);
+    setPending('disconnect');
     try {
       await backup.disconnect();
     } catch (caught) {
       setError(friendlyError(caught, t.backup.connectFailed, 'backup.disconnect'));
     } finally {
-      setBusy(false);
+      setPending(null);
     }
   };
 
@@ -344,6 +406,16 @@ export default function BackupSettingsScreen() {
   ];
 
   const running = backup.phase !== null;
+  /** Something is in flight. Which one it is decides who gets the spinner. */
+  const busy = pending !== null;
+  /**
+   * The mark a working button wears in place of its icon. Filled buttons put a
+   * light label on the brand colour, so their spinner has to invert too.
+   */
+  const spinner = (onBrand: boolean): ReactNode => (
+    <ActivityIndicator size="small" color={onBrand ? theme.color.onBrand : theme.color.text} />
+  );
+
   const setup = backupSetup({
     configured: backup.configured,
     connected: backup.connected,
@@ -397,10 +469,14 @@ export default function BackupSettingsScreen() {
   };
 
   /**
-   * The buttons the outstanding step carries. "I already have a key" rides
-   * along with both key steps, because somebody restoring onto a new phone is
-   * *at* one of those two moments and typing their old key is the whole answer
-   * — it satisfies the step and the one after it in a single tap.
+   * The buttons the outstanding step carries.
+   *
+   * "I already have a key" rides along with both key steps, because somebody
+   * restoring onto a new phone is *at* one of those two moments and typing
+   * their old key is the whole answer — it satisfies the step and the one after
+   * it in a single tap. At step 2 it is a `secondary`, not a ghost: the two are
+   * genuinely equal choices, and drawing the wrong one louder is how somebody
+   * with a backup to recover ends up minting a key that cannot open it.
    */
   const stepActions = (step: BackupStep): ReactNode => {
     if (step === BackupStep.Account) {
@@ -409,6 +485,7 @@ export default function BackupSettingsScreen() {
           label={t.backup.connect}
           onPress={() => void onConnect()}
           disabled={busy}
+          icon={pending === 'connect' ? spinner(true) : undefined}
           fullWidth
         />
       );
@@ -423,12 +500,13 @@ export default function BackupSettingsScreen() {
           label={primary.label}
           onPress={() => void primary.run()}
           disabled={busy}
+          icon={pending === 'key' ? spinner(true) : undefined}
           fullWidth
         />
         <Button
           label={t.backup.keyEnter}
-          variant="ghost"
-          size="sm"
+          variant={step === BackupStep.Key ? 'secondary' : 'ghost'}
+          size={step === BackupStep.Key ? 'md' : 'sm'}
           onPress={onEnterKey}
           disabled={busy}
           fullWidth
@@ -442,14 +520,30 @@ export default function BackupSettingsScreen() {
    * button rather than instead of it — a restore has to stay findable even when
    * it is not yet possible, because the moment somebody needs it is the moment
    * they have nothing else.
+   *
+   * The no-key case gets its own sentence rather than borrowing the backup
+   * button's "Create your backup key first." That advice is correct above and
+   * catastrophic here: this is a new phone whose backup is sealed under the key
+   * from the old one, and minting a fresh one does not open it — it makes
+   * `setup.complete` true, which arms "Back up now" and any non-Off schedule,
+   * and `runBackup` overwrites the Drive file in place. Following the wrong
+   * sentence would destroy the only copy of the ledger the person came here
+   * for. So the reason names the old key, and the button beside it is the one
+   * that takes it.
+   *
+   * `settled` is consulted because these flags start false: without it the card
+   * would say "Checking…" while this line flatly told a linked phone to link an
+   * account.
    */
-  const restoreReason = !backup.configured
-    ? t.backup.unavailable
-    : !backup.connected
-      ? t.backup.refusedNotConnected
-      : !backup.hasKey
-        ? t.backup.refusedNoKey
-        : null;
+  const restoreReason = !settled
+    ? t.backup.statusChecking
+    : !backup.configured
+      ? t.backup.unavailable
+      : !backup.connected
+        ? t.backup.refusedNotConnected
+        : !backup.hasKey
+          ? t.backup.restoreNeedsKey
+          : null;
 
   return (
     <Screen>
@@ -539,7 +633,7 @@ export default function BackupSettingsScreen() {
                   disabled={busy || running}
                   fullWidth
                   icon={
-                    running ? (
+                    running || pending === 'backup' ? (
                       <ActivityIndicator size="small" color={theme.color.onBrand} />
                     ) : (
                       <Ionicons
@@ -550,14 +644,17 @@ export default function BackupSettingsScreen() {
                     )
                   }
                 />
-                {/* Never a grey button on its own: a run in progress says which
-                    part it is on, a button held down by something else on the
-                    screen says so, and a finished run says what it did. */}
+                {/* A run in progress says which part it is on; the gap between
+                    the tap and the first phase — network checks and a token
+                    refresh — says something rather than nothing; and a finished
+                    run says what it did. Scoped to this button's own action, so
+                    pressing something else on the screen does not make this one
+                    sprout a progress line. */}
                 {phaseLine ? (
                   <Text variant="micro" tone="muted" align="center">
                     {phaseLine}
                   </Text>
-                ) : busy ? (
+                ) : pending === 'backup' ? (
                   <Text variant="micro" tone="muted" align="center">
                     {t.backup.busy}
                   </Text>
@@ -635,9 +732,11 @@ export default function BackupSettingsScreen() {
           {t.backup.intro}
         </Text>
 
-        {/* Which Google account. Only once linking is no longer a step: while it
-            is, the checklist above holds the only "Link Google Drive" button. */}
-        {backup.connected ? (
+        {/* Which Google account. Rendered whenever one is linked *and* the
+            checklist is not itself asking for one — so the two never offer the
+            same tap, and a build that has lost `configured` under a linked
+            account can still unlink it. */}
+        {backup.connected && setup.outstanding !== BackupStep.Account ? (
           <View style={{ gap: theme.spacing.sm }}>
             <SectionHeader title={t.backup.accountSection} />
             <Card style={{ gap: theme.spacing.md }}>
@@ -655,16 +754,20 @@ export default function BackupSettingsScreen() {
                 variant="ghostDanger"
                 onPress={() => setUnlinking(true)}
                 disabled={busy}
+                icon={pending === 'disconnect' ? spinner(false) : undefined}
                 fullWidth
               />
             </Card>
           </View>
         ) : null}
 
-        {/* The key, once it is settled. Making one and saving one are steps and
-            live in the checklist; what is left here is showing it again and
-            replacing it with the key from another phone. */}
-        {setup.complete ? (
+        {/* The key. Rendered whenever this phone holds one and the checklist is
+            not itself asking to be shown it. Gating this on `setup.complete`
+            was wrong: `configured` is a runtime conjunction (a client id *and*
+            the native Google module), so a build that loses either would hide
+            the only way to read back a key already on the device — and the
+            Drive file it opens would then be unrecoverable. */}
+        {backup.hasKey && setup.outstanding !== BackupStep.SaveKey ? (
           <View style={{ gap: theme.spacing.sm }}>
             <SectionHeader title={t.backup.keySection} />
             <Card style={{ gap: theme.spacing.md }}>
@@ -683,6 +786,7 @@ export default function BackupSettingsScreen() {
                     size="sm"
                     onPress={() => void onShowKey()}
                     disabled={busy}
+                    icon={pending === 'key' ? spinner(false) : undefined}
                     fullWidth
                   />
                 </View>
@@ -803,12 +907,25 @@ export default function BackupSettingsScreen() {
               variant="secondary"
               onPress={() => void onCheckForBackup()}
               disabled={restoreReason !== null || busy}
+              icon={pending === 'scan' ? spinner(false) : undefined}
               fullWidth
             />
             {restoreReason ? (
               <Text variant="micro" tone="faint" align="center">
                 {restoreReason}
               </Text>
+            ) : null}
+            {/* The way out of the one blocked state that has one, right here,
+                so nobody has to go looking for it in the checklist — where the
+                other button is the one that would cost them the backup. */}
+            {settled && backup.configured && backup.connected && !backup.hasKey ? (
+              <Button
+                label={t.backup.keyEnter}
+                variant="secondary"
+                onPress={onEnterKey}
+                disabled={busy}
+                fullWidth
+              />
             ) : null}
           </Card>
         </View>
@@ -873,7 +990,7 @@ export default function BackupSettingsScreen() {
               value={typedKey}
               onChangeText={(value) => {
                 setTypedKey(value);
-                setTypedInvalid(false);
+                setTypedProblem(null);
               }}
               placeholder={t.backup.keyEnterPlaceholder}
               placeholderTextColor={theme.color.textFaint}
@@ -893,7 +1010,7 @@ export default function BackupSettingsScreen() {
               }}
             />
           </Card>
-          {typedInvalid ? <Callout tone="negative">{t.backup.keyEnterInvalid}</Callout> : null}
+          {typedProblem ? <Callout tone="negative">{typedProblem}</Callout> : null}
           <Button label={t.backup.keyEnterSave} onPress={() => void onAcceptKey()} fullWidth />
         </View>
       </Sheet>
@@ -920,6 +1037,7 @@ export default function BackupSettingsScreen() {
                   label={t.backup.restoreConfirm}
                   onPress={() => void onRestore()}
                   disabled={busy}
+                  icon={pending === 'restore' ? spinner(true) : undefined}
                   fullWidth
                 />
               ) : null}

--- a/apps/mobile/src/app/settings/backup.tsx
+++ b/apps/mobile/src/app/settings/backup.tsx
@@ -1,28 +1,61 @@
 /**
  * Backing the private "Me" ledger up to the person's own Google Drive.
  *
- * The shape is WhatsApp's chat-backup screen, because that screen is the mental
- * model people already have for this and inventing a different one would only
- * cost them: back up now with a live line saying what is happening, how often
- * to do it automatically, which account it goes to, over which networks, and
- * when the last one landed. What WhatsApp puts behind "End-to-end encrypted
- * backup" is here up front instead — the key is the thing that decides whether
- * a backup is worth anything on a new phone, so it is a section, not a
- * disclosure.
+ * THE SHAPE, AND WHY IT CHANGED. This was WhatsApp's chat-backup screen — six
+ * peer sections: back up now, account, key, schedule, network, restore. That
+ * shape assumes the feature already works. It does not until three separate
+ * things are true (an account is linked, this device holds the key, and the
+ * person has kept a copy of it), and until then four of the six sections were
+ * inert: "Back up now" a grey slab with no reason attached, "Check for a
+ * backup" the same, and the one control that unblocked either — "Create a key"
+ * — a small chip two screens further down, under a heading that gave no hint it
+ * gated everything above it. A setup flow wearing a settings screen's clothes
+ * reads, correctly, as a screen that is broken.
  *
- * Two ordering decisions worth naming. The key section sits *above* the
- * schedule, because a schedule with no key backs nothing up and the screen
- * should not let somebody set one and walk away believing otherwise. And
- * Restore is last: it is the half people need once, at the worst moment, and
- * burying it would be cruel — but putting it near "Back up now" invites the
- * wrong tap.
+ * So the screen now has two modes and one anchor.
+ *
+ * The anchor is the card at the top, which always says the same three things in
+ * the same place: whether the ledger is protected, when it last was, and that
+ * the lock is a key only this person holds. That is WhatsApp's own status card
+ * (Chat backup: last backup, total size, "End-to-end encrypted"), and it is
+ * first because "am I safe" is the question somebody opened this screen with.
+ *
+ * Below the fold of that card the screen forks. **Until a backup can run**, the
+ * card continues into a three-step checklist and the outstanding step — and
+ * only that one — carries a button. Steps already taken collapse to a line with
+ * "Done" beside them; steps further out are dimmed and silent. That is Uber
+ * Eats' account checkup, where the item needing attention expands in place with
+ * its own action and the satisfied ones shrink to checked rows. **Once it can
+ * run**, the checklist disappears entirely and the card continues into "Back up
+ * now" — an ordinary settings screen, with no scaffolding left to nag somebody
+ * whose backups have been running for a year.
+ *
+ * THE ORDERING, in the order it is rendered:
+ *
+ * 1. Status + the one thing to do. Both answers within a thumb of the top.
+ * 2. The promise ("nothing legible leaves the phone"), because *what to do*
+ *    outranks *why* on a screen somebody came to with a problem.
+ * 3. Account, and then the key — but each only once it is no longer a step.
+ *    While a step is outstanding the checklist owns its buttons, so the two are
+ *    never on screen at the same time offering the same tap.
+ * 4. The schedule, which now refuses to lie. "Daily" with no key backs nothing
+ *    up, so when the steps are unfinished the schedule says so directly under
+ *    the picker rather than sitting there looking live.
+ * 5. Which networks.
+ * 6. Restore, last: it is the half people need once, at the worst moment, and
+ *    burying it would be cruel — but putting it near "Back up now" invites the
+ *    wrong tap. Unchanged, and deliberately so.
+ *
+ * THE RULE THE WHOLE FILE OBEYS: no control is ever disabled and silent. Either
+ * the reason is written next to it, or the control is not rendered at all and
+ * the step that unblocks it stands in its place.
  *
  * The one promise this screen makes, and must keep: nothing legible leaves the
  * phone. What goes to Drive is a sealed blob; the key that opens it is shown to
  * the person and never sent anywhere.
  */
 
-import { useCallback, useState } from 'react';
+import { useCallback, useState, type ReactNode } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import * as Clipboard from 'expo-clipboard';
 import { ActivityIndicator, ScrollView, TextInput, View } from 'react-native';
@@ -51,6 +84,7 @@ import { formatBytes } from '@/lib/bytes';
 import { useBackup, type BackupOutcome } from '@/lib/backup/useBackup';
 import { BackupFrequency } from '@/lib/backup/schedule';
 import { formatRecoveryKey } from '@/lib/backup/recoveryKey';
+import { backupSetup, BackupStep } from '@/lib/backup/setup';
 import type { RestoreScan } from '@/lib/backup/engine';
 import { CloudAuthError } from '@/lib/cloud/oauth';
 import { friendlyError } from '@/lib/errors';
@@ -62,6 +96,46 @@ type FoundBackup = Extract<RestoreScan, { ok: true }>;
 
 /** A brand name, not copy — the same word in every locale, so not translated. */
 const PROVIDER_LABEL = 'Google Drive';
+
+/** The checklist mark's diameter, and so the indent its buttons hang under. */
+const STEP_MARK = 26;
+
+/**
+ * The disc at the head of a checklist row: a tick once the step is taken, its
+ * number in the brand colour while it is the one being asked for, and a hollow
+ * outline for the steps still ahead.
+ *
+ * Three states rather than two, because "done" and "not done" cannot express
+ * the thing this screen exists to say — which of the not-done ones is *yours to
+ * do right now*. Every checklist that works (Chime's "Finish setup", Plum's
+ * "Get set up", Shopify's "Get ready to sell") draws that distinction.
+ */
+function StepMark({ number, done, active }: { number: number; done: boolean; active: boolean }) {
+  const theme = useTheme();
+  const fill = done ? theme.color.positive : active ? theme.color.brand : 'transparent';
+  return (
+    <View
+      style={{
+        width: STEP_MARK,
+        height: STEP_MARK,
+        borderRadius: STEP_MARK / 2,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: fill,
+        borderWidth: done || active ? 0 : 1,
+        borderColor: theme.color.border,
+      }}
+    >
+      {done ? (
+        <Ionicons name="checkmark" size={iconSize.base} color={theme.color.onBrand} />
+      ) : (
+        <Text variant="micro" tone={active ? 'onBrand' : 'faint'}>
+          {String(number)}
+        </Text>
+      )}
+    </View>
+  );
+}
 
 export default function BackupSettingsScreen() {
   const theme = useTheme();
@@ -191,6 +265,12 @@ export default function BackupSettingsScreen() {
     setShownKey(await backup.revealKey());
   };
 
+  const onEnterKey = (): void => {
+    setTypedKey('');
+    setTypedInvalid(false);
+    setEntering(true);
+  };
+
   const onAcceptKey = async (): Promise<void> => {
     if (!(await backup.acceptKey(typedKey))) {
       setTypedInvalid(true);
@@ -264,10 +344,112 @@ export default function BackupSettingsScreen() {
   ];
 
   const running = backup.phase !== null;
-  // A backup needs a linked account and a key the person has confirmed they
-  // kept. Anything less and the button would produce a file nobody can open.
-  const canBackUp =
-    backup.configured && backup.connected && backup.hasKey && backup.settings.keySeen;
+  const setup = backupSetup({
+    configured: backup.configured,
+    connected: backup.connected,
+    hasKey: backup.hasKey,
+    keySeen: backup.settings.keySeen,
+  });
+  const last = backup.settings.last;
+
+  /**
+   * The status card's face. `loading` gets its own one rather than borrowing
+   * "not set up": the hook's first pass reads two stores *and* asks Drive who
+   * the linked account is, so on a slow network a fully configured phone would
+   * otherwise open on "Not backing up yet" and correct itself a second later —
+   * the one sentence on this screen that must never be shown wrongly.
+   */
+  const settled = !backup.loading;
+  const statusTone: 'warning' | 'brand' | 'positive' =
+    !settled || (setup.complete && !last) ? 'brand' : setup.complete ? 'positive' : 'warning';
+  const statusColor =
+    statusTone === 'positive'
+      ? { fg: theme.color.positive, bg: theme.color.positiveSoft }
+      : statusTone === 'brand'
+        ? { fg: theme.color.brand, bg: theme.color.brandSoft }
+        : { fg: theme.color.warning, bg: theme.color.warningSoft };
+
+  const statusTitle = !settled
+    ? t.backup.statusChecking
+    : setup.complete
+      ? last
+        ? t.backup.statusOn
+        : t.backup.statusReady
+      : t.backup.statusOff;
+
+  const statusDetail = !settled
+    ? null
+    : setup.unavailable
+      ? t.backup.unavailable
+      : setup.complete
+        ? last
+          ? t.backup.lastLine
+              .replace('{date}', dateTime(last.at))
+              .replace('{size}', formatBytes(last.size, locale))
+          : t.backup.never
+        : plural(locale, setup.total - setup.done, t.backup.stepsLeft);
+
+  /** One title and one sentence per step; the sentence shows only on the active one. */
+  const stepCopy: Record<BackupStep, { title: string; body: string }> = {
+    [BackupStep.Account]: { title: t.backup.stepAccountTitle, body: t.backup.stepAccountBody },
+    [BackupStep.Key]: { title: t.backup.stepKeyTitle, body: t.backup.stepKeyBody },
+    [BackupStep.SaveKey]: { title: t.backup.stepSaveTitle, body: t.backup.stepSaveBody },
+  };
+
+  /**
+   * The buttons the outstanding step carries. "I already have a key" rides
+   * along with both key steps, because somebody restoring onto a new phone is
+   * *at* one of those two moments and typing their old key is the whole answer
+   * — it satisfies the step and the one after it in a single tap.
+   */
+  const stepActions = (step: BackupStep): ReactNode => {
+    if (step === BackupStep.Account) {
+      return (
+        <Button
+          label={t.backup.connect}
+          onPress={() => void onConnect()}
+          disabled={busy}
+          fullWidth
+        />
+      );
+    }
+    const primary =
+      step === BackupStep.Key
+        ? { label: t.backup.keyCreate, run: onCreateKey }
+        : { label: t.backup.keyShow, run: onShowKey };
+    return (
+      <>
+        <Button
+          label={primary.label}
+          onPress={() => void primary.run()}
+          disabled={busy}
+          fullWidth
+        />
+        <Button
+          label={t.backup.keyEnter}
+          variant="ghost"
+          size="sm"
+          onPress={onEnterKey}
+          disabled={busy}
+          fullWidth
+        />
+      </>
+    );
+  };
+
+  /**
+   * Why "Check for a backup" cannot run, in the person's terms, beside the
+   * button rather than instead of it — a restore has to stay findable even when
+   * it is not yet possible, because the moment somebody needs it is the moment
+   * they have nothing else.
+   */
+  const restoreReason = !backup.configured
+    ? t.backup.unavailable
+    : !backup.connected
+      ? t.backup.refusedNotConnected
+      : !backup.hasKey
+        ? t.backup.refusedNoKey
+        : null;
 
   return (
     <Screen>
@@ -295,142 +477,232 @@ export default function BackupSettingsScreen() {
         }}
         showsVerticalScrollIndicator={false}
       >
+        {error ? <Callout tone="negative">{error}</Callout> : null}
+
+        {/* The anchor: where things stand, and — under the same rule — either
+            the one step outstanding or the button that is now possible. */}
+        <Card style={{ gap: theme.spacing.lg }}>
+          <Row gap={theme.spacing.md} style={{ alignItems: 'flex-start' }}>
+            <View
+              style={{
+                width: 44,
+                height: 44,
+                borderRadius: 22,
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: statusColor.bg,
+              }}
+            >
+              {settled ? (
+                <Ionicons
+                  name={
+                    setup.complete
+                      ? last
+                        ? 'cloud-done'
+                        : 'cloud-upload-outline'
+                      : 'cloud-offline-outline'
+                  }
+                  size={iconSize.xxl}
+                  color={statusColor.fg}
+                />
+              ) : (
+                <ActivityIndicator size="small" color={statusColor.fg} />
+              )}
+            </View>
+            <View style={{ flex: 1, gap: 2 }}>
+              <Text variant="heading">{statusTitle}</Text>
+              {statusDetail ? (
+                <Text variant="caption" tone="muted">
+                  {statusDetail}
+                </Text>
+              ) : null}
+              {/* WhatsApp's "End-to-end encrypted" line: the reassurance belongs
+                  where the good news is, not three sections further down. */}
+              {settled && setup.complete ? (
+                <Row gap={theme.spacing.xs} style={{ marginTop: 2 }}>
+                  <Ionicons name="lock-closed" size={iconSize.xs} color={theme.color.textFaint} />
+                  <Text variant="micro" tone="faint">
+                    {t.backup.statusSealed}
+                  </Text>
+                </Row>
+              ) : null}
+            </View>
+          </Row>
+
+          {settled && setup.complete ? (
+            <>
+              <Divider />
+              <View style={{ gap: theme.spacing.md }}>
+                <Button
+                  label={t.backup.backUpNow}
+                  onPress={() => void onBackUpNow()}
+                  disabled={busy || running}
+                  fullWidth
+                  icon={
+                    running ? (
+                      <ActivityIndicator size="small" color={theme.color.onBrand} />
+                    ) : (
+                      <Ionicons
+                        name="cloud-upload-outline"
+                        size={iconSize.md}
+                        color={theme.color.onBrand}
+                      />
+                    )
+                  }
+                />
+                {/* Never a grey button on its own: a run in progress says which
+                    part it is on, a button held down by something else on the
+                    screen says so, and a finished run says what it did. */}
+                {phaseLine ? (
+                  <Text variant="micro" tone="muted" align="center">
+                    {phaseLine}
+                  </Text>
+                ) : busy ? (
+                  <Text variant="micro" tone="muted" align="center">
+                    {t.backup.busy}
+                  </Text>
+                ) : backup.outcome ? (
+                  <Text
+                    variant="micro"
+                    tone={backup.outcome.kind === 'ok' ? 'muted' : 'faint'}
+                    align="center"
+                  >
+                    {refusalLine(backup.outcome)}
+                  </Text>
+                ) : null}
+              </View>
+            </>
+          ) : settled && !setup.unavailable ? (
+            <>
+              <Divider />
+              <View style={{ gap: theme.spacing.lg }}>
+                <Row style={{ justifyContent: 'space-between' }}>
+                  <Text variant="micro" tone="faint">
+                    {t.backup.setupSection}
+                  </Text>
+                  <Text variant="micro" tone="faint">
+                    {t.backup.setupProgress
+                      .replace('{done}', String(setup.done))
+                      .replace('{total}', String(setup.total))}
+                  </Text>
+                </Row>
+                {setup.steps.map(({ step, done }, index) => {
+                  const active = setup.outstanding === step;
+                  const copy = stepCopy[step];
+                  return (
+                    <View key={step} style={{ gap: theme.spacing.md }}>
+                      <Row gap={theme.spacing.md} style={{ alignItems: 'flex-start' }}>
+                        <StepMark number={index + 1} done={done} active={active} />
+                        <View style={{ flex: 1, gap: 2 }}>
+                          <Text variant="subheading" tone={active ? 'default' : 'muted'}>
+                            {copy.title}
+                          </Text>
+                          {active ? (
+                            <Text variant="caption" tone="muted">
+                              {copy.body}
+                            </Text>
+                          ) : null}
+                        </View>
+                        {done ? (
+                          <Text variant="micro" tone="positive">
+                            {t.backup.stepDone}
+                          </Text>
+                        ) : null}
+                      </Row>
+                      {active ? (
+                        // Hung under the row's text rather than the mark, so the
+                        // button reads as belonging to this step and not to the
+                        // list. `paddingStart` so it hangs off the right edge in
+                        // Arabic.
+                        <View
+                          style={{
+                            paddingStart: STEP_MARK + theme.spacing.md,
+                            gap: theme.spacing.sm,
+                          }}
+                        >
+                          {stepActions(step)}
+                        </View>
+                      ) : null}
+                    </View>
+                  );
+                })}
+              </View>
+            </>
+          ) : null}
+        </Card>
+
         <Text variant="body" tone="muted">
           {t.backup.intro}
         </Text>
 
-        {!backup.configured ? <Callout tone="warning">{t.backup.unavailable}</Callout> : null}
-        {error ? <Callout tone="negative">{error}</Callout> : null}
-
-        {/* Back up now, and the last one. The button and the record it produces
-            belong together — a result line under a button somewhere else is a
-            result nobody connects to what they just pressed. */}
-        <Card style={{ gap: theme.spacing.md }}>
-          <Button
-            label={t.backup.backUpNow}
-            onPress={() => void onBackUpNow()}
-            disabled={!canBackUp || busy || running}
-            fullWidth
-            icon={
-              running ? (
-                <ActivityIndicator size="small" color={theme.color.onBrand} />
-              ) : (
-                <Ionicons
-                  name="cloud-upload-outline"
-                  size={iconSize.md}
-                  color={theme.color.onBrand}
-                />
-              )
-            }
-          />
-          {phaseLine ? (
-            <Text variant="micro" tone="muted" align="center">
-              {phaseLine}
-            </Text>
-          ) : backup.outcome ? (
-            <Text
-              variant="micro"
-              tone={backup.outcome.kind === 'ok' ? 'muted' : 'faint'}
-              align="center"
-            >
-              {refusalLine(backup.outcome)}
-            </Text>
-          ) : null}
-
-          <Divider />
-          <Row style={{ justifyContent: 'space-between' }}>
-            <Text variant="micro" tone="faint">
-              {t.backup.lastSection}
-            </Text>
-            <Text variant="micro" tone="muted">
-              {backup.settings.last
-                ? `${dateTime(backup.settings.last.at)} · ${formatBytes(
-                    backup.settings.last.size,
-                    locale,
-                  )}`
-                : t.backup.never}
-            </Text>
-          </Row>
-        </Card>
-
-        {/* Which Google account. */}
-        <View style={{ gap: theme.spacing.sm }}>
-          <SectionHeader title={t.backup.accountSection} />
-          <Card style={{ gap: theme.spacing.md }}>
-            <Row style={{ gap: theme.spacing.md }}>
-              <Ionicons
-                name={backup.connected ? 'logo-google' : 'cloud-offline-outline'}
-                size={iconSize.xl}
-                color={backup.connected ? theme.color.brand : theme.color.textFaint}
+        {/* Which Google account. Only once linking is no longer a step: while it
+            is, the checklist above holds the only "Link Google Drive" button. */}
+        {backup.connected ? (
+          <View style={{ gap: theme.spacing.sm }}>
+            <SectionHeader title={t.backup.accountSection} />
+            <Card style={{ gap: theme.spacing.md }}>
+              <Row style={{ gap: theme.spacing.md }}>
+                <Ionicons name="logo-google" size={iconSize.xl} color={theme.color.brand} />
+                {/* The linked address when Drive will say who it is, and the
+                    destination's own name when it will not — never a guess, and
+                    never a blank row that reads as "not connected". */}
+                <Text variant="body" style={{ flex: 1 }}>
+                  {backup.account ?? PROVIDER_LABEL}
+                </Text>
+              </Row>
+              <Button
+                label={t.backup.disconnect}
+                variant="ghostDanger"
+                onPress={() => setUnlinking(true)}
+                disabled={busy}
+                fullWidth
               />
-              {/* The linked address when Drive will say who it is, and the
-                  destination's own name when it will not — never a guess, and
-                  never a blank row that reads as "not connected". */}
-              <Text variant="body" style={{ flex: 1 }}>
-                {backup.connected ? (backup.account ?? PROVIDER_LABEL) : t.backup.notConnected}
+            </Card>
+          </View>
+        ) : null}
+
+        {/* The key, once it is settled. Making one and saving one are steps and
+            live in the checklist; what is left here is showing it again and
+            replacing it with the key from another phone. */}
+        {setup.complete ? (
+          <View style={{ gap: theme.spacing.sm }}>
+            <SectionHeader title={t.backup.keySection} />
+            <Card style={{ gap: theme.spacing.md }}>
+              <Row style={{ gap: theme.spacing.sm }}>
+                <Ionicons name="key" size={iconSize.md} color={theme.color.brand} />
+                <Text variant="body">{t.backup.keyPresent}</Text>
+              </Row>
+              <Text variant="micro" tone="muted">
+                {t.backup.keyIntro}
               </Text>
-            </Row>
-            <Button
-              label={backup.connected ? t.backup.disconnect : t.backup.connect}
-              variant={backup.connected ? 'ghostDanger' : 'secondary'}
-              onPress={() => (backup.connected ? setUnlinking(true) : void onConnect())}
-              disabled={!backup.configured || busy}
-              fullWidth
-            />
-          </Card>
-        </View>
+              <Row style={{ gap: theme.spacing.sm }}>
+                <View style={{ flex: 1 }}>
+                  <Button
+                    label={t.backup.keyShow}
+                    variant="secondary"
+                    size="sm"
+                    onPress={() => void onShowKey()}
+                    disabled={busy}
+                    fullWidth
+                  />
+                </View>
+                <View style={{ flex: 1 }}>
+                  <Button
+                    label={t.backup.keyEnter}
+                    variant="ghost"
+                    size="sm"
+                    onPress={onEnterKey}
+                    disabled={busy}
+                    fullWidth
+                  />
+                </View>
+              </Row>
+            </Card>
+          </View>
+        ) : null}
 
-        {/* The key. Above the schedule on purpose — see the file header. */}
-        <View style={{ gap: theme.spacing.sm }}>
-          <SectionHeader title={t.backup.keySection} />
-          <Card style={{ gap: theme.spacing.md }}>
-            <Text variant="micro" tone="muted">
-              {t.backup.keyIntro}
-            </Text>
-            <Row style={{ gap: theme.spacing.sm }}>
-              <Ionicons
-                name={backup.hasKey ? 'key' : 'key-outline'}
-                size={iconSize.md}
-                color={backup.hasKey ? theme.color.brand : theme.color.textFaint}
-              />
-              <Text variant="body">{backup.hasKey ? t.backup.keyPresent : t.backup.keyAbsent}</Text>
-            </Row>
-            {/* A key made and then dismissed without confirming leaves "Back up
-                now" disabled with nothing on screen explaining why. Say it, and
-                point at the button that fixes it. */}
-            {backup.hasKey && !backup.settings.keySeen ? (
-              <Callout tone="warning">{t.backup.keyWarning}</Callout>
-            ) : null}
-            <Row style={{ gap: theme.spacing.sm }}>
-              <View style={{ flex: 1 }}>
-                <Button
-                  label={backup.hasKey ? t.backup.keyShow : t.backup.keyCreate}
-                  variant="secondary"
-                  size="sm"
-                  onPress={() => void (backup.hasKey ? onShowKey() : onCreateKey())}
-                  disabled={busy}
-                  fullWidth
-                />
-              </View>
-              <View style={{ flex: 1 }}>
-                <Button
-                  label={t.backup.keyEnter}
-                  variant="ghost"
-                  size="sm"
-                  onPress={() => {
-                    setTypedKey('');
-                    setTypedInvalid(false);
-                    setEntering(true);
-                  }}
-                  disabled={busy}
-                  fullWidth
-                />
-              </View>
-            </Row>
-          </Card>
-        </View>
-
-        {/* How often. */}
+        {/* How often — and, when it cannot yet run, saying so rather than
+            sitting there reading "Daily" over a key that does not exist. */}
         <View style={{ gap: theme.spacing.sm }}>
           <SectionHeader title={t.backup.frequencySection} />
           <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
@@ -459,6 +731,14 @@ export default function BackupSettingsScreen() {
               );
             })}
           </Card>
+          {/* Not in a build that cannot back up at all: the card at the top
+              already says why, and "the steps above" would point at nothing. */}
+          {settled &&
+          !setup.complete &&
+          !setup.unavailable &&
+          backup.settings.frequency !== BackupFrequency.Off ? (
+            <Callout tone="warning">{t.backup.frequencyBlocked}</Callout>
+          ) : null}
           <Text variant="micro" tone="faint">
             {t.backup.frequencyNote}
           </Text>
@@ -522,9 +802,14 @@ export default function BackupSettingsScreen() {
               label={t.backup.restoreCheck}
               variant="secondary"
               onPress={() => void onCheckForBackup()}
-              disabled={!backup.configured || !backup.connected || !backup.hasKey || busy}
+              disabled={restoreReason !== null || busy}
               fullWidth
             />
+            {restoreReason ? (
+              <Text variant="micro" tone="faint" align="center">
+                {restoreReason}
+              </Text>
+            ) : null}
           </Card>
         </View>
       </ScrollView>

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1692,6 +1692,30 @@ export interface UiStrings {
     /** Shown when this build carries no Drive OAuth client id. */
     unavailable: string;
 
+    /** The card at the top, which wears one of four faces: still reading the
+     *  stored state, not set up, set up but never run, and running. The sealed
+     *  line is the promise repeated where the good news is. */
+    statusChecking: string;
+    statusOff: string;
+    statusReady: string;
+    statusOn: string;
+    statusSealed: string;
+    /** How much of the setup is left, under "Not backing up yet". */
+    stepsLeft: PluralForms;
+
+    /** The checklist that stands in for the controls until a backup can run. */
+    setupSection: string;
+    /** "{done} of {total}" — the checklist's own progress. */
+    setupProgress: string;
+    /** The state word on a step already taken. */
+    stepDone: string;
+    stepAccountTitle: string;
+    stepAccountBody: string;
+    stepKeyTitle: string;
+    stepKeyBody: string;
+    stepSaveTitle: string;
+    stepSaveBody: string;
+
     accountSection: string;
     notConnected: string;
     connect: string;
@@ -1706,8 +1730,9 @@ export interface UiStrings {
     phaseUploading: string;
     backedUp: PluralForms;
     backupFailed: string;
+    /** Under a button held down by some other in-flight action on the screen. */
+    busy: string;
 
-    lastSection: string;
     never: string;
     /** "{date} · {size}" — when the last backup landed, and how big it was. */
     lastLine: string;
@@ -1719,6 +1744,8 @@ export interface UiStrings {
     freqMonthly: string;
     /** Why "daily" means "daily, when you open the app". */
     frequencyNote: string;
+    /** Said next to a schedule that is set and cannot yet run. */
+    frequencyBlocked: string;
 
     networkSection: string;
     networkWifi: string;
@@ -4236,6 +4263,26 @@ const en: UiStrings = {
       'Your private Me ledger, copied to your own Google Drive and locked with a key only you hold. Neither Waves nor Google can read it.',
     unavailable: 'Backup is not available in this build.',
 
+    statusChecking: 'Checking…',
+    statusOff: 'Not backing up yet',
+    statusReady: 'Ready to back up',
+    statusOn: 'Backed up',
+    statusSealed: 'Locked with your key',
+    stepsLeft: {
+      one: '{n} step left',
+      other: '{n} steps left',
+    },
+
+    setupSection: 'Finish setting up',
+    setupProgress: '{done} of {total}',
+    stepDone: 'Done',
+    stepAccountTitle: 'Link your Google Drive',
+    stepAccountBody: 'The backup goes to a private folder in your own Drive.',
+    stepKeyTitle: 'Create your key',
+    stepKeyBody: 'The 64 characters that lock the backup. Waves never sees them.',
+    stepSaveTitle: 'Save your key',
+    stepSaveBody: 'Write it down somewhere that is not this phone. Then backups can start.',
+
     accountSection: 'Google account',
     notConnected: 'No account linked yet',
     connect: 'Link Google Drive',
@@ -4254,8 +4301,8 @@ const en: UiStrings = {
       other: '{n} records backed up',
     },
     backupFailed: 'The backup did not finish. Try again in a moment.',
+    busy: 'Just a moment…',
 
-    lastSection: 'Last backup',
     never: 'Never backed up',
     lastLine: '{date} · {size}',
 
@@ -4265,6 +4312,7 @@ const en: UiStrings = {
     freqWeekly: 'Weekly',
     freqMonthly: 'Monthly',
     frequencyNote: 'Automatic backups run when you open the app, not while it is closed.',
+    frequencyBlocked: 'Nothing will be backed up on this schedule until the steps above are done.',
 
     networkSection: 'Back up over',
     networkWifi: 'Wi‑Fi only',
@@ -6776,6 +6824,27 @@ const ta: UiStrings = {
       'உங்கள் தனிப்பட்ட "நான்" கணக்கு, உங்கள் சொந்த Google Drive-க்கு நகலெடுக்கப்பட்டு, உங்களிடம் மட்டுமே உள்ள சாவியால் பூட்டப்படுகிறது. Waves-ஆலும் Google-ஆலும் அதைப் படிக்க முடியாது.',
     unavailable: 'இந்தப் பதிப்பில் காப்புப்பிரதி கிடைக்கவில்லை.',
 
+    statusChecking: 'பார்க்கிறது…',
+    statusOff: 'இன்னும் காப்பு எடுக்கப்படவில்லை',
+    statusReady: 'காப்பு எடுக்கத் தயார்',
+    statusOn: 'காப்பு எடுக்கப்பட்டது',
+    statusSealed: 'உங்கள் சாவியால் பூட்டப்பட்டது',
+    stepsLeft: {
+      one: 'இன்னும் {n} படி',
+      other: 'இன்னும் {n} படிகள்',
+    },
+
+    setupSection: 'அமைப்பை முடியுங்கள்',
+    setupProgress: '{total}-இல் {done}',
+    stepDone: 'முடிந்தது',
+    stepAccountTitle: 'உங்கள் Google Drive-ஐ இணையுங்கள்',
+    stepAccountBody: 'காப்புப்பிரதி உங்கள் சொந்த Drive-இல் ஒரு தனிப்பட்ட கோப்புறைக்குச் செல்கிறது.',
+    stepKeyTitle: 'உங்கள் சாவியை உருவாக்குங்கள்',
+    stepKeyBody: 'காப்பைப் பூட்டும் 64 எழுத்துகள். Waves அவற்றைப் பார்ப்பதே இல்லை.',
+    stepSaveTitle: 'உங்கள் சாவியைச் சேமியுங்கள்',
+    stepSaveBody:
+      'இந்த ஃபோன் அல்லாத இடத்தில் எழுதி வையுங்கள். அதன் பிறகு காப்புப்பிரதிகள் தொடங்கும்.',
+
     accountSection: 'Google கணக்கு',
     notConnected: 'எந்தக் கணக்கும் இணைக்கப்படவில்லை',
     connect: 'Google Drive-ஐ இணை',
@@ -6794,8 +6863,8 @@ const ta: UiStrings = {
       other: '{n} பதிவுகள் காப்பு செய்யப்பட்டன',
     },
     backupFailed: 'காப்புப்பிரதி முடியவில்லை. சிறிது நேரம் கழித்து முயலுங்கள்.',
+    busy: 'ஒரு நிமிடம்…',
 
-    lastSection: 'கடைசி காப்புப்பிரதி',
     never: 'இதுவரை காப்பு எடுக்கவில்லை',
     lastLine: '{date} · {size}',
 
@@ -6805,6 +6874,8 @@ const ta: UiStrings = {
     freqWeekly: 'வாரம் ஒருமுறை',
     freqMonthly: 'மாதம் ஒருமுறை',
     frequencyNote: 'செயலியைத் திறக்கும்போது தானியங்கி காப்பு இயங்கும்; மூடியிருக்கும்போது அல்ல.',
+    frequencyBlocked:
+      'மேலே உள்ள படிகள் முடியும் வரை இந்த அட்டவணையில் எதுவும் காப்பு எடுக்கப்படாது.',
 
     networkSection: 'எதன் வழியாகக் காப்பு எடுக்க',
     networkWifi: 'Wi‑Fi மட்டும்',
@@ -9341,6 +9412,26 @@ const hi: UiStrings = {
       'आपका निजी "मैं" खाता, आपकी अपनी Google Drive पर कॉपी होता है और सिर्फ़ आपके पास मौजूद चाबी से बंद रहता है। इसे न Waves पढ़ सकता है, न Google।',
     unavailable: 'इस बिल्ड में बैकअप उपलब्ध नहीं है।',
 
+    statusChecking: 'देखा जा रहा है…',
+    statusOff: 'अभी बैकअप नहीं हो रहा',
+    statusReady: 'बैकअप के लिए तैयार',
+    statusOn: 'बैकअप हो गया',
+    statusSealed: 'आपकी चाबी से बंद',
+    stepsLeft: {
+      one: '{n} कदम बाकी',
+      other: '{n} कदम बाकी',
+    },
+
+    setupSection: 'सेटअप पूरा करें',
+    setupProgress: '{total} में से {done}',
+    stepDone: 'हो गया',
+    stepAccountTitle: 'अपनी Google Drive जोड़ें',
+    stepAccountBody: 'बैकअप आपकी अपनी Drive के एक निजी फ़ोल्डर में जाता है।',
+    stepKeyTitle: 'अपनी चाबी बनाएँ',
+    stepKeyBody: 'वे 64 अक्षर जो बैकअप को बंद करते हैं। Waves उन्हें कभी नहीं देखता।',
+    stepSaveTitle: 'अपनी चाबी सुरक्षित रखें',
+    stepSaveBody: 'इसे इस फ़ोन के अलावा कहीं लिख लीजिए। उसके बाद बैकअप शुरू हो सकते हैं।',
+
     accountSection: 'Google खाता',
     notConnected: 'अभी कोई खाता जुड़ा नहीं है',
     connect: 'Google Drive जोड़ें',
@@ -9359,8 +9450,8 @@ const hi: UiStrings = {
       other: '{n} रिकॉर्ड का बैकअप हो गया',
     },
     backupFailed: 'बैकअप पूरा नहीं हुआ। थोड़ी देर में फिर कोशिश करें।',
+    busy: 'एक पल…',
 
-    lastSection: 'पिछला बैकअप',
     never: 'अभी तक कोई बैकअप नहीं',
     lastLine: '{date} · {size}',
 
@@ -9370,6 +9461,7 @@ const hi: UiStrings = {
     freqWeekly: 'हफ़्ते में एक बार',
     freqMonthly: 'महीने में एक बार',
     frequencyNote: 'अपने आप बैकअप तब चलता है जब आप ऐप खोलते हैं, बंद रहने पर नहीं।',
+    frequencyBlocked: 'ऊपर के कदम पूरे होने तक इस समय-सारणी पर कुछ भी बैकअप नहीं होगा।',
 
     networkSection: 'किस पर बैकअप लें',
     networkWifi: 'सिर्फ़ Wi‑Fi',
@@ -11941,6 +12033,30 @@ const ar: UiStrings = {
       'دفترك الخاص في تبويب "أنا"، يُنسخ إلى Google Drive الخاص بك ويُقفل بمفتاح لا يملكه سواك. لا يستطيع Waves ولا Google قراءته.',
     unavailable: 'النسخ الاحتياطي غير متاح في هذه النسخة.',
 
+    statusChecking: 'يتحقق…',
+    statusOff: 'لا نسخ احتياطي بعد',
+    statusReady: 'جاهز للنسخ',
+    statusOn: 'تم النسخ',
+    statusSealed: 'مقفل بمفتاحك',
+    stepsLeft: {
+      zero: 'لم تبقَ خطوات',
+      one: 'بقيت خطوة واحدة',
+      two: 'بقيت خطوتان',
+      few: 'بقيت {n} خطوات',
+      many: 'بقيت {n} خطوة',
+      other: 'بقيت {n} خطوة',
+    },
+
+    setupSection: 'أكمل الإعداد',
+    setupProgress: '{done} من {total}',
+    stepDone: 'تم',
+    stepAccountTitle: 'اربط Google Drive الخاص بك',
+    stepAccountBody: 'تذهب النسخة إلى مجلد خاص داخل Drive الخاص بك.',
+    stepKeyTitle: 'أنشئ مفتاحك',
+    stepKeyBody: 'الـ 64 حرفًا التي تقفل النسخة. لا يراها Waves أبدًا.',
+    stepSaveTitle: 'احفظ مفتاحك',
+    stepSaveBody: 'اكتبه في مكان غير هذا الهاتف. عندها يبدأ النسخ الاحتياطي.',
+
     accountSection: 'حساب Google',
     notConnected: 'لم يُربط أي حساب بعد',
     connect: 'اربط Google Drive',
@@ -11963,8 +12079,8 @@ const ar: UiStrings = {
       other: 'نُسخ {n} سجل',
     },
     backupFailed: 'لم يكتمل النسخ. حاول بعد قليل.',
+    busy: 'لحظة…',
 
-    lastSection: 'آخر نسخة احتياطية',
     never: 'لم يحدث نسخ بعد',
     lastLine: '{date} · {size}',
 
@@ -11974,6 +12090,7 @@ const ar: UiStrings = {
     freqWeekly: 'أسبوعيًا',
     freqMonthly: 'شهريًا',
     frequencyNote: 'يعمل النسخ التلقائي عند فتحك للتطبيق، لا وهو مغلق.',
+    frequencyBlocked: 'لن يُنسخ شيء وفق هذا الجدول حتى تكتمل الخطوات أعلاه.',
 
     networkSection: 'النسخ عبر',
     networkWifi: 'Wi‑Fi فقط',

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1717,7 +1717,6 @@ export interface UiStrings {
     stepSaveBody: string;
 
     accountSection: string;
-    notConnected: string;
     connect: string;
     connectFailed: string;
     disconnect: string;
@@ -1754,7 +1753,9 @@ export interface UiStrings {
     keySection: string;
     keyIntro: string;
     keyPresent: string;
-    keyAbsent: string;
+    /** The keystore would not give the key back, or would not take one. */
+    keyUnreadable: string;
+    keySaveFailed: string;
     keyCreate: string;
     keyShow: string;
     keyEnter: string;
@@ -1780,6 +1781,10 @@ export interface UiStrings {
     restoreDone: PluralForms;
     restoreFailed: string;
     restoreWrongKey: string;
+    /** Why a restore is blocked when this phone holds no key. Emphatically
+     *  not "create one": a new key cannot open an old backup, and making
+     *  one would let the next run overwrite that backup. */
+    restoreNeedsKey: string;
 
     /** Why a run did nothing. Each one is a different way out. */
     refusedNotConnected: string;
@@ -4284,7 +4289,6 @@ const en: UiStrings = {
     stepSaveBody: 'Write it down somewhere that is not this phone. Then backups can start.',
 
     accountSection: 'Google account',
-    notConnected: 'No account linked yet',
     connect: 'Link Google Drive',
     connectFailed: 'Could not link that account. Try again.',
     disconnect: 'Unlink',
@@ -4322,7 +4326,8 @@ const en: UiStrings = {
     keyIntro:
       'The backup is locked with a 64-character key. Write it down: it is the only way to open the backup on a new phone, and nobody can give it back to you — not Waves, not Google.',
     keyPresent: 'This phone has your key',
-    keyAbsent: 'No key on this phone yet',
+    keyUnreadable: 'This phone could not read your key. Try again in a moment.',
+    keySaveFailed: 'That key could not be saved on this phone. Try again in a moment.',
     keyCreate: 'Create a key',
     keyShow: 'Show my key',
     keyEnter: 'I already have a key',
@@ -4354,6 +4359,8 @@ const en: UiStrings = {
     },
     restoreFailed: 'Could not read that backup. Try again in a moment.',
     restoreWrongKey: 'That key does not open this backup.',
+    restoreNeedsKey:
+      'Enter the key from the phone that made this backup. A new key will not open it.',
 
     refusedNotConnected: 'Link a Google account first.',
     refusedNoKey: 'Create your backup key first.',
@@ -6846,7 +6853,6 @@ const ta: UiStrings = {
       'இந்த ஃபோன் அல்லாத இடத்தில் எழுதி வையுங்கள். அதன் பிறகு காப்புப்பிரதிகள் தொடங்கும்.',
 
     accountSection: 'Google கணக்கு',
-    notConnected: 'எந்தக் கணக்கும் இணைக்கப்படவில்லை',
     connect: 'Google Drive-ஐ இணை',
     connectFailed: 'அந்தக் கணக்கை இணைக்க முடியவில்லை. மீண்டும் முயலுங்கள்.',
     disconnect: 'இணைப்பை நீக்கு',
@@ -6885,7 +6891,10 @@ const ta: UiStrings = {
     keyIntro:
       'காப்புப்பிரதி 64 எழுத்துச் சாவியால் பூட்டப்படுகிறது. அதை எழுதி வையுங்கள்: புதிய ஃபோனில் அதைத் திறக்க அதுவே ஒரே வழி. Waves-ஆலும் Google-ஆலும் அதைத் திரும்பத் தர முடியாது.',
     keyPresent: 'இந்த ஃபோனில் உங்கள் சாவி உள்ளது',
-    keyAbsent: 'இந்த ஃபோனில் இன்னும் சாவி இல்லை',
+    keyUnreadable:
+      'இந்த ஃபோனால் உங்கள் சாவியைப் படிக்க முடியவில்லை. சிறிது நேரம் கழித்து முயலுங்கள்.',
+    keySaveFailed:
+      'அந்தச் சாவியை இந்த ஃபோனில் சேமிக்க முடியவில்லை. சிறிது நேரம் கழித்து முயலுங்கள்.',
     keyCreate: 'சாவியை உருவாக்கு',
     keyShow: 'என் சாவியைக் காட்டு',
     keyEnter: 'என்னிடம் ஏற்கனவே சாவி உள்ளது',
@@ -6917,6 +6926,7 @@ const ta: UiStrings = {
     },
     restoreFailed: 'அந்தக் காப்பைப் படிக்க முடியவில்லை. சிறிது நேரம் கழித்து முயலுங்கள்.',
     restoreWrongKey: 'அந்தச் சாவி இந்தக் காப்பைத் திறக்காது.',
+    restoreNeedsKey: 'காப்பு எடுத்த ஃபோனின் சாவியை உள்ளிடுங்கள். புதிய சாவி அதைத் திறக்காது.',
 
     refusedNotConnected: 'முதலில் ஒரு Google கணக்கை இணையுங்கள்.',
     refusedNoKey: 'முதலில் உங்கள் காப்புச் சாவியை உருவாக்குங்கள்.',
@@ -9433,7 +9443,6 @@ const hi: UiStrings = {
     stepSaveBody: 'इसे इस फ़ोन के अलावा कहीं लिख लीजिए। उसके बाद बैकअप शुरू हो सकते हैं।',
 
     accountSection: 'Google खाता',
-    notConnected: 'अभी कोई खाता जुड़ा नहीं है',
     connect: 'Google Drive जोड़ें',
     connectFailed: 'वह खाता नहीं जुड़ सका। फिर कोशिश करें।',
     disconnect: 'हटाएँ',
@@ -9471,7 +9480,8 @@ const hi: UiStrings = {
     keyIntro:
       'बैकअप 64 अक्षरों की एक चाबी से बंद रहता है। उसे लिख लीजिए: नए फ़ोन पर बैकअप खोलने का यही एक रास्ता है, और उसे कोई लौटा नहीं सकता — न Waves, न Google।',
     keyPresent: 'इस फ़ोन पर आपकी चाबी है',
-    keyAbsent: 'इस फ़ोन पर अभी कोई चाबी नहीं',
+    keyUnreadable: 'यह फ़ोन आपकी चाबी नहीं पढ़ सका। थोड़ी देर में फिर कोशिश करें।',
+    keySaveFailed: 'वह चाबी इस फ़ोन पर सेव नहीं हो सकी। थोड़ी देर में फिर कोशिश करें।',
     keyCreate: 'चाबी बनाएँ',
     keyShow: 'मेरी चाबी दिखाएँ',
     keyEnter: 'मेरे पास पहले से चाबी है',
@@ -9503,6 +9513,7 @@ const hi: UiStrings = {
     },
     restoreFailed: 'वह बैकअप पढ़ा नहीं जा सका। थोड़ी देर में फिर कोशिश करें।',
     restoreWrongKey: 'यह चाबी इस बैकअप को नहीं खोलती।',
+    restoreNeedsKey: 'जिस फ़ोन ने यह बैकअप बनाया, उसी की चाबी डालें। नई चाबी इसे नहीं खोलेगी।',
 
     refusedNotConnected: 'पहले एक Google खाता जोड़ें।',
     refusedNoKey: 'पहले अपनी बैकअप चाबी बनाएँ।',
@@ -12058,7 +12069,6 @@ const ar: UiStrings = {
     stepSaveBody: 'اكتبه في مكان غير هذا الهاتف. عندها يبدأ النسخ الاحتياطي.',
 
     accountSection: 'حساب Google',
-    notConnected: 'لم يُربط أي حساب بعد',
     connect: 'اربط Google Drive',
     connectFailed: 'تعذّر ربط هذا الحساب. حاول مرة أخرى.',
     disconnect: 'إلغاء الربط',
@@ -12100,7 +12110,8 @@ const ar: UiStrings = {
     keyIntro:
       'تُقفل النسخة بمفتاح من 64 حرفًا. اكتبه في مكان آمن: هو الطريق الوحيد لفتح النسخة على هاتف جديد، ولا أحد يستطيع إعادته لك — لا Waves ولا Google.',
     keyPresent: 'هذا الهاتف يحمل مفتاحك',
-    keyAbsent: 'لا مفتاح على هذا الهاتف بعد',
+    keyUnreadable: 'تعذّر على هذا الهاتف قراءة مفتاحك. حاول بعد قليل.',
+    keySaveFailed: 'تعذّر حفظ هذا المفتاح على هذا الهاتف. حاول بعد قليل.',
     keyCreate: 'أنشئ مفتاحًا',
     keyShow: 'أظهر مفتاحي',
     keyEnter: 'لديّ مفتاح بالفعل',
@@ -12139,6 +12150,7 @@ const ar: UiStrings = {
     },
     restoreFailed: 'تعذّرت قراءة تلك النسخة. حاول بعد قليل.',
     restoreWrongKey: 'هذا المفتاح لا يفتح هذه النسخة.',
+    restoreNeedsKey: 'أدخل مفتاح الهاتف الذي أنشأ هذه النسخة. المفتاح الجديد لن يفتحها.',
 
     refusedNotConnected: 'اربط حساب Google أولًا.',
     refusedNoKey: 'أنشئ مفتاح النسخة أولًا.',

--- a/apps/mobile/src/lib/backup/setup.ts
+++ b/apps/mobile/src/lib/backup/setup.ts
@@ -1,0 +1,98 @@
+/**
+ * Which of the three things a backup needs is still missing, and which one the
+ * person should be handed a button for.
+ *
+ * A backup needs a linked Drive account, a key on this device, and — the one
+ * everybody forgets is a step — the person having actually kept a copy of that
+ * key. Until all three are true, `runBackup` refuses and the screen has nothing
+ * useful to offer except the step that is outstanding.
+ *
+ * The order is not cosmetic. Linking comes first because it is the only step
+ * that can fail for reasons outside the app (no Play services, a cancelled
+ * consent page), and finding that out after minting a key would leave a key on
+ * a phone with nowhere to send it. Saving the key comes last because it is the
+ * only step whose "done" is a claim by the person rather than a fact the app
+ * can check — `keySeen` is a promise, not a proof, and a promise is worth
+ * asking for only once there is something to promise about.
+ *
+ * This lives away from the screen so the branching can be tested without a
+ * renderer, which the mobile vitest setup deliberately does not have.
+ */
+
+/** The three things, in the order the screen asks for them. */
+export enum BackupStep {
+  /** A Google account linked, so there is somewhere to put the file. */
+  Account = 'account',
+  /** A key on this device, so there is something to seal it with. */
+  Key = 'key',
+  /** The key written down somewhere that is not this phone. */
+  SaveKey = 'save-key',
+}
+
+/** The steps, in order, always all three — a checklist hides nothing. */
+export const BACKUP_STEPS: readonly BackupStep[] = [
+  BackupStep.Account,
+  BackupStep.Key,
+  BackupStep.SaveKey,
+];
+
+/** What the hook knows that bears on whether a backup can run. */
+export interface BackupSetupInput {
+  /** False when this build carries no OAuth client id for the provider. */
+  readonly configured: boolean;
+  readonly connected: boolean;
+  readonly hasKey: boolean;
+  readonly keySeen: boolean;
+}
+
+export interface BackupSetupStep {
+  readonly step: BackupStep;
+  readonly done: boolean;
+}
+
+export interface BackupSetupState {
+  readonly steps: readonly BackupSetupStep[];
+  /**
+   * The first step not yet done — the only one the screen gives a button, so
+   * there is never a choice about what to tap next. Null when everything is
+   * done, and null when nothing can be done at all.
+   */
+  readonly outstanding: BackupStep | null;
+  readonly done: number;
+  readonly total: number;
+  /** True when a backup would actually run. Everything on screen keys off it. */
+  readonly complete: boolean;
+  /** No client id in this build: the steps are not the person's to take. */
+  readonly unavailable: boolean;
+}
+
+/**
+ * Read the four flags as a checklist.
+ *
+ * `SaveKey` is reported done only when there is a key to have saved. `keySeen`
+ * outliving its key is not reachable today — `acceptKey` sets both, and unlink
+ * clears both — but a checklist that could claim "key saved" over "no key on
+ * this phone" would be lying about the one thing this screen must not lie
+ * about, so the conjunction is written down rather than assumed.
+ */
+export function backupSetup(input: BackupSetupInput): BackupSetupState {
+  const steps: readonly BackupSetupStep[] = [
+    { step: BackupStep.Account, done: input.configured && input.connected },
+    { step: BackupStep.Key, done: input.hasKey },
+    { step: BackupStep.SaveKey, done: input.hasKey && input.keySeen },
+  ];
+  const done = steps.filter((entry) => entry.done).length;
+  const complete = input.configured && done === steps.length;
+  return {
+    steps,
+    outstanding: input.configured
+      ? (steps.find((entry) => !entry.done)?.step ?? null)
+      : // Nothing to point at: no tap on this screen changes a missing client
+        // id, so the screen says so once instead of offering a dead button.
+        null,
+    done,
+    total: steps.length,
+    complete,
+    unavailable: !input.configured,
+  };
+}

--- a/apps/mobile/src/lib/backup/setup.ts
+++ b/apps/mobile/src/lib/backup/setup.ts
@@ -4,8 +4,15 @@
  *
  * A backup needs a linked Drive account, a key on this device, and — the one
  * everybody forgets is a step — the person having actually kept a copy of that
- * key. Until all three are true, `runBackup` refuses and the screen has nothing
- * useful to offer except the step that is outstanding.
+ * key. Until all three are true the screen has nothing useful to offer except
+ * the step that is outstanding.
+ *
+ * Two of the three are the engine's own refusals: `runBackup` returns
+ * `not-connected` with no tokens and `no-key` with no key. The third is not.
+ * `engine.ts` never reads `keySeen` — that gate is enforced by the two callers
+ * instead, this screen and `AutoBackup.tsx`, because "have you written it
+ * down?" is a question about a person and the engine only knows about bytes.
+ * Which is exactly why it belongs on a checklist.
  *
  * The order is not cosmetic. Linking comes first because it is the only step
  * that can fail for reasons outside the app (no Play services, a cancelled
@@ -28,13 +35,6 @@ export enum BackupStep {
   /** The key written down somewhere that is not this phone. */
   SaveKey = 'save-key',
 }
-
-/** The steps, in order, always all three — a checklist hides nothing. */
-export const BACKUP_STEPS: readonly BackupStep[] = [
-  BackupStep.Account,
-  BackupStep.Key,
-  BackupStep.SaveKey,
-];
 
 /** What the hook knows that bears on whether a backup can run. */
 export interface BackupSetupInput {

--- a/apps/mobile/src/lib/backup/useBackup.ts
+++ b/apps/mobile/src/lib/backup/useBackup.ts
@@ -27,6 +27,7 @@ import { useSync } from '@/sync';
 
 import { providerFor } from '../cloud/providers';
 import { loadTokens, saveTokens } from '../cloud/tokens';
+import type { CloudTokens } from '../cloud/types';
 import type { SyncNetworkPreference } from '../syncNetwork';
 import {
   clearBackupState,
@@ -61,7 +62,11 @@ export type BackupOutcome =
   | { readonly kind: 'refused'; readonly refusal: BackupRefusal };
 
 export interface BackupState {
-  /** False while the stored settings and tokens are still being read. */
+  /**
+   * True only while the three local reads are in flight. Deliberately not the
+   * account-address lookup: nothing the screen decides may wait on a network
+   * call that has no timeout.
+   */
   readonly loading: boolean;
   readonly settings: BackupSettings;
   /** False when this build has no OAuth client id — everything else is inert. */
@@ -107,7 +112,15 @@ export function useBackup(): BackupState & BackupActions {
   const records = usePersonalRecords();
   const localIds = usePersonalRecordIds();
 
-  const [loading, setLoading] = useState(true);
+  /**
+   * Whose local reads have landed, rather than a boolean somebody has to
+   * remember to raise again. `loading` is then derived, so switching accounts
+   * re-arms it for free: the moment `ownerId` changes it stops matching, and
+   * the screen goes back to "Checking…" instead of showing the previous
+   * person's answers under the new person's name.
+   */
+  const [loadedFor, setLoadedFor] = useState<string | null>(null);
+  const loading = loadedFor !== ownerId;
   const [settings, setSettings] = useState<BackupSettings>(NO_BACKUP_SETTINGS);
   const [connected, setConnected] = useState(false);
   const [account, setAccount] = useState<string | null>(null);
@@ -118,21 +131,39 @@ export function useBackup(): BackupState & BackupActions {
   const provider = providerFor(PRIMARY_PROVIDER);
   const configured = provider.isConfigured();
 
-  const refreshAccount = useCallback(async (): Promise<void> => {
+  /**
+   * Whether an account is linked, from the tokens on disk. A local read and
+   * nothing else — no network — because this is the answer the screen decides
+   * its whole layout with.
+   */
+  const refreshLink = useCallback(async (): Promise<CloudTokens | null> => {
     const tokens = ownerId ? await loadTokens(PRIMARY_PROVIDER, ownerId) : null;
     setConnected(tokens !== null);
-    if (!tokens) {
-      setAccount(null);
-      return;
-    }
-    // Best effort, and quietly: the address is a nicety, and a failed lookup
-    // must not make a working link look broken.
-    setAccount(
-      await providerFor(PRIMARY_PROVIDER)
-        .account(tokens)
-        .catch(() => null),
-    );
+    if (!tokens) setAccount(null);
+    return tokens;
   }, [ownerId]);
+
+  /**
+   * Ask Drive whose account it is, and never wait for the answer.
+   *
+   * The address is a nicety — the screen falls back to the provider's own name
+   * — so nothing may be blocked on it. It used to be awaited inside the first
+   * load, which meant `loading` stayed true for the length of a Drive round
+   * trip; `lib/cloud/http` puts no timeout on `fetch` and Android's OkHttp
+   * defaults to none, so a socket that connects and never answers left the
+   * screen saying "Checking…" with no controls, indefinitely. Fired and
+   * forgotten, the worst it can now do is leave one line reading
+   * "Google Drive" instead of an address.
+   */
+  const fillAddress = useCallback((tokens: CloudTokens | null): void => {
+    if (!tokens) return;
+    void providerFor(PRIMARY_PROVIDER)
+      .account(tokens)
+      .then(
+        (address) => setAccount(address),
+        () => setAccount(null),
+      );
+  }, []);
 
   // Everything below is keyed by the signed-in account, so a sign-out or a
   // switch has to re-read rather than keep showing what the previous person
@@ -140,20 +171,26 @@ export function useBackup(): BackupState & BackupActions {
   useEffect(() => {
     let alive = true;
     void (async () => {
-      const [stored, key] = await Promise.all([
+      const [stored, key, tokens] = await Promise.all([
         loadBackupSettings(ownerId),
         ownerId ? loadRecoveryKey(ownerId) : Promise.resolve(null),
+        ownerId ? loadTokens(PRIMARY_PROVIDER, ownerId) : Promise.resolve(null),
       ]);
       if (!alive) return;
       setSettings(stored);
       setHasKey(key !== null);
-      await refreshAccount();
-      if (alive) setLoading(false);
+      setConnected(tokens !== null);
+      if (!tokens) setAccount(null);
+      // Three local reads, and the screen knows everything it decides with —
+      // in the same batch as the values, so there is no frame where the screen
+      // believes it has settled on somebody else's answers.
+      setLoadedFor(ownerId);
+      if (tokens) fillAddress(tokens);
     })();
     return () => {
       alive = false;
     };
-  }, [ownerId, refreshAccount]);
+  }, [ownerId, fillAddress]);
 
   const connect = useCallback(async (): Promise<boolean> => {
     if (!ownerId) return false;
@@ -162,9 +199,11 @@ export function useBackup(): BackupState & BackupActions {
     // the caller must not dress it as one.
     if (!tokens) return false;
     await saveTokens(PRIMARY_PROVIDER, ownerId, tokens);
-    await refreshAccount();
+    // The link is what the caller is waiting on; the address arrives when it
+    // arrives, so a slow Drive cannot hold the connect button down.
+    fillAddress(await refreshLink());
     return true;
-  }, [ownerId, provider, refreshAccount]);
+  }, [ownerId, provider, refreshLink, fillAddress]);
 
   const disconnect = useCallback(async (): Promise<void> => {
     if (!ownerId) return;
@@ -181,8 +220,8 @@ export function useBackup(): BackupState & BackupActions {
     setSettings(NO_BACKUP_SETTINGS);
     setHasKey(false);
     setOutcome(null);
-    await refreshAccount();
-  }, [ownerId, provider, refreshAccount]);
+    await refreshLink();
+  }, [ownerId, provider, refreshLink]);
 
   const backupNow = useCallback(async (): Promise<BackupOutcome> => {
     const key = ownerId ? await loadRecoveryKey(ownerId) : null;
@@ -207,7 +246,7 @@ export function useBackup(): BackupState & BackupActions {
         // A dead grant clears the tokens inside the engine; reflect that here so
         // the screen swaps to "Connect" instead of offering a retry that cannot
         // work.
-        if (result.refusal === 'auth') await refreshAccount();
+        if (result.refusal === 'auth') await refreshLink();
         return refused;
       }
       await saveLastBackup(ownerId, result.last);
@@ -218,7 +257,7 @@ export function useBackup(): BackupState & BackupActions {
     } finally {
       setPhase(null);
     }
-  }, [ownerId, records, settings.network, refreshAccount]);
+  }, [ownerId, records, settings.network, refreshLink]);
 
   const setFrequencyAction = useCallback(
     async (frequency: BackupFrequency): Promise<void> => {

--- a/apps/mobile/test/backupSetup.test.ts
+++ b/apps/mobile/test/backupSetup.test.ts
@@ -1,0 +1,82 @@
+/**
+ * The checklist behind the backup screen. What is worth pinning down is not
+ * the happy path but the three states that produced the "doesn't seem to work"
+ * report: a linked account with no key, a key nobody has confirmed keeping, and
+ * a build with no client id at all — where the screen must offer nothing rather
+ * than a button that cannot work.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { backupSetup, BackupStep } from '../src/lib/backup/setup';
+
+const setup = backupSetup;
+
+describe('nothing set up yet', () => {
+  it('points at the account first, because linking can fail on its own', () => {
+    const state = setup({ configured: true, connected: false, hasKey: false, keySeen: false });
+    expect(state.outstanding).toBe(BackupStep.Account);
+    expect(state.done).toBe(0);
+    expect(state.total).toBe(3);
+    expect(state.complete).toBe(false);
+  });
+});
+
+describe('linked, but no key — the state that was reported as broken', () => {
+  const state = setup({ configured: true, connected: true, hasKey: false, keySeen: false });
+
+  it('counts the link and points at the key', () => {
+    expect(state.done).toBe(1);
+    expect(state.outstanding).toBe(BackupStep.Key);
+  });
+
+  it('is not complete, so nothing on the screen may claim a backup will run', () => {
+    expect(state.complete).toBe(false);
+  });
+});
+
+describe('a key made and then dismissed without confirming', () => {
+  const state = setup({ configured: true, connected: true, hasKey: true, keySeen: false });
+
+  it('points at saving it, not at making another one', () => {
+    expect(state.outstanding).toBe(BackupStep.SaveKey);
+    expect(state.done).toBe(2);
+    expect(state.complete).toBe(false);
+  });
+});
+
+describe('all three done', () => {
+  const state = setup({ configured: true, connected: true, hasKey: true, keySeen: true });
+
+  it('has nothing outstanding and settles into an ordinary settings screen', () => {
+    expect(state.outstanding).toBeNull();
+    expect(state.done).toBe(3);
+    expect(state.complete).toBe(true);
+    expect(state.unavailable).toBe(false);
+  });
+});
+
+describe('a key-seen flag with no key behind it', () => {
+  it('never reports the key as saved — the screen must not claim what is gone', () => {
+    const state = setup({ configured: true, connected: true, hasKey: false, keySeen: true });
+    expect(state.steps.find((entry) => entry.step === BackupStep.SaveKey)?.done).toBe(false);
+    expect(state.outstanding).toBe(BackupStep.Key);
+  });
+});
+
+describe('a build with no OAuth client id', () => {
+  const state = setup({ configured: false, connected: false, hasKey: false, keySeen: false });
+
+  it('offers no step, because no tap here changes it', () => {
+    expect(state.unavailable).toBe(true);
+    expect(state.outstanding).toBeNull();
+    expect(state.complete).toBe(false);
+  });
+
+  it('does not credit a link that the build could not have made', () => {
+    const stale = setup({ configured: false, connected: true, hasKey: true, keySeen: true });
+    expect(stale.steps[0]?.done).toBe(false);
+    expect(stale.complete).toBe(false);
+    expect(stale.outstanding).toBeNull();
+  });
+});

--- a/apps/mobile/test/backupSetup.test.ts
+++ b/apps/mobile/test/backupSetup.test.ts
@@ -12,12 +12,41 @@ import { backupSetup, BackupStep } from '../src/lib/backup/setup';
 
 const setup = backupSetup;
 
+describe('the order of the steps', () => {
+  it('is account, then key, then saving it, whatever the flags say', () => {
+    // The order is the module's central claim — the reason it exists rather
+    // than the screen branching inline — so it is asserted directly, and on a
+    // state where the flags would not produce it by accident.
+    const state = setup({ configured: true, connected: false, hasKey: true, keySeen: true });
+    expect(state.steps.map((entry) => entry.step)).toEqual([
+      BackupStep.Account,
+      BackupStep.Key,
+      BackupStep.SaveKey,
+    ]);
+  });
+});
+
 describe('nothing set up yet', () => {
   it('points at the account first, because linking can fail on its own', () => {
     const state = setup({ configured: true, connected: false, hasKey: false, keySeen: false });
     expect(state.outstanding).toBe(BackupStep.Account);
     expect(state.done).toBe(0);
     expect(state.total).toBe(3);
+    expect(state.complete).toBe(false);
+  });
+});
+
+describe('a link that died under a key that did not', () => {
+  // Reachable on every `auth` refusal: the engine drops the dead tokens and
+  // `useBackup` re-reads, leaving a phone that still holds its key with nothing
+  // linked. Two of three done, and the outstanding one is the *first* gap, not
+  // the last — a checklist that walked forward from the count would point at
+  // the wrong step here.
+  const state = setup({ configured: true, connected: false, hasKey: true, keySeen: true });
+
+  it('counts two done but asks for the account again', () => {
+    expect(state.done).toBe(2);
+    expect(state.outstanding).toBe(BackupStep.Account);
     expect(state.complete).toBe(false);
   });
 });


### PR DESCRIPTION
## The diagnosis — confirmed, with one correction

The report was "this screen is confusing.. doesn't seem to work". Reading
`useBackup.ts`, `engine.ts`, `settings.ts` and `schedule.ts`, the premise holds:

`canBackUp = configured && connected && hasKey && settings.keySeen`. On the
device in the screenshots — Google linked, **no key on this phone**, never
backed up — that is false, so "Back up now" rendered `disabled`: a grey slab
with nothing on screen saying why. "Check for a backup" was disabled by the
same missing key, also silently. The only control that unblocked either was
"Create a key", a `size="sm"` secondary chip roughly two screens down, under a
section header reading "Your key" that gave no hint it gated everything above.

Three faults, all confirmed:

1. **A setup flow wearing a settings screen's clothes.** Until account + key
   exist, four of the six sections are inert, and all six are peers.
2. **Disabled controls never said why.** That is the whole "doesn't seem to
   work" — the app refusing without explaining.
3. **"Automatic backup: Daily" was a lie in that state.** The old file header
   explicitly named this trap ("a schedule with no key backs nothing up and the
   screen should not let somebody set one and walk away believing otherwise")
   and the layout walked into it anyway, because the key section sat below the
   fold while the schedule read as live.

**The one correction.** `DEFAULT_FREQUENCY` is `Off`, so a fresh install does
not ship a phantom schedule — the person in the screenshots had chosen Daily
themselves. Fault 3 is real but it is a *reachable* state rather than the
default. It is still worth fixing, because `AutoBackup.tsx` bails silently
(`if (!settings.keySeen) return;`) with nothing anywhere telling them.

**One thing genuinely broken rather than merely confusing.** `useBackup`'s
`loading` flag was ignored by the screen, and it stays true until
`refreshAccount()` finishes — which includes an HTTP call to Drive to fetch the
account address. On a slow network a fully set-up phone would open on the wrong
state and correct itself a second later. That was survivable when the wrong
state was a grey button; with a status card that says "Not backing up yet" in
the largest type on the screen, it is not. The card now has a fourth face
("Checking…", with a spinner in the badge) and the checklist does not render
until the state has settled.

## Mobbin research

Named references, and what each one decided:

- **WhatsApp — Chat backup** ([screen](https://mobbin.com/screens/3bd9f793-f41a-4e17-972b-3411e834b133)).
  The status card: a cloud mark, "Last backup: Today, 9:18 AM / Total size:
  1.8 MB / End-to-end encrypted", above everything else. This is the anchor
  the redesign is built on — including the little lock line, which is why
  "Locked with your key" now sits inside the card rather than three sections
  down as prose.
- **WhatsApp — Encrypted backup, "Turn on"**
  ([screen](https://mobbin.com/screens/4303125f-e9d0-4f29-bf53-4eb7c5c5c605)).
  WhatsApp makes the key a *flow with its own CTA*, not a settings row. That is
  the argument for the key becoming steps 2 and 3 with real buttons rather than
  a `size="sm"` chip.
- **Uber Eats — Account checkup**
  ([screen](https://mobbin.com/screens/8937f705-9d46-4236-824a-1bfd20145330)).
  The outstanding item expands *in place* with its own card and action; the
  satisfied ones collapse to one-line green-checked rows. This is exactly the
  "must not nag someone whose backups have run for a year" requirement, and it
  is the layout of the checklist here.
- **OKX — Security center**
  ([screen](https://mobbin.com/screens/41f1ac07-80a5-4b8f-98af-c7f4400159e1)).
  Every method carries its own state word inline ("Not enabled", "Not set up")
  — nothing is grey-and-silent. That is the rule this file now states in its
  header and obeys everywhere, including the reason line under a blocked
  "Check for a backup".
- **Binance — Security**
  ([screen](https://mobbin.com/screens/0d238516-b7b4-49d4-b41e-30a1360cf962)).
  An amber "Account At Risk" panel with the single unblocking button *inside*
  it, above the list. That is why the warning-toned status card and the CTA are
  one card and not two.
- **Chime — Finish setup**
  ([screen](https://mobbin.com/screens/5964d1f6-e082-4612-a968-568b09e2cc8a)),
  **Plum — Get set up**
  ([screen](https://mobbin.com/screens/bdf284fa-4681-4835-94b8-e7792e6ca25d)),
  **Shopify — Get ready to sell**
  ([screen](https://mobbin.com/screens/daf8849c-fc23-41e2-8088-35141f4972d0)).
  All three head their checklist with a count ("1 of 4", "4 of 5 Complete",
  "5 / 6 completed"). Hence the "Finish setting up · 1 of 3" line, and the
  three-state step mark (done tick / active numbered / pending outline) rather
  than a checkbox that cannot say which one is *yours to do now*.
- **Lex — You're on your way!**
  ([screen](https://mobbin.com/screens/fec5309b-bbd1-4b8d-ae01-e4aba0d80d8d)).
  Outstanding steps keep their border and weight; completed ones go grey and
  quiet. That is the tone difference between an active row and a done one here.
- **Revolut Business — Activate your account**
  ([screen](https://mobbin.com/screens/15bb35c9-44d8-4c5d-bdf0-a77a86307f62)).
  "Requires action" in amber under each title — a reason travelling with the
  row rather than living in a banner.
- **NordVPN — Threat Protection**
  ([screen](https://mobbin.com/screens/5be902c3-993a-4f98-a578-2be251ced17e)),
  for the state pill under the shield: one word settling whether the thing is
  on. Here it is the card's heading line.
- The key sheet was already close to the genre and mostly kept —
  **Finch "Your Encryption Key"**
  ([screen](https://mobbin.com/screens/5323c997-b144-42ed-95aa-f23f2af0acca))
  is literally a hex key in a mono block with a copy button, and
  **Phantom's "OK, I Saved It"**
  ([screen](https://mobbin.com/screens/fa3d1040-f206-4de4-b236-435f1760fd1e))
  is the confirm-seen affordance this already had. Left alone deliberately.

## The structure, and why

**One card at the top, always.** Badge + state line + detail, then a divider,
then *either* the checklist *or* "Back up now". Four faces: Checking… /
Not backing up yet / Ready to back up / Backed up. When set up it also carries
the lock line. That guarantees the two questions — "am I safe" and "what do I
tap" — are both answered above the fold, in that order, in every state.

**The checklist is three steps, in a defended order** (`lib/backup/setup.ts`):
link the account, create the key, save the key. Linking is first because it is
the only step that can fail for reasons outside the app, and finding that out
after minting a key leaves a key on a phone with nowhere to send it. Saving is
last because it is the only step whose "done" is a claim rather than a fact —
`keySeen` is a promise, not a proof.

**The account and key sections render only once they have stopped being steps.**
Otherwise the checklist and the section would offer the same two buttons at the
same time. Nothing is lost: while the account is unlinked there is nothing to
unlink; while there is no key there is nothing to show; and "I already have a
key" rides along with *both* key steps, because someone setting up a new phone
is at exactly one of those moments and typing their old key satisfies the step
and the one after it in a single tap.

**The intro paragraph moved below the card.** What to do outranks why on a
screen somebody arrived at with a problem — the same order WhatsApp uses.

**The schedule keeps its picker** and, when set to anything but Off while the
steps are unfinished, gains one warning line saying nothing will be backed up
on it yet. Not shown in a build with no OAuth client id, where "the steps
above" would point at nothing and the card already says why.

**Restore stayed last**, as requested, and its blocked state now carries the
reason ("Link a Google account first." / "Create your backup key first.") right
under the button — reusing the existing `refused*` strings rather than inventing
new ones. It keeps its disabled button rather than being replaced: the moment
somebody needs a restore is the moment they have nothing else, and it has to
stay findable even when it is not yet possible.

**Every existing capability is kept**: back up now + live phase line, last
backup + size (now the card's detail line), link/unlink Google with its
confirm popup, create key / show key / enter an existing key / copy /
confirm-seen, frequency, network preference, scan + restore with the preview
sheet. `t.backup.lastSection` ("Last backup") is the only string removed — the
status card's detail line is that row now — and it is gone from the type and
all four locale tables.

## i18n

17 new keys, added to the type block and all four locale tables (en/ta/hi/ar),
checked by eye since nested-key parity is not test-covered. Arabic `stepsLeft`
carries the full zero/one/two/few/many/other set the file uses elsewhere.

| key | en |
| --- | --- |
| `statusChecking` | Checking… |
| `statusOff` | Not backing up yet |
| `statusReady` | Ready to back up |
| `statusOn` | Backed up |
| `statusSealed` | Locked with your key |
| `stepsLeft` (plural) | {n} step(s) left |
| `setupSection` | Finish setting up |
| `setupProgress` | {done} of {total} |
| `stepDone` | Done |
| `stepAccountTitle` / `stepAccountBody` | Link your Google Drive / The backup goes to a private folder in your own Drive. |
| `stepKeyTitle` / `stepKeyBody` | Create your key / The 64 characters that lock the backup. Waves never sees them. |
| `stepSaveTitle` / `stepSaveBody` | Save your key / Write it down somewhere that is not this phone. Then backups can start. |
| `busy` | Just a moment… |
| `frequencyBlocked` | Nothing will be backed up on this schedule until the steps above are done. |

Removed: `lastSection`.

RTL: `Row`, `directionalIcon`, and `paddingStart` for the step-button indent —
no physical left/right anywhere new. Only `__DEV__` text stays hardcoded.
`useTabBarClearance()` unchanged; no `insets.bottom` added.

## Tests

`apps/mobile/test/backupSetup.test.ts` covers the pure step arithmetic: nothing
set up, linked-with-no-key (the reported state), a key made and dismissed
without confirming, all three done, a `keySeen` flag with no key behind it, and
a build with no client id where the checklist must offer nothing.

## Gates (Windows node)

- `pnpm format` → clean; `pnpm format:check` → **All matched files use Prettier code style!**
- `pnpm lint` → **all 12 projects Done** at `--max-warnings 0`
- `pnpm typecheck` → **all 12 projects Done**
- `pnpm test` → mobile **89 files / 1190 tests passed** (includes the new suite);
  core 957, api 63, web 53, admin 40, api-client 12, agent-mcp 25 — all passed.

`packages/db`'s suite needs a live local Postgres (`localhost:54330`), which
this worktree has no `packages/db/.env` for; it fails on connection setup
before any assertion and is untouched by this change. Everything else is green.

## Not done, deliberately

- **Not device-tested.** No emulator or handset in this session, and the flow
  needs a real Google consent sheet. The layout is argued from the primitives'
  measured sizes, not observed.
- **Left the `AutoBackup` silence alone.** An automatic run that skipped
  because `keySeen` is false still says nothing at the time; the status card is
  now the place that tells you, which was the design intent all along. A push
  or a badge would be a separate decision.
- **Left the key sheet as it was**, apart from being reachable from the
  checklist. It already matches the genre (mono block, copy, "I have saved it").
- **No `connectNoPlayServices` string.** The existing TODO in `connectFailure`
  is out of scope and untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned backup settings with a clear protection-status card and guided three-step setup checklist.
  - Added progress indicators for account linking, device-key creation, and key storage.
  - Added a “Back up now” action with live progress and outcome status after setup is complete.
  - Backup frequency now displays why scheduled backups are unavailable during incomplete setup.
  - Restore controls now show an explanatory reason when unavailable.
  - Added localized text for backup statuses and setup guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->