### PR TITLE
Deleting a group is an admin's decision, and it now says whose

### DIFF
--- a/apps/mobile/src/data/activity.ts
+++ b/apps/mobile/src/data/activity.ts
@@ -229,6 +229,12 @@ export function activityHeadline(entry: ActivityRow): string {
       return 'Group imported';
     case 'auto_archived':
       return 'Group archived';
+    // Its own verb rather than the plain 'deleted' above, which is about an
+    // expense and would render this as "Deleted expense". The row is written
+    // into the group it is about, so almost nobody will ever see it — it exists
+    // so that afterwards there is a record of who did this.
+    case 'group_deleted':
+      return 'Group deleted';
     default:
       // A verb from a newer build. Say what is known rather than dropping the row.
       return `${entry.verb} ${entry.object_type}`;

--- a/apps/mobile/src/data/activity.ts
+++ b/apps/mobile/src/data/activity.ts
@@ -156,6 +156,11 @@ export function describeActivity(
         typeof payload.name === 'string' && payload.name.trim() ? payload.name.trim() : null;
       return name ? `${who} created ${name}` : `${who} created the group`;
     }
+    case 'group_deleted': {
+      const name =
+        typeof payload.name === 'string' && payload.name.trim() ? payload.name.trim() : null;
+      return name ? `${who} deleted ${name}` : `${who} deleted the group`;
+    }
     default:
       // An unknown verb is a row written by a newer build than this one. Say
       // what is known rather than dropping it — a feed with holes in it is

--- a/apps/mobile/test/activity.test.ts
+++ b/apps/mobile/test/activity.test.ts
@@ -213,9 +213,9 @@ describe('activityHeadline', () => {
   });
 
   it('describes a group delete as a sentence, not a raw verb', () => {
-    expect(describeActivity(row({ verb: 'group_deleted', payload: { name: 'Goa Trip' } }), null)).toBe(
-      'Ravi deleted Goa Trip',
-    );
+    expect(
+      describeActivity(row({ verb: 'group_deleted', payload: { name: 'Goa Trip' } }), null),
+    ).toBe('Ravi deleted Goa Trip');
     expect(describeActivity(row({ actor: ME, verb: 'group_deleted' }), 'profile-asha')).toBe(
       'You deleted the group',
     );

--- a/apps/mobile/test/activity.test.ts
+++ b/apps/mobile/test/activity.test.ts
@@ -207,8 +207,18 @@ describe('activityHeadline', () => {
     ['auto_confirmed', 'Settlement auto-confirmed'],
     ['joined', 'Joined the group'],
     ['created', 'Group created'],
+    ['group_deleted', 'Group deleted'],
   ])('words the non-expense event %s', (verb, expected) => {
     expect(activityHeadline(row({ verb }))).toBe(expected);
+  });
+
+  it('describes a group delete as a sentence, not a raw verb', () => {
+    expect(describeActivity(row({ verb: 'group_deleted', payload: { name: 'Goa Trip' } }), null)).toBe(
+      'Ravi deleted Goa Trip',
+    );
+    expect(describeActivity(row({ actor: ME, verb: 'group_deleted' }), 'profile-asha')).toBe(
+      'You deleted the group',
+    );
   });
 
   it('names the group in the title when a create carries one', () => {

--- a/packages/db/prisma/migrations/20260910090000_group_column_guard/migration.sql
+++ b/packages/db/prisma/migrations/20260910090000_group_column_guard/migration.sql
@@ -1,0 +1,245 @@
+-- Any member could delete anybody's group, and nothing recorded who did.
+--
+-- `waves_delete_group` checks `is_group_admin` before it stamps the tombstone,
+-- and the client only shows the button to an admin. Neither is the boundary,
+-- because the RPC is not the only door to the column.
+--
+-- `authenticated` holds a table-wide `GRANT SELECT, INSERT, UPDATE ON
+-- public.groups` (baseline, re-granted by 20260904160000_anon_surface_on_hosted),
+-- the `groups_update` RLS policy scopes that UPDATE with `is_group_member(id)` —
+-- the row, not the columns — and there are no column-level ACLs anywhere in this
+-- schema. So the only thing standing between "a member may edit this group" and
+-- "a member may edit *this column*" is `waves_guard_group_columns`, a
+-- hand-maintained list of forbidden columns. `deleted_at` was not on it.
+--
+-- Any ordinary member could therefore send PostgREST a plain
+--
+--     PATCH /rest/v1/groups?id=eq.<id>   {"deleted_at": "2026-09-10T00:00:00Z"}
+--
+-- and delete the group for everybody without being an admin — or send
+-- `{"deleted_at": null}` and resurrect one an admin had deleted. Worse than
+-- accepted: the write fires `groups_stamp_seq`, so a forged delete is broadcast
+-- to every member's mirror and the group vanishes off all their devices.
+-- `/sync` was never the hole — its `GROUP_UPDATABLE_FIELDS` whitelist correctly
+-- omits `deleted_at` — but a whitelist in an edge function cannot defend a grant
+-- in the database.
+--
+-- Guests sign in as `authenticated` and are ordinary members, so this was
+-- reachable by anybody who had been let into a group at all.
+--
+-- ─────────────────────────────────────────── it was not the only omission ──
+--
+-- `budget_minor` and `budget_currency` have exactly the same shape:
+-- `waves_set_group_budget` refuses a non-admin with NOT_AN_ADMIN, the two
+-- columns are absent from the `/sync` whitelist, and they were absent from the
+-- guard — so a direct PATCH set or wiped a group's overall budget with no admin
+-- check at all. The guard already protected the sibling `category_budgets`. Two
+-- hand-maintained lists that have now drifted apart twice is not a list problem,
+-- it is the wrong shape of list.
+--
+-- So this stops enumerating what is forbidden and enumerates what is allowed:
+-- exactly the columns `/sync` already lets a member write, and nothing else. A
+-- column added to `public.groups` next year is refused by default rather than
+-- exposed by default, which is the only version of this trigger that stays
+-- correct without somebody remembering it exists.
+--
+-- What that deliberately keeps writable:
+--
+--   * `archived_at` — this is *not* the same bug. It is in the `/sync`
+--     whitelist, so any member archiving a group for everyone is the shipped,
+--     intended capability and the app's own archive button is an ordinary
+--     `group.update`. Whether archiving should be admin-only is a real product
+--     question, and it is not one to settle inside a security fix by breaking
+--     the button.
+--   * name, type, cover emoji, photo path, simplify_debts, default currency,
+--     country code, the trip dates, the time zone and the three reminder
+--     settings — ordinary editable fields the app already writes directly
+--     (`updateGroup` in the mobile client and in `@waves/api-client`, and
+--     `PATCH /v1/groups/:id` in the developer API, all send only these).
+--
+-- And what it now refuses that it did not name before: `updated_at`, which no
+-- caller sends and which is self-reported anyway; `deleted_at`; `budget_minor`;
+-- `budget_currency`. The four columns it did name — `updated_seq`, `created_by`,
+-- `id`, `created_at` — are refused by the same rule instead of by four `IF`s.
+--
+-- The `photo_path` paid gate is not a "may this column be written" rule but a
+-- "may *you* write it" rule, so it stays as its own check after the allowlist.
+--
+-- ─────────────────────────────────────────────── two mechanical footnotes ──
+--
+-- The guard runs only for `anon` and `authenticated`, so the definer RPCs that
+-- legitimately write these columns — `waves_delete_group`,
+-- `waves_set_group_budget`, `waves_set_group_fx_rate` and the join-token
+-- functions — execute as their owner and pass straight through, exactly as they
+-- did before.
+--
+-- Trigger order matters and is load-bearing: `groups_guard_columns` sorts before
+-- `groups_stamp_seq`, so the guard sees `NEW.updated_seq` still equal to
+-- `OLD.updated_seq` on an ordinary member's write, and the stamp bumps it
+-- afterwards. That is why `updated_seq` can be refused outright here without
+-- rejecting every legitimate update.
+--
+-- `waves_guard_membership_columns` is deliberately left alone. Its three entries
+-- look like the same drift and are not: on `group_members` the stamp trigger
+-- assigns `updated_seq` unconditionally, so a client's value is discarded rather
+-- than needing to be refused. The asymmetry is real and correct.
+
+CREATE OR REPLACE FUNCTION public.waves_guard_group_columns() RETURNS trigger
+    LANGUAGE plpgsql
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+DECLARE
+  -- Kept in step with `GROUP_UPDATABLE_FIELDS` in supabase/functions/sync/index.ts.
+  -- These are the same list, and this one is the authority: `/sync` is a
+  -- convenience filter that returns a tidy 400, the trigger is the boundary that
+  -- holds when somebody skips `/sync` entirely.
+  v_allowed constant text[] := ARRAY[
+    'name',
+    'type',
+    'cover_emoji',
+    'photo_path',
+    'simplify_debts',
+    'default_currency',
+    'country_code',
+    'archived_at',
+    'start_date',
+    'end_date',
+    'time_zone',
+    'remind_daily',
+    'remind_morning_at',
+    'remind_evening_at'
+  ];
+  v_refused text;
+BEGIN
+  IF current_user NOT IN ('anon', 'authenticated') THEN
+    RETURN NEW;
+  END IF;
+
+  -- Compare the whole row rather than named columns, so the list above is the
+  -- only thing anybody has to maintain. `to_jsonb` on a record gives one key per
+  -- column with a jsonb `null` (not SQL NULL) for an empty one, so `IS DISTINCT
+  -- FROM` compares cleanly in both directions — including the null-to-value and
+  -- value-to-null writes, which is how a group gets resurrected.
+  SELECT string_agg(changed.key, ', ' ORDER BY changed.key)
+    INTO v_refused
+    FROM jsonb_each(to_jsonb(NEW)) AS changed(key, value)
+   WHERE changed.value IS DISTINCT FROM (to_jsonb(OLD) -> changed.key)
+     AND NOT (changed.key = ANY (v_allowed));
+
+  IF v_refused IS NOT NULL THEN
+    -- Named in the message because the caller is usually our own client and the
+    -- useful bug report is "which column", not "something was refused". The
+    -- names are column names, not user data, so there is nothing to leak.
+    RAISE EXCEPTION
+      'FORBIDDEN_COLUMN: % is set by the server or through its own RPC, not by a direct write', v_refused
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Not a forbidden column — a forbidden *writer*. A member may set the photo
+  -- path; only a group entitled to a photo may have one set.
+  IF NEW.photo_path IS DISTINCT FROM OLD.photo_path
+     AND NEW.photo_path IS NOT NULL
+     AND NOT public.waves_can_upload_group_photo(NEW.id) THEN
+    RAISE EXCEPTION 'PHOTO_GATE: a group photo is a paid feature'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  RETURN NEW;
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.waves_guard_group_columns() TO anon, authenticated, service_role;
+
+-- ─────────────────────────────────── who deleted this, and when, and why ──
+--
+-- `waves_delete_group` has never written anything down. The tombstone records
+-- that a group was deleted and the instant it happened; it records nobody. Which
+-- means an admin's legitimate delete and the forged PATCH above are, in the data
+-- that survives, the same event — and there is no way to go back through
+-- production afterwards and tell which groups were deleted by somebody who had
+-- no right to.
+--
+-- That is worth fixing on its own terms and not only as forensics for this bug.
+-- Deleting a group destroys the record of who owed whom for every member, not
+-- just for the one who tapped the button; it is the most consequential thing one
+-- person can do to everybody else's copy of the app, and it was the only such
+-- action leaving no line in the feed. `waves_auto_archive_stale_groups` and
+-- `waves_auto_confirm_settlements` both already write one for far smaller
+-- things.
+--
+-- The row is written before the tombstone, inside the same transaction and under
+-- the same `FOR UPDATE` lock, so either both land or neither does. `actor_member_id`
+-- is the caller's own membership, which is what makes it an audit row rather than
+-- a timestamp — and it stays non-null because the admin gate above has already
+-- established that the caller is a member.
+--
+-- Everything else is 20260907160000_admin_deletes_unsettled_group verbatim: same
+-- signature, same void return (so `CREATE OR REPLACE` is enough and there is no
+-- 42P13 to drop around), same lock, same admin gate, same idempotent re-delete —
+-- and the idempotency is why the row goes after that check and not before, so a
+-- retried offline queue flush does not write a second line for the same delete.
+CREATE OR REPLACE FUNCTION public.waves_delete_group(p_group_id uuid) RETURNS void
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+DECLARE
+  v_profile_id uuid := public.waves_current_profile_id();
+  v_deleted_at timestamptz;
+  v_actor      uuid;
+BEGIN
+  IF v_profile_id IS NULL THEN
+    RAISE EXCEPTION 'NOT_AUTHENTICATED: sign in to delete a group'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Lock the group row up front (FOR UPDATE), so the read of `deleted_at` and
+  -- the tombstone that follows see the same serialized view of the row. This
+  -- closes the delete-vs-delete window and gives a single coordination point a
+  -- balance-mutating writer can share (take the same row lock) to be serialized
+  -- against a delete; on its own it does not stop a writer that never locks
+  -- this row (see A49 review notes).
+  SELECT deleted_at INTO v_deleted_at FROM public.groups WHERE id = p_group_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'NOT_FOUND: no such group' USING ERRCODE = 'no_data_found';
+  END IF;
+
+  -- Only an admin/owner may delete the group for everyone. The button hides for
+  -- everyone else, but the client gate is a courtesy — this is the boundary.
+  IF NOT public.is_group_admin(p_group_id) THEN
+    RAISE EXCEPTION 'NOT_ADMIN: only an admin deletes a group'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Idempotent: deleting an already-deleted group is a no-op, so a retried queue
+  -- flush or a second tap lands cleanly rather than raising. Checked after the
+  -- admin gate so a re-delete still answers a non-admin with NOT_ADMIN.
+  IF v_deleted_at IS NOT NULL THEN
+    RETURN;
+  END IF;
+
+  v_actor := public.waves_my_member_id_for(p_group_id, v_profile_id);
+
+  INSERT INTO public.activity_log
+    (group_id, actor_member_id, verb, object_type, object_id, payload)
+  SELECT p_group_id, v_actor, 'group_deleted', 'group', p_group_id,
+         jsonb_build_object('name', g.name)
+    FROM public.groups g
+   WHERE g.id = p_group_id;
+
+  -- The tombstone. The stamp trigger bumps `updated_seq`, so the change reaches
+  -- every member's mirror on their next sync and the group leaves all their lists.
+  UPDATE public.groups SET deleted_at = now() WHERE id = p_group_id;
+END
+$$;
+
+-- CREATE OR REPLACE keeps the ACL the baseline set, so nothing is actually
+-- open here. The grants are restated anyway because that is the rule the
+-- repository enforces on every SECURITY DEFINER function: such a function
+-- bypasses RLS and Postgres grants EXECUTE to PUBLIC by default, so a
+-- migration that stays silent about its caller model is one signature change
+-- away from minting a *new* function with the default back on — which is
+-- exactly how waves_consume_invite once regained anon. Saying it in the same
+-- file makes the intent survive the next edit.
+REVOKE ALL ON FUNCTION public.waves_delete_group(p_group_id uuid) FROM PUBLIC;
+GRANT ALL ON FUNCTION public.waves_delete_group(p_group_id uuid) TO authenticated;
+GRANT ALL ON FUNCTION public.waves_delete_group(p_group_id uuid) TO service_role;

--- a/packages/db/test/group-column-guard.test.ts
+++ b/packages/db/test/group-column-guard.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Which columns of a group an ordinary member may write, and which they may not.
+ *
+ * `authenticated` holds a table-wide UPDATE on `public.groups` and the
+ * `groups_update` policy scopes it to members of the row. There are no
+ * column-level ACLs anywhere in this schema, so `waves_guard_group_columns` is
+ * the only thing between "a member may edit this group" and "a member may edit
+ * *this column*" — and it is reached by a plain PostgREST PATCH, with no RPC and
+ * no `/sync` in the way.
+ *
+ * These tests go through the same door: `SET ROLE authenticated` and a bare
+ * UPDATE. That is the shape of the exploit — a member deleting a group for
+ * everybody by writing `deleted_at` themselves, or resurrecting one by clearing
+ * it — so it is the shape the test has to take. Anything routed through an RPC
+ * would prove nothing, because the RPCs are exactly what the exploit skips.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { connect, expectDenied, seedGroup } from './helpers.js';
+
+let client: Client;
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client?.end();
+});
+
+async function asUser<T>(profileId: string, run: () => Promise<T>): Promise<T> {
+  await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+    JSON.stringify({ sub: profileId, role: 'authenticated' }),
+  ]);
+  await client.query(`SET ROLE authenticated`);
+  try {
+    return await run();
+  } finally {
+    await client.query(`RESET ROLE`);
+    await client.query(`SELECT set_config('request.jwt.claims', '', false)`);
+  }
+}
+
+/** One `UPDATE groups SET <column> = <value>` run as an ordinary member. */
+function patch(profileId: string, groupId: string, column: string, value: unknown) {
+  return asUser(profileId, () =>
+    client.query(`UPDATE groups SET ${column} = $1 WHERE id = $2`, [value, groupId]),
+  );
+}
+
+async function deletedAt(groupId: string): Promise<string | null> {
+  const { rows } = await client.query(`SELECT deleted_at FROM groups WHERE id = $1`, [groupId]);
+  const value = (rows[0]?.deleted_at as Date | string | null) ?? null;
+  return value === null ? null : new Date(value).toISOString();
+}
+
+describe('a member cannot delete a group by hand', () => {
+  it('refuses a direct write to deleted_at', async () => {
+    // profileIds[1] is an ordinary member. `waves_delete_group` would answer
+    // NOT_ADMIN; before the guard learned this column, the same person could
+    // simply write it and skip the question.
+    const { groupId, profileIds } = await seedGroup(client, { memberCount: 2 });
+
+    const message = await expectDenied(
+      patch(profileIds[1]!, groupId, 'deleted_at', new Date().toISOString()),
+    );
+
+    expect(message).toMatch(/FORBIDDEN_COLUMN/);
+    expect(message).toMatch(/deleted_at/);
+    expect(await deletedAt(groupId)).toBeNull();
+  });
+
+  it('refuses it to an admin too, because the RPC is the only door', async () => {
+    // Not because an admin may not delete — they may — but because the delete
+    // has to go through the function that takes the row lock and writes the
+    // audit row. A guard that made an exception for admins would be a guard
+    // that has to work out who is an admin, which is the RPC's job.
+    const { groupId, profileIds } = await seedGroup(client, { memberCount: 2 });
+
+    const message = await expectDenied(
+      patch(profileIds[0]!, groupId, 'deleted_at', new Date().toISOString()),
+    );
+
+    expect(message).toMatch(/FORBIDDEN_COLUMN/);
+    expect(await deletedAt(groupId)).toBeNull();
+  });
+
+  it('refuses clearing deleted_at, which is the same authority in reverse', async () => {
+    const { groupId, profileIds } = await seedGroup(client, { memberCount: 2 });
+    await asUser(profileIds[0]!, () => client.query(`SELECT waves_delete_group($1)`, [groupId]));
+    const stamped = await deletedAt(groupId);
+    expect(stamped).not.toBeNull();
+
+    const message = await expectDenied(patch(profileIds[1]!, groupId, 'deleted_at', null));
+
+    expect(message).toMatch(/FORBIDDEN_COLUMN/);
+    expect(await deletedAt(groupId)).toBe(stamped);
+  });
+});
+
+describe('the guard is an allowlist, not a list of known villains', () => {
+  it('refuses the overall trip budget, which is admin-only in its RPC', async () => {
+    const { groupId, profileIds } = await seedGroup(client, { memberCount: 2 });
+
+    const message = await expectDenied(patch(profileIds[1]!, groupId, 'budget_minor', '500000'));
+    expect(message).toMatch(/FORBIDDEN_COLUMN/);
+
+    const currency = await expectDenied(patch(profileIds[1]!, groupId, 'budget_currency', 'EUR'));
+    expect(currency).toMatch(/FORBIDDEN_COLUMN/);
+
+    const { rows } = await client.query(
+      `SELECT budget_minor, budget_currency FROM groups WHERE id = $1`,
+      [groupId],
+    );
+    expect(rows[0]?.budget_minor).toBeNull();
+    expect(rows[0]?.budget_currency).toBeNull();
+  });
+
+  it('still refuses the four columns the old enumerated guard named', async () => {
+    const { groupId, profileIds } = await seedGroup(client, { memberCount: 2 });
+    const member = profileIds[1]!;
+
+    for (const [column, value] of [
+      ['updated_seq', '9999'],
+      ['created_by', randomUUID()],
+      ['created_at', new Date(0).toISOString()],
+      ['category_budgets', '{"food":{"amountMinor":"100","currency":"INR"}}'],
+      ['fx_rates', '{"EUR":{"num":"90","den":"1"}}'],
+      ['join_token', 'forged-token'],
+    ] as const) {
+      const message = await expectDenied(patch(member, groupId, column, value));
+      expect(message, column).toMatch(/FORBIDDEN_COLUMN/);
+    }
+  });
+
+  it('names the column it refused, so a bug report says which one', async () => {
+    const { groupId, profileIds } = await seedGroup(client, { memberCount: 2 });
+    const message = await expectDenied(patch(profileIds[1]!, groupId, 'updated_seq', '4'));
+    expect(message).toMatch(/updated_seq/);
+  });
+});
+
+describe('the columns the app actually writes still go through', () => {
+  it('lets a member rename, re-emoji and re-date the group', async () => {
+    // Exactly the fields `/sync`'s GROUP_UPDATABLE_FIELDS allows. If this test
+    // fails, the allowlist and the edge function have drifted apart.
+    const { groupId, profileIds } = await seedGroup(client, { memberCount: 2 });
+    const member = profileIds[1]!;
+
+    await patch(member, groupId, 'name', 'Goa 2026');
+    await patch(member, groupId, 'cover_emoji', '🏖️');
+    await patch(member, groupId, 'start_date', '2026-01-01');
+    await patch(member, groupId, 'end_date', '2026-01-08');
+    await patch(member, groupId, 'time_zone', 'Asia/Kolkata');
+    await patch(member, groupId, 'remind_daily', false);
+    await patch(member, groupId, 'simplify_debts', false);
+    await patch(member, groupId, 'default_currency', 'EUR');
+    await patch(member, groupId, 'country_code', 'IN');
+
+    const { rows } = await client.query(
+      `SELECT name, cover_emoji, remind_daily FROM groups WHERE id = $1`,
+      [groupId],
+    );
+    expect(rows[0]?.name).toBe('Goa 2026');
+    expect(rows[0]?.remind_daily).toBe(false);
+  });
+
+  it('lets a member archive and unarchive, which is deliberate', async () => {
+    // Archiving is in the `/sync` whitelist: any member putting a finished trip
+    // away is the shipped capability, not an escalation. It is the one column on
+    // this list that looks like `deleted_at` and is not.
+    const { groupId, profileIds } = await seedGroup(client, { memberCount: 2 });
+    const member = profileIds[1]!;
+
+    await patch(member, groupId, 'archived_at', new Date().toISOString());
+    await patch(member, groupId, 'archived_at', null);
+
+    const { rows } = await client.query(`SELECT archived_at FROM groups WHERE id = $1`, [groupId]);
+    expect(rows[0]?.archived_at).toBeNull();
+  });
+
+  it('leaves the stamp trigger free to bump updated_seq behind the guard', async () => {
+    // The guard sorts before the stamp, so an ordinary write arrives with
+    // NEW.updated_seq still equal to OLD's and is stamped afterwards. Refusing
+    // the column outright would be useless if that order were the other way.
+    const { groupId, profileIds } = await seedGroup(client, { memberCount: 2 });
+    const before = await client.query(`SELECT updated_seq FROM groups WHERE id = $1`, [groupId]);
+
+    await patch(profileIds[1]!, groupId, 'name', 'Bumped');
+
+    const after = await client.query(`SELECT updated_seq FROM groups WHERE id = $1`, [groupId]);
+    expect(BigInt(String(after.rows[0]?.updated_seq))).toBeGreaterThan(
+      BigInt(String(before.rows[0]?.updated_seq)),
+    );
+  });
+
+  it('leaves the definer RPCs alone', async () => {
+    // The guard only fires for anon/authenticated, so a SECURITY DEFINER
+    // function writing a guarded column runs as its owner and passes through.
+    // Proving it on the one that matters most: the delete still works.
+    const { groupId, profileIds } = await seedGroup(client, { memberCount: 2 });
+    await asUser(profileIds[0]!, () => client.query(`SELECT waves_delete_group($1)`, [groupId]));
+    expect(await deletedAt(groupId)).not.toBeNull();
+  });
+});

--- a/packages/db/test/group-delete.test.ts
+++ b/packages/db/test/group-delete.test.ts
@@ -119,6 +119,44 @@ describe('deleting a group', () => {
     expect(await deletedAt(groupId)).toBeNull();
   });
 
+  it('writes down who did it', async () => {
+    // The tombstone says a group was deleted and when; on its own it does not
+    // say by whom, so a legitimate delete and a forged one were the same event
+    // in the data that survives. Deleting a group destroys the record of who
+    // owed whom for every member — the one action of that weight that left no
+    // line in the feed.
+    const { groupId, profileIds, memberIds } = await seedGroup(client, { memberCount: 2 });
+
+    await asUser(profileIds[0]!, () => client.query(`SELECT waves_delete_group($1)`, [groupId]));
+
+    const { rows } = await client.query(
+      `SELECT actor_member_id, object_type, payload FROM activity_log
+        WHERE group_id = $1 AND verb = 'group_deleted'`,
+      [groupId],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.actor_member_id).toBe(memberIds[0]);
+    expect(rows[0]?.object_type).toBe('group');
+    // The name is captured before the row goes, because afterwards nothing in
+    // the app will ever show that group again to read it off.
+    expect(rows[0]?.payload?.name).toBe('Goa trip');
+  });
+
+  it('does not write a second audit row for a repeated delete', async () => {
+    // The row goes after the idempotency check, so a retried offline queue flush
+    // records the delete once rather than once per attempt.
+    const { groupId, profileIds } = await seedGroup(client, { memberCount: 2 });
+
+    await asUser(profileIds[0]!, () => client.query(`SELECT waves_delete_group($1)`, [groupId]));
+    await asUser(profileIds[0]!, () => client.query(`SELECT waves_delete_group($1)`, [groupId]));
+
+    const { rows } = await client.query(
+      `SELECT count(*)::int AS n FROM activity_log WHERE group_id = $1 AND verb = 'group_deleted'`,
+      [groupId],
+    );
+    expect(rows[0]?.n).toBe(1);
+  });
+
   it('is idempotent — a second delete is a clean no-op', async () => {
     const { groupId, profileIds } = await seedGroup(client, { memberCount: 2 });
 


### PR DESCRIPTION
## The exposure

`waves_delete_group` checks `is_group_admin` before it stamps `groups.deleted_at`. That check is not the boundary, because the RPC is not the only door to the column.

- `authenticated` holds a **table-wide** `GRANT SELECT, INSERT, UPDATE ON public.groups` (baseline `:12737`, re-granted `20260904160000_anon_surface_on_hosted:82`).
- The `groups_update` RLS policy (`baseline:10738`) scopes that UPDATE with `is_group_member(id)` — the *row*, not the columns.
- There are **no column-level ACLs anywhere in this schema** (`GRANT/REVOKE (col)` has zero hits).
- So the only column defence is `waves_guard_group_columns` (`baseline:3587`), a hand-maintained list of forbidden columns. `deleted_at` was not on it.

**Reachable by any ordinary authenticated user who is a member of the group** — guests included, since a guest signs in as `authenticated`:

```
PATCH /rest/v1/groups?id=eq.<group-id>
{"deleted_at": "2026-09-10T00:00:00Z"}     -> deletes the group for everybody
{"deleted_at": null}                        -> resurrects one an admin deleted
```

It is worse than merely accepted: the write fires `groups_stamp_seq`, so a forged delete bumps `updated_seq` and is **broadcast to every member's mirror**. The group vanishes off all their devices.

`/sync` was never the hole — its `GROUP_UPDATABLE_FIELDS` whitelist (`supabase/functions/sync/index.ts:135-150`) correctly omits `deleted_at`. But a whitelist in an edge function cannot defend a grant in the database.

### A second instance of the same hole

`budget_minor` / `budget_currency`: `waves_set_group_budget` (`baseline:6045`) refuses a non-admin with `NOT_AN_ADMIN`, the columns are absent from the `/sync` whitelist, and they were absent from the guard. So a direct PATCH set or wiped a group's overall budget with no admin check. Smaller stakes, identical shape — and the guard already protected the sibling `category_budgets`.

## What operators should check for past abuse

**Short answer: it cannot be reconstructed from the data, which is why this PR also adds the audit row.**

`waves_delete_group` has never written an `activity_log` row, in either version. So a legitimate admin delete and a forged PATCH are indistinguishable in what survives: both leave a `deleted_at` timestamp and nothing else. There is no actor, no verb, no distinguishing trace.

Two things are still worth looking at before this lands, both weak signals rather than proof:

1. **Resurrections.** A group with `deleted_at IS NULL` whose feed contains no delete but whose members remember one. Nothing in the app has ever cleared `deleted_at`, so *any* group that was deleted and is now alive was cleared by a direct write. There is no record of the clearing either, but a support report of "my group came back" is now explicable.
2. **PostgREST request logs**, if retained: `PATCH /rest/v1/groups` carrying `deleted_at` in the body, from a user who is not an admin of that group. This is the only place the evidence could exist, and only for as long as the logs are kept.

After this lands, every delete writes `activity_log(verb='group_deleted', actor_member_id=<who>)`, so the same question is answerable going forward.

## The fix

**1. The guard stops enumerating villains and enumerates what is allowed.**

Two hand-maintained lists that have already drifted apart twice is not a list problem, it is the wrong shape of list. The trigger now compares `to_jsonb(NEW)` against `to_jsonb(OLD)` and refuses any changed column that is not in an allowlist — which is exactly `/sync`'s `GROUP_UPDATABLE_FIELDS`. A column added to `public.groups` next year is **refused by default rather than exposed by default**.

Newly refused: `deleted_at`, `budget_minor`, `budget_currency`, `updated_at`. Still refused, by the same rule instead of four separate `IF`s: `updated_seq`, `created_by`, `id`, `created_at`, `category_budgets`, `fx_rates`, `join_token`. The `photo_path` paid gate stays as its own check, because it is a "may *you* write it" rule, not a "may this column be written" rule.

**`archived_at` is deliberately still writable, and is not the same bug.** It is in the `/sync` whitelist: any member archiving a group for everyone is the shipped, intended capability, and the app's own archive button is an ordinary `group.update`. Whether archiving should be admin-only is a real product question — raised here, not settled inside a security fix by breaking the button.

`waves_guard_membership_columns` is deliberately left alone. Its three entries look like the same drift and are not: on `group_members` the stamp trigger assigns `updated_seq` unconditionally, so a client value is discarded rather than needing to be refused. The asymmetry is real.

**2. `waves_delete_group` writes an audit row.**

`activity_log(verb='group_deleted', object_type='group', actor_member_id=<the caller's membership>, payload={name})`, inside the same transaction and under the same `FOR UPDATE` lock, after the idempotency check so a retried queue flush records one delete rather than one per attempt. The name is captured before the row goes, because afterwards nothing in the app will show that group again to read it off.

Deleting a group destroys the record of who owed whom for every member, not just for the one who tapped the button. It was the most consequential thing one person can do to everybody else's copy of the app, and the only action of that weight leaving no line in the feed — `waves_auto_archive_stale_groups` and `waves_auto_confirm_settlements` both already write one for far smaller things.

**3. One client line.** `activityHeadline` gets a `group_deleted` case, so the new verb renders as "Group deleted" rather than falling through to the raw-verb default. Its own verb rather than the existing `deleted`, which is about an expense and would have rendered this as "Deleted expense".

## Trigger ordering (load-bearing)

`groups_guard_columns` sorts before `groups_stamp_seq`, so the guard sees `NEW.updated_seq` still equal to `OLD.updated_seq` on an ordinary member's write and the stamp bumps it afterwards. That is why `updated_seq` can be refused outright without rejecting every legitimate update. There is a test pinning it.

## Testing

- `packages/db/test/group-column-guard.test.ts` (new) — goes through the same door as the exploit (`SET ROLE authenticated`, bare `UPDATE`, no RPC and no `/sync` in the way): a member cannot write `deleted_at`, an admin cannot either (the RPC is the only door), clearing it is refused, the budget columns are refused, the previously-named columns are still refused, the error names the column, and the fourteen allowlisted columns still go through — archive and unarchive included.
- `packages/db/test/group-delete.test.ts` — the audit row is written with the right actor and name, and a repeated delete writes only one.

**Unverified locally**: this worktree has no Postgres on `localhost:54330`, so the whole `@waves/db` suite (67 files, not only these) fails to connect here. Everything else is green: `pnpm format:check`, `pnpm lint` (all projects, `--max-warnings 0`), `pnpm typecheck`, and `core` 957 / `mobile` 1217 / `web` 53 / `api` 63 / `edge` 254 / `admin` 40 / `api-client` 12 / `agent-mcp` 25.

## Deploy

Migration only — no prod changes made here. This is the half worth deploying on its own; the correctness follow-up (deleted groups counting towards balances, the digest and nudges firing for deleted groups) is a separate PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Group deletion activity now appears with a clear “Group deleted” headline and identifies the group when its name is available.
  * Group deletion records who performed the action for activity history.

* **Bug Fixes**
  * Direct edits to protected group fields are now blocked, while permitted settings and archive actions continue to work.
  * Repeated group deletion no longer creates duplicate activity entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->