### PR TITLE
Stop asking people to write down a key before they can have a backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,14 +433,26 @@ Three decisions worth knowing:
   token was never issued for it. The file does not appear in their Drive either
   — Drive's storage settings are where they can see and delete it.
 
-- **The key is the user's, and only the user's.** The file is sealed with
-  XChaCha20-Poly1305 under a 256-bit key the app generates and shows once as 64
-  hexadecimal characters, the same `seal`/`open` the offline mirror uses. It is
-  kept in this device's keystore for convenience and typed in on a new phone.
-  Waves never sees it and Google holds only ciphertext, so **a lost key is a
-  lost backup** — the screen says that before it makes one. The reasoning, and
-  the two options rejected, are in the header of
-  `apps/mobile/src/lib/backup/recoveryKey.ts`.
+- **Two tiers, and the default asks for nothing.** The file is sealed with
+  XChaCha20-Poly1305 under a 256-bit key, the same `seal`/`open` the offline
+  mirror uses. What differs is where that key lives.
+
+  **Standard**, the default: the key is minted silently and a copy is written
+  into the _same hidden `appDataFolder` as the backup_, so signing into the same
+  Google account on a new phone finds both and restores with no ceremony. The
+  honest trade, which the screen states plainly rather than dressing up: whoever
+  reaches the Google account can read the backup.
+
+  **Extra protection**, opt-in: the key is shown once as 64 hexadecimal
+  characters, lives only in this device's keystore, and is never escrowed, so
+  Waves and Google are both locked out and **a lost key is a lost backup**. That
+  is what the previous build made everybody do before they could have a backup
+  at all, which is why it is now a choice instead of a toll-gate.
+
+  Upgrading re-seals the blob under a key Drive does not hold and only then
+  deletes the escrowed copy. There is no downgrade — the way back is to unlink
+  the account and link it again. The reasoning is in the headers of
+  `apps/mobile/src/lib/backup/tier.ts` and `recoveryKey.ts`.
 
 - **A restore only adds.** Records carry client-chosen ids that are already the
   idempotency key for `personal.upsert`, so a restore re-queues what this device
@@ -452,8 +464,10 @@ Three decisions worth knowing:
   last-backup preferences, and the remote filename all carry the owner id, and
   signing out wipes the departing account's set (`clearBackupState`, called from
   `clearLocalPrivateData`). The Drive file itself is left alone: it is the
-  user's, it is unreadable without their key, and outliving the app's state is
-  the whole point of it.
+  user's, and outliving the app's state is the whole point of it. On Extra
+  protection it is unreadable without the key the person kept; on Standard the
+  key is still in their Google account, which is what makes signing in on a new
+  phone enough.
 
 Drive needs **its own OAuth clients**, which the app does not otherwise have:
 sign-in goes through Supabase's hosted Google flow and holds no Google client id

--- a/apps/mobile/src/app/settings/backup.tsx
+++ b/apps/mobile/src/app/settings/backup.tsx
@@ -1,6 +1,30 @@
 /**
  * Backing the private "Me" ledger up to the person's own Google Drive.
  *
+ * TWO TIERS, AND WHICH ONE THIS SCREEN IS FOR. The first version of this screen
+ * had one tier and it was the wrong one: a 64-character key, shown once, that
+ * nothing worked without. That is WhatsApp's *advanced* option — its end-to-end
+ * encrypted backup, four taps down in settings — shipped as though it were the
+ * default. WhatsApp's actual default asks for no key at all, and so does ours
+ * now. On **Standard** the app mints a key, keeps a copy in the same hidden
+ * Drive folder as the backup, and never mentions it; linking the account is the
+ * whole of the setup. On **Extra protection**, opt-in, the key is shown once and
+ * lives only on this phone.
+ *
+ * We ship WhatsApp's advanced tier minus its password half. WhatsApp offers a
+ * password first and demotes the 64-digit key to a text link beneath it; a
+ * password is only safe behind a memory-hard KDF, which is a new crypto
+ * dependency and a tuning decision this app has deliberately not taken (see
+ * `recoveryKey.ts`). So our version of that screen has one primary button and
+ * no fork.
+ *
+ * WHERE THE TIER IS SAID, and where it is not. Following WhatsApp's chat-backup
+ * card, the tier is a padlocked line *inside the status card*, beside the date
+ * and the size — not a badge and not a section heading. And "Extra protection"
+ * is the last card on the screen, visually apart, reading Off or On with a
+ * one-line footnote: it is an upgrade, not a step, and it must not compete with
+ * "Back up now" for the attention of somebody whose backup is already working.
+ *
  * THE SHAPE, AND WHY IT CHANGED. This was WhatsApp's chat-backup screen — six
  * peer sections: back up now, account, key, schedule, network, restore. That
  * shape assumes the feature already works. It does not until three separate
@@ -16,6 +40,10 @@
  *
  * The anchor is the card at the top. It always answers "is this protected",
  * in the same place, in one line: still reading / not yet / ready / backed up.
+ * It is not updated optimistically: a run in progress replaces the *button*
+ * with its own progress line and leaves the status card saying what was last
+ * true, which is what WhatsApp does and what stops the screen claiming a backup
+ * that has not landed.
  * The other two things WhatsApp's chat-backup card carries — when the last one
  * landed, and that the lock is a key only this person holds — appear once
  * there is a truthful answer to give, which is once the setup is done; a
@@ -24,8 +52,10 @@
  * question somebody opened this screen with.
  *
  * Below the fold of that card the screen forks. **Until a backup can run**, the
- * card continues into a three-step checklist and the outstanding step — and
- * only that one — carries a button. Steps already taken collapse to a line with
+ * card continues into the checklist and the outstanding step — and only that
+ * one — carries a button. On Standard there is exactly one step, so it is not
+ * drawn as a checklist at all: no marks, no "1 of 1", just the button. A
+ * progress counter over a single item is scaffolding measuring itself. Steps already taken collapse to a line with
  * "Done" beside them; steps further out are dimmed and silent. That is Uber
  * Eats' account checkup, where the item needing attention expands in place with
  * its own action and the satisfied ones shrink to checked rows. **Once it can
@@ -50,7 +80,7 @@
  *    cannot back up at all, where the card has already said why and "the steps
  *    above" would point at nothing.
  * 5. Which networks.
- * 6. Restore, last: it is the half people need once, at the worst moment, and
+ * 6. Restore: it is the half people need once, at the worst moment, and
  *    burying it would be cruel — but putting it near "Back up now" invites the
  *    wrong tap. Its position is unchanged and deliberately so; what changed is
  *    that when it is blocked for want of a key it now says which key and
@@ -58,6 +88,11 @@
  *    a tap the checklist also offers, and it is worth it: the alternative was
  *    a person on a new phone reading "Create your backup key first", doing it,
  *    and having the next run overwrite the backup they came to recover.
+ * 7. Extra protection, last and set apart, exactly where WhatsApp puts its own
+ *    end-to-end row. Below Restore rather than above it, because the reason
+ *    Restore sits low — that it must not be next to "Back up now" — is
+ *    unaffected by what comes after it, and an upgrade offered before the way
+ *    back is offered would be the wrong order of business.
  *
  * THE RULE THE WHOLE FILE OBEYS, stated exactly. A control that *cannot* run
  * either carries its reason beside it or is not rendered at all, with the step
@@ -67,9 +102,13 @@
  * that takes. What is ruled out is the third case, which is what was here
  * before — a grey button, nothing running, and no reason anywhere on screen.
  *
- * The one promise this screen makes, and must keep: nothing legible leaves the
- * phone. What goes to Drive is a sealed blob; the key that opens it is shown to
- * the person and never sent anywhere.
+ * THE PROMISE, WHICH IS NOW TWO PROMISES, AND NEITHER MAY BE OVERSTATED. What
+ * goes to Drive is a sealed blob either way. On Extra protection the key that
+ * opens it is shown to the person and sent nowhere, and the screen says so. On
+ * Standard the key is in their Google account, which means whoever reaches that
+ * account can read the ledger — so the Standard copy says *that*, and does not
+ * borrow the sentence about Google not being able to read it. Getting this
+ * wrong is worse than any other mistake available on this screen.
  */
 
 import { useCallback, useState, type ReactNode } from 'react';
@@ -92,6 +131,7 @@ import {
   SectionHeader,
   Sheet,
   Text,
+  Toggle,
   useTabBarClearance,
   useTheme,
 } from '@waves/ui';
@@ -102,6 +142,7 @@ import { useBackup, type BackupOutcome } from '@/lib/backup/useBackup';
 import { BackupFrequency } from '@/lib/backup/schedule';
 import { formatRecoveryKey } from '@/lib/backup/recoveryKey';
 import { backupSetup, BackupStep } from '@/lib/backup/setup';
+import { BackupTier } from '@/lib/backup/tier';
 import type { RestoreScan } from '@/lib/backup/engine';
 import { CloudAuthError } from '@/lib/cloud/oauth';
 import { friendlyError } from '@/lib/errors';
@@ -118,6 +159,16 @@ const PROVIDER_LABEL = 'Google Drive';
 const STEP_MARK = 26;
 
 /**
+ * How tall the key sheet's scroller may get, in points and not a percentage.
+ *
+ * A percentage height resolves against a parent that has none — the sheet sizes
+ * itself to its content — so it collapses to nothing visible and quietly clips
+ * whatever was at the bottom. Here that would be the consent toggle and the
+ * button beside it, on the one sheet where the last control is the point.
+ */
+const KEY_SHEET_MAX_HEIGHT = 460;
+
+/**
  * Which action is in flight, rather than a bare `busy` flag.
  *
  * A screen-wide boolean greys every button at once and says nothing about any
@@ -127,7 +178,7 @@ const STEP_MARK = 26;
  * action lets the pressed button carry a spinner and read as *working*, while
  * the rest go quiet for a second or two beside something visibly running.
  */
-type PendingAction = 'connect' | 'disconnect' | 'key' | 'backup' | 'scan' | 'restore';
+type PendingAction = 'connect' | 'disconnect' | 'key' | 'backup' | 'scan' | 'restore' | 'extra';
 
 /**
  * The disc at the head of a checklist row: a tick once the step is taken, its
@@ -180,9 +231,43 @@ export default function BackupSettingsScreen() {
   const [typedKey, setTypedKey] = useState('');
   /** What went wrong with the key just typed — not a key, or the keystore. */
   const [typedProblem, setTypedProblem] = useState<string | null>(null);
+  /** "What is a backup key?", opened from inside the entry sheet. */
+  const [explaining, setExplaining] = useState(false);
   const [unlinking, setUnlinking] = useState(false);
   const [found, setFound] = useState<FoundBackup | null>(null);
   const [restored, setRestored] = useState<number | null>(null);
+  /** The Extra-protection pitch, before any key has been minted. */
+  const [pitching, setPitching] = useState(false);
+  /**
+   * True while the key on screen is one that has not been committed to
+   * anything. It is what makes the same sheet serve two jobs — "here is the key
+   * you already have" and "here is the key that is about to replace Drive's
+   * copy" — and the second one carries the consent gate and the button that
+   * actually does the work.
+   */
+  const [upgrading, setUpgrading] = useState(false);
+  /** Solflare's gate: the destructive button stays inert until this is on. */
+  const [understood, setUnderstood] = useState(false);
+  /**
+   * Set when a scan finds a backup this phone cannot open. Until then the
+   * restore card does not offer "I already have a key" on Standard, where
+   * nobody is expected to have one; after it, that button is the only way out.
+   */
+  const [needsOldKey, setNeedsOldKey] = useState(false);
+  /**
+   * A backup that was found and cannot be opened from here, with what it says
+   * about itself. Shown as a sheet of its own rather than as an error, because
+   * a person who asked "is there a backup" got a yes — what changes is what
+   * opening it takes, and that is a fork to offer, not a failure to report.
+   */
+  const [blocked, setBlocked] = useState<Extract<RestoreScan, { ok: false }> | null>(null);
+  /**
+   * Why the last scan came to nothing, said inside the restore card. The button
+   * that produced it is directly above, so the retry is where the answer is —
+   * "no backup found" is very often "not loaded yet", and a sentence stranded
+   * in the callout at the top of the screen leaves the retry a scroll away.
+   */
+  const [restoreNote, setRestoreNote] = useState<string | null>(null);
 
   const dateTime = useCallback(
     (at: number): string =>
@@ -202,6 +287,10 @@ export default function BackupSettingsScreen() {
         return t.backup.refusedNotConnected;
       case 'no-key':
         return t.backup.refusedNoKey;
+      case 'needs-key':
+        return t.backup.refusedNeedsKey;
+      case 'key-lost':
+        return t.backup.refusedKeyLost;
       case 'offline':
         return t.backup.refusedOffline;
       case 'network-policy':
@@ -282,12 +371,74 @@ export default function BackupSettingsScreen() {
     setError(null);
     try {
       setCopied(false);
+      setUpgrading(false);
       setShownKey(await backup.createKey());
     } catch (caught) {
       setError(friendlyError(caught, t.backup.keySaveFailed, 'backup.createKey'));
     } finally {
       setPending(null);
     }
+  };
+
+  /**
+   * Turn Extra protection on: mint the key, and show it.
+   *
+   * Nothing is committed here. The key exists on this screen and nowhere else
+   * until the person works the consent gate below it, which is deliberate —
+   * backing out of the sheet leaves the account exactly as it was, still
+   * Standard, still opening with the key Drive holds.
+   */
+  const onOfferExtra = (): void => {
+    setPitching(false);
+    setError(null);
+    setCopied(false);
+    setUnderstood(false);
+    setUpgrading(true);
+    setShownKey(backup.beginExtra());
+  };
+
+  /**
+   * Commit it: re-seal the backup under the new key, then take Drive's copy of
+   * the old one away — in that order, and never the other.
+   *
+   * The sheet stays open for the length of it, with the button wearing the
+   * spinner, because this is a Drive read and a Drive write and a Drive delete
+   * and closing over it would leave somebody looking at a screen that had not
+   * changed yet. It closes on success, and on failure it stays open carrying
+   * the reason, with the key still on it — which is the whole point of failing
+   * before the escrow is touched.
+   */
+  const onCommitExtra = async (): Promise<void> => {
+    if (!shownKey) return;
+    setPending('extra');
+    setError(null);
+    try {
+      const outcome = await backup.commitExtra(shownKey);
+      if (outcome.kind === 'refused') {
+        setError(refusalLine(outcome));
+        return;
+      }
+      setUpgrading(false);
+      setShownKey(null);
+    } catch (caught) {
+      setError(friendlyError(caught, t.backup.extraFailed, 'backup.upgrade'));
+    } finally {
+      setPending(null);
+    }
+  };
+
+  /**
+   * Put the key sheet away, and forget everything that only made sense while it
+   * was open. Refused outright mid-upgrade: the sheet is at that moment the
+   * only place the new key exists, and losing it between the re-seal and the
+   * escrow delete would leave the Drive file sealed under something nobody can
+   * read back.
+   */
+  const closeKeySheet = (): void => {
+    if (pending === 'extra') return;
+    setShownKey(null);
+    setUpgrading(false);
+    setUnderstood(false);
   };
 
   /**
@@ -304,6 +455,7 @@ export default function BackupSettingsScreen() {
     setError(null);
     try {
       setCopied(false);
+      setUpgrading(false);
       const key = await backup.revealKey();
       if (!key) {
         setError(t.backup.keyUnreadable);
@@ -320,6 +472,7 @@ export default function BackupSettingsScreen() {
   const onEnterKey = (): void => {
     setTypedKey('');
     setTypedProblem(null);
+    setExplaining(false);
     setEntering(true);
   };
 
@@ -338,6 +491,8 @@ export default function BackupSettingsScreen() {
       }
       setEntering(false);
       setTypedKey('');
+      setNeedsOldKey(false);
+      setBlocked(null);
     } catch (caught) {
       setTypedProblem(friendlyError(caught, t.backup.keySaveFailed, 'backup.acceptKey'));
     }
@@ -346,11 +501,24 @@ export default function BackupSettingsScreen() {
   const onCheckForBackup = async (): Promise<void> => {
     setPending('scan');
     setError(null);
+    setRestoreNote(null);
     setRestored(null);
     try {
       const result = await backup.scan();
-      if (result.ok) setFound(result);
-      else setError(refusalLine({ kind: 'refused', refusal: result.refusal }));
+      if (result.ok) {
+        setFound(result);
+        return;
+      }
+      // A backup that exists and needs something gets its own surface, with the
+      // date and the size it announced and the one button that would open it.
+      // Everything else — nothing there, no link, no connection — is a line
+      // under the button that would try again.
+      if (result.found) {
+        setBlocked(result);
+        if (result.refusal === 'needs-key') setNeedsOldKey(true);
+      } else {
+        setRestoreNote(refusalLine({ kind: 'refused', refusal: result.refusal }));
+      }
     } catch (caught) {
       // A key that does not open the file throws out of the AEAD. That is the
       // whole diagnosis and it is worth saying precisely; anything else is a
@@ -421,7 +589,14 @@ export default function BackupSettingsScreen() {
     connected: backup.connected,
     hasKey: backup.hasKey,
     keySeen: backup.settings.keySeen,
+    tier: backup.tier,
   });
+  const extra = backup.tier === BackupTier.Extra;
+  /**
+   * One step is not a checklist. On Standard the card carries the Link button
+   * on its own — no marks, no numbers, no "1 of 1" measuring itself.
+   */
+  const checklist = setup.total > 1;
   const last = backup.settings.last;
 
   /**
@@ -534,6 +709,12 @@ export default function BackupSettingsScreen() {
    * `settled` is consulted because these flags start false: without it the card
    * would say "Checking…" while this line flatly told a linked phone to link an
    * account.
+   *
+   * The no-key block now applies **only on Extra protection**. On Standard a
+   * phone that has never held a key is the ordinary case — a new phone, signed
+   * into the same Google account — and the key it needs is in the folder beside
+   * the backup. Blocking there would be the same mistake in a new costume:
+   * refusing the one action that was going to work.
    */
   const restoreReason = !settled
     ? t.backup.statusChecking
@@ -541,7 +722,7 @@ export default function BackupSettingsScreen() {
       ? t.backup.unavailable
       : !backup.connected
         ? t.backup.refusedNotConnected
-        : !backup.hasKey
+        : extra && !backup.hasKey
           ? t.backup.restoreNeedsKey
           : null;
 
@@ -615,8 +796,13 @@ export default function BackupSettingsScreen() {
               {settled && setup.complete ? (
                 <Row gap={theme.spacing.xs} style={{ marginTop: 2 }}>
                   <Ionicons name="lock-closed" size={iconSize.xs} color={theme.color.textFaint} />
+                  {/* Two padlocks, two different sentences. The Extra one is
+                      WhatsApp's "End-to-end encrypted"; the Standard one names
+                      where the key is kept, because a line that only said
+                      "locked" would let somebody read the stronger promise into
+                      it. */}
                   <Text variant="micro" tone="faint">
-                    {t.backup.statusSealed}
+                    {extra ? t.backup.statusSealedExtra : t.backup.statusSealedStandard}
                   </Text>
                 </Row>
               ) : null}
@@ -673,63 +859,83 @@ export default function BackupSettingsScreen() {
             <>
               <Divider />
               <View style={{ gap: theme.spacing.lg }}>
-                <Row style={{ justifyContent: 'space-between' }}>
-                  <Text variant="micro" tone="faint">
-                    {t.backup.setupSection}
-                  </Text>
-                  <Text variant="micro" tone="faint">
-                    {t.backup.setupProgress
-                      .replace('{done}', String(setup.done))
-                      .replace('{total}', String(setup.total))}
-                  </Text>
-                </Row>
-                {setup.steps.map(({ step, done }, index) => {
-                  const active = setup.outstanding === step;
-                  const copy = stepCopy[step];
-                  return (
-                    <View key={step} style={{ gap: theme.spacing.md }}>
-                      <Row gap={theme.spacing.md} style={{ alignItems: 'flex-start' }}>
-                        <StepMark number={index + 1} done={done} active={active} />
-                        <View style={{ flex: 1, gap: 2 }}>
-                          <Text variant="subheading" tone={active ? 'default' : 'muted'}>
-                            {copy.title}
-                          </Text>
-                          {active ? (
-                            <Text variant="caption" tone="muted">
-                              {copy.body}
+                {/* A one-item list gets no heading and no counter: on Standard
+                    the only thing outstanding is linking the account, and a
+                    progress bar over it would be scaffolding measuring itself.
+                    Its copy still comes from the step, so the single button
+                    carries the same sentence it would have on a list. */}
+                {checklist ? (
+                  <Row style={{ justifyContent: 'space-between' }}>
+                    <Text variant="micro" tone="faint">
+                      {t.backup.setupSection}
+                    </Text>
+                    <Text variant="micro" tone="faint">
+                      {t.backup.setupProgress
+                        .replace('{done}', String(setup.done))
+                        .replace('{total}', String(setup.total))}
+                    </Text>
+                  </Row>
+                ) : null}
+                {!checklist && setup.outstanding ? (
+                  <View style={{ gap: theme.spacing.md }}>
+                    <View style={{ gap: 2 }}>
+                      <Text variant="subheading">{stepCopy[setup.outstanding].title}</Text>
+                      <Text variant="caption" tone="muted">
+                        {stepCopy[setup.outstanding].body}
+                      </Text>
+                    </View>
+                    {stepActions(setup.outstanding)}
+                  </View>
+                ) : null}
+                {checklist &&
+                  setup.steps.map(({ step, done }, index) => {
+                    const active = setup.outstanding === step;
+                    const copy = stepCopy[step];
+                    return (
+                      <View key={step} style={{ gap: theme.spacing.md }}>
+                        <Row gap={theme.spacing.md} style={{ alignItems: 'flex-start' }}>
+                          <StepMark number={index + 1} done={done} active={active} />
+                          <View style={{ flex: 1, gap: 2 }}>
+                            <Text variant="subheading" tone={active ? 'default' : 'muted'}>
+                              {copy.title}
+                            </Text>
+                            {active ? (
+                              <Text variant="caption" tone="muted">
+                                {copy.body}
+                              </Text>
+                            ) : null}
+                          </View>
+                          {done ? (
+                            <Text variant="micro" tone="positive">
+                              {t.backup.stepDone}
                             </Text>
                           ) : null}
-                        </View>
-                        {done ? (
-                          <Text variant="micro" tone="positive">
-                            {t.backup.stepDone}
-                          </Text>
+                        </Row>
+                        {active ? (
+                          // Hung under the row's text rather than the mark, so the
+                          // button reads as belonging to this step and not to the
+                          // list. `paddingStart` so it hangs off the right edge in
+                          // Arabic.
+                          <View
+                            style={{
+                              paddingStart: STEP_MARK + theme.spacing.md,
+                              gap: theme.spacing.sm,
+                            }}
+                          >
+                            {stepActions(step)}
+                          </View>
                         ) : null}
-                      </Row>
-                      {active ? (
-                        // Hung under the row's text rather than the mark, so the
-                        // button reads as belonging to this step and not to the
-                        // list. `paddingStart` so it hangs off the right edge in
-                        // Arabic.
-                        <View
-                          style={{
-                            paddingStart: STEP_MARK + theme.spacing.md,
-                            gap: theme.spacing.sm,
-                          }}
-                        >
-                          {stepActions(step)}
-                        </View>
-                      ) : null}
-                    </View>
-                  );
-                })}
+                      </View>
+                    );
+                  })}
               </View>
             </>
           ) : null}
         </Card>
 
+        {/* The promise, in whichever of its two forms is true. */}
         <Text variant="body" tone="muted">
-          {t.backup.intro}
+          {extra ? t.backup.introExtra : t.backup.introStandard}
         </Text>
 
         {/* Which Google account. Rendered whenever one is linked *and* the
@@ -761,13 +967,17 @@ export default function BackupSettingsScreen() {
           </View>
         ) : null}
 
-        {/* The key. Rendered whenever this phone holds one and the checklist is
-            not itself asking to be shown it. Gating this on `setup.complete`
-            was wrong: `configured` is a runtime conjunction (a client id *and*
-            the native Google module), so a build that loses either would hide
-            the only way to read back a key already on the device — and the
-            Drive file it opens would then be unrecoverable. */}
-        {backup.hasKey && setup.outstanding !== BackupStep.SaveKey ? (
+        {/* The key. Extra protection only — on Standard this phone holds a key
+            too, minted on the first run, but showing it would put back the
+            ceremony the tier exists to remove and would invite somebody to
+            treat a key Google also has as the thing keeping them safe.
+            Otherwise unchanged: rendered whenever this phone holds one and the
+            checklist is not itself asking to be shown it. Gating this on
+            `setup.complete` was wrong — `configured` is a runtime conjunction
+            (a client id *and* the native Google module), so a build that loses
+            either would hide the only way to read back a key already on the
+            device, and the Drive file it opens would then be unrecoverable. */}
+        {extra && backup.hasKey && setup.outstanding !== BackupStep.SaveKey ? (
           <View style={{ gap: theme.spacing.sm }}>
             <SectionHeader title={t.backup.keySection} />
             <Card style={{ gap: theme.spacing.md }}>
@@ -914,11 +1124,27 @@ export default function BackupSettingsScreen() {
               <Text variant="micro" tone="faint" align="center">
                 {restoreReason}
               </Text>
+            ) : restoreNote ? (
+              // Where the last look ended up, under the button that would look
+              // again. "There is no backup on this Drive account yet" is often
+              // a slow folder rather than an empty one.
+              <Text variant="micro" tone="muted" align="center">
+                {restoreNote}
+              </Text>
             ) : null}
             {/* The way out of the one blocked state that has one, right here,
                 so nobody has to go looking for it in the checklist — where the
-                other button is the one that would cost them the backup. */}
-            {settled && backup.configured && backup.connected && !backup.hasKey ? (
+                other button is the one that would cost them the backup.
+                On Standard it appears only once a scan has actually found a
+                backup this phone cannot open: offering "I already have a key"
+                to somebody who was never given one is a question with no
+                answer, and it would quietly undercut the tier's promise that
+                nothing has to be kept. */}
+            {settled &&
+            backup.configured &&
+            backup.connected &&
+            !backup.hasKey &&
+            (extra || needsOldKey) ? (
               <Button
                 label={t.backup.keyEnter}
                 variant="secondary"
@@ -929,16 +1155,72 @@ export default function BackupSettingsScreen() {
             ) : null}
           </Card>
         </View>
+
+        {/* Extra protection: the opt-in tier, last on the screen and set apart,
+            where WhatsApp puts its end-to-end row. One line saying Off or On,
+            one footnote, and a door — never a tap that does the thing. */}
+        {settled && !setup.unavailable ? (
+          <View style={{ gap: theme.spacing.sm }}>
+            <SectionHeader title={t.backup.extraSection} />
+            <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+              <ListRow
+                title={t.backup.extraSection}
+                // Both states open something. "On" opens the sheet that says
+                // what it means and why there is no switch back; a row that
+                // read "On" and did nothing would be the disabled-and-silent
+                // control this screen was rebuilt to get rid of.
+                onPress={() => setPitching(true)}
+                accessibilityLabel={`${t.backup.extraSection}, ${
+                  extra ? t.backup.extraOn : t.backup.extraOff
+                }`}
+                leading={
+                  <Ionicons
+                    name={extra ? 'shield-checkmark' : 'shield-outline'}
+                    size={iconSize.xl}
+                    color={extra ? theme.color.positive : theme.color.text}
+                  />
+                }
+                trailing={
+                  <Row gap={theme.spacing.xs}>
+                    <Text variant="body" tone="muted">
+                      {extra ? t.backup.extraOn : t.backup.extraOff}
+                    </Text>
+                    <Ionicons
+                      name={directionalIcon('chevron-forward')}
+                      size={iconSize.md}
+                      color={theme.color.textFaint}
+                    />
+                  </Row>
+                }
+              />
+            </Card>
+            <Text variant="micro" tone="faint">
+              {extra ? t.backup.extraFootnoteOn : t.backup.extraFootnoteOff}
+            </Text>
+          </View>
+        ) : null}
       </ScrollView>
 
-      {/* The key, shown once — or again, on request. */}
-      <Sheet
-        visible={shownKey !== null}
-        onClose={() => setShownKey(null)}
-        closeLabel={t.common.close}
-      >
-        <View style={{ gap: theme.spacing.md }}>
-          <Text variant="heading">{t.backup.keyTitle}</Text>
+      {/* The key: shown once on the way into Extra protection, or again later
+          on request. One sheet, two jobs — and the upgrade job is the one that
+          carries the consent gate, because the tap after it deletes Drive's
+          copy of the old key. */}
+      <Sheet visible={shownKey !== null} onClose={closeKeySheet} closeLabel={t.common.close}>
+        {/* A definite `maxHeight` in points and `flexGrow: 0`, per the Sheet's
+            own contract: a percentage against a parent that has no height of
+            its own silently clips the last control off the bottom, which here
+            would be the button that finishes the upgrade. */}
+        <ScrollView
+          style={{ flexGrow: 0, maxHeight: KEY_SHEET_MAX_HEIGHT }}
+          contentContainerStyle={{ gap: theme.spacing.md }}
+          showsVerticalScrollIndicator={false}
+        >
+          <Text variant="heading">{upgrading ? t.backup.extraKeyTitle : t.backup.keyTitle}</Text>
+          {upgrading ? (
+            <Text variant="body" tone="muted">
+              {t.backup.extraKeyBody}
+            </Text>
+          ) : null}
           <Card flat style={{ backgroundColor: theme.color.surfaceMuted }}>
             <Text
               variant="body"
@@ -950,9 +1232,41 @@ export default function BackupSettingsScreen() {
               {shownKey ? formatRecoveryKey(shownKey) : ''}
             </Text>
           </Card>
-          <Callout tone="warning">{t.backup.keyWarning}</Callout>
-          <Row style={{ gap: theme.spacing.sm }}>
-            <View style={{ flex: 1 }}>
+          {/* WhatsApp's warning card, and deliberately not a red one: black on
+              the ordinary surface, bordered, with a triangle as the only alarm
+              signal. Red is reserved on this screen for something that has
+              already gone wrong — using it here would spend the same colour on
+              a consequence that has not happened and may never. */}
+          <Card
+            flat
+            style={{
+              borderWidth: 1,
+              borderColor: theme.color.border,
+              gap: theme.spacing.sm,
+              alignItems: 'center',
+            }}
+          >
+            <Ionicons name="warning-outline" size={iconSize.xxl} color={theme.color.text} />
+            <Text variant="caption" align="center">
+              {t.backup.keyWarning}
+            </Text>
+          </Card>
+          {/* Uniswap names the account it is about to strand and shows its
+              balance. The equivalent here is how much ledger is going behind
+              this key — an abstraction ("your backup") is easy to shrug at, a
+              number is not. */}
+          {upgrading ? (
+            <Text variant="micro" tone="muted" align="center">
+              {plural(
+                locale,
+                backup.settings.last?.records ?? backup.recordCount,
+                t.backup.extraCovers,
+              )}
+            </Text>
+          ) : null}
+
+          {upgrading ? (
+            <>
               <Button
                 label={copied ? t.backup.keyCopied : t.backup.keyCopy}
                 variant="secondary"
@@ -961,20 +1275,104 @@ export default function BackupSettingsScreen() {
                   void Clipboard.setStringAsync(formatRecoveryKey(shownKey));
                   setCopied(true);
                 }}
+                disabled={pending === 'extra'}
                 fullWidth
               />
-            </View>
-            <View style={{ flex: 1 }}>
+              {/* Solflare's gate. A confirm button on its own is answered
+                  reflexively, and what follows this one cannot be undone: the
+                  escrowed key leaves Drive and the old backup is re-locked.
+                  The sentence is Uniswap's shape — an assertion in the past
+                  tense, and a consequence that names who cannot help. */}
+              <Row gap={theme.spacing.md} style={{ alignItems: 'flex-start' }}>
+                <Text variant="caption" style={{ flex: 1 }}>
+                  {t.backup.extraConsent}
+                </Text>
+                <Toggle
+                  value={understood}
+                  onValueChange={setUnderstood}
+                  disabled={pending === 'extra'}
+                  accessibilityLabel={t.backup.extraConsent}
+                />
+              </Row>
               <Button
-                label={t.backup.keyConfirm}
-                onPress={() => {
-                  void backup.confirmKeySeen();
-                  setShownKey(null);
-                }}
+                label={t.backup.extraTurnOn}
+                onPress={() => void onCommitExtra()}
+                // The reason it will not press is the row directly above it,
+                // which is the whole of Solflare's answer to "no control is
+                // disabled and silent": the gate is the explanation.
+                disabled={!understood || pending === 'extra'}
+                icon={pending === 'extra' ? spinner(true) : undefined}
                 fullWidth
               />
-            </View>
-          </Row>
+              {pending === 'extra' ? (
+                <Text variant="micro" tone="muted" align="center">
+                  {t.backup.extraTurningOn}
+                </Text>
+              ) : null}
+            </>
+          ) : (
+            <Row style={{ gap: theme.spacing.sm }}>
+              <View style={{ flex: 1 }}>
+                <Button
+                  label={copied ? t.backup.keyCopied : t.backup.keyCopy}
+                  variant="secondary"
+                  onPress={() => {
+                    if (!shownKey) return;
+                    void Clipboard.setStringAsync(formatRecoveryKey(shownKey));
+                    setCopied(true);
+                  }}
+                  fullWidth
+                />
+              </View>
+              <View style={{ flex: 1 }}>
+                <Button
+                  label={t.backup.keyConfirm}
+                  onPress={() => {
+                    void backup.confirmKeySeen();
+                    setShownKey(null);
+                  }}
+                  fullWidth
+                />
+              </View>
+            </Row>
+          )}
+        </ScrollView>
+      </Sheet>
+
+      {/* Extra protection, explained — the pitch when it is off, and what it
+          means when it is on. WhatsApp's equivalent screen carries no warning
+          at all: benefit, then mechanism, then who is locked out, then one
+          button. The warning belongs on the *next* screen, next to the key,
+          which is where ours is. */}
+      <Sheet visible={pitching} onClose={() => setPitching(false)} closeLabel={t.common.close}>
+        <View style={{ gap: theme.spacing.md }}>
+          <Text variant="heading">{extra ? t.backup.extraOnTitle : t.backup.extraPitchTitle}</Text>
+          {extra ? (
+            <>
+              <Text variant="body" tone="muted">
+                {t.backup.extraOnBody}
+              </Text>
+              {/* Said here rather than left to be discovered: there is no
+                  switch back, and the route that does exist is a different
+                  control on this screen. See the file header on why. */}
+              <Text variant="body" tone="muted">
+                {t.backup.extraNoWayBack}
+              </Text>
+            </>
+          ) : (
+            <>
+              <Text variant="body" tone="muted">
+                {t.backup.extraPitchBenefit}
+              </Text>
+              <Text variant="body" tone="muted">
+                {t.backup.extraPitchMechanism}
+              </Text>
+              <Text variant="body" tone="muted">
+                {t.backup.extraPitchAdversary}
+              </Text>
+              <Button label={t.backup.extraTurnOn} onPress={onOfferExtra} fullWidth />
+            </>
+          )}
         </View>
       </Sheet>
 
@@ -985,7 +1383,7 @@ export default function BackupSettingsScreen() {
           <Text variant="micro" tone="muted">
             {t.backup.keyEnterBody}
           </Text>
-          <Card flat style={{ backgroundColor: theme.color.surfaceMuted }}>
+          <Card flat style={{ backgroundColor: theme.color.surfaceMuted, gap: theme.spacing.sm }}>
             <TextInput
               value={typedKey}
               onChangeText={(value) => {
@@ -1009,9 +1407,46 @@ export default function BackupSettingsScreen() {
                 writingDirection: 'ltr',
               }}
             />
+            {/* The three things a long-string field owes the person typing into
+                it: somewhere to paste from, what the right answer looks like,
+                and a way to ask what is even being asked for. A 64-character
+                key is not typed by hand if there is any alternative. */}
+            <Row style={{ justifyContent: 'flex-end' }}>
+              <Button
+                label={t.backup.keyEnterPaste}
+                variant="ghost"
+                size="sm"
+                onPress={() => {
+                  void (async () => {
+                    const clip = await Clipboard.getStringAsync().catch(() => '');
+                    if (!clip) return;
+                    setTypedKey(clip);
+                    setTypedProblem(null);
+                  })();
+                }}
+              />
+            </Row>
           </Card>
+          <Text variant="micro" tone="faint">
+            {t.backup.keyEnterHint}
+          </Text>
           {typedProblem ? <Callout tone="negative">{typedProblem}</Callout> : null}
           <Button label={t.backup.keyEnterSave} onPress={() => void onAcceptKey()} fullWidth />
+          {/* The escape hatch for somebody who does not recognise the question.
+              A door rather than a paragraph: most people typing here know
+              exactly what they are holding. */}
+          <Button
+            label={explaining ? t.common.close : t.backup.keyEnterWhat}
+            variant="ghost"
+            size="sm"
+            onPress={() => setExplaining((open) => !open)}
+            fullWidth
+          />
+          {explaining ? (
+            <Text variant="micro" tone="muted">
+              {t.backup.keyEnterWhatBody}
+            </Text>
+          ) : null}
         </View>
       </Sheet>
 
@@ -1021,11 +1456,15 @@ export default function BackupSettingsScreen() {
           <Text variant="heading">{t.backup.restoreSection}</Text>
           {found ? (
             <>
+              {/* Date and size, the two things WhatsApp's restore card shows,
+                  plus the one nobody in the field shows and a ledger badly
+                  needs: how much of it is actually coming back. */}
               <Text variant="micro" tone="muted">
                 {t.backup.restoreFrom.replace(
                   '{date}',
                   found.body.createdAt ? dateTime(Date.parse(found.body.createdAt)) : '—',
                 )}
+                {found.size > 0 ? ` · ${formatBytes(found.size, locale)}` : ''}
               </Text>
               <Text variant="body">
                 {found.plan.restore.length === 0
@@ -1046,11 +1485,57 @@ export default function BackupSettingsScreen() {
         </View>
       </Sheet>
 
+      {/* A backup that is there and will not open from this phone.
+          Deliberately not an error: the question asked was "is there a backup",
+          and the answer is yes. What the sheet adds is which kind it is and
+          what opening it takes — the fork before the attempt, which is how
+          every restore flow worth copying does it, rather than a wall somebody
+          walks into halfway through. */}
+      <Sheet
+        visible={blocked !== null}
+        onClose={() => setBlocked(null)}
+        closeLabel={t.common.close}
+      >
+        <View style={{ gap: theme.spacing.md }}>
+          <Text variant="heading">{t.backup.restoreFoundTitle}</Text>
+          {blocked?.found ? (
+            <Text variant="micro" tone="muted">
+              {t.backup.restoreFrom.replace(
+                '{date}',
+                blocked.found.createdAt ? dateTime(Date.parse(blocked.found.createdAt)) : '—',
+              )}
+              {blocked.found.size > 0 ? ` · ${formatBytes(blocked.found.size, locale)}` : ''}
+            </Text>
+          ) : null}
+          <Text variant="body">
+            {blocked?.refusal === 'needs-key' ? t.backup.restoreIsExtra : t.backup.refusedKeyLost}
+          </Text>
+          {blocked?.refusal === 'needs-key' ? (
+            // The key path *is* the primary here, because on this file it is
+            // the only path. The one button this sheet must never carry is
+            // "create a key": a new one does not open this backup, and making
+            // one arms a run that would overwrite it.
+            <Button
+              label={t.backup.keyEnter}
+              onPress={() => {
+                setBlocked(null);
+                onEnterKey();
+              }}
+              fullWidth
+            />
+          ) : null}
+        </View>
+      </Sheet>
+
       <Popup visible={unlinking} onClose={() => setUnlinking(false)} closeLabel={t.common.close}>
         <View style={{ gap: theme.spacing.md }}>
           <Text variant="heading">{t.backup.disconnectTitle}</Text>
+          {/* What unlinking costs is different in each tier, and neither
+              sentence would be true of the other. On Standard the key goes with
+              the account, which is also why relinking is the honest way back to
+              Standard from Extra — see the file header. */}
           <Text variant="body" tone="muted">
-            {t.backup.disconnectBody}
+            {extra ? t.backup.disconnectBodyExtra : t.backup.disconnectBodyStandard}
           </Text>
           <Row style={{ gap: theme.spacing.sm }}>
             <View style={{ flex: 1 }}>

--- a/apps/mobile/src/components/SignOutSheet.tsx
+++ b/apps/mobile/src/components/SignOutSheet.tsx
@@ -62,6 +62,7 @@ import { Button, Callout, iconSize, Row, Sheet, Text, useTheme } from '@waves/ui
 import { plural, useStrings } from '@/i18n';
 import { loadRecoveryKey } from '@/lib/backup/recoveryKey';
 import { loadBackupSettings } from '@/lib/backup/settings';
+import { BackupTier, resolveTier } from '@/lib/backup/tier';
 import { useAuth } from '@/lib/auth';
 import { saveDeviceCopy } from '@/lib/deviceCopy';
 import { friendlyError } from '@/lib/errors';
@@ -185,6 +186,15 @@ function useDeviceDrafts(visible: boolean): readonly DeviceDraft[] {
  * this keystore, which sign-out clears (`clearBackupState`). Once somebody has
  * written it down there is nothing here to warn about — the file on Drive
  * outlives the app either way.
+ *
+ * **And only on Extra protection.** Standard mints a key on its first run too
+ * and never shows it, because Drive holds a copy beside the backup — so on
+ * Standard there is nothing to have written down, `keySeen` is never set, and
+ * asking about the key alone made this warn *every* Standard user, at every
+ * sign-out, that their backup was about to become unopenable. It was not: the
+ * key is in the Google account they are still signed into, which the same
+ * sheet's own disconnect copy says. It also sent them looking for a control
+ * that does not exist on Standard.
  */
 function useUnconfirmedBackupKey(visible: boolean, ownerId: string): boolean {
   const [atRisk, setAtRisk] = useState(false);
@@ -196,7 +206,8 @@ function useUnconfirmedBackupKey(visible: boolean, ownerId: string): boolean {
         loadRecoveryKey(ownerId),
         loadBackupSettings(ownerId),
       ]);
-      if (alive) setAtRisk(key !== null && !settings.keySeen);
+      const tier = resolveTier(settings.tier, key !== null, settings.keySeen);
+      if (alive) setAtRisk(tier === BackupTier.Extra && key !== null && !settings.keySeen);
     })().catch((error: unknown) => reportHandled(error, 'signOut.backupKey'));
     return () => {
       alive = false;

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1687,8 +1687,11 @@ export interface UiStrings {
     title: string;
     /** The settings-row label. */
     row: string;
-    /** The promise the screen leads with. */
-    intro: string;
+    /** The promise the screen leads with, in whichever form is true. The
+     *  Standard one must not borrow the Extra one's claim about Google: on
+     *  Standard the key is in the Google account the backup goes to. */
+    introStandard: string;
+    introExtra: string;
     /** Shown when this build carries no Drive OAuth client id. */
     unavailable: string;
 
@@ -1699,7 +1702,8 @@ export interface UiStrings {
     statusOff: string;
     statusReady: string;
     statusOn: string;
-    statusSealed: string;
+    statusSealedStandard: string;
+    statusSealedExtra: string;
     /** How much of the setup is left, under "Not backing up yet". */
     stepsLeft: PluralForms;
 
@@ -1721,7 +1725,10 @@ export interface UiStrings {
     connectFailed: string;
     disconnect: string;
     disconnectTitle: string;
-    disconnectBody: string;
+    /** What unlinking costs — different in each tier, and neither is true of
+     *  the other. Relinking is also the deliberate way back from Extra. */
+    disconnectBodyStandard: string;
+    disconnectBodyExtra: string;
 
     backUpNow: string;
     phaseCollecting: string;
@@ -1769,6 +1776,11 @@ export interface UiStrings {
     keyEnterPlaceholder: string;
     keyEnterInvalid: string;
     keyEnterSave: string;
+    /** The three things a 64-character field owes whoever is typing into it. */
+    keyEnterPaste: string;
+    keyEnterHint: string;
+    keyEnterWhat: string;
+    keyEnterWhatBody: string;
 
     restoreSection: string;
     restoreIntro: string;
@@ -1781,6 +1793,10 @@ export interface UiStrings {
     restoreDone: PluralForms;
     restoreFailed: string;
     restoreWrongKey: string;
+    /** The sheet for a backup that was found and will not open from here — the
+     *  fork stated before the attempt, not a failure reported after it. */
+    restoreFoundTitle: string;
+    restoreIsExtra: string;
     /** Why a restore is blocked when this phone holds no key. Emphatically
      *  not "create one": a new key cannot open an old backup, and making
      *  one would let the next run overwrite that backup. */
@@ -1789,11 +1805,43 @@ export interface UiStrings {
     /** Why a run did nothing. Each one is a different way out. */
     refusedNotConnected: string;
     refusedNoKey: string;
+    /** The found backup is under extra protection and only its key opens it. */
+    refusedNeedsKey: string;
+    /** A standard backup whose escrowed key has gone from the Drive folder. */
+    refusedKeyLost: string;
     refusedOffline: string;
     refusedNetwork: string;
     refusedAuth: string;
     refusedNoBackup: string;
     refusedBusy: string;
+
+    /** Extra protection: the opt-in tier, last on the screen and set apart. */
+    extraSection: string;
+    extraOn: string;
+    extraOff: string;
+    extraFootnoteOff: string;
+    extraFootnoteOn: string;
+    /** The pitch: benefit, then mechanism, then who is locked out. No warning
+     *  here — that belongs beside the key, on the screen after this one. */
+    extraPitchTitle: string;
+    extraPitchBenefit: string;
+    extraPitchMechanism: string;
+    extraPitchAdversary: string;
+    extraTurnOn: string;
+    /** What it means once it is on, and why there is no switch back. */
+    extraOnTitle: string;
+    extraOnBody: string;
+    extraNoWayBack: string;
+    /** The key, shown on the way in, with the consent gate under it. */
+    extraKeyTitle: string;
+    extraKeyBody: string;
+    /** "{n} records will be locked behind this key" — what is at stake. */
+    extraCovers: PluralForms;
+    /** Asserted in the past tense, and it names who cannot help. */
+    extraConsent: string;
+    extraTurningOn: string;
+    extraFailed: string;
+
     /** Screen-reader suffix on a chosen option row. */
     selected: string;
   };
@@ -4265,15 +4313,18 @@ const en: UiStrings = {
   backup: {
     title: 'Backup',
     row: 'Back up to Google Drive',
-    intro:
-      'Your private Me ledger, copied to your own Google Drive and locked with a key only you hold. Neither Waves nor Google can read it.',
+    introStandard:
+      'Your private Me ledger, copied to a hidden folder in your own Google Drive and locked with a key kept there too — so a new phone signed in to the same Google account opens it by itself. Waves cannot read it. Anyone who can get into your Google account can.',
+    introExtra:
+      'Your private Me ledger, copied to your own Google Drive and locked with a key only you hold. Neither Waves nor Google can read it, and nothing opens it without your key.',
     unavailable: 'Backup is not available in this build.',
 
     statusChecking: 'Checking…',
     statusOff: 'Not backing up yet',
     statusReady: 'Ready to back up',
     statusOn: 'Backed up',
-    statusSealed: 'Locked with your key',
+    statusSealedStandard: 'Locked with a key kept in your Google account',
+    statusSealedExtra: 'Locked with a key only you have',
     stepsLeft: {
       one: '{n} step left',
       other: '{n} steps left',
@@ -4294,7 +4345,9 @@ const en: UiStrings = {
     connectFailed: 'Could not link that account. Try again.',
     disconnect: 'Unlink',
     disconnectTitle: 'Unlink Google Drive?',
-    disconnectBody:
+    disconnectBodyStandard:
+      'Automatic backups stop. The backup and its key stay in your Google Drive, and linking this account again brings both back.',
+    disconnectBodyExtra:
       'Automatic backups stop and this phone forgets its key. The backup already on Drive stays there, and the key you wrote down still opens it.',
 
     backUpNow: 'Back up now',
@@ -4342,6 +4395,11 @@ const en: UiStrings = {
     keyEnterPlaceholder: '64 characters',
     keyEnterInvalid: 'That is not a backup key. A key is 64 letters and digits.',
     keyEnterSave: 'Use this key',
+    keyEnterPaste: 'Paste',
+    keyEnterHint: '64 letters and digits, in 16 groups of four. Spaces and dashes are ignored.',
+    keyEnterWhat: 'What is a backup key?',
+    keyEnterWhatBody:
+      'It is the 64 characters shown when extra protection was turned on, on the phone that made the backup. Without it that backup cannot be opened — not by us, and not by Google.',
 
     restoreSection: 'Restore',
     restoreIntro:
@@ -4359,17 +4417,55 @@ const en: UiStrings = {
       other: '{n} records restored',
     },
     restoreFailed: 'Could not read that backup. Try again in a moment.',
-    restoreWrongKey: 'That key does not open this backup.',
+    restoreWrongKey:
+      'That key does not open this backup. Check it against the phone that made the backup — one wrong character is enough.',
+    restoreFoundTitle: 'Backup found',
+    restoreIsExtra:
+      'This backup is under extra protection. Enter the key from the phone that made it. A new key will not open it.',
     restoreNeedsKey:
       'Enter the key from the phone that made this backup. A new key will not open it.',
 
     refusedNotConnected: 'Link a Google account first.',
     refusedNoKey: 'Create your backup key first.',
+    refusedNeedsKey: 'That backup is under extra protection. Only its key opens it.',
+    refusedKeyLost:
+      'The key for that backup is no longer in your Google account, so it can no longer be opened.',
     refusedOffline: 'No connection. The backup will run when you are back online.',
     refusedNetwork: 'Waiting for Wi‑Fi. Change Back up over to use mobile data.',
     refusedAuth: 'Google asked for the link again. Reconnect the account.',
     refusedNoBackup: 'There is no backup on this Drive account yet.',
     refusedBusy: 'A backup is already running.',
+
+    extraSection: 'Extra protection',
+    extraOn: 'On',
+    extraOff: 'Off',
+    extraFootnoteOff: 'Lock the backup with a key only you have, so not even Google can open it.',
+    extraFootnoteOn:
+      'This backup is locked with your key. Keep it safe — nobody can give it back to you.',
+    extraPitchTitle: 'Lock your backup with a key only you have',
+    extraPitchBenefit: 'Your backup stays safe even if somebody gets into your Google account.',
+    extraPitchMechanism:
+      'A 64-character key is made for you and shown once. You keep it, and so does this phone.',
+    extraPitchAdversary: 'Nobody else can open the backup. Not Google, and not Waves.',
+    extraTurnOn: 'Turn on',
+    extraOnTitle: 'Extra protection is on',
+    extraOnBody:
+      'Your backup is locked with your key, and Google keeps no copy of it. Only a phone that has the key can open it.',
+    extraNoWayBack:
+      'There is no switch back. To return to the standard backup, unlink your Google account and link it again — that starts a fresh backup with a new key.',
+    extraKeyTitle: 'Save your backup key',
+    extraKeyBody:
+      'This key locks your backup from now on, and it is shown only here. You will need it to restore on another phone.',
+    extraCovers: {
+      one: '{n} record will be locked behind this key',
+      other: '{n} records will be locked behind this key',
+    },
+    extraConsent:
+      'I have saved my key, and I understand that Waves cannot open this backup for me if I lose it.',
+    extraTurningOn: 'Re-locking your backup…',
+    extraFailed:
+      'Extra protection could not be turned on. Your backup is unchanged. Try again in a moment.',
+
     selected: 'selected',
   },
   group: {
@@ -6828,15 +6924,18 @@ const ta: UiStrings = {
   backup: {
     title: 'காப்புப்பிரதி',
     row: 'Google Drive-இல் காப்பு',
-    intro:
-      'உங்கள் தனிப்பட்ட "நான்" கணக்கு, உங்கள் சொந்த Google Drive-க்கு நகலெடுக்கப்பட்டு, உங்களிடம் மட்டுமே உள்ள சாவியால் பூட்டப்படுகிறது. Waves-ஆலும் Google-ஆலும் அதைப் படிக்க முடியாது.',
+    introStandard:
+      'உங்கள் தனிப்பட்ட "நான்" கணக்கு, உங்கள் சொந்த Google Drive-இல் ஒரு மறைவான கோப்புறைக்கு நகலெடுக்கப்பட்டு, அங்கேயே வைக்கப்படும் சாவியால் பூட்டப்படுகிறது — அதே Google கணக்கில் நுழையும் புதிய ஃபோன் தானாகவே அதைத் திறக்கும். Waves-ஆல் அதைப் படிக்க முடியாது; உங்கள் Google கணக்கை அணுகும் எவரும் படிக்க முடியும்.',
+    introExtra:
+      'உங்கள் தனிப்பட்ட "நான்" கணக்கு, உங்கள் சொந்த Google Drive-க்கு நகலெடுக்கப்பட்டு, உங்களிடம் மட்டுமே உள்ள சாவியால் பூட்டப்படுகிறது. Waves-ஆலும் Google-ஆலும் அதைப் படிக்க முடியாது; உங்கள் சாவி இல்லாமல் அதை எதுவும் திறக்காது.',
     unavailable: 'இந்தப் பதிப்பில் காப்புப்பிரதி கிடைக்கவில்லை.',
 
     statusChecking: 'பார்க்கிறது…',
     statusOff: 'இன்னும் காப்பு எடுக்கப்படவில்லை',
     statusReady: 'காப்பு எடுக்கத் தயார்',
     statusOn: 'காப்பு எடுக்கப்பட்டது',
-    statusSealed: 'உங்கள் சாவியால் பூட்டப்பட்டது',
+    statusSealedStandard: 'உங்கள் Google கணக்கில் வைக்கப்பட்ட சாவியால் பூட்டப்பட்டது',
+    statusSealedExtra: 'உங்களிடம் மட்டுமே உள்ள சாவியால் பூட்டப்பட்டது',
     stepsLeft: {
       one: 'இன்னும் {n} படி',
       other: 'இன்னும் {n} படிகள்',
@@ -6858,7 +6957,9 @@ const ta: UiStrings = {
     connectFailed: 'அந்தக் கணக்கை இணைக்க முடியவில்லை. மீண்டும் முயலுங்கள்.',
     disconnect: 'இணைப்பை நீக்கு',
     disconnectTitle: 'Google Drive இணைப்பை நீக்கவா?',
-    disconnectBody:
+    disconnectBodyStandard:
+      'தானியங்கி காப்புப்பிரதிகள் நிற்கும். காப்புப்பிரதியும் அதன் சாவியும் உங்கள் Google Drive-இலேயே இருக்கும்; இந்தக் கணக்கை மீண்டும் இணைத்தால் இரண்டும் திரும்பும்.',
+    disconnectBodyExtra:
       'தானியங்கி காப்புப்பிரதிகள் நிற்கும், இந்த ஃபோன் தன் சாவியை மறக்கும். Drive-இல் உள்ள காப்புப்பிரதி அப்படியே இருக்கும் — நீங்கள் எழுதி வைத்த சாவி இன்னும் அதைத் திறக்கும்.',
 
     backUpNow: 'இப்போது காப்பு எடு',
@@ -6909,6 +7010,12 @@ const ta: UiStrings = {
     keyEnterPlaceholder: '64 எழுத்துகள்',
     keyEnterInvalid: 'இது காப்புச் சாவி அல்ல. சாவி 64 எழுத்துகளும் இலக்கங்களும் கொண்டது.',
     keyEnterSave: 'இந்தச் சாவியைப் பயன்படுத்து',
+    keyEnterPaste: 'ஒட்டு',
+    keyEnterHint:
+      '64 எழுத்துகளும் இலக்கங்களும், நான்கு நான்காக 16 குழுக்களில். இடைவெளிகளும் கோடுகளும் கணக்கில் எடுக்கப்படுவதில்லை.',
+    keyEnterWhat: 'காப்புச் சாவி என்றால் என்ன?',
+    keyEnterWhatBody:
+      'காப்புப்பிரதியை உருவாக்கிய ஃபோனில் கூடுதல் பாதுகாப்பை இயக்கியபோது காட்டப்பட்ட அந்த 64 எழுத்துகள் தான். அது இல்லாமல் அந்தக் காப்பைத் திறக்க முடியாது — எங்களாலும் முடியாது, Google-ஆலும் முடியாது.',
 
     restoreSection: 'மீட்டெடு',
     restoreIntro:
@@ -6926,17 +7033,59 @@ const ta: UiStrings = {
       other: '{n} பதிவுகள் மீட்கப்பட்டன',
     },
     restoreFailed: 'அந்தக் காப்பைப் படிக்க முடியவில்லை. சிறிது நேரம் கழித்து முயலுங்கள்.',
-    restoreWrongKey: 'அந்தச் சாவி இந்தக் காப்பைத் திறக்காது.',
+    restoreWrongKey:
+      'அந்தச் சாவி இந்தக் காப்பைத் திறக்காது. காப்பை உருவாக்கிய ஃபோனில் உள்ளதுடன் ஒப்பிட்டுப் பாருங்கள் — ஒரு எழுத்து தவறினாலும் போதும்.',
+    restoreFoundTitle: 'காப்புப்பிரதி கிடைத்தது',
+    restoreIsExtra:
+      'இந்தக் காப்பு கூடுதல் பாதுகாப்பில் உள்ளது. அதை உருவாக்கிய ஃபோனின் சாவியை உள்ளிடுங்கள்; புதிய சாவி அதைத் திறக்காது.',
     restoreNeedsKey: 'காப்பு எடுத்த ஃபோனின் சாவியை உள்ளிடுங்கள். புதிய சாவி அதைத் திறக்காது.',
 
     refusedNotConnected: 'முதலில் ஒரு Google கணக்கை இணையுங்கள்.',
     refusedNoKey: 'முதலில் உங்கள் காப்புச் சாவியை உருவாக்குங்கள்.',
+    refusedNeedsKey:
+      'அந்தக் காப்பு கூடுதல் பாதுகாப்பில் உள்ளது. அதன் சாவி மட்டுமே அதைத் திறக்கும்.',
+    refusedKeyLost:
+      'அந்தக் காப்பின் சாவி உங்கள் Google கணக்கில் இனி இல்லை, எனவே அதைத் திறக்க முடியாது.',
     refusedOffline: 'இணைப்பு இல்லை. மீண்டும் ஆன்லைனுக்கு வரும்போது காப்பு எடுக்கப்படும்.',
     refusedNetwork:
       'Wi‑Fi-க்காகக் காத்திருக்கிறது. மொபைல் டேட்டாவைப் பயன்படுத்த அமைப்பை மாற்றுங்கள்.',
     refusedAuth: 'Google மீண்டும் அனுமதி கேட்கிறது. கணக்கை மீண்டும் இணையுங்கள்.',
     refusedNoBackup: 'இந்த Drive கணக்கில் இன்னும் காப்புப்பிரதி இல்லை.',
     refusedBusy: 'ஒரு காப்பு ஏற்கனவே இயங்குகிறது.',
+
+    extraSection: 'கூடுதல் பாதுகாப்பு',
+    extraOn: 'இயக்கத்தில்',
+    extraOff: 'இல்லை',
+    extraFootnoteOff:
+      'உங்களிடம் மட்டுமே உள்ள சாவியால் காப்பைப் பூட்டுங்கள் — Google-ஆல் கூட அதைத் திறக்க முடியாது.',
+    extraFootnoteOn:
+      'இந்தக் காப்பு உங்கள் சாவியால் பூட்டப்பட்டுள்ளது. அதைப் பத்திரமாக வையுங்கள் — யாராலும் அதைத் திரும்பத் தர முடியாது.',
+    extraPitchTitle: 'உங்களிடம் மட்டுமே உள்ள சாவியால் காப்பைப் பூட்டுங்கள்',
+    extraPitchBenefit:
+      'உங்கள் Google கணக்குக்குள் யாரோ நுழைந்தாலும் உங்கள் காப்பு பாதுகாப்பாகவே இருக்கும்.',
+    extraPitchMechanism:
+      '64 எழுத்துச் சாவி ஒன்று உங்களுக்காக உருவாக்கப்பட்டு ஒரு முறை மட்டும் காட்டப்படும். அதை நீங்களும் இந்த ஃபோனும் வைத்திருப்பீர்கள்.',
+    extraPitchAdversary:
+      'வேறு யாராலும் காப்பைத் திறக்க முடியாது. Google-ஆலும் இல்லை, Waves-ஆலும் இல்லை.',
+    extraTurnOn: 'இயக்கு',
+    extraOnTitle: 'கூடுதல் பாதுகாப்பு இயக்கத்தில் உள்ளது',
+    extraOnBody:
+      'உங்கள் காப்பு உங்கள் சாவியால் பூட்டப்பட்டுள்ளது; Google அதன் நகலை வைத்திருக்கவில்லை. அந்தச் சாவி உள்ள ஃபோன் மட்டுமே அதைத் திறக்க முடியும்.',
+    extraNoWayBack:
+      'திரும்பச் செல்ல ஒரு நிலைமாற்றி இல்லை. வழக்கமான காப்புக்குத் திரும்ப, உங்கள் Google கணக்கின் இணைப்பை நீக்கி மீண்டும் இணையுங்கள் — அது புதிய சாவியுடன் புதிய காப்பைத் தொடங்கும்.',
+    extraKeyTitle: 'உங்கள் காப்புச் சாவியைச் சேமியுங்கள்',
+    extraKeyBody:
+      'இனிமேல் இந்தச் சாவி தான் உங்கள் காப்பைப் பூட்டும், அது இங்கே மட்டுமே காட்டப்படுகிறது. வேறு ஃபோனில் மீட்டெடுக்க இது தேவைப்படும்.',
+    extraCovers: {
+      one: '{n} பதிவு இந்தச் சாவிக்குப் பின் பூட்டப்படும்',
+      other: '{n} பதிவுகள் இந்தச் சாவிக்குப் பின் பூட்டப்படும்',
+    },
+    extraConsent:
+      'என் சாவியைச் சேமித்துவிட்டேன்; அதை இழந்தால் Waves-ஆல் இந்தக் காப்பை எனக்குத் திறக்க முடியாது என்பதைப் புரிந்துகொள்கிறேன்.',
+    extraTurningOn: 'உங்கள் காப்பை மீண்டும் பூட்டுகிறது…',
+    extraFailed:
+      'கூடுதல் பாதுகாப்பை இயக்க முடியவில்லை. உங்கள் காப்பு மாறாமல் உள்ளது. சிறிது நேரத்தில் மீண்டும் முயலுங்கள்.',
+
     selected: 'தேர்ந்தெடுக்கப்பட்டது',
   },
   group: {
@@ -9419,15 +9568,18 @@ const hi: UiStrings = {
   backup: {
     title: 'बैकअप',
     row: 'Google Drive पर बैकअप',
-    intro:
-      'आपका निजी "मैं" खाता, आपकी अपनी Google Drive पर कॉपी होता है और सिर्फ़ आपके पास मौजूद चाबी से बंद रहता है। इसे न Waves पढ़ सकता है, न Google।',
+    introStandard:
+      'आपका निजी "मैं" खाता, आपकी अपनी Google Drive के एक छिपे फ़ोल्डर में कॉपी होता है और वहीं रखी एक चाबी से बंद रहता है — इसलिए उसी Google खाते में साइन इन किया नया फ़ोन इसे खुद ही खोल लेता है। Waves इसे नहीं पढ़ सकता। आपके Google खाते तक पहुँचने वाला कोई भी पढ़ सकता है।',
+    introExtra:
+      'आपका निजी "मैं" खाता, आपकी अपनी Google Drive पर कॉपी होता है और सिर्फ़ आपके पास मौजूद चाबी से बंद रहता है। इसे न Waves पढ़ सकता है, न Google — और आपकी चाबी के बिना इसे कुछ भी नहीं खोलता।',
     unavailable: 'इस बिल्ड में बैकअप उपलब्ध नहीं है।',
 
     statusChecking: 'देखा जा रहा है…',
     statusOff: 'अभी बैकअप नहीं हो रहा',
     statusReady: 'बैकअप के लिए तैयार',
     statusOn: 'बैकअप हो गया',
-    statusSealed: 'आपकी चाबी से बंद',
+    statusSealedStandard: 'आपके Google खाते में रखी चाबी से बंद',
+    statusSealedExtra: 'सिर्फ़ आपके पास मौजूद चाबी से बंद',
     stepsLeft: {
       one: '{n} कदम बाकी',
       other: '{n} कदम बाकी',
@@ -9448,7 +9600,9 @@ const hi: UiStrings = {
     connectFailed: 'वह खाता नहीं जुड़ सका। फिर कोशिश करें।',
     disconnect: 'हटाएँ',
     disconnectTitle: 'Google Drive हटाएँ?',
-    disconnectBody:
+    disconnectBodyStandard:
+      'अपने आप होने वाले बैकअप रुक जाएँगे। बैकअप और उसकी चाबी आपकी Google Drive में ही रहते हैं, और इस खाते को दोबारा जोड़ने पर दोनों वापस आ जाते हैं।',
+    disconnectBodyExtra:
       'अपने आप होने वाले बैकअप रुक जाएँगे और यह फ़ोन अपनी चाबी भूल जाएगा। Drive पर मौजूद बैकअप वहीं रहेगा — आपकी लिखी हुई चाबी उसे अब भी खोल देगी।',
 
     backUpNow: 'अभी बैकअप लें',
@@ -9496,6 +9650,11 @@ const hi: UiStrings = {
     keyEnterPlaceholder: '64 अक्षर',
     keyEnterInvalid: 'यह बैकअप चाबी नहीं है। चाबी में 64 अक्षर और अंक होते हैं।',
     keyEnterSave: 'यही चाबी इस्तेमाल करें',
+    keyEnterPaste: 'पेस्ट करें',
+    keyEnterHint: '64 अक्षर और अंक, चार-चार के 16 समूहों में। स्पेस और डैश नहीं गिने जाते।',
+    keyEnterWhat: 'बैकअप चाबी क्या है?',
+    keyEnterWhatBody:
+      'यह वही 64 अक्षर हैं जो उस फ़ोन पर अतिरिक्त सुरक्षा चालू करते समय दिखाए गए थे जिसने बैकअप बनाया था। उसके बिना वह बैकअप नहीं खुल सकता — न हमसे, न Google से।',
 
     restoreSection: 'वापस लाएँ',
     restoreIntro:
@@ -9513,16 +9672,55 @@ const hi: UiStrings = {
       other: '{n} रिकॉर्ड वापस आ गए',
     },
     restoreFailed: 'वह बैकअप पढ़ा नहीं जा सका। थोड़ी देर में फिर कोशिश करें।',
-    restoreWrongKey: 'यह चाबी इस बैकअप को नहीं खोलती।',
+    restoreWrongKey:
+      'यह चाबी इस बैकअप को नहीं खोलती। जिस फ़ोन ने बैकअप बनाया था, उसकी चाबी से मिलाकर देखें — एक अक्षर की गलती भी काफ़ी है।',
+    restoreFoundTitle: 'बैकअप मिला',
+    restoreIsExtra:
+      'यह बैकअप अतिरिक्त सुरक्षा में है। जिस फ़ोन ने इसे बनाया था, उसी की चाबी डालें। नई चाबी इसे नहीं खोलेगी।',
     restoreNeedsKey: 'जिस फ़ोन ने यह बैकअप बनाया, उसी की चाबी डालें। नई चाबी इसे नहीं खोलेगी।',
 
     refusedNotConnected: 'पहले एक Google खाता जोड़ें।',
     refusedNoKey: 'पहले अपनी बैकअप चाबी बनाएँ।',
+    refusedNeedsKey: 'वह बैकअप अतिरिक्त सुरक्षा में है। उसे सिर्फ़ उसकी चाबी ही खोलती है।',
+    refusedKeyLost:
+      'उस बैकअप की चाबी अब आपके Google खाते में नहीं है, इसलिए उसे खोला नहीं जा सकता।',
     refusedOffline: 'कोई कनेक्शन नहीं। ऑनलाइन आते ही बैकअप चल जाएगा।',
     refusedNetwork: 'Wi‑Fi का इंतज़ार है। मोबाइल डेटा इस्तेमाल करने के लिए सेटिंग बदलें।',
     refusedAuth: 'Google ने फिर से अनुमति माँगी है। खाता दोबारा जोड़ें।',
     refusedNoBackup: 'इस Drive खाते पर अभी कोई बैकअप नहीं है।',
     refusedBusy: 'एक बैकअप पहले से चल रहा है।',
+
+    extraSection: 'अतिरिक्त सुरक्षा',
+    extraOn: 'चालू',
+    extraOff: 'बंद',
+    extraFootnoteOff:
+      'बैकअप को ऐसी चाबी से बंद करें जो सिर्फ़ आपके पास हो — तब Google भी उसे नहीं खोल सकेगा।',
+    extraFootnoteOn:
+      'यह बैकअप आपकी चाबी से बंद है। उसे सँभालकर रखें — कोई भी उसे आपको वापस नहीं दे सकता।',
+    extraPitchTitle: 'बैकअप को ऐसी चाबी से बंद करें जो सिर्फ़ आपके पास हो',
+    extraPitchBenefit: 'कोई आपके Google खाते तक पहुँच भी जाए, तब भी आपका बैकअप सुरक्षित रहता है।',
+    extraPitchMechanism:
+      '64 अक्षरों की एक चाबी आपके लिए बनती है और सिर्फ़ एक बार दिखती है। वह आपके पास रहती है, और इस फ़ोन के पास भी।',
+    extraPitchAdversary: 'और कोई बैकअप नहीं खोल सकता। न Google, न Waves।',
+    extraTurnOn: 'चालू करें',
+    extraOnTitle: 'अतिरिक्त सुरक्षा चालू है',
+    extraOnBody:
+      'आपका बैकअप आपकी चाबी से बंद है और Google उसकी कोई कॉपी नहीं रखता। सिर्फ़ वही फ़ोन उसे खोल सकता है जिसके पास चाबी हो।',
+    extraNoWayBack:
+      'वापस जाने का कोई स्विच नहीं है। सामान्य बैकअप पर लौटने के लिए अपना Google खाता हटाएँ और दोबारा जोड़ें — इससे नई चाबी के साथ नया बैकअप शुरू होता है।',
+    extraKeyTitle: 'अपनी बैकअप चाबी सुरक्षित रखें',
+    extraKeyBody:
+      'अब से यही चाबी आपके बैकअप को बंद करती है, और यह सिर्फ़ यहीं दिख रही है। दूसरे फ़ोन पर वापस लाने के लिए यह ज़रूरी होगी।',
+    extraCovers: {
+      one: '{n} रिकॉर्ड इस चाबी के पीछे बंद होगा',
+      other: '{n} रिकॉर्ड इस चाबी के पीछे बंद होंगे',
+    },
+    extraConsent:
+      'मैंने अपनी चाबी सुरक्षित रख ली है, और मैं समझता हूँ कि खो जाने पर Waves इस बैकअप को मेरे लिए नहीं खोल सकता।',
+    extraTurningOn: 'आपका बैकअप दोबारा बंद किया जा रहा है…',
+    extraFailed:
+      'अतिरिक्त सुरक्षा चालू नहीं हो सकी। आपका बैकअप जैसा था वैसा ही है। थोड़ी देर में फिर कोशिश करें।',
+
     selected: 'चुना गया',
   },
   group: {
@@ -12041,15 +12239,18 @@ const ar: UiStrings = {
   backup: {
     title: 'النسخ الاحتياطي',
     row: 'نسخ احتياطي إلى Google Drive',
-    intro:
-      'دفترك الخاص في تبويب "أنا"، يُنسخ إلى Google Drive الخاص بك ويُقفل بمفتاح لا يملكه سواك. لا يستطيع Waves ولا Google قراءته.',
+    introStandard:
+      'دفترك الخاص في تبويب "أنا"، يُنسخ إلى مجلد مخفي داخل Google Drive الخاص بك ويُقفل بمفتاح محفوظ هناك أيضًا — فيفتحه وحده أي هاتف جديد يسجّل الدخول إلى حساب Google نفسه. لا يستطيع Waves قراءته، أما من يصل إلى حساب Google الخاص بك فيستطيع.',
+    introExtra:
+      'دفترك الخاص في تبويب "أنا"، يُنسخ إلى Google Drive الخاص بك ويُقفل بمفتاح لا يملكه سواك. لا يستطيع Waves ولا Google قراءته، ولا شيء يفتحه دون مفتاحك.',
     unavailable: 'النسخ الاحتياطي غير متاح في هذه النسخة.',
 
     statusChecking: 'يتحقق…',
     statusOff: 'لا نسخ احتياطي بعد',
     statusReady: 'جاهز للنسخ',
     statusOn: 'تم النسخ',
-    statusSealed: 'مقفل بمفتاحك',
+    statusSealedStandard: 'مقفل بمفتاح محفوظ في حساب Google الخاص بك',
+    statusSealedExtra: 'مقفل بمفتاح لا يملكه سواك',
     stepsLeft: {
       zero: 'لم تبقَ خطوات',
       one: 'بقيت خطوة واحدة',
@@ -12074,7 +12275,9 @@ const ar: UiStrings = {
     connectFailed: 'تعذّر ربط هذا الحساب. حاول مرة أخرى.',
     disconnect: 'إلغاء الربط',
     disconnectTitle: 'إلغاء ربط Google Drive؟',
-    disconnectBody:
+    disconnectBodyStandard:
+      'يتوقف النسخ التلقائي. تبقى النسخة ومفتاحها داخل Google Drive الخاص بك، وربط هذا الحساب من جديد يعيدهما معًا.',
+    disconnectBodyExtra:
       'يتوقف النسخ التلقائي وينسى هذا الهاتف مفتاحه. تبقى النسخة الموجودة على Drive كما هي، والمفتاح الذي كتبته ما زال يفتحها.',
 
     backUpNow: 'انسخ الآن',
@@ -12126,6 +12329,11 @@ const ar: UiStrings = {
     keyEnterPlaceholder: '64 حرفًا',
     keyEnterInvalid: 'هذا ليس مفتاح نسخة. المفتاح 64 حرفًا ورقمًا.',
     keyEnterSave: 'استخدم هذا المفتاح',
+    keyEnterPaste: 'لصق',
+    keyEnterHint: '64 حرفًا ورقمًا، في 16 مجموعة من أربعة. المسافات والشرطات لا تُحتسب.',
+    keyEnterWhat: 'ما هو مفتاح النسخة؟',
+    keyEnterWhatBody:
+      'هو الـ 64 حرفًا التي ظهرت عند تشغيل الحماية الإضافية على الهاتف الذي أنشأ النسخة. من دونه لا يمكن فتح تلك النسخة — لا نحن ولا Google.',
 
     restoreSection: 'الاستعادة',
     restoreIntro: 'أعد السجلات من نسخة Drive. لا يتغيّر ولا يُحذف شيء موجود على هذا الهاتف.',
@@ -12150,16 +12358,53 @@ const ar: UiStrings = {
       other: 'استُعيد {n} سجل',
     },
     restoreFailed: 'تعذّرت قراءة تلك النسخة. حاول بعد قليل.',
-    restoreWrongKey: 'هذا المفتاح لا يفتح هذه النسخة.',
+    restoreWrongKey:
+      'هذا المفتاح لا يفتح هذه النسخة. قارنه بما في الهاتف الذي أنشأ النسخة — حرف واحد خاطئ يكفي.',
+    restoreFoundTitle: 'وُجدت نسخة احتياطية',
+    restoreIsExtra:
+      'هذه النسخة تحت الحماية الإضافية. أدخل المفتاح من الهاتف الذي أنشأها؛ المفتاح الجديد لن يفتحها.',
     restoreNeedsKey: 'أدخل مفتاح الهاتف الذي أنشأ هذه النسخة. المفتاح الجديد لن يفتحها.',
 
     refusedNotConnected: 'اربط حساب Google أولًا.',
     refusedNoKey: 'أنشئ مفتاح النسخة أولًا.',
+    refusedNeedsKey: 'تلك النسخة تحت الحماية الإضافية. لا يفتحها إلا مفتاحها.',
+    refusedKeyLost: 'لم يعد مفتاح تلك النسخة في حساب Google الخاص بك، لذا لا يمكن فتحها.',
     refusedOffline: 'لا اتصال. سيجري النسخ عند عودتك للاتصال.',
     refusedNetwork: 'في انتظار Wi‑Fi. غيّر الإعداد لاستخدام بيانات الجوال.',
     refusedAuth: 'طلب Google الإذن من جديد. أعد ربط الحساب.',
     refusedNoBackup: 'لا توجد نسخة على حساب Drive هذا بعد.',
     refusedBusy: 'هناك نسخ جارٍ بالفعل.',
+
+    extraSection: 'حماية إضافية',
+    extraOn: 'مُفعّلة',
+    extraOff: 'متوقفة',
+    extraFootnoteOff: 'اقفل النسخة بمفتاح لا يملكه سواك، فلا يستطيع حتى Google فتحها.',
+    extraFootnoteOn: 'هذه النسخة مقفلة بمفتاحك. احفظه جيدًا — لا أحد يستطيع أن يعيده إليك.',
+    extraPitchTitle: 'اقفل نسختك بمفتاح لا يملكه سواك',
+    extraPitchBenefit: 'تبقى نسختك آمنة حتى لو وصل أحدهم إلى حساب Google الخاص بك.',
+    extraPitchMechanism: 'يُنشأ لك مفتاح من 64 حرفًا ويُعرض مرة واحدة. يبقى عندك، وعند هذا الهاتف.',
+    extraPitchAdversary: 'لا يستطيع أحد غيرك فتح النسخة. لا Google ولا Waves.',
+    extraTurnOn: 'تشغيل',
+    extraOnTitle: 'الحماية الإضافية مُفعّلة',
+    extraOnBody:
+      'نسختك مقفلة بمفتاحك، ولا يحتفظ Google بأي نسخة منه. لا يفتحها إلا هاتف يملك ذلك المفتاح.',
+    extraNoWayBack:
+      'لا يوجد زر للعودة. للرجوع إلى النسخ العادي، افصل حساب Google ثم اربطه من جديد — عندها تبدأ نسخة جديدة بمفتاح جديد.',
+    extraKeyTitle: 'احفظ مفتاح النسخة',
+    extraKeyBody:
+      'هذا المفتاح هو ما يقفل نسختك من الآن، وهو معروض هنا فقط. ستحتاجه لاستعادتها على هاتف آخر.',
+    extraCovers: {
+      zero: 'لن يُقفل أي سجل خلف هذا المفتاح',
+      one: 'سيُقفل سجل واحد خلف هذا المفتاح',
+      two: 'سيُقفل سجلّان خلف هذا المفتاح',
+      few: 'ستُقفل {n} سجلات خلف هذا المفتاح',
+      many: 'سيُقفل {n} سجلًا خلف هذا المفتاح',
+      other: 'سيُقفل {n} سجل خلف هذا المفتاح',
+    },
+    extraConsent: 'حفظت مفتاحي، وأفهم أن Waves لن يستطيع فتح هذه النسخة لي إن فقدته.',
+    extraTurningOn: 'يُعاد قفل نسختك…',
+    extraFailed: 'تعذّر تشغيل الحماية الإضافية. نسختك كما هي دون تغيير. حاول بعد قليل.',
+
     selected: 'محدد',
   },
   group: {

--- a/apps/mobile/src/lib/backup/AutoBackup.tsx
+++ b/apps/mobile/src/lib/backup/AutoBackup.tsx
@@ -30,6 +30,7 @@ import { runBackup } from './engine';
 import { loadRecoveryKey } from './recoveryKey';
 import { isDue } from './schedule';
 import { loadBackupSettings, saveLastBackup } from './settings';
+import { resolveTier, tierAllowsBackup } from './tier';
 
 /** Don't re-ask the question more than this often, however often we foreground. */
 const CHECK_THROTTLE_MS = 5 * 60 * 1000;
@@ -60,16 +61,20 @@ export function AutoBackup() {
 
       const settings = await loadBackupSettings(ownerId);
       if (!isDue(settings.last?.at ?? null, settings.frequency, now)) return;
-      // Nothing goes out until the person has been shown the recovery key and
-      // said they have it — a backup they cannot open is worse than none.
-      if (!settings.keySeen) return;
-      const key = await loadRecoveryKey(ownerId);
-      if (!key) return;
+
+      // The keystore read is now only here to answer the tier question for an
+      // account carried over from the build before tiers — the engine finds,
+      // adopts or mints the key it actually seals with.
+      const tier = resolveTier(settings.tier, (await loadRecoveryKey(ownerId)) !== null);
+      // On Extra protection nothing goes out until the person has been shown
+      // the key and said they have it: a backup they cannot open is worse than
+      // none. On Standard there is nothing to have kept, so there is no gate.
+      if (!tierAllowsBackup(tier, settings.keySeen)) return;
 
       const result = await runBackup({
         ownerId,
         records: recordsRef.current,
-        key,
+        tier,
         network: settings.network,
         // The whole point of the network preference is to gate *this* run.
         manual: false,

--- a/apps/mobile/src/lib/backup/AutoBackup.tsx
+++ b/apps/mobile/src/lib/backup/AutoBackup.tsx
@@ -65,7 +65,11 @@ export function AutoBackup() {
       // The keystore read is now only here to answer the tier question for an
       // account carried over from the build before tiers — the engine finds,
       // adopts or mints the key it actually seals with.
-      const tier = resolveTier(settings.tier, (await loadRecoveryKey(ownerId)) !== null);
+      const tier = resolveTier(
+        settings.tier,
+        (await loadRecoveryKey(ownerId)) !== null,
+        settings.keySeen,
+      );
       // On Extra protection nothing goes out until the person has been shown
       // the key and said they have it: a backup they cannot open is worse than
       // none. On Standard there is nothing to have kept, so there is no gate.

--- a/apps/mobile/src/lib/backup/engine.ts
+++ b/apps/mobile/src/lib/backup/engine.ts
@@ -13,6 +13,21 @@
  * words. A **failure** is a thrown error carrying a provider message that must
  * never reach a screen; it goes through `friendlyError` at the call site, which
  * reports the original and returns a sentence.
+ *
+ * WHERE THE KEY COMES FROM is now the engine's problem rather than the
+ * caller's, because the answer depends on things only the engine can see. On
+ * **Extra protection** it is the device's key or nothing. On **Standard** it is
+ * the escrowed copy in the appDataFolder, adopted onto this device on the way
+ * past — and minted and put there if the folder is empty. That is what makes
+ * the default tier ceremony-free: a new phone that signs into the same Google
+ * account finds the key sitting beside the blob and opens it with no screen in
+ * between. `tier.ts` holds the decision table and the reasoning; this file does
+ * the I/O the table asks for.
+ *
+ * Under Standard the escrow costs one extra `find` per run, alongside the one
+ * for the blob and issued at the same time. That is one small list request on a
+ * path that runs at most daily, in exchange for two phones on one Google
+ * account never sealing their backups under different keys.
  */
 
 import * as Network from 'expo-network';
@@ -21,20 +36,45 @@ import { networkAllows, type SyncNetworkPreference } from '../syncNetwork';
 import { isAuthFailure } from '../cloud/http';
 import { providerFor } from '../cloud/providers';
 import { clearTokens, loadTokens, saveTokens } from '../cloud/tokens';
-import type { CloudProviderId, CloudTokens } from '../cloud/types';
+import type { CloudFile, CloudProvider, CloudProviderId, CloudTokens } from '../cloud/types';
 import {
   backupAad,
   buildBody,
   buildFile,
+  fileTier,
   parseBody,
   parseFile,
   planRestore,
   type BackupBody,
+  type BackupFile,
   type RestorePlan,
   type SourceRecord,
 } from './payload';
-import { backupNonce, clearRecoveryKey, openBackup, sealBackup } from './recoveryKey';
-import { clearBackupSettings, type LastBackup } from './settings';
+import {
+  backupNonce,
+  bytesToHex,
+  clearRecoveryKey,
+  loadRecoveryKey,
+  mintRecoveryKey,
+  openBackup,
+  parseRecoveryKey,
+  saveRecoveryKey,
+  sealBackup,
+} from './recoveryKey';
+import { clearBackupSettings, saveTier, type LastBackup } from './settings';
+import {
+  advanceUpgrade,
+  BackupTier,
+  buildEscrow,
+  escrowFileName,
+  keyForBackup,
+  keyForRestore,
+  KeySource,
+  mayClearEscrow,
+  parseEscrow,
+  UPGRADE_START,
+  type UpgradeState,
+} from './tier';
 
 /**
  * The one file in the provider's app-private storage, per account. Overwritten
@@ -71,6 +111,10 @@ export type BackupRefusal =
   | 'not-connected'
   /** No recovery key on this device — nothing to seal (or open) with. */
   | 'no-key'
+  /** The backup on Drive is under extra protection and only the person has its key. */
+  | 'needs-key'
+  /** A standard backup whose escrowed key is no longer in the Drive folder. */
+  | 'key-lost'
   /** No usable connection at all. */
   | 'offline'
   /** Connected, but not over a network the person allows backups on. */
@@ -87,8 +131,12 @@ export type BackupResult =
 export interface BackupRunInput {
   readonly ownerId: string;
   readonly records: readonly SourceRecord[];
-  /** The 32-byte recovery key. See `recoveryKey.ts` for why it is user-held. */
-  readonly key: Uint8Array;
+  /**
+   * Which promise this account's backup makes. Decides where the key comes
+   * from, what goes in the envelope, and whether a copy of the key is left in
+   * the Drive folder — see `tier.ts`.
+   */
+  readonly tier: BackupTier;
   readonly network: SyncNetworkPreference;
   /**
    * True for "Back up now". A person tapping the button has made the data-plan
@@ -189,6 +237,126 @@ export async function clearBackupState(ownerId: string): Promise<void> {
   if (failures.length > 0) throw failures[0];
 }
 
+// ────────────────────────────────────────────────── the escrowed key ──
+
+/**
+ * What the appDataFolder holds for one account: the sealed ledger, and — on
+ * Standard — the key that opens it.
+ *
+ * Both looked up in one pass and issued together, because the interesting
+ * questions are about the pair. "Is there a backup, and is its key beside it"
+ * is one state, and asking for the halves in sequence would double the latency
+ * of the check every restore begins with.
+ */
+interface FolderState {
+  readonly blob: CloudFile | null;
+  readonly escrow: CloudFile | null;
+}
+
+async function readFolder(
+  provider: CloudProvider,
+  tokens: CloudTokens,
+  ownerId: string,
+): Promise<FolderState> {
+  const [blob, escrow] = await Promise.all([
+    provider.find(tokens, backupFileName(ownerId)),
+    provider.find(tokens, escrowFileName(ownerId)),
+  ]);
+  return { blob, escrow };
+}
+
+/**
+ * The escrowed key as bytes, or null when the file is there but unusable.
+ *
+ * A key file we cannot parse is treated as no key file rather than as a
+ * failure. It can only have come from a future version of this app, or from
+ * something else writing into the folder, and in either case the useful next
+ * move is the one taken for an empty folder — mint a key and escrow it on a
+ * backup path; say the key is gone on a restore path. Throwing would leave a
+ * person unable to back up because of a file they cannot see or delete.
+ */
+async function openEscrow(
+  provider: CloudProvider,
+  tokens: CloudTokens,
+  file: CloudFile,
+): Promise<Uint8Array | null> {
+  try {
+    return parseRecoveryKey(parseEscrow(await provider.read(tokens, file.remoteId)).key);
+  } catch (error) {
+    if (isAuthFailure(error)) throw error;
+    return null;
+  }
+}
+
+/** Put a key in the folder beside the blob, creating or overwriting the file. */
+async function writeEscrow(
+  provider: CloudProvider,
+  tokens: CloudTokens,
+  ownerId: string,
+  key: Uint8Array,
+  existing: CloudFile | null,
+): Promise<void> {
+  const content = JSON.stringify(buildEscrow(bytesToHex(key), new Date().toISOString()));
+  await provider.put(tokens, escrowFileName(ownerId), content, existing?.remoteId ?? null);
+}
+
+/**
+ * The key to seal the next backup with, doing whatever the tier says that takes.
+ *
+ * The decision itself is `keyForBackup`; everything here is the I/O it asks
+ * for. Two of the answers have a side effect, and both are deliberate: adopting
+ * the escrowed key writes it into this device's keystore, so the next run needs
+ * no round trip and a later upgrade has something to hand over; and minting
+ * writes the new key to *both* places, because a Standard key that exists only
+ * on the phone is an Extra key nobody was warned about.
+ */
+async function keyForRun(
+  provider: CloudProvider,
+  tokens: CloudTokens,
+  input: BackupRunInput,
+  folder: FolderState,
+): Promise<Uint8Array | null> {
+  const deviceKey = await loadRecoveryKey(input.ownerId);
+  const escrowKey =
+    input.tier === BackupTier.Standard && folder.escrow
+      ? await openEscrow(provider, tokens, folder.escrow)
+      : null;
+
+  switch (
+    keyForBackup({
+      tier: input.tier,
+      hasDeviceKey: deviceKey !== null,
+      remoteTier: null,
+      hasEscrow: escrowKey !== null,
+    })
+  ) {
+    case KeySource.Device:
+      return deviceKey;
+    case KeySource.Escrow: {
+      // Not null: `hasEscrow` was true only because this one opened.
+      const key = escrowKey as Uint8Array;
+      // Written back only when it differs, so an ordinary run does not touch
+      // the keystore on every pass. A differing local key here is a stale one —
+      // a half-finished upgrade, or a second phone that minted before it looked.
+      if (!deviceKey || bytesToHex(deviceKey) !== bytesToHex(key)) {
+        await saveRecoveryKey(input.ownerId, key);
+      }
+      return key;
+    }
+    case KeySource.Mint: {
+      const key = mintRecoveryKey();
+      // Escrow first. A key on the phone with no copy in the folder is the one
+      // state Standard must never be in, because the screen is at that moment
+      // telling the person a new phone will find it.
+      await writeEscrow(provider, tokens, input.ownerId, key, folder.escrow);
+      await saveRecoveryKey(input.ownerId, key);
+      return key;
+    }
+    default:
+      return null;
+  }
+}
+
 /**
  * Back the personal ledger up. Resolves with a refusal rather than throwing for
  * anything the person can fix; throws for a genuine transport or provider
@@ -201,7 +369,6 @@ export async function runBackup(input: BackupRunInput): Promise<BackupResult> {
   try {
     const provider = providerFor(PRIMARY_PROVIDER);
     if (!provider.isConfigured()) return { ok: false, refusal: 'not-configured' };
-    if (input.key.length === 0) return { ok: false, refusal: 'no-key' };
 
     const net = await connection();
     if (!net.online) return { ok: false, refusal: 'offline' };
@@ -215,23 +382,37 @@ export async function runBackup(input: BackupRunInput): Promise<BackupResult> {
     }
     const tokens = lookup.tokens;
 
-    input.onPhase?.('collecting');
-    const body = buildBody(input.ownerId, input.records, new Date());
-
-    input.onPhase?.('sealing');
-    const sealed = sealBackup(
-      input.key,
-      backupNonce(),
-      JSON.stringify(body),
-      backupAad(input.ownerId),
-    );
-    const content = JSON.stringify(buildFile(sealed, body.createdAt));
-
-    input.onPhase?.('uploading');
-    const fileName = backupFileName(input.ownerId);
     try {
-      const existing = await provider.find(tokens, fileName);
-      const stored = await provider.put(tokens, fileName, content, existing?.remoteId ?? null);
+      const folder = await readFolder(provider, tokens, input.ownerId);
+      const key = await keyForRun(provider, tokens, input, folder);
+      // Extra protection with nothing in the keystore. The person holds the
+      // only copy, and the screen's job is to ask for it rather than mint a
+      // second one that would seal the next backup away from the first.
+      if (!key) return { ok: false, refusal: 'no-key' };
+
+      input.onPhase?.('collecting');
+      const body = buildBody(input.ownerId, input.records, new Date());
+
+      input.onPhase?.('sealing');
+      const sealed = sealBackup(key, backupNonce(), JSON.stringify(body), backupAad(input.ownerId));
+      const content = JSON.stringify(buildFile(sealed, body.createdAt, input.tier));
+
+      input.onPhase?.('uploading');
+      const stored = await provider.put(
+        tokens,
+        backupFileName(input.ownerId),
+        content,
+        folder.blob?.remoteId ?? null,
+      );
+
+      // The sweep. An upgrade whose escrow delete failed leaves behind a key
+      // file that opens nothing — `keyForRestore` reads the blob's tier, not
+      // the file's presence — but it is still a copy of a key in a folder the
+      // person was told held none, so every later Extra run tries again.
+      if (input.tier === BackupTier.Extra && folder.escrow) {
+        await provider.remove(tokens, folder.escrow.remoteId).catch(() => undefined);
+      }
+
       return {
         ok: true,
         last: {
@@ -257,6 +438,24 @@ export async function runBackup(input: BackupRunInput): Promise<BackupResult> {
   }
 }
 
+/**
+ * What a found backup says about itself before anybody tries to open it.
+ *
+ * The date, the size and the tier are all outside the AEAD, so they can be read
+ * without a key — which is exactly what makes it possible to tell somebody
+ * *what opening this will take* instead of letting them find out by failing.
+ * Every restore flow worth copying (Coinbase Wallet's import fork, LINE's
+ * "restore or enter it yourself", WhatsApp's date-and-size card) puts that
+ * choice before the attempt, not after it.
+ */
+export interface FoundBackupMeta {
+  /** ISO, from the envelope. Empty when an older file did not record one. */
+  readonly createdAt: string;
+  /** Bytes as Drive stores it, or 0 when Drive would not say. */
+  readonly size: number;
+  readonly tier: BackupTier;
+}
+
 export type RestoreScan =
   | {
       readonly ok: true;
@@ -264,12 +463,22 @@ export type RestoreScan =
       readonly plan: RestorePlan;
       /** Bytes of the file as stored, for the confirmation line. */
       readonly size: number;
+      /** Which tier sealed the *found file*, whatever this phone believes. */
+      readonly tier: BackupTier;
     }
-  | { readonly ok: false; readonly refusal: BackupRefusal };
+  | {
+      readonly ok: false;
+      readonly refusal: BackupRefusal;
+      /**
+       * Set when the refusal is about a backup we *found* and could not open —
+       * `needs-key` and `key-lost`. It is what lets the screen present the
+       * fork rather than an error: here is your backup, here is what it takes.
+       */
+      readonly found?: FoundBackupMeta;
+    };
 
 export interface RestoreScanInput {
   readonly ownerId: string;
-  readonly key: Uint8Array;
   /** Every personal record id this device knows, tombstones included. */
   readonly localIds: ReadonlySet<string>;
 }
@@ -280,6 +489,22 @@ export interface RestoreScanInput {
  * date before they commit, because "restore" is the word people are most afraid
  * of pressing.
  *
+ * THE FILE'S TIER BEATS THE PHONE'S, and this is the moment it matters most. A
+ * phone freshly signed in has whatever tier its defaults gave it and knows
+ * nothing about what made the blob; the envelope knows exactly. So the tier is
+ * read out of the file, and `keyForRestore` decides from that:
+ *
+ * - **Standard** — the key is in the folder. Read it, adopt it, open the file.
+ *   Nobody is asked anything, which is the entire point of the default tier.
+ * - **Extra, and this phone holds the key** — open it.
+ * - **Extra, and it does not** — `needs-key`. The screen points at "I already
+ *   have a key" and must not, ever, point at "create one": a new key does not
+ *   open this file, and making one arms a backup run that would overwrite it.
+ * - **Standard, and the key file is gone** — `key-lost`. Somebody used Drive's
+ *   "Delete hidden app data", or a failure left the folder half-empty. There is
+ *   nothing to type and nothing to recover, and saying so is the only honest
+ *   move left.
+ *
  * The network policy is deliberately not applied: a restore is always somebody
  * standing there having asked for it, usually on a phone that has just been set
  * up and may well not be on Wi‑Fi yet.
@@ -287,7 +512,6 @@ export interface RestoreScanInput {
 export async function scanBackup(input: RestoreScanInput): Promise<RestoreScan> {
   const provider = providerFor(PRIMARY_PROVIDER);
   if (!provider.isConfigured()) return { ok: false, refusal: 'not-configured' };
-  if (input.key.length === 0) return { ok: false, refusal: 'no-key' };
 
   const net = await connection();
   if (!net.online) return { ok: false, refusal: 'offline' };
@@ -299,25 +523,197 @@ export async function scanBackup(input: RestoreScanInput): Promise<RestoreScan> 
   const tokens = lookup.tokens;
 
   try {
-    const file = await provider.find(tokens, backupFileName(input.ownerId));
-    if (!file) return { ok: false, refusal: 'no-backup' };
+    const folder = await readFolder(provider, tokens, input.ownerId);
+    if (!folder.blob) return { ok: false, refusal: 'no-backup' };
 
-    const envelope = parseFile(await provider.read(tokens, file.remoteId));
+    const envelope = parseFile(await provider.read(tokens, folder.blob.remoteId));
+    const remoteTier = fileTier(envelope);
+    const deviceKey = await loadRecoveryKey(input.ownerId);
+    const escrowKey =
+      remoteTier === BackupTier.Standard && folder.escrow
+        ? await openEscrow(provider, tokens, folder.escrow)
+        : null;
+
+    const source = keyForRestore({
+      tier: remoteTier,
+      hasDeviceKey: deviceKey !== null,
+      remoteTier,
+      hasEscrow: escrowKey !== null,
+    });
+    const meta: FoundBackupMeta = {
+      createdAt: envelope.createdAt,
+      size: folder.blob.size > 0 ? folder.blob.size : 0,
+      tier: remoteTier,
+    };
+    if (source === KeySource.AskPerson) return { ok: false, refusal: 'needs-key', found: meta };
+    if (source === KeySource.Lost) return { ok: false, refusal: 'key-lost', found: meta };
+
+    const key = source === KeySource.Escrow ? (escrowKey as Uint8Array) : (deviceKey as Uint8Array);
+    // Adopt the escrowed key, so this phone can back up from here on without
+    // fetching it again — and so the tier the person is told they are on is one
+    // this device can actually honour.
+    if (source === KeySource.Escrow) await saveRecoveryKey(input.ownerId, key);
+
     // Throws on the wrong key (the AEAD tag fails) — the screen turns that into
     // "that key does not open this backup", which is the whole diagnosis.
-    const plain = openBackup(input.key, envelope.sealed, backupAad(input.ownerId));
+    const plain = openBackup(key, envelope.sealed, backupAad(input.ownerId));
     const body = parseBody(plain, input.ownerId);
     return {
       ok: true,
       body,
       plan: planRestore(input.localIds, body),
-      size: file.size > 0 ? file.size : 0,
+      size: folder.blob.size > 0 ? folder.blob.size : 0,
+      tier: remoteTier,
     };
   } catch (error) {
     if (isAuthFailure(error)) {
       await clearTokens(PRIMARY_PROVIDER, input.ownerId).catch(() => undefined);
       return { ok: false, refusal: 'auth' };
     }
+    throw error;
+  }
+}
+
+// ──────────────────────────────────────── turning Extra protection on ──
+
+export interface UpgradeInput {
+  readonly ownerId: string;
+  /** The ledger as it stands, for the case where there is nothing to re-seal. */
+  readonly records: readonly SourceRecord[];
+  /** The key just minted and shown to the person. Not yet stored anywhere. */
+  readonly key: Uint8Array;
+}
+
+export type UpgradeResult =
+  | { readonly ok: true; readonly state: UpgradeState; readonly last: LastBackup }
+  | { readonly ok: false; readonly refusal: BackupRefusal; readonly state: UpgradeState };
+
+/**
+ * Standard → Extra protection: re-lock the backup under a key Drive does not
+ * have, and only then take Drive's copy away.
+ *
+ * The order *is* the promise. `tier.ts` sets out the state machine and every
+ * window in it; what this function adds is the I/O the machine asks for, and
+ * one decision it cannot make for itself — **what to re-seal**.
+ *
+ * It re-seals the *body already on Drive* whenever it can read one: that file
+ * is what the person is being handed a key for, and a fresh capture of the live
+ * ledger, however nearly identical, is a different thing from the backup they
+ * have. When there is no file, or its body cannot be opened with any key we
+ * hold, it falls back to sealing the ledger as it stands — the same bytes an
+ * ordinary run would send. Either way exactly one blob leaves, under the new
+ * key, marked `extra`.
+ *
+ * The new key goes into the keystore *before* the upload, and that is not an
+ * oversight. Until the escrow file is deleted Drive still holds the old key,
+ * and `keyForBackup` prefers it under Standard — so a phone that dies in this
+ * window comes back holding a stale local key that the next run quietly
+ * replaces from the folder. Writing the key after the upload would instead
+ * leave a blob nothing on earth could open.
+ */
+export async function upgradeToExtra(input: UpgradeInput): Promise<UpgradeResult> {
+  // Past `Confirm` already: the caller only gets here once the key has been
+  // shown and the person has said they kept it.
+  let state = advanceUpgrade(UPGRADE_START, 'ok');
+  const provider = providerFor(PRIMARY_PROVIDER);
+  const stop = (refusal: BackupRefusal): UpgradeResult => ({
+    ok: false,
+    refusal,
+    state: advanceUpgrade(state, 'failed'),
+  });
+
+  if (!provider.isConfigured()) return stop('not-configured');
+
+  const net = await connection();
+  if (!net.online) return stop('offline');
+
+  const lookup = await freshTokens(PRIMARY_PROVIDER, input.ownerId);
+  if (lookup.kind !== 'ok') return stop(lookup.kind === 'auth' ? 'auth' : 'not-connected');
+  const tokens = lookup.tokens;
+
+  try {
+    const folder = await readFolder(provider, tokens, input.ownerId);
+
+    // What is going back up: the body already there, or the ledger in hand.
+    let body: BackupBody | null = null;
+    if (folder.blob) {
+      const envelope: BackupFile = parseFile(await provider.read(tokens, folder.blob.remoteId));
+      const oldKey =
+        (folder.escrow ? await openEscrow(provider, tokens, folder.escrow) : null) ??
+        (await loadRecoveryKey(input.ownerId));
+      if (oldKey) {
+        try {
+          body = parseBody(
+            openBackup(oldKey, envelope.sealed, backupAad(input.ownerId)),
+            input.ownerId,
+          );
+        } catch {
+          // Unreadable with every key we have. Nothing is lost by sending the
+          // live ledger instead — it is where those records came from — and
+          // refusing here would strand somebody on Standard over a file that
+          // was already beyond saving.
+          body = null;
+        }
+      }
+    }
+    const outgoing = body ?? buildBody(input.ownerId, input.records, new Date());
+
+    // The keystore, before the network. See the note in the doc comment.
+    await saveRecoveryKey(input.ownerId, input.key);
+
+    const sealed = sealBackup(
+      input.key,
+      backupNonce(),
+      JSON.stringify(outgoing),
+      backupAad(input.ownerId),
+    );
+    const content = JSON.stringify(buildFile(sealed, outgoing.createdAt, BackupTier.Extra));
+    const stored = await provider.put(
+      tokens,
+      backupFileName(input.ownerId),
+      content,
+      folder.blob?.remoteId ?? null,
+    );
+    state = advanceUpgrade(state, 'ok');
+
+    // The tier is now true of the file, so it is written down before the escrow
+    // delete rather than after: somebody who closes the app here is on Extra,
+    // and the file left in the folder opens nothing.
+    await saveTier(input.ownerId, BackupTier.Extra);
+
+    if (folder.escrow && mayClearEscrow(state)) {
+      try {
+        await provider.remove(tokens, folder.escrow.remoteId);
+        state = advanceUpgrade(state, 'ok');
+      } catch (error) {
+        if (isAuthFailure(error)) throw error;
+        // Recorded as a stage failure, not as a failed upgrade: the blob is
+        // already sealed under a key Google does not hold, which is the whole
+        // promise. Every later Extra run sweeps for the file again.
+        state = advanceUpgrade(state, 'failed');
+      }
+    } else {
+      state = advanceUpgrade(state, 'ok');
+    }
+
+    return {
+      ok: true,
+      state,
+      last: {
+        at: Date.now(),
+        size: stored.size > 0 ? stored.size : content.length,
+        records: outgoing.records.length,
+      },
+    };
+  } catch (error) {
+    if (isAuthFailure(error)) {
+      await clearTokens(PRIMARY_PROVIDER, input.ownerId).catch(() => undefined);
+      return stop('auth');
+    }
+    // Anything else is a transport failure. Nothing on Drive changed — the
+    // escrowed key is still there, the blob is still the one it opens, and the
+    // account is still Standard — so it goes up to the caller to be laundered
+    // into a sentence and offered another go.
     throw error;
   }
 }

--- a/apps/mobile/src/lib/backup/engine.ts
+++ b/apps/mobile/src/lib/backup/engine.ts
@@ -33,6 +33,7 @@
 import * as Network from 'expo-network';
 
 import { networkAllows, type SyncNetworkPreference } from '../syncNetwork';
+import { reportHandled } from '../observability';
 import { isAuthFailure } from '../cloud/http';
 import { providerFor } from '../cloud/providers';
 import { clearTokens, loadTokens, saveTokens } from '../cloud/tokens';
@@ -67,6 +68,7 @@ import {
   BackupTier,
   buildEscrow,
   escrowFileName,
+  EscrowFormatError,
   keyForBackup,
   keyForRestore,
   KeySource,
@@ -266,25 +268,39 @@ async function readFolder(
 }
 
 /**
- * The escrowed key as bytes, or null when the file is there but unusable.
+ * The escrowed key as bytes, or null when the file is there but *unusable*.
  *
- * A key file we cannot parse is treated as no key file rather than as a
- * failure. It can only have come from a future version of this app, or from
- * something else writing into the folder, and in either case the useful next
- * move is the one taken for an empty folder — mint a key and escrow it on a
- * backup path; say the key is gone on a restore path. Throwing would leave a
- * person unable to back up because of a file they cannot see or delete.
+ * The distinction this makes is the whole safety of the Standard tier, and it
+ * used to be missing. "The file did not parse" and "the request to read it
+ * failed" arrive at the same `catch`, and they mean opposite things:
+ *
+ *   * A file that does not parse can only have come from a future version of
+ *     this app, or from something else writing into the folder. It will never
+ *     parse, no retry helps, and the useful next move is the one taken for an
+ *     empty folder — mint a key and escrow it. Returning null says that.
+ *   * A read that *failed* — a 500, a timeout, a truncated body — says nothing
+ *     at all about what is in the folder. Answering null there tells the caller
+ *     "there is no key", and the caller mints a new one, writes it over the file
+ *     it could not read, and re-seals the backup under it. One unlucky HTTP
+ *     request and the only copy of somebody's ledger is unopenable, with a
+ *     cheerful "N records backed up" on screen. So it throws, and the run
+ *     refuses instead of guessing.
  */
 async function openEscrow(
   provider: CloudProvider,
   tokens: CloudTokens,
   file: CloudFile,
 ): Promise<Uint8Array | null> {
+  // Outside the try on purpose: a failed read must leave through here, not be
+  // mistaken below for a file that does not parse.
+  const raw = await provider.read(tokens, file.remoteId);
   try {
-    return parseRecoveryKey(parseEscrow(await provider.read(tokens, file.remoteId)).key);
+    // `parseRecoveryKey` answers null for a well-formed file holding something
+    // that is not a key, which is the same "will never work" as a bad envelope.
+    return parseRecoveryKey(parseEscrow(raw).key);
   } catch (error) {
-    if (isAuthFailure(error)) throw error;
-    return null;
+    if (error instanceof EscrowFormatError) return null;
+    throw error;
   }
 }
 
@@ -315,7 +331,29 @@ async function keyForRun(
   tokens: CloudTokens,
   input: BackupRunInput,
   folder: FolderState,
-): Promise<Uint8Array | null> {
+): Promise<Uint8Array | 'needs-key' | null> {
+  // A Standard phone that finds a blob and *no* escrow beside it is looking at
+  // one of two things, and they need opposite answers. Either the folder lost
+  // its key file (Drive offers "Delete hidden app data", and it deletes exactly
+  // this), in which case minting a fresh key and re-escrowing is the repair —
+  // or another phone on this account upgraded to Extra protection, which is
+  // precisely what deletes the escrow, and the blob is now sealed under a key
+  // that lives only on that phone.
+  //
+  // Minting in the second case overwrites somebody else's Extra backup with a
+  // Standard one sealed under a key they do not have, and leaves no escrow for
+  // any third device either: the backup becomes unopenable by everyone. The
+  // blob's own tier is the only thing that tells the two apart, so it is worth
+  // the one read — which happens only in this narrow case, never on an ordinary
+  // run where the escrow is sitting right there.
+  if (input.tier === BackupTier.Standard && folder.blob && !folder.escrow) {
+    const remoteTier = parseFile(await provider.read(tokens, folder.blob.remoteId)).tier;
+    // The file's tier beats the phone's — the phone may simply not have heard
+    // yet. Answering `needs-key` sends the screen to "I already have a key",
+    // which is exactly what this phone needs from its owner.
+    if (remoteTier === BackupTier.Extra) return 'needs-key';
+  }
+
   const deviceKey = await loadRecoveryKey(input.ownerId);
   const escrowKey =
     input.tier === BackupTier.Standard && folder.escrow
@@ -385,6 +423,8 @@ export async function runBackup(input: BackupRunInput): Promise<BackupResult> {
     try {
       const folder = await readFolder(provider, tokens, input.ownerId);
       const key = await keyForRun(provider, tokens, input, folder);
+      // Somebody else's Extra blob. Refusing leaves it exactly as it is.
+      if (key === 'needs-key') return { ok: false, refusal: 'needs-key' };
       // Extra protection with nothing in the keystore. The person holds the
       // only copy, and the screen's job is to ask for it rather than mint a
       // second one that would seal the next backup away from the first.
@@ -683,7 +723,19 @@ export async function upgradeToExtra(input: UpgradeInput): Promise<UpgradeResult
     // The tier is now true of the file, so it is written down before the escrow
     // delete rather than after: somebody who closes the app here is on Extra,
     // and the file left in the folder opens nothing.
-    await saveTier(input.ownerId, BackupTier.Extra);
+    //
+    // Its failure must not travel. This is AsyncStorage, it can throw, and
+    // everything above it has already happened — the blob is re-sealed under the
+    // new key and the keystore holds that key. Letting it out of here would put
+    // the screen's "could not be turned on, your backup is unchanged" in front
+    // of somebody whose backup very much did change, and anyone who believed
+    // that sentence and discarded the key would have lost it. The local tier
+    // being briefly wrong is survivable — `keyForRun` now reads the blob's own
+    // tier when the escrow is gone, which is exactly this state — and the next
+    // read of the settings writes it again.
+    await saveTier(input.ownerId, BackupTier.Extra).catch((error: unknown) =>
+      reportHandled(error, 'backup.upgrade.saveTier'),
+    );
 
     if (folder.escrow && mayClearEscrow(state)) {
       try {

--- a/apps/mobile/src/lib/backup/engine.ts
+++ b/apps/mobile/src/lib/backup/engine.ts
@@ -615,23 +615,27 @@ export async function upgradeToExtra(input: UpgradeInput): Promise<UpgradeResult
   // Past `Confirm` already: the caller only gets here once the key has been
   // shown and the person has said they kept it.
   let state = advanceUpgrade(UPGRADE_START, 'ok');
-  const provider = providerFor(PRIMARY_PROVIDER);
   const stop = (refusal: BackupRefusal): UpgradeResult => ({
     ok: false,
     refusal,
     state: advanceUpgrade(state, 'failed'),
   });
-
-  if (!provider.isConfigured()) return stop('not-configured');
-
-  const net = await connection();
-  if (!net.online) return stop('offline');
-
-  const lookup = await freshTokens(PRIMARY_PROVIDER, input.ownerId);
-  if (lookup.kind !== 'ok') return stop(lookup.kind === 'auth' ? 'auth' : 'not-connected');
-  const tokens = lookup.tokens;
+  if (running) return stop('busy');
+  // Claimed before the first await, so AutoBackup cannot race a Standard write
+  // over the Extra blob while this upgrade is still resealing it.
+  running = true;
+  const provider = providerFor(PRIMARY_PROVIDER);
 
   try {
+    if (!provider.isConfigured()) return stop('not-configured');
+
+    const net = await connection();
+    if (!net.online) return stop('offline');
+
+    const lookup = await freshTokens(PRIMARY_PROVIDER, input.ownerId);
+    if (lookup.kind !== 'ok') return stop(lookup.kind === 'auth' ? 'auth' : 'not-connected');
+    const tokens = lookup.tokens;
+
     const folder = await readFolder(provider, tokens, input.ownerId);
 
     // What is going back up: the body already there, or the ledger in hand.
@@ -715,5 +719,7 @@ export async function upgradeToExtra(input: UpgradeInput): Promise<UpgradeResult
     // account is still Standard — so it goes up to the caller to be laundered
     // into a sentence and offered another go.
     throw error;
+  } finally {
+    running = false;
   }
 }

--- a/apps/mobile/src/lib/backup/payload.ts
+++ b/apps/mobile/src/lib/backup/payload.ts
@@ -24,9 +24,17 @@
  * file is that it cannot.
  */
 
+import { BackupTier } from './tier';
+
 /** Marks a file as ours before anything is decrypted. */
 export const BACKUP_FORMAT = 'waves.personal.backup';
-/** The envelope version. Bumped only when the *outer* shape changes. */
+/**
+ * The envelope version. Bumped only when the *outer* shape changes — and note
+ * that "adding a field" is not that. The version is inside the AEAD's
+ * associated data (see `backupAad`), so bumping it makes every backup taken
+ * under the old number fail to open. The `tier` field below was added without
+ * touching this, precisely so the files the first build wrote stay readable.
+ */
 export const BACKUP_VERSION = 1;
 /** The AEAD the body is sealed with — see `recoveryKey.ts`. */
 export const BACKUP_ALG = 'xchacha20poly1305';
@@ -62,6 +70,21 @@ export interface BackupFile {
   readonly createdAt: string;
   /** The sealed body, in the `v1:`-tagged form `rowCipher.seal` produces. */
   readonly sealed: string;
+  /**
+   * Which tier sealed this file — and so whether a key sits beside it in the
+   * appDataFolder or only in somebody's notebook.
+   *
+   * Optional, and **absent means Extra protection**. Every file the first build
+   * wrote was sealed with a device-only key and carries no tier, so reading the
+   * absence that way is not a default, it is the truth about those files. See
+   * `tier.ts` for why this could not be a version bump.
+   *
+   * In the clear, like the format name, because a restore has to decide whether
+   * to go looking for a key or ask for one *before* it can decrypt anything.
+   * What it discloses to whoever reads the folder — that a key is or is not
+   * beside the blob — the presence of the key file discloses anyway.
+   */
+  readonly tier?: BackupTier;
 }
 
 /** A file that is not ours, or is from a future version we cannot read. */
@@ -125,14 +148,24 @@ export function buildBody(
 }
 
 /** Wrap a sealed body in the envelope that goes to the cloud. */
-export function buildFile(sealed: string, createdAt: string): BackupFile {
+export function buildFile(sealed: string, createdAt: string, tier: BackupTier): BackupFile {
   return {
     format: BACKUP_FORMAT,
     version: BACKUP_VERSION,
     alg: BACKUP_ALG,
     createdAt,
     sealed,
+    tier,
   };
+}
+
+/**
+ * Which tier a found file belongs to. The one place the "absent means Extra"
+ * rule is applied, so no caller has to remember it — and so a file written by a
+ * build older than tiers reads as exactly what it is.
+ */
+export function fileTier(file: BackupFile): BackupTier {
+  return file.tier ?? BackupTier.Extra;
 }
 
 /** Read an envelope back, or say which way it is wrong. */
@@ -160,6 +193,13 @@ export function parseFile(text: string): BackupFile {
     alg: file.alg,
     createdAt: typeof file.createdAt === 'string' ? file.createdAt : '',
     sealed: file.sealed,
+    // A tier this build does not recognise is dropped rather than carried, so
+    // it falls through to `fileTier`'s "absent means Extra". That is the safe
+    // way to be wrong: it asks for a key that may not be needed, rather than
+    // promising an automatic restore that cannot happen.
+    ...(file.tier === BackupTier.Standard || file.tier === BackupTier.Extra
+      ? { tier: file.tier }
+      : {}),
   };
 }
 

--- a/apps/mobile/src/lib/backup/recoveryKey.ts
+++ b/apps/mobile/src/lib/backup/recoveryKey.ts
@@ -42,6 +42,31 @@
  * A future password option can be added beside this without changing the file
  * format: the envelope already names its algorithm, and a password variant
  * would add a `kdf` block rather than replace anything.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * WHAT THE ABOVE GOT WRONG, and where the answer moved to. Everything from
+ * "THE THREE OPTIONS" down is still exactly right about the *cryptography* and
+ * exactly wrong about the *default*. It ends by naming this "WhatsApp's
+ * '64-digit encryption key' option, minus the password option beside it", and
+ * misses that in WhatsApp this is not a default at all: it is the opt-in
+ * end-to-end encrypted backup, buried in settings, and WhatsApp's default Drive
+ * backup asks for no key whatsoever. Shipping the advanced tier as the only
+ * tier produced a Backup screen where nothing worked until you copied 64 hex
+ * characters somewhere, which is the report that started the rework.
+ *
+ * So the key model now has two tiers, and this file is the machinery for both
+ * of them rather than the argument for one. `tier.ts` holds the argument: on
+ * **Standard**, the default, everything below still happens except that the key
+ * is never shown to anybody and a copy of it goes into the same hidden Drive
+ * folder as the backup. On **Extra protection**, opt-in, it is exactly what is
+ * described above — shown once, this device only, never escrowed.
+ *
+ * Nothing in the code below changed. The key is the same 32 bytes, minted the
+ * same way, used directly as the XChaCha20-Poly1305 key through the same
+ * `seal`/`open`; what changed is who else gets a copy, and that is a question
+ * about tiers, not about crypto. `formatRecoveryKey` and `parseRecoveryKey` are
+ * still only reached on the Extra path, because Standard has nothing to show.
  */
 
 import * as Crypto from 'expo-crypto';

--- a/apps/mobile/src/lib/backup/settings.ts
+++ b/apps/mobile/src/lib/backup/settings.ts
@@ -27,15 +27,23 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import { SyncNetworkPreference } from '../syncNetwork';
 import { BackupFrequency, DEFAULT_FREQUENCY, parseFrequency } from './schedule';
+import { BackupTier, parseTier } from './tier';
 
 const FREQUENCY_KEY = 'waves.backup.frequency';
 const NETWORK_KEY = 'waves.backup.network';
 const LAST_KEY = 'waves.backup.last';
 /** Set once the person has been shown their recovery key and confirmed it. */
 const KEY_SEEN_KEY = 'waves.backup.key_seen';
+/**
+ * Which tier the account is on. Absent on a phone that set its backup up before
+ * tiers existed, and on one that has never set anything up — two states that
+ * are not the same, which is why `resolveTier` needs the key flag to tell them
+ * apart, and why the caller writes the answer down the first time it asks.
+ */
+const TIER_KEY = 'waves.backup.tier';
 
 /** Every stored key, for the sign-out wipe. */
-const ALL_KEYS = [FREQUENCY_KEY, NETWORK_KEY, LAST_KEY, KEY_SEEN_KEY] as const;
+const ALL_KEYS = [FREQUENCY_KEY, NETWORK_KEY, LAST_KEY, KEY_SEEN_KEY, TIER_KEY] as const;
 
 const scoped = (base: string, ownerId: string): string => `${base}.${ownerId}`;
 
@@ -62,6 +70,12 @@ export interface BackupSettings {
   readonly last: LastBackup | null;
   /** False until the recovery key has been shown and acknowledged. */
   readonly keySeen: boolean;
+  /**
+   * The tier as stored, or null when nothing has been stored yet. Deliberately
+   * not resolved here: turning null into a tier needs to know whether this
+   * phone holds a key, which is a keystore read this module does not do.
+   */
+  readonly tier: BackupTier | null;
 }
 
 function parseNetwork(raw: string | null): SyncNetworkPreference {
@@ -91,22 +105,39 @@ export const NO_BACKUP_SETTINGS: BackupSettings = {
   network: DEFAULT_BACKUP_NETWORK,
   last: null,
   keySeen: false,
+  tier: null,
 };
 
 export async function loadBackupSettings(ownerId: string): Promise<BackupSettings> {
   if (!ownerId) return NO_BACKUP_SETTINGS;
-  const [frequency, network, last, keySeen] = await Promise.all([
+  const [frequency, network, last, keySeen, tier] = await Promise.all([
     AsyncStorage.getItem(scoped(FREQUENCY_KEY, ownerId)).catch(() => null),
     AsyncStorage.getItem(scoped(NETWORK_KEY, ownerId)).catch(() => null),
     AsyncStorage.getItem(scoped(LAST_KEY, ownerId)).catch(() => null),
     AsyncStorage.getItem(scoped(KEY_SEEN_KEY, ownerId)).catch(() => null),
+    AsyncStorage.getItem(scoped(TIER_KEY, ownerId)).catch(() => null),
   ]);
   return {
     frequency: parseFrequency(frequency),
     network: parseNetwork(network),
     last: parseLast(last),
     keySeen: keySeen === '1',
+    tier: parseTier(tier),
   };
+}
+
+/**
+ * Write the tier down.
+ *
+ * Unlike the frequency and the network, the default is stored rather than
+ * elided. "Standard" and "nothing here yet" have to stay distinguishable: the
+ * second one is what an account carried over from the pre-tier build looks
+ * like, and collapsing them would put every one of those people on Standard —
+ * silently downgrading a key they were told nobody else would ever hold.
+ */
+export async function saveTier(ownerId: string, tier: BackupTier): Promise<void> {
+  if (!ownerId) return;
+  await AsyncStorage.setItem(scoped(TIER_KEY, ownerId), tier);
 }
 
 export async function saveFrequency(ownerId: string, frequency: BackupFrequency): Promise<void> {

--- a/apps/mobile/src/lib/backup/setup.ts
+++ b/apps/mobile/src/lib/backup/setup.ts
@@ -1,18 +1,36 @@
 /**
- * Which of the three things a backup needs is still missing, and which one the
- * person should be handed a button for.
+ * What is still missing before a backup can run, and which one thing the person
+ * should be handed a button for.
  *
- * A backup needs a linked Drive account, a key on this device, and — the one
- * everybody forgets is a step — the person having actually kept a copy of that
- * key. Until all three are true the screen has nothing useful to offer except
- * the step that is outstanding.
+ * ## What changed, and why the list got shorter
  *
- * Two of the three are the engine's own refusals: `runBackup` returns
+ * This used to be three steps for everybody: link an account, make a key, keep
+ * a copy of the key. That was the right checklist for the only tier that
+ * existed and the wrong checklist for the tier that should have been the
+ * default. On **Standard** there is no key ceremony at all — the key is minted
+ * silently and escrowed in the same hidden Drive folder as the backup — so
+ * steps two and three are questions with no answer, and the whole list collapses
+ * to the one thing that genuinely needs a person: linking the Google account.
+ * Link, and it is done.
+ *
+ * On **Extra protection** all three steps are exactly what they were, in the
+ * same order, with the same rules. That is not backwards compatibility for its
+ * own sake: somebody on Extra really does have to be shown a key and really
+ * does have to keep it, and the checklist is the honest way to say so.
+ *
+ * A one-item checklist is not a checklist, so the screen does not draw it as
+ * one — `total` is 1 and it renders the button on its own. The counting still
+ * happens here rather than in the screen because `complete` is the flag the
+ * whole screen keys off, and it must mean the same thing in both tiers: *a
+ * backup would actually run right now*.
+ *
+ * ## The rules that did not change
+ *
+ * Two of the steps are the engine's own refusals: `runBackup` returns
  * `not-connected` with no tokens and `no-key` with no key. The third is not.
- * `engine.ts` never reads `keySeen` — that gate is enforced by the two callers
- * instead, this screen and `AutoBackup.tsx`, because "have you written it
- * down?" is a question about a person and the engine only knows about bytes.
- * Which is exactly why it belongs on a checklist.
+ * `engine.ts` never reads `keySeen` — that gate is enforced by the two callers,
+ * this screen and `AutoBackup.tsx`, because "have you written it down?" is a
+ * question about a person and the engine only knows about bytes.
  *
  * The order is not cosmetic. Linking comes first because it is the only step
  * that can fail for reasons outside the app (no Play services, a cancelled
@@ -26,7 +44,9 @@
  * renderer, which the mobile vitest setup deliberately does not have.
  */
 
-/** The three things, in the order the screen asks for them. */
+import { BackupTier } from './tier';
+
+/** The things a backup needs, in the order the screen asks for them. */
 export enum BackupStep {
   /** A Google account linked, so there is somewhere to put the file. */
   Account = 'account',
@@ -43,6 +63,7 @@ export interface BackupSetupInput {
   readonly connected: boolean;
   readonly hasKey: boolean;
   readonly keySeen: boolean;
+  readonly tier: BackupTier;
 }
 
 export interface BackupSetupStep {
@@ -67,20 +88,29 @@ export interface BackupSetupState {
 }
 
 /**
- * Read the four flags as a checklist.
+ * Read the flags as a checklist.
  *
- * `SaveKey` is reported done only when there is a key to have saved. `keySeen`
- * outliving its key is not reachable today — `acceptKey` sets both, and unlink
- * clears both — but a checklist that could claim "key saved" over "no key on
- * this phone" would be lying about the one thing this screen must not lie
- * about, so the conjunction is written down rather than assumed.
+ * On Extra, `SaveKey` is reported done only when there is a key to have saved.
+ * `keySeen` outliving its key is not reachable today — `acceptKey` sets both,
+ * and unlink clears both — but a checklist that could claim "key saved" over
+ * "no key on this phone" would be lying about the one thing this screen must
+ * not lie about, so the conjunction is written down rather than assumed.
+ *
+ * On Standard the key steps are absent rather than pre-ticked. A step that
+ * ticks itself the moment it appears is noise on a screen whose whole problem
+ * was scaffolding that had outlived its purpose — and worse, it would imply the
+ * person did something they did not do.
  */
 export function backupSetup(input: BackupSetupInput): BackupSetupState {
-  const steps: readonly BackupSetupStep[] = [
-    { step: BackupStep.Account, done: input.configured && input.connected },
-    { step: BackupStep.Key, done: input.hasKey },
-    { step: BackupStep.SaveKey, done: input.hasKey && input.keySeen },
-  ];
+  const linked = input.configured && input.connected;
+  const steps: readonly BackupSetupStep[] =
+    input.tier === BackupTier.Standard
+      ? [{ step: BackupStep.Account, done: linked }]
+      : [
+          { step: BackupStep.Account, done: linked },
+          { step: BackupStep.Key, done: input.hasKey },
+          { step: BackupStep.SaveKey, done: input.hasKey && input.keySeen },
+        ];
   const done = steps.filter((entry) => entry.done).length;
   const complete = input.configured && done === steps.length;
   return {

--- a/apps/mobile/src/lib/backup/tier.ts
+++ b/apps/mobile/src/lib/backup/tier.ts
@@ -279,9 +279,10 @@ export interface KeyLookup {
  * safe: the upgrade writes a new key to the keystore before it re-seals
  * anything, so a phone that died in between holds a key that opens nothing
  * while Drive still holds the one that opens the blob. Preferring the escrow
- * discards the stale local copy and everything keeps working. It also makes a
- * second phone on the same Google account converge on one key instead of
- * quietly sealing every other backup under a different one.
+ * discards the stale local copy and everything keeps working. If the escrow is
+ * absent or unreadable, Standard mints and escrows a fresh key instead of using
+ * the device-only copy, because a Standard backup must always be restorable from
+ * Drive alone.
  *
  * Under **Extra there is no escrow to consult**, by construction, so the
  * device's key is the only answer and its absence is the person's to fix.
@@ -291,7 +292,6 @@ export function keyForBackup(lookup: KeyLookup): KeySource {
     return lookup.hasDeviceKey ? KeySource.Device : KeySource.AskPerson;
   }
   if (lookup.hasEscrow) return KeySource.Escrow;
-  if (lookup.hasDeviceKey) return KeySource.Device;
   return KeySource.Mint;
 }
 

--- a/apps/mobile/src/lib/backup/tier.ts
+++ b/apps/mobile/src/lib/backup/tier.ts
@@ -113,20 +113,41 @@ export function parseTier(raw: string | null): BackupTier | null {
  * a network answer to a local question and would make the screen's own claims
  * wait on a Drive round trip.
  *
- * The inference exists for exactly one population and runs exactly once: people
- * who set a backup up under the previous build. They have a key in the keystore
- * and no stored tier, because the previous build had no tiers to store. In the
- * new vocabulary they are on Extra protection — that is precisely what their
- * key is — so they keep working with no prompt, their Drive file stays
- * readable, and nothing about their screen changes except its words. The caller
- * writes the answer down the first time it is asked, so the inference is a
- * migration and not a standing rule.
+ * The inference is for people who set a backup up under the previous build:
+ * they hold a key and no stored tier, because the previous build had no tiers
+ * to store. In the new vocabulary they are on Extra protection — that is
+ * precisely what their key is — so they keep working with no prompt and their
+ * Drive file stays readable.
+ *
+ * **Why it asks about `keySeen` and not only about the key.** "Holds a key" was
+ * proof of Extra for exactly as long as Extra was the only tier. It is not any
+ * more: a Standard phone mints a key on its first run too, so on its own the
+ * signal now says nothing. And the ambiguity is reachable, not theoretical —
+ * iOS keeps keychain items across an app being deleted and reinstalled while it
+ * throws AsyncStorage away, so a reinstall lands on exactly "key, no stored
+ * tier". Reading that as Extra would flip a Standard account over, and the next
+ * run would sweep the escrowed key out of Drive, leaving the person depending
+ * on 64 characters Standard deliberately never showed them.
+ *
+ * `keySeen` separates them because the previous build *could not back up
+ * without it* — it gated the button on exactly this flag — so every migrating
+ * Extra user has it, and it lives in the same AsyncStorage the reinstall wiped.
+ * Someone who minted a key under the old build and never confirmed it reads as
+ * Standard, which is right in the only way that matters: they never had a
+ * backup to keep openable.
+ *
+ * The caller writes the answer down the first time it is asked, so this stays a
+ * migration rather than a standing rule.
  *
  * A phone with no stored tier and no key is a fresh setup, and gets the default.
  */
-export function resolveTier(stored: BackupTier | null, hasKey: boolean): BackupTier {
+export function resolveTier(
+  stored: BackupTier | null,
+  hasKey: boolean,
+  keySeen: boolean,
+): BackupTier {
   if (stored !== null) return stored;
-  return hasKey ? BackupTier.Extra : DEFAULT_TIER;
+  return hasKey && keySeen ? BackupTier.Extra : DEFAULT_TIER;
 }
 
 /**
@@ -452,7 +473,14 @@ export interface BackupStanding {
    * changed the note on one" is not.
    */
   readonly upToDate: boolean;
-  /** True when a backup would run right now if something asked it to. */
+  /**
+   * True when a backup would run right now if something asked it to.
+   *
+   * "Configured" is part of it and not an afterthought: a build shipped without
+   * Google client ids can be linked-looking (tokens on disk from a previous
+   * build) and still have every run refuse with `not-configured`. Leaving it
+   * out made this field say yes to a question the engine always answered no to.
+   */
   readonly canBackUp: boolean;
   /**
    * Whether a restore on a *new* phone would have to ask for a key. False on
@@ -464,6 +492,8 @@ export interface BackupStanding {
 export interface StandingInput {
   readonly tier: BackupTier;
   readonly keySeen: boolean;
+  /** Whether this build can talk to the provider at all. */
+  readonly configured: boolean;
   readonly connected: boolean;
   /** Epoch ms, or null. */
   readonly lastAt: number | null;
@@ -483,7 +513,7 @@ export function backupStanding(input: StandingInput): BackupStanding {
     everBackedUp,
     newSince: input.newSince,
     upToDate: everBackedUp && input.newSince === 0 && input.recordCount === input.lastRecords,
-    canBackUp: input.connected && tierAllowsBackup(input.tier, input.keySeen),
+    canBackUp: input.configured && input.connected && tierAllowsBackup(input.tier, input.keySeen),
     restoreNeedsKey: input.tier === BackupTier.Extra,
   };
 }

--- a/apps/mobile/src/lib/backup/tier.ts
+++ b/apps/mobile/src/lib/backup/tier.ts
@@ -1,0 +1,489 @@
+/**
+ * Two tiers of backup, and the arithmetic that decides which one somebody is on.
+ *
+ * ## What was wrong
+ *
+ * `recoveryKey.ts` reasons its way to a 32-byte key shown once as 64 hex
+ * characters, and calls that "WhatsApp's '64-digit encryption key' option,
+ * minus the password option beside it". The reasoning is sound and the
+ * conclusion was wrong, because in WhatsApp that option is *not the default*.
+ * It is the opt-in end-to-end encrypted backup, four taps down in settings,
+ * behind a screen whose whole job is to talk you out of it unless you mean it.
+ * WhatsApp's default Drive backup asks for no key at all. We shipped the
+ * advanced tier as the only tier, and the result was a Backup screen where
+ * nothing worked until you copied 64 hex characters somewhere.
+ *
+ * ## The two tiers
+ *
+ * **Standard**, the default. The app mints the same 32-byte key and never shows
+ * it to anybody. A copy goes into the *same hidden Drive appDataFolder as the
+ * backup blob*, in a small file beside it. Signing in with the same Google
+ * account on a new phone finds both and restores with no ceremony. Whoever
+ * holds the Google account holds the ledger — that is the honest trade, and it
+ * is exactly what WhatsApp's default tier trades.
+ *
+ * **Extra protection**, opt-in. What shipped before: the key is shown once,
+ * lives only in this device's keystore, is never escrowed, and a restore on a
+ * new phone means typing it back in. Waves and Google are both locked out, and
+ * losing the key loses the backup for good.
+ *
+ * ## Why escrowing in `appDataFolder` costs nothing
+ *
+ * `nativeGoogle.ts` already asks for `drive.appdata` and nothing else, and the
+ * blob already lives there. A second small file in the same folder needs no new
+ * scope, no new consent screen, and no second provider. That is the whole
+ * reason this design is cheap enough to be the default.
+ *
+ * ## The escrowed key is in the clear, and that is the point
+ *
+ * The escrow file holds the key as plain hex. Encrypting it under something
+ * Drive also holds would be theatre — a lock whose key is taped to it — and
+ * pretending otherwise on the screen would be worse than the plain statement
+ * the Standard copy actually makes: the key is kept in your Google account, so
+ * whoever reaches your Google account can read the backup. Say it, don't
+ * obfuscate it.
+ *
+ * ## How a restore knows which tier it found
+ *
+ * The backup envelope carries an optional `tier`. **Absent means Extra**, which
+ * is exactly right for every file the previous build ever wrote: those were
+ * device-only keys, so a v1 file with no tier field *is* an extra-protection
+ * backup. That is why nothing here bumps `BACKUP_VERSION`: the version is in
+ * the AEAD's associated data, so bumping it would make every existing backup
+ * fail to open — the one thing this change must not do. An added optional field
+ * is invisible to `parseFile`'s older self and load-bearing to its newer one.
+ *
+ * The tier travels in the clear, next to the format name. That tells whoever
+ * reads the folder whether a key sits beside the blob — which the presence of
+ * the key file tells them anyway. It buys the restore the ability to say
+ * *which* kind of "I cannot open this" it is looking at, which is the
+ * difference between "type your key" and "this backup can never be opened".
+ *
+ * ## There is no downgrade, and that is a decision
+ *
+ * Extra protection → Standard would mean uploading to Google the key we told
+ * the person, in the strongest words this app owns, that nobody but them would
+ * ever hold — and re-sealing the ledger under a key Drive then keeps. The
+ * screen says *lose it and the backup can never be opened*. A switch that
+ * quietly makes that untrue does not just weaken one account's backup; it
+ * teaches people that the warnings in this app are decoration.
+ *
+ * It is also the one direction where no ordering helps. The upgrade has a safe
+ * sequence because each step leaves the data better protected than the step
+ * before, so a failure anywhere is survivable. A downgrade is the opposite at
+ * every stage, and there is no arrangement of it that fails safe.
+ *
+ * The way back exists and is deliberately not a switch: **unlink the Google
+ * account and link it again.** Unlinking already clears the key, the tier and
+ * the schedule together — the Drive file is left behind, unreadable, exactly as
+ * it always was — and the next link starts a fresh setup on Standard. One
+ * visible, deliberate route with its own confirmation, instead of a toggle that
+ * reverses a promise. The unlink dialog says what it costs, in the tier's own
+ * words.
+ *
+ * ## Everything here is pure
+ *
+ * The tier arithmetic, the escrow envelope, and the upgrade state machine have
+ * no keystore, no network and no React in them, so the decisions that matter —
+ * an existing device-only user staying readable, escrow being deleted only
+ * after a successful re-seal — are testable in a suite with no renderer.
+ */
+
+/** Which promise this account's backup is making. */
+export enum BackupTier {
+  /** Key escrowed in Drive's appDataFolder. No ceremony, automatic restore. */
+  Standard = 'standard',
+  /** Key on this device only. Shown once, typed back on a new phone. */
+  Extra = 'extra',
+}
+
+/** What a fresh account gets, and what the whole rework is for. */
+export const DEFAULT_TIER = BackupTier.Standard;
+
+/** A stored value that is not one of ours reads as "nothing stored". */
+export function parseTier(raw: string | null): BackupTier | null {
+  return raw === BackupTier.Standard || raw === BackupTier.Extra ? raw : null;
+}
+
+/**
+ * Which tier this account is on, given what is stored and what this phone holds.
+ *
+ * The stored value wins whenever there is one — tier is explicit state, not an
+ * inference, and certainly not "is there a file in the appDataFolder", which is
+ * a network answer to a local question and would make the screen's own claims
+ * wait on a Drive round trip.
+ *
+ * The inference exists for exactly one population and runs exactly once: people
+ * who set a backup up under the previous build. They have a key in the keystore
+ * and no stored tier, because the previous build had no tiers to store. In the
+ * new vocabulary they are on Extra protection — that is precisely what their
+ * key is — so they keep working with no prompt, their Drive file stays
+ * readable, and nothing about their screen changes except its words. The caller
+ * writes the answer down the first time it is asked, so the inference is a
+ * migration and not a standing rule.
+ *
+ * A phone with no stored tier and no key is a fresh setup, and gets the default.
+ */
+export function resolveTier(stored: BackupTier | null, hasKey: boolean): BackupTier {
+  if (stored !== null) return stored;
+  return hasKey ? BackupTier.Extra : DEFAULT_TIER;
+}
+
+/**
+ * Whether a backup may run without anybody being asked anything else.
+ *
+ * On Extra this is the `keySeen` gate the previous build enforced in its two
+ * callers: nothing goes to Drive until the person has been shown the key and
+ * said they kept it, because a backup nobody can open is worse than none. On
+ * Standard there is nothing to have kept — the key is in the Google account the
+ * backup is going to — so the gate would be a question with no answer.
+ */
+export function tierAllowsBackup(tier: BackupTier, keySeen: boolean): boolean {
+  return tier === BackupTier.Standard || keySeen;
+}
+
+// ───────────────────────────────────────────────────── the escrow file ──
+
+/** Marks the key file as ours before anything is read out of it. */
+export const ESCROW_FORMAT = 'waves.personal.backup.key';
+
+/**
+ * The escrow envelope's own version, independent of the backup's.
+ *
+ * Versioned from the start because this is now a format with two tiers and
+ * there will one day be a third — a password tier, a second provider, a key
+ * wrapped under something the phone actually holds. A reader that refuses a
+ * version it does not know is the only way a future tier can be added without
+ * an old build quietly mis-reading it.
+ */
+export const ESCROW_VERSION = 1;
+
+/** The file that sits beside the blob, holding the key that opens it. */
+export interface EscrowFile {
+  readonly format: typeof ESCROW_FORMAT;
+  readonly version: number;
+  /**
+   * Which tier the key was escrowed for. Only ever `standard` — an escrowed
+   * Extra key is a contradiction — but written down rather than assumed, so a
+   * future tier that also escrows cannot be mistaken for this one.
+   */
+  readonly tier: BackupTier.Standard;
+  /** When it was put there. For nothing but a diagnosis; the file is one line. */
+  readonly createdAt: string;
+  /** The 32-byte key, as 64 lowercase hex characters. See the header. */
+  readonly key: string;
+}
+
+/** A key file that is not ours, or is from a version we must not guess at. */
+export class EscrowFormatError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'EscrowFormatError';
+  }
+}
+
+/**
+ * The escrow file's name in the appDataFolder, beside the blob's.
+ *
+ * Owner-scoped for the same reason `backupFileName` is: two Waves accounts can
+ * link one Google account, and one folder would otherwise hold one file that
+ * both of them overwrite — here that would mean handing B the key to A's
+ * ledger, which is worse than the lost-update the blob's own scoping prevents.
+ */
+export function escrowFileName(ownerId: string): string {
+  const safe = ownerId.toLowerCase().replace(/[^a-z0-9-]/g, '');
+  return `waves-personal-backup-key-${safe}.json`;
+}
+
+export function buildEscrow(keyHex: string, createdAt: string): EscrowFile {
+  return {
+    format: ESCROW_FORMAT,
+    version: ESCROW_VERSION,
+    tier: BackupTier.Standard,
+    createdAt,
+    key: keyHex,
+  };
+}
+
+/**
+ * Read a key file back, or say which way it is wrong.
+ *
+ * Deliberately does not parse the key into bytes: that is `parseRecoveryKey`'s
+ * job and it already forgives spacing and case, and keeping the two apart means
+ * this module never touches key material as anything but an opaque string.
+ */
+export function parseEscrow(text: string): EscrowFile {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch {
+    throw new EscrowFormatError('backup key file is not JSON');
+  }
+  const file = raw as Partial<EscrowFile>;
+  if (file?.format !== ESCROW_FORMAT) throw new EscrowFormatError('not a Waves backup key');
+  if (typeof file.version !== 'number' || file.version > ESCROW_VERSION) {
+    throw new EscrowFormatError(
+      `backup key version ${String(file.version)} is newer than this app`,
+    );
+  }
+  if (file.tier !== BackupTier.Standard) {
+    throw new EscrowFormatError(`unknown escrow tier ${String(file.tier)}`);
+  }
+  if (typeof file.key !== 'string' || file.key.length === 0) {
+    throw new EscrowFormatError('backup key file holds no key');
+  }
+  return {
+    format: ESCROW_FORMAT,
+    version: file.version,
+    tier: BackupTier.Standard,
+    createdAt: typeof file.createdAt === 'string' ? file.createdAt : '',
+    key: file.key,
+  };
+}
+
+// ────────────────────────────────────────────── choosing a key to use ──
+
+/** What the engine should do about a key before it can seal or open anything. */
+export enum KeySource {
+  /** The key already in this device's keystore. */
+  Device = 'device',
+  /** The escrowed copy in Drive — adopt it into the keystore on the way past. */
+  Escrow = 'escrow',
+  /** Nothing anywhere. Mint one, escrow it, and carry on. Standard only. */
+  Mint = 'mint',
+  /** An extra-protection backup and no key here. Only the person has it. */
+  AskPerson = 'ask',
+  /** A standard backup whose escrowed key is gone. Nothing opens it. */
+  Lost = 'lost',
+}
+
+/**
+ * What the phone in front of us has to work with, for one account.
+ *
+ * `remoteTier` is the tier of the backup *found on Drive*, or null when there
+ * is no backup there at all — which is the ordinary state on a first run and
+ * must not be confused with "found one and could not read it".
+ */
+export interface KeyLookup {
+  readonly tier: BackupTier;
+  readonly hasDeviceKey: boolean;
+  readonly remoteTier: BackupTier | null;
+  readonly hasEscrow: boolean;
+}
+
+/**
+ * Where the key for the *next backup run* comes from.
+ *
+ * Under **Standard the escrow is authoritative**, ahead of the device's own
+ * copy, and that ordering is doing real work. It makes a half-finished upgrade
+ * safe: the upgrade writes a new key to the keystore before it re-seals
+ * anything, so a phone that died in between holds a key that opens nothing
+ * while Drive still holds the one that opens the blob. Preferring the escrow
+ * discards the stale local copy and everything keeps working. It also makes a
+ * second phone on the same Google account converge on one key instead of
+ * quietly sealing every other backup under a different one.
+ *
+ * Under **Extra there is no escrow to consult**, by construction, so the
+ * device's key is the only answer and its absence is the person's to fix.
+ */
+export function keyForBackup(lookup: KeyLookup): KeySource {
+  if (lookup.tier === BackupTier.Extra) {
+    return lookup.hasDeviceKey ? KeySource.Device : KeySource.AskPerson;
+  }
+  if (lookup.hasEscrow) return KeySource.Escrow;
+  if (lookup.hasDeviceKey) return KeySource.Device;
+  return KeySource.Mint;
+}
+
+/**
+ * Where the key for *opening a backup that was found* comes from.
+ *
+ * The difference from `keyForBackup` is that this one is answering about a file
+ * that already exists and already has a tier of its own, and the file's tier
+ * beats the phone's. A phone freshly signed in has whatever local tier its
+ * defaults gave it and knows nothing; the blob knows exactly what sealed it.
+ *
+ * The two failures are kept apart because they are not the same news. An extra-
+ * protection blob with no key here is *waiting for something the person has* —
+ * `AskPerson`, and the screen points at "I already have a key". A standard blob
+ * whose escrowed key is no longer in the appDataFolder (Drive's storage settings
+ * offer "Delete hidden app data", and it deletes exactly this) is `Lost`: there
+ * is no key anywhere, nothing to type, and the only honest thing the screen can
+ * do is say so rather than send somebody hunting for 64 characters that never
+ * existed.
+ */
+export function keyForRestore(lookup: KeyLookup): KeySource {
+  if (lookup.remoteTier === BackupTier.Extra) {
+    return lookup.hasDeviceKey ? KeySource.Device : KeySource.AskPerson;
+  }
+  if (lookup.hasEscrow) return KeySource.Escrow;
+  if (lookup.hasDeviceKey) return KeySource.Device;
+  return KeySource.Lost;
+}
+
+// ──────────────────────────────────────────── Standard → Extra upgrade ──
+
+/**
+ * The stages of turning Extra protection on, in the order they must happen.
+ *
+ * The ordering is the whole safety argument, so it is written down as a machine
+ * rather than left to the shape of an async function.
+ *
+ * 1. `Confirm` — the key is minted and shown, and nothing has changed yet. A
+ *    person who backs out here has lost nothing and changed nothing.
+ * 2. `Reseal` — the blob on Drive is re-sealed under the new key and rewritten
+ *    with `tier: extra`. **This must succeed before the escrow is touched.**
+ *    Deleting the escrowed key while a blob the old key still opens sits beside
+ *    it would be a lie about the promise just made: the key Google held would be
+ *    gone from the folder but not necessarily from Google, and the ciphertext it
+ *    opens would still be there.
+ * 3. `Escrow` — and only now, delete the escrowed key.
+ * 4. `Done`.
+ *
+ * What happens when a stage fails, in each window:
+ *
+ * - **Re-seal fails.** Nothing on Drive changed. The escrow still holds the old
+ *   key, the blob is still sealed under it, and the account is still Standard.
+ *   The person is told, and can try again. This is the failure the ordering is
+ *   designed to make cheap.
+ * - **Re-seal succeeded, delete failed.** Drive holds a key that opens nothing:
+ *   the blob beside it is already sealed under the new one and says `tier:
+ *   extra`, and `keyForRestore` reads the *blob's* tier, so the stale file is
+ *   inert rather than a way in. It is still untidy and still a file the person
+ *   did not ask to keep, so every later run under Extra sweeps for it.
+ * - **The process dies between minting and re-sealing.** The keystore holds a
+ *   key that opens nothing. `keyForBackup` prefers the escrow under Standard
+ *   precisely so this state resolves itself: the stale local key is overwritten
+ *   from the escrow on the next run, and the account is exactly where it was.
+ *
+ * The one thing none of these can cost is data, because the backup is never the
+ * only copy of the ledger at the moment of an upgrade — the records are on the
+ * phone, and a lost remote copy is remade by the next run. That is what lets
+ * this fail loudly instead of trying to be clever.
+ */
+export enum UpgradeStage {
+  Confirm = 'confirm',
+  Reseal = 'reseal',
+  Escrow = 'escrow',
+  Done = 'done',
+}
+
+export interface UpgradeState {
+  readonly stage: UpgradeStage;
+  /** The blob on Drive is sealed under the new key and marked extra. */
+  readonly resealed: boolean;
+  /** The escrowed copy of the old key is gone from the appDataFolder. */
+  readonly escrowCleared: boolean;
+  /** Which tier the account is on *right now*, mid-flight included. */
+  readonly tier: BackupTier;
+  /** Set when a stage refused; the caller shows it and stops. */
+  readonly failedAt: UpgradeStage | null;
+}
+
+export const UPGRADE_START: UpgradeState = {
+  stage: UpgradeStage.Confirm,
+  resealed: false,
+  escrowCleared: false,
+  tier: BackupTier.Standard,
+  failedAt: null,
+};
+
+/** What the caller reports back about the stage it just attempted. */
+export type UpgradeOutcome = 'ok' | 'failed';
+
+/**
+ * Advance the upgrade by one stage.
+ *
+ * The tier flips to Extra the moment the re-seal lands, not when the escrow
+ * delete does — the blob is at that point sealed under a key Drive does not
+ * have, which is the promise; the leftover file opens nothing. Flipping it
+ * later would leave the screen saying "Standard" over a backup only the person
+ * can open, which is the same class of lie in the other direction.
+ *
+ * A failure freezes the state where it stands and records the stage, so the
+ * caller can neither carry on to a later stage nor report success.
+ */
+export function advanceUpgrade(state: UpgradeState, outcome: UpgradeOutcome): UpgradeState {
+  if (state.failedAt !== null || state.stage === UpgradeStage.Done) return state;
+  if (outcome === 'failed') return { ...state, failedAt: state.stage };
+
+  switch (state.stage) {
+    case UpgradeStage.Confirm:
+      return { ...state, stage: UpgradeStage.Reseal };
+    case UpgradeStage.Reseal:
+      return { ...state, stage: UpgradeStage.Escrow, resealed: true, tier: BackupTier.Extra };
+    case UpgradeStage.Escrow:
+      return { ...state, stage: UpgradeStage.Done, escrowCleared: true };
+    default:
+      return state;
+  }
+}
+
+/**
+ * Whether the escrowed key may be deleted yet. The single rule this whole
+ * module exists to enforce, stated once so nothing has to re-derive it: not
+ * until the blob is sealed under a key Drive no longer holds.
+ */
+export function mayClearEscrow(state: UpgradeState): boolean {
+  return state.resealed && state.failedAt === null;
+}
+
+// ──────────────────────────────────── what the rest of the app can ask ──
+
+/**
+ * The account's backup standing, as one value — for the sign-out guard and the
+ * sign-in restore prompt, which are a separate change and need to ask these
+ * three questions without knowing anything about tiers, escrow or Drive.
+ */
+export interface BackupStanding {
+  readonly tier: BackupTier;
+  /** Epoch ms of the last successful backup, or null for never. */
+  readonly lastAt: number | null;
+  readonly everBackedUp: boolean;
+  /** Records added since the last backup. Zero is not the same as up to date. */
+  readonly newSince: number;
+  /**
+   * Nothing has been added or removed since the last backup landed.
+   *
+   * Honest about its limits: an edit in place changes no count and moves no
+   * created-at, so this is a claim about the *shape* of the ledger, not its
+   * contents. It is the right claim for a sign-out guard — "you have 4 records
+   * that have never left this phone" is worth stopping somebody for; "you
+   * changed the note on one" is not.
+   */
+  readonly upToDate: boolean;
+  /** True when a backup would run right now if something asked it to. */
+  readonly canBackUp: boolean;
+  /**
+   * Whether a restore on a *new* phone would have to ask for a key. False on
+   * Standard, where signing into the same Google account is the whole of it.
+   */
+  readonly restoreNeedsKey: boolean;
+}
+
+export interface StandingInput {
+  readonly tier: BackupTier;
+  readonly keySeen: boolean;
+  readonly connected: boolean;
+  /** Epoch ms, or null. */
+  readonly lastAt: number | null;
+  /** How many records the last backup carried. */
+  readonly lastRecords: number;
+  /** How many the ledger holds now. */
+  readonly recordCount: number;
+  /** How many of those were created after `lastAt`. */
+  readonly newSince: number;
+}
+
+export function backupStanding(input: StandingInput): BackupStanding {
+  const everBackedUp = input.lastAt !== null;
+  return {
+    tier: input.tier,
+    lastAt: input.lastAt,
+    everBackedUp,
+    newSince: input.newSince,
+    upToDate: everBackedUp && input.newSince === 0 && input.recordCount === input.lastRecords,
+    canBackUp: input.connected && tierAllowsBackup(input.tier, input.keySeen),
+    restoreNeedsKey: input.tier === BackupTier.Extra,
+  };
+}

--- a/apps/mobile/src/lib/backup/useBackup.ts
+++ b/apps/mobile/src/lib/backup/useBackup.ts
@@ -17,7 +17,7 @@
  * people are least likely to have signal: setting up a new phone.
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { MutationKind, personalScope } from '@waves/core';
 
@@ -34,6 +34,7 @@ import {
   PRIMARY_PROVIDER,
   runBackup,
   scanBackup,
+  upgradeToExtra,
   type BackupPhase,
   type BackupRefusal,
   type RestoreScan,
@@ -53,8 +54,10 @@ import {
   saveFrequency,
   saveLastBackup,
   saveNetwork,
+  saveTier,
   type BackupSettings,
 } from './settings';
+import { backupStanding, BackupTier, resolveTier, type BackupStanding } from './tier';
 
 /** What the screen says after a run: nothing yet, done, or a named refusal. */
 export type BackupOutcome =
@@ -77,8 +80,21 @@ export interface BackupState {
   readonly account: string | null;
   /** True when this device holds the recovery key. */
   readonly hasKey: boolean;
+  /**
+   * Which tier this account is on. Resolved once from what is stored and what
+   * this phone holds, then written down — see `tier.ts` for the one-time
+   * migration that carries pre-tier users onto Extra protection.
+   */
+  readonly tier: BackupTier;
   /** How many personal records a backup would carry right now. */
   readonly recordCount: number;
+  /**
+   * The three questions the sign-out guard and the sign-in restore prompt need
+   * answering, in one value and with no knowledge of tiers or Drive: is there
+   * anything not yet backed up, when did the last one land, and would a restore
+   * on a new phone have to ask for a key.
+   */
+  readonly standing: BackupStanding;
   /** Non-null while a backup is running. */
   readonly phase: BackupPhase | null;
   /** The result of the last run this session. */
@@ -93,6 +109,17 @@ export interface BackupActions {
   setNetwork: (network: SyncNetworkPreference) => Promise<void>;
   /** Mint a key for this device and hand back its hex, for showing once. */
   createKey: () => Promise<string>;
+  /**
+   * Mint the key that Extra protection will be turned on with, and hand back
+   * its hex for showing. Stores nothing: until the person says they have kept
+   * it, the account is still Standard and this key exists only on screen.
+   */
+  beginExtra: () => string;
+  /**
+   * Do the upgrade with the key `beginExtra` produced: re-seal the backup under
+   * it, then take Drive's copy of the old key away. Never the other way round.
+   */
+  commitExtra: (keyHex: string) => Promise<BackupOutcome>;
   /** The key this device holds, as hex, or null. For "show it to me again". */
   revealKey: () => Promise<string | null>;
   /** Accept a key typed in from another device. False when it is not a key. */
@@ -130,6 +157,39 @@ export function useBackup(): BackupState & BackupActions {
 
   const provider = providerFor(PRIMARY_PROVIDER);
   const configured = provider.isConfigured();
+
+  /**
+   * The tier, resolved from the stored value and this phone's key.
+   *
+   * `settings.tier` is written the first time the effect below runs, so this
+   * falls back to the inference only for the frame before that lands — and the
+   * inference and the write agree, so the screen never flickers between tiers.
+   */
+  const tier = resolveTier(settings.tier, hasKey);
+
+  /**
+   * How many records were created after the last backup landed.
+   *
+   * Creation time is the only timestamp the mirror rows carry, so this counts
+   * additions and nothing else — see `backupStanding` for what that does and
+   * does not let the caller claim. Memoised because it walks the whole ledger
+   * and the ledger changes far less often than this hook renders.
+   */
+  const newSince = useMemo(() => {
+    const since = settings.last?.at ?? null;
+    if (since === null) return records.length;
+    return records.filter((row) => Date.parse(row.created_at) > since).length;
+  }, [records, settings.last?.at]);
+
+  const standing = backupStanding({
+    tier,
+    keySeen: settings.keySeen,
+    connected,
+    lastAt: settings.last?.at ?? null,
+    lastRecords: settings.last?.records ?? 0,
+    recordCount: records.length,
+    newSince,
+  });
 
   /**
    * Whether an account is linked, from the tokens on disk. A local read and
@@ -177,7 +237,18 @@ export function useBackup(): BackupState & BackupActions {
         ownerId ? loadTokens(PRIMARY_PROVIDER, ownerId) : Promise.resolve(null),
       ]);
       if (!alive) return;
-      setSettings(stored);
+      // The one-time migration. A phone that set a backup up under the build
+      // before tiers has a key and no stored tier, and that key *is* Extra
+      // protection; a phone with neither is a fresh setup and gets the default.
+      // The answer is written down as soon as it is worked out, so from here on
+      // the tier is state and never an inference — including for the sign-out
+      // guard, which reads the settings without a keystore of its own.
+      const tier = resolveTier(stored.tier, key !== null);
+      if (ownerId && stored.tier === null) {
+        await saveTier(ownerId, tier).catch(() => undefined);
+      }
+      if (!alive) return;
+      setSettings({ ...stored, tier });
       setHasKey(key !== null);
       setConnected(tokens !== null);
       if (!tokens) setAccount(null);
@@ -224,18 +295,16 @@ export function useBackup(): BackupState & BackupActions {
   }, [ownerId, provider, refreshLink]);
 
   const backupNow = useCallback(async (): Promise<BackupOutcome> => {
-    const key = ownerId ? await loadRecoveryKey(ownerId) : null;
-    if (!key) {
-      const refused: BackupOutcome = { kind: 'refused', refusal: 'no-key' };
-      setOutcome(refused);
-      return refused;
-    }
     setOutcome(null);
     try {
+      // No key is loaded here any more. Where it comes from depends on the tier
+      // and on what is in the Drive folder, and the engine is the only place
+      // that can see both — on Standard it will mint and escrow one rather than
+      // refuse, which is the whole of the default tier's setup.
       const result = await runBackup({
         ownerId,
         records,
-        key,
+        tier,
         network: settings.network,
         manual: true,
         onPhase: setPhase,
@@ -251,13 +320,16 @@ export function useBackup(): BackupState & BackupActions {
       }
       await saveLastBackup(ownerId, result.last);
       setSettings((current) => ({ ...current, last: result.last }));
+      // A Standard run may have minted the key itself; the screen's "this phone
+      // holds a key" is only true after that, and nothing else would say so.
+      setHasKey(true);
       const done: BackupOutcome = { kind: 'ok', records: result.last.records };
       setOutcome(done);
       return done;
     } finally {
       setPhase(null);
     }
-  }, [ownerId, records, settings.network, refreshLink]);
+  }, [ownerId, records, tier, settings.network, refreshLink]);
 
   const setFrequencyAction = useCallback(
     async (frequency: BackupFrequency): Promise<void> => {
@@ -296,7 +368,13 @@ export function useBackup(): BackupState & BackupActions {
       // A key typed in from elsewhere has self-evidently been kept somewhere,
       // so there is nothing left to warn this person about.
       await markKeySeen(ownerId);
-      setSettings((current) => ({ ...current, keySeen: true }));
+      // And it declares the tier. Somebody typing a key in is holding one, and
+      // leaving them on Standard would have the next run write `tier: standard`
+      // into the envelope with no key escrowed beside it — a file that says a
+      // key is in the folder when it is in their notebook, which a later
+      // restore would read as "the key is lost".
+      await saveTier(ownerId, BackupTier.Extra);
+      setSettings((current) => ({ ...current, keySeen: true, tier: BackupTier.Extra }));
       return true;
     },
     [ownerId],
@@ -307,10 +385,51 @@ export function useBackup(): BackupState & BackupActions {
     await markKeySeen(ownerId);
   }, [ownerId]);
 
+  /**
+   * Mint the key Extra protection would be turned on with, and hand it back to
+   * be shown. Nothing is written anywhere: back out of the sheet and the
+   * account is untouched, still Standard, still opening with the key Drive
+   * holds. The upgrade only starts at `commitExtra`.
+   */
+  const beginExtra = useCallback((): string => bytesToHex(mintRecoveryKey()), []);
+
+  const commitExtra = useCallback(
+    async (keyHex: string): Promise<BackupOutcome> => {
+      const key = parseRecoveryKey(keyHex);
+      // Only reachable if the hex we minted came back mangled, which would mean
+      // the screen handed us something other than what it was given.
+      if (!key || !ownerId) return { kind: 'refused', refusal: 'no-key' };
+      const result = await upgradeToExtra({ ownerId, records, key });
+      if (!result.ok) {
+        const refused: BackupOutcome = { kind: 'refused', refusal: result.refusal };
+        setOutcome(refused);
+        if (result.refusal === 'auth') await refreshLink();
+        return refused;
+      }
+      // The engine has already written the key and the tier; this is the screen
+      // catching up with what is now true on disk. `keySeen` rides along
+      // because the person confirmed keeping the key before any of it ran.
+      await markKeySeen(ownerId);
+      await saveLastBackup(ownerId, result.last);
+      setHasKey(true);
+      setSettings((current) => ({
+        ...current,
+        tier: BackupTier.Extra,
+        keySeen: true,
+        last: result.last,
+      }));
+      const done: BackupOutcome = { kind: 'ok', records: result.last.records };
+      setOutcome(done);
+      return done;
+    },
+    [ownerId, records, refreshLink],
+  );
+
   const scan = useCallback(async (): Promise<RestoreScan> => {
-    const key = ownerId ? await loadRecoveryKey(ownerId) : null;
-    if (!key) return { ok: false, refusal: 'no-key' };
-    return scanBackup({ ownerId, key, localIds });
+    // The key question belongs to the engine here too, and on Standard it has a
+    // better answer than this hook could give: the key is in the folder next to
+    // the backup, so a phone that has never held one can still open it.
+    return scanBackup({ ownerId, localIds });
   }, [ownerId, localIds]);
 
   const applyRestore = useCallback(
@@ -338,6 +457,8 @@ export function useBackup(): BackupState & BackupActions {
     connected,
     account,
     hasKey,
+    tier,
+    standing,
     recordCount: records.length,
     phase,
     outcome,
@@ -347,6 +468,8 @@ export function useBackup(): BackupState & BackupActions {
     setFrequency: setFrequencyAction,
     setNetwork: setNetworkAction,
     createKey,
+    beginExtra,
+    commitExtra,
     revealKey,
     acceptKey,
     confirmKeySeen,

--- a/apps/mobile/src/lib/backup/useBackup.ts
+++ b/apps/mobile/src/lib/backup/useBackup.ts
@@ -165,7 +165,7 @@ export function useBackup(): BackupState & BackupActions {
    * falls back to the inference only for the frame before that lands — and the
    * inference and the write agree, so the screen never flickers between tiers.
    */
-  const tier = resolveTier(settings.tier, hasKey);
+  const tier = resolveTier(settings.tier, hasKey, settings.keySeen);
 
   /**
    * How many records were created after the last backup landed.
@@ -184,6 +184,7 @@ export function useBackup(): BackupState & BackupActions {
   const standing = backupStanding({
     tier,
     keySeen: settings.keySeen,
+    configured,
     connected,
     lastAt: settings.last?.at ?? null,
     lastRecords: settings.last?.records ?? 0,
@@ -243,7 +244,7 @@ export function useBackup(): BackupState & BackupActions {
       // The answer is written down as soon as it is worked out, so from here on
       // the tier is state and never an inference — including for the sign-out
       // guard, which reads the settings without a keystore of its own.
-      const tier = resolveTier(stored.tier, key !== null);
+      const tier = resolveTier(stored.tier, key !== null, stored.keySeen);
       if (ownerId && stored.tier === null) {
         await saveTier(ownerId, tier).catch(() => undefined);
       }

--- a/apps/mobile/src/lib/cloud/googleDrive.ts
+++ b/apps/mobile/src/lib/cloud/googleDrive.ts
@@ -181,6 +181,28 @@ export const googleDrive: CloudProvider = {
   },
 
   /**
+   * Delete a file outright. Used for the escrowed backup key when somebody
+   * turns Extra protection on, where the whole point is that Google stops
+   * holding it.
+   *
+   * A 404 is treated as done. Drive answers that for a file already deleted,
+   * and this call sits at the end of a sequence that can legitimately be run
+   * twice — the delete is retried on a later run if it failed the first time —
+   * so "it is not there" is exactly the state being asked for.
+   */
+  async remove(tokens: CloudTokens, remoteId: string): Promise<void> {
+    try {
+      await requestRaw(`https://www.googleapis.com/drive/v3/files/${remoteId}`, {
+        method: 'DELETE',
+        headers: authHeader(tokens),
+      });
+    } catch (error) {
+      if (error instanceof CloudHttpError && error.status === 404) return;
+      throw error;
+    }
+  },
+
+  /**
    * Hand the grant back when somebody unlinks, so "disconnect" means it in
    * Google's account settings too and not only in this app's keystore.
    *

--- a/apps/mobile/src/lib/cloud/http.ts
+++ b/apps/mobile/src/lib/cloud/http.ts
@@ -43,10 +43,16 @@ export async function requestJson(
   return parse(text);
 }
 
-/** A request whose body is raw text (an upload); returns the parsed response. */
+/**
+ * A request whose body is raw text (an upload); returns the parsed response.
+ *
+ * The body is optional so the same helper covers a DELETE, which carries none
+ * and answers 204 with nothing — `parse` reads an empty response as an empty
+ * object rather than a failure.
+ */
 export async function requestRaw(
   url: string,
-  options: { method: string; headers: Record<string, string>; body: string },
+  options: { method: string; headers: Record<string, string>; body?: string },
 ): Promise<Record<string, unknown>> {
   const response = await fetch(url, {
     method: options.method,

--- a/apps/mobile/src/lib/cloud/types.ts
+++ b/apps/mobile/src/lib/cloud/types.ts
@@ -69,6 +69,17 @@ export interface CloudProvider {
   ): Promise<CloudFile>;
   /** Read a file's whole text back. */
   read(tokens: CloudTokens, remoteId: string): Promise<string>;
+  /**
+   * Delete a file from the app's private storage, for good.
+   *
+   * Added for the escrowed backup key: turning Extra protection on means the
+   * copy of the key kept beside the blob has to actually leave the folder, and
+   * "overwrite it with something harmless" is not the same promise. A file that
+   * is already gone is a success, not an error — the delete runs after a
+   * re-seal that may have been retried, and a second attempt must not report a
+   * failure for work the first one finished.
+   */
+  remove(tokens: CloudTokens, remoteId: string): Promise<void>;
   /** Best-effort token revocation on unlink. Optional; failure is not fatal. */
   revoke?(tokens: CloudTokens): Promise<void>;
 }

--- a/apps/mobile/test/backupAccountScope.test.ts
+++ b/apps/mobile/test/backupAccountScope.test.ts
@@ -126,6 +126,9 @@ describe('A signs out, B signs in', () => {
       network: SyncNetworkPreference.Wifi,
       last: null,
       keySeen: false,
+      // Including the tier: a phone that remembered A was on Extra protection
+      // would put B's fresh setup behind a key ceremony B was never shown.
+      tier: null,
     });
     // Nothing of A's is left anywhere in the keystore under any name.
     expect([...hoisted.keystore.keys()].filter((key) => key.includes('waves.'))).toEqual([]);

--- a/apps/mobile/test/backupAuthRefusal.test.ts
+++ b/apps/mobile/test/backupAuthRefusal.test.ts
@@ -23,6 +23,7 @@ const hoisted = vi.hoisted(() => ({
   find: vi.fn(),
   put: vi.fn(),
   read: vi.fn(),
+  remove: vi.fn(),
 }));
 
 vi.mock('expo-secure-store', () => ({
@@ -84,13 +85,15 @@ vi.mock('@/lib/cloud/providers', async () => {
     find: hoisted.find,
     put: hoisted.put,
     read: hoisted.read,
+    remove: hoisted.remove,
   };
   return { providerFor: () => provider, allProviders: () => [provider] };
 });
 
 const { loadTokens, saveTokens } = await import('../src/lib/cloud/tokens');
 const { runBackup, scanBackup } = await import('../src/lib/backup/engine');
-const { parseRecoveryKey } = await import('../src/lib/backup/recoveryKey');
+const { parseRecoveryKey, saveRecoveryKey } = await import('../src/lib/backup/recoveryKey');
+const { BackupTier } = await import('../src/lib/backup/tier');
 const { SyncNetworkPreference } = await import('../src/lib/syncNetwork');
 const { asAuthFailure } = await import('../src/lib/cloud/oauth');
 const { isAuthFailure } = await import('../src/lib/cloud/http');
@@ -99,16 +102,20 @@ const OWNER = 'aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa';
 const KEY = parseRecoveryKey('11'.repeat(32))!;
 const TOKENS = { accessToken: 'stale', refreshToken: 'revoked-by-the-user', expiresAt: 1 };
 
+// Extra protection, so the run uses the key in this device's keystore and
+// never goes looking for an escrowed one — the auth behaviour under test is the
+// same in both tiers, and this is the tier with the fewest moving parts.
 const backupInput = {
   ownerId: OWNER,
   records: [],
-  key: KEY,
+  tier: BackupTier.Extra,
   network: SyncNetworkPreference.Both,
   manual: true,
 };
 
-beforeEach(() => {
+beforeEach(async () => {
   hoisted.keystore.clear();
+  await saveRecoveryKey(OWNER, KEY);
   hoisted.refresh = 'ok';
   hoisted.find.mockReset().mockResolvedValue(null);
   hoisted.put.mockReset().mockResolvedValue({
@@ -118,6 +125,7 @@ beforeEach(() => {
     modifiedAt: null,
   });
   hoisted.read.mockReset();
+  hoisted.remove.mockReset().mockResolvedValue(undefined);
 });
 
 describe('a refresh token the user has revoked', () => {
@@ -150,7 +158,7 @@ describe('a refresh token the user has revoked', () => {
     await saveTokens('gdrive', OWNER, TOKENS);
     hoisted.refresh = 'revoked';
 
-    const result = await scanBackup({ ownerId: OWNER, key: KEY, localIds: new Set() });
+    const result = await scanBackup({ ownerId: OWNER, localIds: new Set() });
     expect(result).toEqual({ ok: false, refusal: 'auth' });
     expect(hoisted.read).not.toHaveBeenCalled();
   });
@@ -159,7 +167,7 @@ describe('a refresh token the user has revoked', () => {
 describe('no tokens at all', () => {
   it('is still "not connected", which is a different problem with a different fix', async () => {
     expect(await runBackup(backupInput)).toEqual({ ok: false, refusal: 'not-connected' });
-    expect(await scanBackup({ ownerId: OWNER, key: KEY, localIds: new Set() })).toEqual({
+    expect(await scanBackup({ ownerId: OWNER, localIds: new Set() })).toEqual({
       ok: false,
       refusal: 'not-connected',
     });

--- a/apps/mobile/test/backupAuthRefusal.test.ts
+++ b/apps/mobile/test/backupAuthRefusal.test.ts
@@ -56,6 +56,10 @@ vi.mock('react-native', () => ({
 }));
 
 vi.mock('expo-web-browser', () => ({ maybeCompleteAuthSession: () => undefined }));
+// The engine reports a failed tier write rather than letting it reach the
+// screen; the real module reaches for react-native, which this suite mocks to a
+// stub that has no Promise shim to resolve.
+vi.mock('@/lib/observability', () => ({ reportHandled: vi.fn() }));
 
 vi.mock('expo-auth-session', () => ({
   AuthRequest: class {},

--- a/apps/mobile/test/backupEscrow.test.ts
+++ b/apps/mobile/test/backupEscrow.test.ts
@@ -1,0 +1,389 @@
+/**
+ * The escrowed key, end to end, against a fake appDataFolder.
+ *
+ * `backupTiers.test.ts` pins the decisions; this one pins the I/O they ask for,
+ * because the states that matter are all about *what is left in the folder*
+ * when something stops halfway. Three claims in particular are load-bearing and
+ * would otherwise only ever be tested by somebody on a new phone:
+ *
+ * 1. An account made under the build before tiers keeps working, and its
+ *    envelope — which carries no tier at all — stays readable.
+ * 2. The upgrade deletes the escrowed key only after the re-seal has landed.
+ * 3. A restore knows which tier the blob it found belongs to, and asks for a
+ *    key only when there is one to ask for.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  keystore: new Map<string, string>(),
+  folder: new Map<string, { remoteId: string; name: string; content: string }>(),
+  /** Every provider call in order, so an ordering claim can be asserted. */
+  calls: [] as string[],
+  /** When set, the next `put` of this name throws instead of writing. */
+  failPut: null as string | null,
+  /** When set, `remove` throws. */
+  failRemove: false,
+  nextId: 1,
+}));
+
+vi.mock('expo-secure-store', () => ({
+  AFTER_FIRST_UNLOCK: 'after-first-unlock',
+  AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: 'after-first-unlock-this-device-only',
+  getItemAsync: async (key: string) => hoisted.keystore.get(key) ?? null,
+  setItemAsync: async (key: string, value: string) => {
+    hoisted.keystore.set(key, value);
+  },
+  deleteItemAsync: async (key: string) => {
+    hoisted.keystore.delete(key);
+  },
+}));
+
+vi.mock('expo-crypto', () => ({
+  getRandomBytes: (length: number) => {
+    const bytes = new Uint8Array(length);
+    globalThis.crypto.getRandomValues(bytes);
+    return bytes;
+  },
+}));
+
+vi.mock('expo-network', () => ({
+  getNetworkStateAsync: async () => ({ isInternetReachable: true, type: 'wifi' }),
+  NetworkStateType: { WIFI: 'wifi', CELLULAR: 'cellular' },
+}));
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'android', select: (o: Record<string, unknown>) => o.android ?? o.default },
+}));
+
+vi.mock('expo-web-browser', () => ({ maybeCompleteAuthSession: () => undefined }));
+vi.mock('@/lib/observability', () => ({ reportHandled: vi.fn() }));
+
+vi.mock('expo-auth-session', () => ({
+  AuthRequest: class {},
+  exchangeCodeAsync: async () => ({}),
+  makeRedirectUri: () => 'waves://oauthredirect',
+  refreshAsync: async () => ({}),
+}));
+
+/**
+ * A Drive appDataFolder that actually holds files, so the engine's two-file
+ * dance can be watched rather than stubbed. Names are the engine's own, which
+ * is what makes "the key file is gone" expressible as a test.
+ */
+vi.mock('@/lib/cloud/providers', () => {
+  const provider = {
+    id: 'gdrive' as const,
+    label: 'Google Drive',
+    isConfigured: () => true,
+    connect: async () => null,
+    ensureValid: async (tokens: unknown) => tokens,
+    account: async () => 'someone@example.com',
+    async find(_tokens: unknown, name: string) {
+      hoisted.calls.push(`find:${name}`);
+      const file = hoisted.folder.get(name);
+      return file
+        ? { remoteId: file.remoteId, name, size: file.content.length, modifiedAt: null }
+        : null;
+    },
+    async put(_tokens: unknown, name: string, content: string, existingId: string | null) {
+      hoisted.calls.push(`put:${name}`);
+      if (hoisted.failPut === name) throw new Error('drive said no');
+      const remoteId = existingId ?? `file-${hoisted.nextId++}`;
+      hoisted.folder.set(name, { remoteId, name, content });
+      return { remoteId, name, size: content.length, modifiedAt: null };
+    },
+    async read(_tokens: unknown, remoteId: string) {
+      hoisted.calls.push(`read:${remoteId}`);
+      for (const file of hoisted.folder.values())
+        if (file.remoteId === remoteId) return file.content;
+      throw new Error('no such file');
+    },
+    async remove(_tokens: unknown, remoteId: string) {
+      hoisted.calls.push(`remove:${remoteId}`);
+      if (hoisted.failRemove) throw new Error('drive said no');
+      for (const [name, file] of hoisted.folder)
+        if (file.remoteId === remoteId) hoisted.folder.delete(name);
+    },
+  };
+  return { providerFor: () => provider, allProviders: () => [provider] };
+});
+
+const AsyncStorage = (await import('@react-native-async-storage/async-storage')).default;
+const { saveTokens } = await import('../src/lib/cloud/tokens');
+const { runBackup, scanBackup, upgradeToExtra, backupFileName } =
+  await import('../src/lib/backup/engine');
+const { backupAad, buildBody, buildFile, BACKUP_FORMAT, BACKUP_VERSION, BACKUP_ALG } =
+  await import('../src/lib/backup/payload');
+const { bytesToHex, loadRecoveryKey, parseRecoveryKey, saveRecoveryKey, sealBackup, backupNonce } =
+  await import('../src/lib/backup/recoveryKey');
+const { BackupTier, escrowFileName, parseEscrow } = await import('../src/lib/backup/tier');
+const { loadBackupSettings } = await import('../src/lib/backup/settings');
+const { SyncNetworkPreference } = await import('../src/lib/syncNetwork');
+
+const OWNER = 'aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa';
+const OLD_KEY = parseRecoveryKey('11'.repeat(32))!;
+const TOKENS = { accessToken: 'at', refreshToken: 'rt', expiresAt: null };
+
+const BLOB = backupFileName(OWNER);
+const ESCROW = escrowFileName(OWNER);
+
+/**
+ * Forget only this device's recovery key.
+ *
+ * Not the whole keystore: the OAuth tokens live there too, so clearing it
+ * outright unlinks the Google account and every "a new phone" case below turns
+ * into "not connected" instead of the state it meant to describe.
+ */
+const forgetDeviceKey = (): void => {
+  for (const key of [...hoisted.keystore.keys()]) {
+    if (key.includes('recovery_key')) hoisted.keystore.delete(key);
+  }
+};
+
+const row = (id: string) => ({
+  id,
+  record_kind: 'expense',
+  data: { amount: 1200 },
+  created_at: '2026-09-01T00:00:00.000Z',
+  deleted_at: null,
+});
+
+const run = (tier: (typeof BackupTier)[keyof typeof BackupTier], records = [row('a')]) =>
+  runBackup({
+    ownerId: OWNER,
+    records,
+    tier,
+    network: SyncNetworkPreference.Both,
+    manual: true,
+  });
+
+/** The envelope currently in the folder, parsed as JSON. */
+const envelope = (): Record<string, unknown> =>
+  JSON.parse(hoisted.folder.get(BLOB)!.content) as Record<string, unknown>;
+
+beforeEach(async () => {
+  hoisted.keystore.clear();
+  hoisted.folder.clear();
+  hoisted.calls.length = 0;
+  hoisted.failPut = null;
+  hoisted.failRemove = false;
+  hoisted.nextId = 1;
+  await AsyncStorage.clear();
+  await saveTokens('gdrive', OWNER, TOKENS);
+});
+
+describe('Standard, on a phone that has never held a key', () => {
+  it('mints one, puts a copy in the folder, and says so in the envelope', async () => {
+    expect((await run(BackupTier.Standard)).ok).toBe(true);
+
+    const escrowed = parseEscrow(hoisted.folder.get(ESCROW)!.content);
+    expect(escrowed.tier).toBe(BackupTier.Standard);
+    expect(envelope().tier).toBe(BackupTier.Standard);
+    // And the key is on the phone too, so the next run needs no round trip.
+    expect(bytesToHex((await loadRecoveryKey(OWNER))!)).toBe(escrowed.key);
+  });
+
+  it('escrows before it stores locally, so the folder is never the one without it', async () => {
+    await run(BackupTier.Standard);
+    // The state Standard must never be in is a key on the phone with no copy in
+    // the folder, because the screen is at that moment promising a new phone
+    // will find it.
+    expect(hoisted.calls.indexOf(`put:${ESCROW}`)).toBeLessThan(
+      hoisted.calls.indexOf(`put:${BLOB}`),
+    );
+  });
+});
+
+describe('Standard, on a second phone signed into the same Google account', () => {
+  it('adopts the escrowed key instead of minting a rival one', async () => {
+    await run(BackupTier.Standard);
+    const first = hoisted.folder.get(ESCROW)!.content;
+
+    // A new phone: same folder, no key of its own.
+    forgetDeviceKey();
+    expect((await run(BackupTier.Standard)).ok).toBe(true);
+
+    expect(hoisted.folder.get(ESCROW)!.content).toBe(first);
+    expect(bytesToHex((await loadRecoveryKey(OWNER))!)).toBe(parseEscrow(first).key);
+  });
+
+  it('restores with nothing asked of anybody', async () => {
+    await run(BackupTier.Standard, [row('a'), row('b')]);
+    forgetDeviceKey();
+
+    const scan = await scanBackup({ ownerId: OWNER, localIds: new Set() });
+    expect(scan.ok).toBe(true);
+    if (!scan.ok) return;
+    expect(scan.tier).toBe(BackupTier.Standard);
+    expect(scan.plan.restore.map((record) => record.id)).toEqual(['a', 'b']);
+  });
+
+  it('throws the phone’s stale key away rather than sealing under it', async () => {
+    await run(BackupTier.Standard);
+    const escrowed = parseEscrow(hoisted.folder.get(ESCROW)!.content).key;
+    // The half-finished-upgrade state: a newer key on the phone, the older one
+    // still in the folder, the blob still sealed under the older one.
+    await saveRecoveryKey(OWNER, parseRecoveryKey('22'.repeat(32))!);
+
+    await run(BackupTier.Standard);
+    expect(bytesToHex((await loadRecoveryKey(OWNER))!)).toBe(escrowed);
+    expect((await scanBackup({ ownerId: OWNER, localIds: new Set() })).ok).toBe(true);
+  });
+});
+
+describe('an account made under the build before tiers', () => {
+  /** Exactly what the first build wrote: no tier field, no key in the folder. */
+  const writeLegacyBlob = (records: readonly ReturnType<typeof row>[]) => {
+    const body = buildBody(OWNER, records, new Date('2026-09-01T00:00:00.000Z'));
+    const sealed = sealBackup(OLD_KEY, backupNonce(), JSON.stringify(body), backupAad(OWNER));
+    hoisted.folder.set(BLOB, {
+      remoteId: 'legacy-1',
+      name: BLOB,
+      content: JSON.stringify({
+        format: BACKUP_FORMAT,
+        version: BACKUP_VERSION,
+        alg: BACKUP_ALG,
+        createdAt: body.createdAt,
+        sealed,
+      }),
+    });
+  };
+
+  it('still opens, with no prompt and no loss', async () => {
+    writeLegacyBlob([row('a'), row('b')]);
+    await saveRecoveryKey(OWNER, OLD_KEY);
+
+    const scan = await scanBackup({ ownerId: OWNER, localIds: new Set() });
+    expect(scan.ok).toBe(true);
+    if (!scan.ok) return;
+    // A file with no tier is an extra-protection file, because that is what it
+    // was — the key was never anywhere but that phone.
+    expect(scan.tier).toBe(BackupTier.Extra);
+    expect(scan.plan.restore).toHaveLength(2);
+  });
+
+  it('keeps backing up on Extra without ever touching the folder’s key file', async () => {
+    writeLegacyBlob([row('a')]);
+    await saveRecoveryKey(OWNER, OLD_KEY);
+
+    expect((await run(BackupTier.Extra)).ok).toBe(true);
+    expect(hoisted.folder.has(ESCROW)).toBe(false);
+    expect(envelope().tier).toBe(BackupTier.Extra);
+    // And the key it used is still theirs, unchanged.
+    expect(bytesToHex((await loadRecoveryKey(OWNER))!)).toBe(bytesToHex(OLD_KEY));
+  });
+
+  it('refuses rather than minting a second key when the keystore is empty', async () => {
+    writeLegacyBlob([row('a')]);
+    expect(await run(BackupTier.Extra)).toEqual({ ok: false, refusal: 'no-key' });
+    expect(hoisted.folder.get(BLOB)!.remoteId).toBe('legacy-1');
+  });
+});
+
+describe('a restore that cannot happen from here', () => {
+  it('tells the person which key to find, and says what it found', async () => {
+    await saveRecoveryKey(OWNER, OLD_KEY);
+    await run(BackupTier.Extra);
+    forgetDeviceKey();
+
+    const scan = await scanBackup({ ownerId: OWNER, localIds: new Set() });
+    expect(scan.ok).toBe(false);
+    if (scan.ok) return;
+    expect(scan.refusal).toBe('needs-key');
+    // The metadata is outside the AEAD, so the fork can be offered before the
+    // attempt rather than reported after it.
+    expect(scan.found?.tier).toBe(BackupTier.Extra);
+    expect(scan.found?.size).toBeGreaterThan(0);
+  });
+
+  it('says a Standard backup is beyond saving when its key file has gone', async () => {
+    await run(BackupTier.Standard);
+    // Drive's storage settings offer "Delete hidden app data", and it deletes
+    // exactly this. There is nothing to type, so nothing may ask for it.
+    hoisted.folder.delete(ESCROW);
+    forgetDeviceKey();
+
+    const scan = await scanBackup({ ownerId: OWNER, localIds: new Set() });
+    expect(scan.ok).toBe(false);
+    if (scan.ok) return;
+    expect(scan.refusal).toBe('key-lost');
+  });
+});
+
+describe('turning Extra protection on', () => {
+  const NEW_KEY = parseRecoveryKey('33'.repeat(32))!;
+
+  it('re-seals first and only then deletes the escrowed key', async () => {
+    await run(BackupTier.Standard, [row('a'), row('b')]);
+    hoisted.calls.length = 0;
+
+    const result = await upgradeToExtra({ ownerId: OWNER, records: [], key: NEW_KEY });
+    expect(result.ok).toBe(true);
+
+    const put = hoisted.calls.indexOf(`put:${BLOB}`);
+    const removed = hoisted.calls.findIndex((call) => call.startsWith('remove:'));
+    expect(put).toBeGreaterThanOrEqual(0);
+    expect(removed).toBeGreaterThan(put);
+    expect(hoisted.folder.has(ESCROW)).toBe(false);
+    expect(envelope().tier).toBe(BackupTier.Extra);
+  });
+
+  it('carries the records over rather than starting a new backup', async () => {
+    await run(BackupTier.Standard, [row('a'), row('b')]);
+    await upgradeToExtra({ ownerId: OWNER, records: [], key: NEW_KEY });
+
+    const scan = await scanBackup({ ownerId: OWNER, localIds: new Set() });
+    expect(scan.ok).toBe(true);
+    if (!scan.ok) return;
+    expect(scan.plan.restore.map((record) => record.id)).toEqual(['a', 'b']);
+  });
+
+  it('leaves the key in the folder when the re-seal fails', async () => {
+    await run(BackupTier.Standard, [row('a')]);
+    const before = hoisted.folder.get(BLOB)!.content;
+    hoisted.failPut = BLOB;
+
+    await expect(upgradeToExtra({ ownerId: OWNER, records: [], key: NEW_KEY })).rejects.toThrow();
+
+    // Nothing on Drive moved: the escrowed key is still there, the blob is
+    // still the one it opens, and the account is still Standard. That is the
+    // failure the ordering exists to make cheap.
+    expect(hoisted.folder.has(ESCROW)).toBe(true);
+    expect(hoisted.folder.get(BLOB)!.content).toBe(before);
+    expect((await loadBackupSettings(OWNER)).tier).toBeNull();
+    expect((await scanBackup({ ownerId: OWNER, localIds: new Set() })).ok).toBe(true);
+  });
+
+  it('still counts as done when only the delete fails, and sweeps it next run', async () => {
+    await run(BackupTier.Standard, [row('a')]);
+    hoisted.failRemove = true;
+
+    const result = await upgradeToExtra({ ownerId: OWNER, records: [], key: NEW_KEY });
+    expect(result.ok).toBe(true);
+    // The blob is already sealed under a key Google does not hold, which is the
+    // promise; the file left behind opens nothing, because a restore reads the
+    // blob's tier and not the folder's contents.
+    expect(result.ok && result.state.escrowCleared).toBe(false);
+    expect(hoisted.folder.has(ESCROW)).toBe(true);
+    expect((await loadBackupSettings(OWNER)).tier).toBe(BackupTier.Extra);
+
+    hoisted.failRemove = false;
+    expect((await run(BackupTier.Extra)).ok).toBe(true);
+    expect(hoisted.folder.has(ESCROW)).toBe(false);
+  });
+
+  it('works from nothing at all, sealing the ledger in hand', async () => {
+    // Somebody who links an account and turns Extra protection on before a
+    // single backup has run. There is no body to re-seal, so the live ledger is
+    // what goes up — the same bytes an ordinary run would have sent.
+    const result = await upgradeToExtra({
+      ownerId: OWNER,
+      records: [row('a')],
+      key: NEW_KEY,
+    });
+    expect(result.ok).toBe(true);
+    expect(envelope().tier).toBe(BackupTier.Extra);
+    expect(hoisted.folder.has(ESCROW)).toBe(false);
+  });
+});

--- a/apps/mobile/test/backupEscrow.test.ts
+++ b/apps/mobile/test/backupEscrow.test.ts
@@ -24,6 +24,8 @@ const hoisted = vi.hoisted(() => ({
   failPut: null as string | null,
   /** When set, `remove` throws. */
   failRemove: false,
+  /** When set, the next `read` of this remote id throws instead of answering. */
+  failRead: null as string | null,
   nextId: 1,
 }));
 
@@ -95,6 +97,7 @@ vi.mock('@/lib/cloud/providers', () => {
     },
     async read(_tokens: unknown, remoteId: string) {
       hoisted.calls.push(`read:${remoteId}`);
+      if (hoisted.failRead === remoteId) throw new Error('drive said 500');
       for (const file of hoisted.folder.values())
         if (file.remoteId === remoteId) return file.content;
       throw new Error('no such file');
@@ -168,6 +171,7 @@ beforeEach(async () => {
   hoisted.calls.length = 0;
   hoisted.failPut = null;
   hoisted.failRemove = false;
+  hoisted.failRead = null;
   hoisted.nextId = 1;
   await AsyncStorage.clear();
   await saveTokens('gdrive', OWNER, TOKENS);
@@ -433,6 +437,77 @@ describe('turning Extra protection on', () => {
     });
     expect(result.ok).toBe(true);
     expect(envelope().tier).toBe(BackupTier.Extra);
+    expect(hoisted.folder.has(ESCROW)).toBe(false);
+  });
+});
+
+describe('when the folder cannot be read rather than being empty', () => {
+  it('refuses the run instead of minting over the key it failed to read', async () => {
+    // The worst path this design has. `openEscrow` used to answer null for any
+    // failure, so a 500 on the key file read as "there is no key" — and the
+    // engine would mint a fresh one, PATCH it over the file it could not read,
+    // and re-seal the blob under it. One unlucky request and the only copy of
+    // somebody's ledger is unopenable, reported as a successful backup.
+    await run(BackupTier.Standard);
+    const escrowedBefore = hoisted.folder.get(ESCROW)!.content;
+    const blobBefore = hoisted.folder.get(BLOB)!.content;
+    // A phone that holds no key of its own, so the escrow is the only way it
+    // can seal anything — the new-phone case, where the local ledger is also
+    // the emptiest it will ever be.
+    forgetDeviceKey();
+    hoisted.failRead = hoisted.folder.get(ESCROW)!.remoteId;
+
+    await expect(run(BackupTier.Standard, [row('b')])).rejects.toThrow();
+
+    // Nothing moved. Both files are byte-for-byte what they were.
+    expect(hoisted.folder.get(ESCROW)!.content).toBe(escrowedBefore);
+    expect(hoisted.folder.get(BLOB)!.content).toBe(blobBefore);
+  });
+
+  it('still treats a key file that will never parse as no key file', async () => {
+    // The other half of the distinction: this one cannot be retried into
+    // working, so minting is the repair rather than the mistake.
+    await run(BackupTier.Standard);
+    forgetDeviceKey();
+    const file = hoisted.folder.get(ESCROW)!;
+    hoisted.folder.set(ESCROW, { ...file, content: 'not json at all' });
+
+    expect((await run(BackupTier.Standard, [row('b')])).ok).toBe(true);
+    expect(parseEscrow(hoisted.folder.get(ESCROW)!.content).key).toHaveLength(64);
+  });
+});
+
+describe('a second phone that has not heard about an upgrade', () => {
+  it('refuses rather than overwriting the Extra blob with a Standard one', async () => {
+    // Phone A upgraded: the blob is sealed under a key only A holds and the
+    // escrow is gone. Phone B is still Standard and still holds the old key. It
+    // must not seal its own Standard backup over A's — that would leave a blob
+    // A cannot open, with no escrow beside it for anybody else either.
+    await run(BackupTier.Standard);
+    await saveRecoveryKey(OWNER, OLD_KEY);
+    hoisted.folder.set(BLOB, {
+      ...hoisted.folder.get(BLOB)!,
+      content: JSON.stringify(
+        buildFile(
+          sealBackup(
+            OLD_KEY,
+            backupNonce(),
+            JSON.stringify(buildBody(OWNER, [row('a')], new Date())),
+            backupAad(OWNER),
+          ),
+          new Date().toISOString(),
+          BackupTier.Extra,
+        ),
+      ),
+    });
+    hoisted.folder.delete(ESCROW);
+    const blobBefore = hoisted.folder.get(BLOB)!.content;
+
+    const result = await run(BackupTier.Standard, [row('b')]);
+
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.refusal).toBe('needs-key');
+    expect(hoisted.folder.get(BLOB)!.content).toBe(blobBefore);
     expect(hoisted.folder.has(ESCROW)).toBe(false);
   });
 });

--- a/apps/mobile/test/backupEscrow.test.ts
+++ b/apps/mobile/test/backupEscrow.test.ts
@@ -230,6 +230,22 @@ describe('Standard, on a second phone signed into the same Google account', () =
     expect(bytesToHex((await loadRecoveryKey(OWNER))!)).toBe(escrowed);
     expect((await scanBackup({ ownerId: OWNER, localIds: new Set() })).ok).toBe(true);
   });
+
+  it('repairs a missing escrow instead of sealing Standard under a device-only key', async () => {
+    await run(BackupTier.Standard, [row('a')]);
+    const first = parseEscrow(hoisted.folder.get(ESCROW)!.content).key;
+    hoisted.folder.delete(ESCROW);
+
+    expect((await run(BackupTier.Standard, [row('b')])).ok).toBe(true);
+    const second = parseEscrow(hoisted.folder.get(ESCROW)!.content).key;
+    expect(second).not.toBe(first);
+    expect(bytesToHex((await loadRecoveryKey(OWNER))!)).toBe(second);
+    forgetDeviceKey();
+    const scan = await scanBackup({ ownerId: OWNER, localIds: new Set() });
+    expect(scan.ok).toBe(true);
+    if (!scan.ok) return;
+    expect(scan.plan.restore.map((record) => record.id)).toEqual(['b']);
+  });
 });
 
 describe('an account made under the build before tiers', () => {
@@ -327,6 +343,39 @@ describe('turning Extra protection on', () => {
     expect(removed).toBeGreaterThan(put);
     expect(hoisted.folder.has(ESCROW)).toBe(false);
     expect(envelope().tier).toBe(BackupTier.Extra);
+  });
+
+  it('keeps a concurrent automatic Standard run out while the upgrade is in flight', async () => {
+    await run(BackupTier.Standard, [row('a')]);
+    let releaseRead!: () => void;
+    const originalRead = hoisted.folder.get(BLOB)!.remoteId;
+    const pendingRead = new Promise<string>((resolve) => {
+      releaseRead = () => resolve(hoisted.folder.get(BLOB)!.content);
+    });
+    const readName = `read:${originalRead}`;
+    hoisted.calls.length = 0;
+    const provider = (await import('../src/lib/cloud/providers')).providerFor('gdrive');
+    const realRead = provider.read;
+    provider.read = async (tokens, remoteId) => {
+      if (remoteId === originalRead) {
+        hoisted.calls.push(readName);
+        return pendingRead;
+      }
+      return realRead(tokens, remoteId);
+    };
+
+    try {
+      const upgrading = upgradeToExtra({ ownerId: OWNER, records: [], key: NEW_KEY });
+      await vi.waitFor(() => expect(hoisted.calls).toContain(readName));
+      await expect(run(BackupTier.Standard, [row('auto')])).resolves.toEqual({
+        ok: false,
+        refusal: 'busy',
+      });
+      releaseRead();
+      expect((await upgrading).ok).toBe(true);
+    } finally {
+      provider.read = realRead;
+    }
   });
 
   it('carries the records over rather than starting a new backup', async () => {

--- a/apps/mobile/test/backupPayload.test.ts
+++ b/apps/mobile/test/backupPayload.test.ts
@@ -22,6 +22,7 @@ import {
   BackupOpenError,
   type SourceRecord,
 } from '../src/lib/backup/payload';
+import { BackupTier } from '../src/lib/backup/tier';
 
 const OWNER = '11111111-1111-4111-8111-111111111111';
 const NOW = new Date('2026-09-05T10:00:00.000Z');
@@ -61,7 +62,7 @@ describe('building a backup body', () => {
 describe('the envelope', () => {
   it('says almost nothing in the clear — no counts, no dates of spending', () => {
     const body = buildBody(OWNER, [row('a'), row('b')], NOW);
-    const file = buildFile('v1:sealed', body.createdAt);
+    const file = buildFile('v1:sealed', body.createdAt, BackupTier.Standard);
     const text = JSON.stringify(file);
     expect(text).not.toContain(OWNER);
     expect(text).not.toContain('1200');
@@ -69,7 +70,7 @@ describe('the envelope', () => {
   });
 
   it('round-trips through parseFile', () => {
-    const file = buildFile('v1:sealed', NOW.toISOString());
+    const file = buildFile('v1:sealed', NOW.toISOString(), BackupTier.Extra);
     expect(parseFile(JSON.stringify(file))).toEqual(file);
   });
 

--- a/apps/mobile/test/backupSetup.test.ts
+++ b/apps/mobile/test/backupSetup.test.ts
@@ -8,9 +8,17 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { backupSetup, BackupStep } from '../src/lib/backup/setup';
+import { backupSetup, BackupStep, type BackupSetupInput } from '../src/lib/backup/setup';
+import { BackupTier } from '../src/lib/backup/tier';
 
-const setup = backupSetup;
+/**
+ * Everything below without a tier of its own is about Extra protection, whose
+ * checklist is the three-step one this module has always had — and which every
+ * account made under the build before tiers is now on. Standard has its own
+ * block at the bottom.
+ */
+const setup = (input: Omit<BackupSetupInput, 'tier'>) =>
+  backupSetup({ ...input, tier: BackupTier.Extra });
 
 describe('the order of the steps', () => {
   it('is account, then key, then saving it, whatever the flags say', () => {
@@ -107,5 +115,58 @@ describe('a build with no OAuth client id', () => {
     expect(stale.steps[0]?.done).toBe(false);
     expect(stale.complete).toBe(false);
     expect(stale.outstanding).toBeNull();
+  });
+});
+
+describe('Standard, where there is no key ceremony at all', () => {
+  const standard = (connected: boolean, configured = true) =>
+    backupSetup({
+      configured,
+      connected,
+      // Deliberately the flags that would make the old checklist say "two of
+      // three done": on Standard neither of them is a step, and neither may
+      // count towards anything.
+      hasKey: false,
+      keySeen: false,
+      tier: BackupTier.Standard,
+    });
+
+  it('asks for one thing, and it is the account', () => {
+    const state = standard(false);
+    expect(state.steps.map((entry) => entry.step)).toEqual([BackupStep.Account]);
+    expect(state.outstanding).toBe(BackupStep.Account);
+    expect(state.total).toBe(1);
+    expect(state.done).toBe(0);
+  });
+
+  it('is complete the moment the account is linked, with no key on the phone', () => {
+    // The whole point of the tier. Under the old checklist this same state was
+    // "one of three" and every control on the screen was inert.
+    const state = standard(true);
+    expect(state.complete).toBe(true);
+    expect(state.outstanding).toBeNull();
+    expect(state.done).toBe(1);
+  });
+
+  it('never mentions a key, even on a phone that happens to hold one', () => {
+    // True after the first backup: the engine mints a key and escrows it. It is
+    // not a step, it was not asked for, and a checklist that ticked it would be
+    // claiming credit for something the person did not do.
+    const state = backupSetup({
+      configured: true,
+      connected: true,
+      hasKey: true,
+      keySeen: false,
+      tier: BackupTier.Standard,
+    });
+    expect(state.steps.map((entry) => entry.step)).toEqual([BackupStep.Account]);
+    expect(state.complete).toBe(true);
+  });
+
+  it('still offers nothing in a build with no client id', () => {
+    const state = standard(false, false);
+    expect(state.unavailable).toBe(true);
+    expect(state.outstanding).toBeNull();
+    expect(state.complete).toBe(false);
   });
 });

--- a/apps/mobile/test/backupTiers.test.ts
+++ b/apps/mobile/test/backupTiers.test.ts
@@ -45,24 +45,37 @@ const KEY_HEX = '11'.repeat(32);
 describe('which tier somebody is on', () => {
   it('defaults a fresh account to Standard, which is the whole point', () => {
     expect(DEFAULT_TIER).toBe(BackupTier.Standard);
-    expect(resolveTier(null, false)).toBe(BackupTier.Standard);
+    expect(resolveTier(null, false, false)).toBe(BackupTier.Standard);
   });
 
   it('carries a pre-tier user onto Extra protection, because that is what they have', () => {
     // The migration, and the only inference in the module. A phone that set a
-    // backup up under the build before tiers has a key in its keystore and
+    // backup up under the build before tiers has a key in its keystore, has
+    // confirmed it (the old build refused to back up otherwise), and has
     // nothing stored about tiers; that key *is* Extra protection, and reading
     // it as Standard would silently promise that Google could recover a backup
     // Google has never had the key to.
-    expect(resolveTier(null, true)).toBe(BackupTier.Extra);
+    expect(resolveTier(null, true, true)).toBe(BackupTier.Extra);
+  });
+
+  it('reads a key nobody confirmed as Standard, because a reinstall looks exactly like that', () => {
+    // iOS keeps keychain items when an app is deleted and throws AsyncStorage
+    // away, so a reinstalled Standard phone comes back holding its minted key
+    // with no stored tier — indistinguishable from a migrating Extra user by
+    // the key alone. `keySeen` is what tells them apart: the old build gated
+    // its backup button on it, so every real migrant has it, and it lived in
+    // the storage the reinstall wiped. Guessing Extra here would send the next
+    // run to delete the escrowed key out of Drive and leave the person owning
+    // 64 characters they were never shown.
+    expect(resolveTier(null, true, false)).toBe(BackupTier.Standard);
   });
 
   it('lets the stored answer win over the phone, both ways round', () => {
     // Once written down it is state, not a guess — including for the account
     // that turned Extra protection on and then had its keystore cleared, and
     // for a Standard phone that holds a minted key.
-    expect(resolveTier(BackupTier.Extra, false)).toBe(BackupTier.Extra);
-    expect(resolveTier(BackupTier.Standard, true)).toBe(BackupTier.Standard);
+    expect(resolveTier(BackupTier.Extra, false, false)).toBe(BackupTier.Extra);
+    expect(resolveTier(BackupTier.Standard, true, true)).toBe(BackupTier.Standard);
   });
 
   it('reads a stored value it does not recognise as nothing stored', () => {
@@ -267,6 +280,7 @@ describe('what the sign-out guard will ask', () => {
     backupStanding({
       tier: BackupTier.Standard,
       keySeen: false,
+      configured: true,
       connected: true,
       lastAt: 1_757_000_000_000,
       lastRecords: 12,

--- a/apps/mobile/test/backupTiers.test.ts
+++ b/apps/mobile/test/backupTiers.test.ts
@@ -167,6 +167,12 @@ describe('where the key for the next backup comes from', () => {
     expect(at({ hasDeviceKey: true, hasEscrow: true })).toBe(KeySource.Escrow);
   });
 
+  it('mints on Standard when no escrow can be read, even if this phone has a key', () => {
+    // A Standard backup sealed only under a device key is an Extra backup nobody
+    // opted into. Missing/corrupt escrow must be repaired before upload.
+    expect(at({ hasDeviceKey: true, hasEscrow: false })).toBe(KeySource.Mint);
+  });
+
   it('uses this phone’s key on Extra, and asks the person when there is none', () => {
     expect(at({ tier: BackupTier.Extra, hasDeviceKey: true })).toBe(KeySource.Device);
     expect(at({ tier: BackupTier.Extra, hasDeviceKey: false })).toBe(KeySource.AskPerson);

--- a/apps/mobile/test/backupTiers.test.ts
+++ b/apps/mobile/test/backupTiers.test.ts
@@ -1,0 +1,296 @@
+/**
+ * The tier arithmetic: which promise an account is on, which key opens what,
+ * and the one ordering rule the upgrade must never break.
+ *
+ * All of it pure, which is the point of putting it in `tier.ts` rather than in
+ * the engine — the mobile suite has no renderer and no network, and these are
+ * exactly the decisions that would otherwise only be exercised by a person on a
+ * new phone at the worst moment of their week.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  BACKUP_FORMAT,
+  BACKUP_VERSION,
+  buildFile,
+  fileTier,
+  parseFile,
+} from '../src/lib/backup/payload';
+import {
+  advanceUpgrade,
+  backupStanding,
+  BackupTier,
+  buildEscrow,
+  DEFAULT_TIER,
+  escrowFileName,
+  EscrowFormatError,
+  ESCROW_FORMAT,
+  keyForBackup,
+  keyForRestore,
+  KeySource,
+  mayClearEscrow,
+  parseEscrow,
+  parseTier,
+  resolveTier,
+  tierAllowsBackup,
+  UPGRADE_START,
+  UpgradeStage,
+  type UpgradeState,
+} from '../src/lib/backup/tier';
+
+const OWNER = 'aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa';
+const KEY_HEX = '11'.repeat(32);
+
+describe('which tier somebody is on', () => {
+  it('defaults a fresh account to Standard, which is the whole point', () => {
+    expect(DEFAULT_TIER).toBe(BackupTier.Standard);
+    expect(resolveTier(null, false)).toBe(BackupTier.Standard);
+  });
+
+  it('carries a pre-tier user onto Extra protection, because that is what they have', () => {
+    // The migration, and the only inference in the module. A phone that set a
+    // backup up under the build before tiers has a key in its keystore and
+    // nothing stored about tiers; that key *is* Extra protection, and reading
+    // it as Standard would silently promise that Google could recover a backup
+    // Google has never had the key to.
+    expect(resolveTier(null, true)).toBe(BackupTier.Extra);
+  });
+
+  it('lets the stored answer win over the phone, both ways round', () => {
+    // Once written down it is state, not a guess — including for the account
+    // that turned Extra protection on and then had its keystore cleared, and
+    // for a Standard phone that holds a minted key.
+    expect(resolveTier(BackupTier.Extra, false)).toBe(BackupTier.Extra);
+    expect(resolveTier(BackupTier.Standard, true)).toBe(BackupTier.Standard);
+  });
+
+  it('reads a stored value it does not recognise as nothing stored', () => {
+    expect(parseTier('gold')).toBeNull();
+    expect(parseTier(null)).toBeNull();
+    expect(parseTier(BackupTier.Standard)).toBe(BackupTier.Standard);
+  });
+});
+
+describe('the "have you kept it?" gate', () => {
+  it('still holds every Extra backup until the key has been acknowledged', () => {
+    expect(tierAllowsBackup(BackupTier.Extra, false)).toBe(false);
+    expect(tierAllowsBackup(BackupTier.Extra, true)).toBe(true);
+  });
+
+  it('does not apply on Standard, where there is nothing to have kept', () => {
+    expect(tierAllowsBackup(BackupTier.Standard, false)).toBe(true);
+  });
+});
+
+describe('an existing device-only backup', () => {
+  it('reads as Extra protection, because a file with no tier had no escrow', () => {
+    // The compatibility claim this whole change rests on. Every envelope the
+    // first build wrote looked exactly like this, and it must keep opening.
+    const legacy = parseFile(
+      JSON.stringify({
+        format: BACKUP_FORMAT,
+        version: BACKUP_VERSION,
+        alg: 'xchacha20poly1305',
+        createdAt: '2026-09-01T00:00:00.000Z',
+        sealed: 'v1:whatever',
+      }),
+    );
+    expect(legacy.tier).toBeUndefined();
+    expect(fileTier(legacy)).toBe(BackupTier.Extra);
+  });
+
+  it('is not made unreadable by the new field — the version did not move', () => {
+    // Bumping the version would have changed `backupAad` and broken the AEAD on
+    // every file already out there. The tier is an added optional field instead.
+    expect(BACKUP_VERSION).toBe(1);
+    expect(parseFile(JSON.stringify(buildFile('v1:x', '', BackupTier.Standard))).version).toBe(1);
+  });
+
+  it('falls back to Extra for a tier this build does not know', () => {
+    // Safe in the right direction: it asks for a key that may not be needed
+    // rather than promising a restore that cannot happen.
+    const odd = parseFile(
+      JSON.stringify({ ...buildFile('v1:x', '', BackupTier.Standard), tier: 'platinum' }),
+    );
+    expect(fileTier(odd)).toBe(BackupTier.Extra);
+  });
+});
+
+describe('the escrow file', () => {
+  it('is named beside the blob and scoped to the owner', () => {
+    // Two Waves accounts can link one Google account, and one shared name would
+    // hand the second of them the key to the first one's ledger.
+    expect(escrowFileName(OWNER)).toContain(OWNER);
+    expect(escrowFileName(OWNER)).not.toBe(escrowFileName('bbbbbbbb-2222-4222-8222-b'));
+  });
+
+  it('round-trips', () => {
+    const file = buildEscrow(KEY_HEX, '2026-09-10T00:00:00.000Z');
+    expect(file.format).toBe(ESCROW_FORMAT);
+    expect(parseEscrow(JSON.stringify(file))).toEqual(file);
+  });
+
+  it('refuses anything that is not ours, or is newer than us', () => {
+    expect(() => parseEscrow('not json')).toThrow(EscrowFormatError);
+    expect(() => parseEscrow(JSON.stringify({ format: 'other', version: 1 }))).toThrow(
+      EscrowFormatError,
+    );
+    expect(() => parseEscrow(JSON.stringify({ ...buildEscrow(KEY_HEX, ''), version: 99 }))).toThrow(
+      EscrowFormatError,
+    );
+    expect(() => parseEscrow(JSON.stringify({ ...buildEscrow(KEY_HEX, ''), key: '' }))).toThrow(
+      EscrowFormatError,
+    );
+  });
+});
+
+describe('where the key for the next backup comes from', () => {
+  const at = (over: Partial<Parameters<typeof keyForBackup>[0]> = {}) =>
+    keyForBackup({
+      tier: BackupTier.Standard,
+      hasDeviceKey: false,
+      remoteTier: null,
+      hasEscrow: false,
+      ...over,
+    });
+
+  it('mints one on Standard when the folder is empty — no screen, no ceremony', () => {
+    expect(at()).toBe(KeySource.Mint);
+  });
+
+  it('prefers the escrowed key over this phone’s, so a half-upgrade heals itself', () => {
+    // The upgrade writes the new key to the keystore before it re-seals
+    // anything. A phone that died in between holds a key that opens nothing
+    // while Drive still holds the one that does; preferring the folder throws
+    // the stale copy away and everything keeps working.
+    expect(at({ hasDeviceKey: true, hasEscrow: true })).toBe(KeySource.Escrow);
+  });
+
+  it('uses this phone’s key on Extra, and asks the person when there is none', () => {
+    expect(at({ tier: BackupTier.Extra, hasDeviceKey: true })).toBe(KeySource.Device);
+    expect(at({ tier: BackupTier.Extra, hasDeviceKey: false })).toBe(KeySource.AskPerson);
+  });
+
+  it('never mints on Extra, however empty the folder is', () => {
+    // Minting a second key there would seal the next backup away from the key
+    // the person is holding — and overwrite the one it opens.
+    expect(at({ tier: BackupTier.Extra, hasEscrow: true })).toBe(KeySource.AskPerson);
+  });
+});
+
+describe('where the key for a backup we found comes from', () => {
+  const at = (over: Partial<Parameters<typeof keyForRestore>[0]>) =>
+    keyForRestore({
+      tier: BackupTier.Standard,
+      hasDeviceKey: false,
+      remoteTier: BackupTier.Standard,
+      hasEscrow: false,
+      ...over,
+    });
+
+  it('reads the file’s tier, not the phone’s', () => {
+    // A phone freshly signed in has whatever tier its defaults gave it. The
+    // blob knows what sealed it, and the blob wins.
+    expect(at({ tier: BackupTier.Standard, remoteTier: BackupTier.Extra, hasEscrow: true })).toBe(
+      KeySource.AskPerson,
+    );
+  });
+
+  it('restores a Standard backup from the escrowed key with nothing asked', () => {
+    expect(at({ hasEscrow: true })).toBe(KeySource.Escrow);
+  });
+
+  it('tells "type your key" apart from "this can never be opened"', () => {
+    // Two different pieces of news. An extra-protection blob is waiting for
+    // something the person has; a standard blob whose key file is gone (Drive
+    // offers "Delete hidden app data", and it deletes exactly this) is waiting
+    // for nothing at all, and saying "enter your key" would be cruel.
+    expect(at({ remoteTier: BackupTier.Extra })).toBe(KeySource.AskPerson);
+    expect(at({ remoteTier: BackupTier.Standard })).toBe(KeySource.Lost);
+  });
+});
+
+describe('turning Extra protection on', () => {
+  const run = (outcomes: readonly ('ok' | 'failed')[]): UpgradeState =>
+    outcomes.reduce(advanceUpgrade, UPGRADE_START);
+
+  it('walks confirm, re-seal, escrow, done — in that order', () => {
+    expect(run(['ok']).stage).toBe(UpgradeStage.Reseal);
+    expect(run(['ok', 'ok']).stage).toBe(UpgradeStage.Escrow);
+    expect(run(['ok', 'ok', 'ok']).stage).toBe(UpgradeStage.Done);
+  });
+
+  it('will not let the escrowed key be deleted before the re-seal has landed', () => {
+    // The single rule the module exists to enforce. Deleting Google's copy of
+    // the key while the blob it opens is still sitting beside it would be a lie
+    // about the promise made one screen earlier.
+    expect(mayClearEscrow(UPGRADE_START)).toBe(false);
+    expect(mayClearEscrow(run(['ok']))).toBe(false);
+    expect(mayClearEscrow(run(['ok', 'ok']))).toBe(true);
+  });
+
+  it('leaves everything alone when the re-seal fails', () => {
+    const failed = run(['ok', 'failed']);
+    expect(failed.failedAt).toBe(UpgradeStage.Reseal);
+    expect(failed.resealed).toBe(false);
+    expect(failed.escrowCleared).toBe(false);
+    expect(failed.tier).toBe(BackupTier.Standard);
+    expect(mayClearEscrow(failed)).toBe(false);
+  });
+
+  it('cannot be walked past a failure', () => {
+    const failed = run(['ok', 'failed', 'ok', 'ok']);
+    expect(failed.stage).toBe(UpgradeStage.Reseal);
+    expect(failed.escrowCleared).toBe(false);
+  });
+
+  it('flips the tier at the re-seal, not at the delete', () => {
+    // By then the blob is sealed under a key Drive does not have, which is the
+    // promise. The file left behind opens nothing, and a screen that still said
+    // "Standard" over it would be the same lie in the other direction.
+    expect(run(['ok', 'ok']).tier).toBe(BackupTier.Extra);
+    const leftover = run(['ok', 'ok', 'failed']);
+    expect(leftover.tier).toBe(BackupTier.Extra);
+    expect(leftover.escrowCleared).toBe(false);
+  });
+});
+
+describe('what the sign-out guard will ask', () => {
+  const standing = (over: Partial<Parameters<typeof backupStanding>[0]> = {}) =>
+    backupStanding({
+      tier: BackupTier.Standard,
+      keySeen: false,
+      connected: true,
+      lastAt: 1_757_000_000_000,
+      lastRecords: 12,
+      recordCount: 12,
+      newSince: 0,
+      ...over,
+    });
+
+  it('says a restore needs no key on Standard, and does on Extra', () => {
+    expect(standing().restoreNeedsKey).toBe(false);
+    expect(standing({ tier: BackupTier.Extra }).restoreNeedsKey).toBe(true);
+  });
+
+  it('is up to date only when nothing has been added and nothing removed', () => {
+    expect(standing().upToDate).toBe(true);
+    expect(standing({ newSince: 3, recordCount: 15 }).upToDate).toBe(false);
+    // A delete moves the count without moving anything into `newSince`.
+    expect(standing({ recordCount: 11 }).upToDate).toBe(false);
+  });
+
+  it('is never up to date before the first backup', () => {
+    const never = standing({ lastAt: null, lastRecords: 0, recordCount: 4, newSince: 4 });
+    expect(never.everBackedUp).toBe(false);
+    expect(never.upToDate).toBe(false);
+    expect(never.newSince).toBe(4);
+  });
+
+  it('knows a backup cannot run with no account linked, or no key acknowledged', () => {
+    expect(standing({ connected: false }).canBackUp).toBe(false);
+    expect(standing({ tier: BackupTier.Extra, keySeen: false }).canBackUp).toBe(false);
+    expect(standing({ tier: BackupTier.Extra, keySeen: true }).canBackUp).toBe(true);
+  });
+});


### PR DESCRIPTION
> "WhatsApp doesn't ask me to create a key or something. I don't know what way to use a passkey or something. Okay, so why should we download it? I mean, without that, you don't take a backup. See how WhatsApp has implemented the same feature."

They were right, and `recoveryKey.ts`'s own header had already written down the mistake without noticing it. It reasons carefully to "a key the app generates … shown to the person once as 64 hexadecimal characters" and calls that *"WhatsApp's '64-digit encryption key' option, minus the password option beside it."* What it missed is that in WhatsApp that option is **not the default** — it is the opt-in end-to-end encrypted backup, buried in settings. WhatsApp's default Drive backup asks for no key at all. We shipped the advanced tier as the only tier, and the result was a Backup screen where nothing worked until you copied 64 hex characters somewhere.

## The two tiers, and what each one promises

**Standard — the default. No key is ever shown.** The app mints the same 32 random bytes and puts a copy in the *same hidden Drive `appDataFolder` as the backup blob*, in a small file beside it. Signing in with Google on a new phone finds both and restores with no ceremony. Whoever holds the Google account holds the ledger — that is the honest trade, and it is exactly what WhatsApp's default tier trades.

**Extra protection — opt-in.** What shipped before: 64 characters shown once, device keystore only, never escrowed, typed back in on a new phone. Waves and Google are both locked out, and losing the key loses the backup for good.

`nativeGoogle.ts` already asks for `drive.appdata` and nothing else, and the blob already lives there. **The escrow needs no new scope and no new consent screen** — which is the whole reason this design was cheap enough to make the default.

The escrowed key is stored as plain hex, deliberately. Encrypting it under something Drive also holds would be theatre — a lock with the key taped to it — and the screen says plainly where the key is instead of obfuscating it.

## Mobbin references

| App | Screen | What we took |
|---|---|---|
| WhatsApp | [Chat backup — never backed up](https://mobbin.com/screens/6553aedd-d37f-48ec-b255-6ffa59fa3a91) | Status card first; **`End-to-end encrypted backup — Off ›` as the last, visually separate card** with a one-line footnote. Our `Extra protection — Off ›` sits in exactly that position. |
| WhatsApp | [Chat backup — backed up, E2EE on](https://mobbin.com/screens/3bd9f793-f41a-4e17-972b-3411e834b133) | The tier is a **padlocked third line inside the status card**, beside date and size — not a badge, not a section. Ours is `statusSealedStandard` / `statusSealedExtra` in that slot. |
| WhatsApp | [Chat backup — mid-upload](https://mobbin.com/screens/0a279c27-750a-49e7-9533-edcf5db0fe9d) | The status card is **not** optimistically updated; the action card is replaced in place by progress. We already did this and it is now written into the file header so it stays. |
| WhatsApp | [Encrypted backup — the pitch](https://mobbin.com/screens/4303125f-e9d0-4f29-bf53-4eb7c5c5c605) | Benefit → mechanism → adversary, three short paragraphs, one `Turn on`, and **no warning at all on the pitch screen**. `extraPitchBenefit` / `extraPitchMechanism` / `extraPitchAdversary`. |
| WhatsApp | [Encrypted backup — the warning](https://mobbin.com/screens/8645c5cf-6cbc-4edf-af82-506913f10e34) | The warning lives on the *next* screen, beside the key, **boxed with a ⚠ triangle and not red**. We replaced the red `Callout` with a bordered neutral card. Red stays for things that already went wrong. |
| Solflare | [Log-out consent gate](https://mobbin.com/screens/96f25c55-91a1-4b9d-9176-5eeaade66618) | A **toggle gates the destructive button**. Our "I have saved it" tap was a reflex; the escrow delete now sits behind a `Toggle`. |
| Uniswap | [Backup consent](https://mobbin.com/screens/4ed71f4a-555f-47b9-81ca-cb78505e11e6) | A **past-tense assertion plus a consequence that names the company**, and a row showing what is about to be stranded. `extraConsent` says *"I have saved my key, and I understand that Waves cannot open this backup for me if I lose it"*, over a line counting the records going behind it. |
| Coinbase Wallet | [Import wallet](https://mobbin.com/screens/0ab6f7de-96b4-4401-aaba-c2491c82f645) | **The restore method is a fork presented up front, never a key wall discovered mid-restore.** This changed the design: see below. |
| LINE | [Restore with a known account](https://mobbin.com/screens/a04bec9a-d56f-41c6-8ee6-ecc03d9ed9e2) | When the automatic path exists it is the filled primary; the manual one is outlined beneath. Ours: on Standard "Check for a backup" just works; "I already have a key" appears only once a scan proves it is needed. |
| WhatsApp | [Restore from backup](https://mobbin.com/screens/52443d1a-819e-4b75-8ed9-9d23e92915a7) | Date and size as the found-backup metadata. We add the thing nobody in the field shows and a ledger needs: **how many records are coming back**. |
| Uniswap | [0 backups found](https://mobbin.com/screens/8d704584-9208-49c8-8982-5465a31c64e2) | "Not found" is often "not loaded yet", so it needs a retry next to it. Scan refusals now render **inside the restore card**, directly under the button that would look again. |
| Trust Wallet | [Enter recovery phrase](https://mobbin.com/screens/98f92ab7-c207-4965-a0c1-e41912119d0c) | The three things a long-string field owes you: a **Paste** affordance, a **format hint**, and a **"what is this?"** escape. All three added to the key-entry sheet. |
| Solflare | [Wrong phrase](https://mobbin.com/screens/bec2a250-1e6c-45eb-a390-c31f8182ff86) | The remedy **names the actual fix**. `restoreWrongKey` now says to check it against the phone that made the backup, not "try again". |

## The escrow file format

Beside `waves-personal-backup-<owner>.json` in `appDataFolder`:

```
waves-personal-backup-key-<owner>.json
{ "format": "waves.personal.backup.key",
  "version": 1,
  "tier": "standard",
  "createdAt": "…",
  "key": "<64 hex>" }
```

Owner-scoped for the same reason the blob is: two Waves accounts can link one Google account, and a shared name would hand the second of them the key to the first one's ledger. Versioned from the start — this is now a format with two tiers and there will be a third.

**How a restore knows which tier it found.** The *backup envelope* carries an optional `tier`, and **absent means Extra**. That is not a default, it is the truth about every file the first build wrote: those keys were device-only. It also means `BACKUP_VERSION` did not move — the version is inside the AEAD's associated data, so bumping it would have made every existing backup fail to open, which is the one thing this change must not do.

## The upgrade, and the ordering that is the promise

`tier.ts` holds the state machine; `mayClearEscrow(state)` is the single rule, and it is tested directly.

1. **Confirm** — key minted and shown. Nothing has changed; backing out costs nothing.
2. **Re-seal** — the body already on Drive is re-sealed under the new key and rewritten with `tier: extra`.
3. **Escrow** — *and only now* delete Drive's copy of the old key.

Deleting escrow while a blob the old key still opens sits beside it would be a lie about the promise made one screen earlier. Each window:

- **Re-seal fails** → nothing on Drive moved. Escrow intact, blob intact, still Standard. The person is told and can retry. This is the failure the ordering makes cheap.
- **Re-seal landed, delete failed** → Drive holds a key that opens nothing, because `keyForRestore` reads the *blob's* tier, not the file's presence. Still untidy, so **every later Extra run sweeps for it**.
- **Died between minting and re-sealing** → the keystore holds a key that opens nothing while Drive still holds the one that does. `keyForBackup` prefers the escrow under Standard precisely so this heals itself on the next run.

The new key is written to the keystore *before* the upload, deliberately: the escrow is still there as the safety net, and writing it after would leave a blob nothing on earth could open.

None of these can cost data, because the backup is never the only copy of the ledger at the moment of an upgrade.

## No downgrade, and why

Extra → Standard means uploading to Google the key we told the person, in the strongest words this app owns, that nobody but them would ever hold. The screen says *lose it and the backup can never be opened*; a switch that quietly makes that untrue teaches people the warnings are decoration. It is also the one direction where no ordering helps — every step makes the data less protected, so there is no arrangement that fails safe.

The way back exists and is deliberately not a switch: **unlink the Google account and link it again.** Unlink already clears the key, the tier and the schedule together, and the next link starts a fresh setup on Standard. One visible route with its own confirmation. Written up in `tier.ts`'s header.

## Existing users

Anyone who already made a device-only key has a key in the keystore and no stored tier, because the previous build had no tiers to store. `resolveTier(null, hasKey)` reads that as Extra protection — which is precisely what it is — and the answer is written down the first time it is asked, so the inference is a migration and not a standing rule. No prompt, no data loss, and their envelope (no `tier` field) still opens. Tested end to end in `backupEscrow.test.ts` against a fake `appDataFolder`.

## The honest privacy copy

- **Standard** — *"Your private Me ledger, copied to a hidden folder in your own Google Drive and locked with a key kept there too — so a new phone signed in to the same Google account opens it by itself. Waves cannot read it. Anyone who can get into your Google account can."*
- **Extra** — *"Your private Me ledger, copied to your own Google Drive and locked with a key only you hold. Neither Waves nor Google can read it, and nothing opens it without your key."*

The old single sentence ended *"Neither Waves nor Google can read it"*, which on Standard is false. The padlock lines split the same way: *"Locked with a key kept in your Google account"* vs *"Locked with a key only you have"*, and so does the unlink dialog.

## Screen

- The three-step checklist is now tier-aware: **Standard has one step (link the account) and it is not drawn as a checklist at all** — no marks, no "1 of 1", just the button. Extra keeps all three, unchanged. `setup.ts` and `backupSetup.test.ts` follow; the "no control is ever disabled and silent" rule is intact throughout.
- "Your key" is Extra-only. A Standard phone holds a key after its first run, but showing it would put back the ceremony the tier exists to remove.
- **Restore: the fork comes before the attempt.** A found backup that will not open from this phone gets its own sheet — date, size, which tier it is, and the one button that would open it — rather than a red error. `restoreReason` no longer blocks on `!hasKey` under Standard, where a keyless phone is the ordinary case; #748's data-loss fix (never "create a key first" on the restore path) is preserved and now also enforced in `refusedNeedsKey` / `restoreIsExtra`.
- Two new refusals: `needs-key` (extra-protection blob, no key here) and `key-lost` (standard blob whose escrowed key is gone — Drive's "Delete hidden app data" deletes exactly this). They are different news and get different sentences.
- The key sheet's `ScrollView` is a direct child with `flexGrow: 0` and a definite `maxHeight` in points, per #747.

No key material is logged, breadcrumbed, or put in an accessibility label; the crypto is unchanged (`seal`/`open` from `@/sync/rowCipher`, no KDF, no new dependency).

## i18n

All new keys in en/ta/hi/ar with identical nesting, real translations, Arabic plural forms for `extraCovers`. Split: `intro` → `introStandard`/`introExtra`; `statusSealed` → `statusSealedStandard`/`statusSealedExtra`; `disconnectBody` → `disconnectBodyStandard`/`disconnectBodyExtra`. Added: `extraSection`, `extraOn`, `extraOff`, `extraFootnoteOff`, `extraFootnoteOn`, `extraPitchTitle`, `extraPitchBenefit`, `extraPitchMechanism`, `extraPitchAdversary`, `extraTurnOn`, `extraOnTitle`, `extraOnBody`, `extraNoWayBack`, `extraKeyTitle`, `extraKeyBody`, `extraCovers`, `extraConsent`, `extraTurningOn`, `extraFailed`, `refusedNeedsKey`, `refusedKeyLost`, `restoreFoundTitle`, `restoreIsExtra`, `keyEnterPaste`, `keyEnterHint`, `keyEnterWhat`, `keyEnterWhatBody`. `restoreWrongKey` rewritten to name the fix.

## For the sign-out guard and the sign-in restore prompt (a follow-up)

`useBackup()` now exposes `standing: BackupStanding` — pure, from `tier.ts`, computed by `backupStanding()` and unit-tested:

```ts
{ tier, lastAt, everBackedUp, newSince, upToDate, canBackUp, restoreNeedsKey }
```

`upToDate` is honest about its limits: creation time is the only timestamp the mirror rows carry, so it is a claim about the *shape* of the ledger (nothing added, nothing removed) and not its contents. That is the right claim for a sign-out guard. `restoreNeedsKey` is false on Standard — a new phone signed into the same Google account restores by itself — which is the question the sign-in prompt needs to decide whether to offer a restore or ask for a key.

## Tests

`backupTiers.test.ts` (28) — tier resolution and the pre-tier migration, the escrow envelope, both key-source tables, the upgrade state machine (escrow is never clearable before a successful re-seal), and `backupStanding`.

`backupEscrow.test.ts` (15) — the engine against a fake `appDataFolder`: Standard mints and escrows (escrow written *before* the blob), a second phone adopts the escrowed key and restores with nothing asked, a stale local key is discarded in favour of the folder's, **a pre-tier envelope with no tier field still opens and still backs up on Extra**, `needs-key` and `key-lost` are told apart, and the upgrade's `put` strictly precedes its `remove` — with the re-seal-failed and delete-failed windows both asserted.

## Gates

`pnpm format` → `pnpm format:check` (clean) → `pnpm lint` (all projects, `--max-warnings 0`, clean) → `pnpm typecheck` (clean) → `pnpm test`: mobile **92 files / 1264 tests passing**, plus core 957, web 53, api 63, admin 40, api-client 12, agent-mcp 25. `packages/db` needs Postgres on `localhost:54330` and a `.env` this worktree does not have — unrelated and untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Standard and optional Extra protection backup tiers.
  - Standard enables automatic recovery on a new device; Extra protection keeps the key only on the device and displays it once.
  - Added a guided upgrade path from Standard to Extra protection.
  - Restore now clearly explains key requirements and recovery options.
  - Backup setup and status adapt to the selected tier.

- **Bug Fixes**
  - Improved handling of incomplete, blocked, and legacy backups.
  - Added safer cleanup after protection upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->