### PR TITLE
Deleted groups stop counting towards what people owe each other

### DIFF
--- a/apps/api/src/routes/v1/groups.ts
+++ b/apps/api/src/routes/v1/groups.ts
@@ -77,6 +77,13 @@ groups.get('/groups', requireScope('groups.read'), async (c) => {
     .order('id', { ascending: false })
     .limit(limit + 1);
   if (!includeArchived) query = query.is('archived_at', null);
+  // No `include_deleted` to go with `include_archived`, and there should not be
+  // one. Archiving puts a group away and can be undone, so a script has reason
+  // to ask for those; a delete is a tombstone the group is never coming back
+  // from, and its rows survive only so the delete can reach other devices
+  // (ADR-004). Serving them over an API would be offering a ledger the app
+  // itself refuses to open.
+  query = query.is('deleted_at', null);
   if (cursor) query = query.or(keysetFilter(cursor, 'created_at'));
 
   const { data, error } = await query;
@@ -144,6 +151,10 @@ groups.get('/groups/:groupId', requireScope('groups.read'), async (c) => {
     .from('groups')
     .select(GROUP_COLUMNS)
     .eq('id', c.req.param('groupId'))
+    // A deleted group answers `not_found` below, which is the truth as far as
+    // anything outside the database is concerned. RLS still hands the row over
+    // — the tombstone has to reach every device — so the filter is here.
+    .is('deleted_at', null)
     .limit(1);
   if (error) throw error;
   const row = (data ?? [])[0] as unknown as GroupRow | undefined;

--- a/apps/mobile/src/app/group/[id]/settings.tsx
+++ b/apps/mobile/src/app/group/[id]/settings.tsx
@@ -361,6 +361,19 @@ export default function GroupSettingsScreen() {
     }
   };
 
+  // An archived group can now be opened, so this screen has to offer the way
+  // back. Before, the only Unarchive in the app was on the archive shelf in
+  // settings, because a group there was the one place you could reach it from;
+  // arriving here instead — from a balance on the Friends list, say — and being
+  // offered "Archive" on a group that is already archived would be a control
+  // that does nothing you can see. No confirmation: putting something back is
+  // not a decision that wants a second thought, and it stays on the screen so
+  // the row simply flips.
+  const archived = Boolean(group.data?.archived_at);
+  const unarchive = (): void => {
+    updateGroup.mutate({ archived_at: null });
+  };
+
   /**
    * The open debts — "Asha owes Ravi", and ₹500 beside it — for the delete
    * warning. Read off the same `transfers` the who-pays-whom screen shows, so
@@ -824,11 +837,16 @@ export default function GroupSettingsScreen() {
             ends things announces itself by being set off, not by a heading. */}
         <View style={{ gap: theme.spacing.xl }}>
           <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+            {/* One row, both directions. The mark stays the same either way: an
+                undo arrow would read better and points left, which is the wrong
+                way round in Arabic and is not in the mirror table — a
+                directional glyph for a reversible action is not worth a
+                wrong-facing arrow. The title says which way this row goes. */}
             <ListRow
-              title={t.group.archiveGroup}
-              subtitle={t.group.archiveHint}
+              title={archived ? t.group.unarchive : t.group.archiveGroup}
+              subtitle={archived ? t.group.unarchiveHint : t.group.archiveHint}
               leading={<ExitChip icon="archive-outline" tone="quiet" />}
-              onPress={() => void archive()}
+              onPress={archived ? unarchive : () => void archive()}
             />
             <View style={{ height: 1, backgroundColor: theme.color.border }} />
             <ListRow

--- a/apps/mobile/src/app/settings/archived.tsx
+++ b/apps/mobile/src/app/settings/archived.tsx
@@ -8,10 +8,16 @@
  * each an Unarchive button; unarchiving is an ordinary group.update clearing
  * `archived_at`, so the row drops out of here and back onto the dashboard the
  * instant it is tapped (ADR-005 — the mirror overlay, not a round trip).
+ *
+ * The row itself now opens the group, which for a long time it could not: the
+ * group screen refused an archived group outright, so the only thing you could
+ * do with a finished trip was put it back on the dashboard you had deliberately
+ * cleared it off. Archiving was always described as not deleting the ledger;
+ * being unable to read that ledger made the description a technicality.
  */
 
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { ScrollView, View } from 'react-native';
+import { Pressable, ScrollView, View } from 'react-native';
 
 import { MutationKind, rowsFor, SyncTable } from '@waves/core';
 import {
@@ -94,23 +100,48 @@ export default function ArchivedGroupsScreen() {
                 key={group.id}
                 style={{ flexDirection: 'row', alignItems: 'center', gap: theme.spacing.md }}
               >
-                <GroupPhoto photoPath={group.photo_path} emoji={group.cover_emoji} size={44} />
-                <View style={{ flex: 1, minWidth: 0 }}>
-                  <Text variant="subheading" numberOfLines={1}>
-                    {groupLabel(group, membersByGroup.get(group.id) ?? [], profile?.id)}
-                  </Text>
-                  {group.archived_at ? (
-                    <Text variant="micro" tone="muted">
-                      {fill(t.group.archivedOn, {
-                        date: new Intl.DateTimeFormat(locale, {
-                          day: 'numeric',
-                          month: 'short',
-                          year: 'numeric',
-                        }).format(new Date(group.archived_at)),
-                      })}
+                {/* The photo and the name open the group; the button beside them
+                    brings it back. This shelf used to offer only the second, so
+                    an archived trip's ledger — which archiving explicitly does
+                    not delete — could not be read without first putting the
+                    group back on the dashboard you had cleared it off. The group
+                    screen opens an archived group now, so the row leads
+                    somewhere. */}
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={groupLabel(
+                    group,
+                    membersByGroup.get(group.id) ?? [],
+                    profile?.id,
+                  )}
+                  onPress={() => router.push(`/group/${group.id}`)}
+                  style={({ pressed }) => ({
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    gap: theme.spacing.md,
+                    flex: 1,
+                    minWidth: 0,
+                    opacity: pressed ? 0.7 : 1,
+                  })}
+                >
+                  <GroupPhoto photoPath={group.photo_path} emoji={group.cover_emoji} size={44} />
+                  <View style={{ flex: 1, minWidth: 0 }}>
+                    <Text variant="subheading" numberOfLines={1}>
+                      {groupLabel(group, membersByGroup.get(group.id) ?? [], profile?.id)}
                     </Text>
-                  ) : null}
-                </View>
+                    {group.archived_at ? (
+                      <Text variant="micro" tone="muted">
+                        {fill(t.group.archivedOn, {
+                          date: new Intl.DateTimeFormat(locale, {
+                            day: 'numeric',
+                            month: 'short',
+                            year: 'numeric',
+                          }).format(new Date(group.archived_at)),
+                        })}
+                      </Text>
+                    ) : null}
+                  </View>
+                </Pressable>
                 <Button
                   label={t.group.unarchive}
                   variant="secondary"

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -25,6 +25,7 @@ import {
   materialiseExpenses,
   materialiseGroup,
   materialiseGroups,
+  materialiseLedgerGroupIds,
   materialiseLedgerGroups,
   materialiseMemberBudgets,
   materialiseMembers,
@@ -855,6 +856,7 @@ export interface DestinationUsage {
 export function useDestinationUsage(): Map<string, DestinationUsage> {
   const { mirror } = useSync();
   return useMemo(() => {
+    const ledgerGroupIds = materialiseLedgerGroupIds(mirror, []);
     const usage = new Map<string, DestinationUsage>();
     for (const row of rowsFor(mirror, SyncTable.Expenses)) {
       const e = row as unknown as {
@@ -862,7 +864,7 @@ export function useDestinationUsage(): Map<string, DestinationUsage> {
         created_at: string;
         deleted_at: string | null;
       };
-      if (e.deleted_at) continue;
+      if (e.deleted_at || !ledgerGroupIds.has(e.group_id)) continue;
       const prev = usage.get(e.group_id);
       if (!prev) {
         usage.set(e.group_id, { lastAt: e.created_at, count: 1 });
@@ -884,10 +886,11 @@ export function useDestinationUsage(): Map<string, DestinationUsage> {
 export function useGroupCreatedAt(): Map<string, string> {
   const { mirror } = useSync();
   return useMemo(() => {
+    const ledgerGroupIds = materialiseLedgerGroupIds(mirror, []);
     const byId = new Map<string, string>();
     for (const row of rowsFor(mirror, SyncTable.Groups)) {
       const g = row as unknown as { id: string; created_at: string };
-      if (g.id && g.created_at) byId.set(g.id, g.created_at);
+      if (g.id && g.created_at && ledgerGroupIds.has(g.id)) byId.set(g.id, g.created_at);
     }
     return byId;
   }, [mirror]);

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -25,6 +25,7 @@ import {
   materialiseExpenses,
   materialiseGroup,
   materialiseGroups,
+  materialiseLedgerGroups,
   materialiseMemberBudgets,
   materialiseMembers,
   materialiseExpenseAttachments,
@@ -493,6 +494,9 @@ function lastActivityByMember(
  *
  * Only groups you are still in are read: the merge RPC refuses a member of a
  * group you are not in, so offering one would be a merge that cannot go through.
+ * Archived ones count — a ghost in a finished trip is still a person, and this
+ * screen is reached from Friends, which now shows their balance. A deleted group
+ * does not: the RPC would refuse it and there is nobody there to point at.
  */
 export function useMergeCandidates(someoneLabel: string): LocalRead<MergeCandidate[]> {
   const { mirror, queue } = useSync();
@@ -503,7 +507,7 @@ export function useMergeCandidates(someoneLabel: string): LocalRead<MergeCandida
     if (!profileId) return [];
     const merges = new Map(ghostMerges(mirror).map((merge) => [merge.member_id, merge]));
     const members: MergeableMember[] = [];
-    for (const group of materialiseGroups(mirror, queue) as unknown as GroupRow[]) {
+    for (const group of materialiseLedgerGroups(mirror, queue) as unknown as GroupRow[]) {
       const rows = materialiseMembers(mirror, queue, {
         groupId: group.id,
       }) as unknown as MemberRow[];
@@ -545,6 +549,11 @@ export function useMergeCandidates(someoneLabel: string): LocalRead<MergeCandida
  * Counted by member row, not by person: a guest in two groups is two here. That
  * is fine for the only question asked of it — is this number zero — and avoids
  * pulling ghost-merge folding (A38) into a check that does not need it.
+ *
+ * Counted over the same groups `usePeopleBalances` sums, archived included:
+ * these two answer halves of one screen, so counting people in a set of groups
+ * the balances are not drawn from would make "no friends yet" appear over a list
+ * of friends.
  */
 export function useKnownPeopleCount(profileId: string | null): LocalRead<number> {
   const { mirror, queue } = useSync();
@@ -552,7 +561,7 @@ export function useKnownPeopleCount(profileId: string | null): LocalRead<number>
   const count = useMemo(() => {
     if (!profileId) return 0;
     let total = 0;
-    for (const group of materialiseGroups(mirror, queue) as unknown as GroupRow[]) {
+    for (const group of materialiseLedgerGroups(mirror, queue) as unknown as GroupRow[]) {
       const members = materialiseMembers(mirror, queue, {
         groupId: group.id,
       }) as unknown as MemberRow[];
@@ -593,6 +602,13 @@ export function useGhostMergePersonIds(): ReadonlyMap<string, string> {
  * queued expense already counts. Gravatar is skipped offline (a hashed email the
  * client does not hold) — a missing photo falls back to initials, as it already
  * does.
+ *
+ * `materialiseLedgerGroups`, not `materialiseGroups`: a debt does not stop being
+ * owed because the trip it came from was put away, and this has to agree with
+ * the RPC, which counts archived groups too. It used to disagree — the Friends
+ * list dropped an archived group's balance while the person screen you reach by
+ * tapping a row in it kept it — and one question with two answers is worse than
+ * either answer. A deleted group is excluded on both sides.
  */
 export function usePeopleBalances(profileId: string | null): LocalRead<PersonBalanceRow[]> {
   const { mirror, queue } = useSync();
@@ -604,7 +620,7 @@ export function usePeopleBalances(profileId: string | null): LocalRead<PersonBal
     const mergeByMember = new Map(ghostMerges(mirror).map((merge) => [merge.member_id, merge]));
 
     const contributions: PersonContribution[] = [];
-    for (const group of materialiseGroups(mirror, queue) as unknown as GroupRow[]) {
+    for (const group of materialiseLedgerGroups(mirror, queue) as unknown as GroupRow[]) {
       const members = materialiseMembers(mirror, queue, {
         groupId: group.id,
       }) as unknown as MemberRow[];
@@ -712,13 +728,23 @@ export function useRecentActivity(myProfileId: string | null = null): RecentActi
   const { mirror } = useSync();
   return useMemo(() => {
     const groups = new Map<string, ActivityGroup>();
+    // Groups the mirror still holds only to carry their tombstone. Their rows
+    // stay in `activity_log` — a delete is a tombstone, not an erasure (ADR-004)
+    // — so without this the feed goes on listing what happened in a group that
+    // is gone, each row linking to the "Group not found" screen.
+    const deleted = new Set<string>();
     for (const row of rowsFor(mirror, SyncTable.Groups)) {
       const g = row as unknown as {
         id: string;
         name: string | null;
         cover_emoji: string | null;
         archived_at: string | null;
+        deleted_at: string | null;
       };
+      if (g.deleted_at) {
+        deleted.add(g.id);
+        continue;
+      }
       groups.set(g.id, {
         id: g.id,
         name: g.name,
@@ -768,14 +794,21 @@ export function useRecentActivity(myProfileId: string | null = null): RecentActi
       }
     }
 
-    return (rowsFor(mirror, SyncTable.ActivityLog) as unknown as ActivityRow[])
-      .map((row) => ({
-        ...row,
-        group: groups.get(row.group_id) ?? null,
-        actor: row.actor_member_id ? (actors.get(row.actor_member_id) ?? null) : null,
-        stake: stakeFor(row, expenseById, myMemberByGroup),
-      }))
-      .sort(byNewest((row) => String(row.created_at)));
+    return (
+      (rowsFor(mirror, SyncTable.ActivityLog) as unknown as ActivityRow[])
+        // A row whose group the mirror has never seen is kept, with a null group —
+        // that is the existing "newer build, unknown group" fallback and it reads
+        // as a plain line. A row whose group the mirror knows to be deleted is
+        // dropped, because there we know the destination is gone.
+        .filter((row) => !deleted.has(row.group_id))
+        .map((row) => ({
+          ...row,
+          group: groups.get(row.group_id) ?? null,
+          actor: row.actor_member_id ? (actors.get(row.actor_member_id) ?? null) : null,
+          stake: stakeFor(row, expenseById, myMemberByGroup),
+        }))
+        .sort(byNewest((row) => String(row.created_at)))
+    );
   }, [mirror, myProfileId]);
 }
 
@@ -871,14 +904,20 @@ export function useGroup(groupId: string) {
   const { mirror, queue } = useSync();
 
   const rows = useMemo(() => {
-    // Build the one group we want instead of materialising, archived-filtering
-    // and sorting every group only to `.find` a single row. `materialiseGroups`
-    // hides archived trips, so preserve that: an archived group resolves to null
-    // here exactly as the old `.find` over the active list did.
+    // Build the one group we want instead of materialising and sorting every
+    // group only to `.find` a single row.
     const built = materialiseGroup(mirror, queue, groupId) as unknown as GroupRow | undefined;
-    // A deleted group (A49) resolves to null exactly as an archived one does, so a
-    // stale deep-link into it lands on the "not found" state, not a live screen.
-    const group = built && !built.archived_at && !built.deleted_at ? built : null;
+    // A deleted group (A49) resolves to null, so a stale deep link into it lands
+    // on the "not found" state rather than a live screen.
+    //
+    // An archived one does not, any more. It used to, on the reasoning that
+    // `materialiseGroups` hides archived trips and this should match — but those
+    // are different questions. Hiding a finished trip from the dashboard is the
+    // point of archiving; refusing to *open* it meant the Friends list could
+    // show a balance owed inside an archived group with nowhere to go, and the
+    // archive shelf in settings could only offer Unarchive, never a look. The
+    // ledger was never deleted; it was only unreachable.
+    const group = built && !built.deleted_at ? built : null;
     const members = materialiseMembers(mirror, queue, { groupId }) as unknown as MemberRow[];
     const settlements = materialiseSettlements(mirror, queue, {
       groupId,

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1890,6 +1890,8 @@ export interface UiStrings {
     archivedEmpty: string;
     archivedEmptyBody: string;
     unarchive: string;
+    /** Subtitle under Unarchive on a group's own settings screen. */
+    unarchiveHint: string;
     /** Caption on an archived row — `{date}` is when it was archived. */
     archivedOn: string;
     nobodyOwes: string;
@@ -4450,6 +4452,7 @@ const en: UiStrings = {
     archivedEmpty: 'Nothing archived',
     archivedEmptyBody: 'Groups you archive show up here, ready to bring back.',
     unarchive: 'Unarchive',
+    unarchiveHint: 'Put it back on your list',
     archivedOn: 'Archived {date}',
     nobodyOwes: 'Nobody owes anybody in this group.',
     recordedNotMoved: 'Recorded, not moved by Waves',
@@ -7019,6 +7022,7 @@ const ta: UiStrings = {
     archivedEmptyBody:
       'நீங்கள் காப்பகப்படுத்தும் குழுக்கள் இங்கே தோன்றும், மீண்டும் கொண்டுவரத் தயார்.',
     unarchive: 'மீட்டெடு',
+    unarchiveHint: 'உங்கள் பட்டியலுக்குத் திரும்பக் கொண்டுவா',
     archivedOn: '{date} அன்று காப்பகப்படுத்தப்பட்டது',
     nobodyOwes: 'இந்தக் குழுவில் யாரும் யாருக்கும் தர வேண்டியதில்லை.',
     recordedNotMoved: 'பதிவு செய்யப்பட்டது, Waves பணத்தை அனுப்பவில்லை',
@@ -9602,6 +9606,7 @@ const hi: UiStrings = {
     archivedEmpty: 'कुछ भी संग्रहित नहीं',
     archivedEmptyBody: 'आप जो समूह संग्रहित करते हैं वे यहाँ दिखते हैं, वापस लाने के लिए तैयार।',
     unarchive: 'वापस लाएँ',
+    unarchiveHint: 'इसे फिर आपकी सूची में लाएँ',
     archivedOn: '{date} को संग्रहित',
     nobodyOwes: 'इस समूह में किसी पर किसी का कुछ बाकी नहीं है।',
     recordedNotMoved: 'दर्ज किया गया, Waves ने पैसा नहीं भेजा',
@@ -12263,6 +12268,7 @@ const ar: UiStrings = {
     archivedEmpty: 'لا شيء في الأرشيف',
     archivedEmptyBody: 'المجموعات التي تؤرشفها تظهر هنا، جاهزة للاستعادة.',
     unarchive: 'إلغاء الأرشفة',
+    unarchiveHint: 'أعِدها إلى قائمتك',
     archivedOn: 'أُرشفت في {date}',
     nobodyOwes: 'لا أحد يدين لأحد في هذه المجموعة.',
     recordedNotMoved: 'مسجَّل، ولم يحوّل Waves المال',

--- a/apps/web/src/components/Overview.tsx
+++ b/apps/web/src/components/Overview.tsx
@@ -113,10 +113,22 @@ export function Overview({ profileId, query }: { profileId: string; query: strin
   }, [groups, byGroup, membersByGroup, pendingGroups]);
 
   // Overall, totalled per currency and never across them.
-  const overall = useMemo(
-    () => totalsByCurrency(myBalances.map((row) => [row.currency, BigInt(row.balance)] as const)),
-    [myBalances],
-  );
+  //
+  // Scoped to the groups this screen is actually showing, which is not what
+  // `myBalances` returns: that reads `group_balances` with no join to `groups`
+  // at all, and RLS hands back rows for every group the reader is a member of —
+  // archived ones, and deleted ones too, since a delete is a tombstone that
+  // leaves the balances in place (ADR-004). So the hero was quietly totalling
+  // groups that are not on the list beneath it, including ones the reader had
+  // deleted. The sum and the rows now come from the same set.
+  const overall = useMemo(() => {
+    const shown = new Set(groups.map((group) => group.id));
+    return totalsByCurrency(
+      myBalances
+        .filter((row) => shown.has(row.group_id))
+        .map((row) => [row.currency, BigInt(row.balance)] as const),
+    );
+  }, [myBalances, groups]);
 
   // The hero's single answer: the currency the reader is furthest from square
   // in leads, the rest fold into "+N more". Net, never a sum across currencies

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -288,6 +288,10 @@ export function createWavesClient({ supabase }: WavesClientOptions) {
           .from('groups')
           .select('id, name, cover_emoji, default_currency, simplify_debts')
           .eq('id', groupId)
+          // Null for a deleted group rather than a row that opens: RLS still
+          // returns it to a member, because the tombstone has to reach every
+          // device (ADR-004), so the caller has to ask.
+          .is('deleted_at', null)
           .limit(1),
       );
       return rows[0] ?? null;

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -410,12 +410,18 @@ export function createWavesClient({ supabase }: WavesClientOptions) {
     // the rows this session may see (ADR-013), so "my groups" is "the groups"
     // and the client never guesses at membership.
 
+    // A deleted group (A49) is a tombstone, not an archive: `waves_delete_group`
+    // stamps `deleted_at` and leaves every row in place so the delete can travel
+    // to other devices, and RLS goes on returning them to a member. So every
+    // read of `groups` here has to say so — otherwise a deleted group comes back
+    // looking exactly like a live one.
     myGroups(): Promise<GroupRow[]> {
       return read<GroupRow>(
         supabase
           .from('groups')
           .select(GROUP_ROW_COLUMNS)
           .is('archived_at', null)
+          .is('deleted_at', null)
           .order('created_at', { ascending: false }),
       );
     },
@@ -423,14 +429,23 @@ export function createWavesClient({ supabase }: WavesClientOptions) {
     /** Every group, archived ones included — the archive shelf reads this. */
     allGroups(): Promise<GroupRow[]> {
       return read<GroupRow>(
-        supabase.from('groups').select(GROUP_ROW_COLUMNS).order('created_at', { ascending: false }),
+        supabase
+          .from('groups')
+          .select(GROUP_ROW_COLUMNS)
+          .is('deleted_at', null)
+          .order('created_at', { ascending: false }),
       );
     },
 
     /** The whole row for one group, not the lean five columns `group` returns. */
     async groupRow(groupId: string): Promise<GroupRow | null> {
       const rows = await read<GroupRow>(
-        supabase.from('groups').select(GROUP_ROW_COLUMNS).eq('id', groupId).limit(1),
+        supabase
+          .from('groups')
+          .select(GROUP_ROW_COLUMNS)
+          .eq('id', groupId)
+          .is('deleted_at', null)
+          .limit(1),
       );
       return rows[0] ?? null;
     },

--- a/packages/core/src/sync/mirror.ts
+++ b/packages/core/src/sync/mirror.ts
@@ -722,6 +722,13 @@ export function materialiseLedgerGroups(
     .sort(byNewest((row) => String(row.created_at)));
 }
 
+export function materialiseLedgerGroupIds(
+  state: MirrorState,
+  queue: readonly QueuedMutation[],
+): ReadonlySet<string> {
+  return new Set(materialiseLedgerGroups(state, queue).map((group) => group.id));
+}
+
 /**
  * One group by id, archived or not. `materialiseGroups` hides archived groups so
  * they leave the dashboard, but a per-group screen (the plan, its budget) still

--- a/packages/core/src/sync/mirror.ts
+++ b/packages/core/src/sync/mirror.ts
@@ -695,6 +695,34 @@ export function materialiseGroups(
 }
 
 /**
+ * Every group whose ledger still counts — archived included, deleted not.
+ *
+ * The difference between this and {@link materialiseGroups} is the difference
+ * between two questions. "What is going on now" is the dashboard's question, and
+ * a trip you have put away is not part of the answer. "What do I owe Priya" is
+ * not about trips at all, and archiving one does not settle a debt: the money is
+ * real, nobody left the group, and one tap of Unarchive brings it back.
+ *
+ * So the person-to-person balances sum through here. The server's
+ * `waves_people_i_owe` draws the line in the same place, and it has to — the
+ * Friends list is read from the mirror and the person screen behind it from that
+ * RPC, so a number that changed depending on which one answered would be its own
+ * bug (and was: the mirror dropped archived groups while the RPC counted them).
+ *
+ * A deleted group is on neither list. It is a tombstone (ADR-004) that rides the
+ * sync pull so every device learns the group is gone, which is exactly why its
+ * rows are still here to be filtered out.
+ */
+export function materialiseLedgerGroups(
+  state: MirrorState,
+  queue: readonly QueuedMutation[],
+): MirrorGroup[] {
+  return buildGroups(state, queue)
+    .filter((group) => !group.deleted_at)
+    .sort(byNewest((row) => String(row.created_at)));
+}
+
+/**
  * One group by id, archived or not. `materialiseGroups` hides archived groups so
  * they leave the dashboard, but a per-group screen (the plan, its budget) still
  * opens on an archived trip and must see its row — including a queued

--- a/packages/core/test/overlay.test.ts
+++ b/packages/core/test/overlay.test.ts
@@ -20,6 +20,7 @@ import {
   materialiseArchivedGroups,
   materialiseCategoryTags,
   materialiseGroups,
+  materialiseLedgerGroupIds,
   materialiseLedgerGroups,
   materialiseMemberBudgets,
   materialiseMembers,
@@ -388,6 +389,27 @@ describe('the groups whose ledger still counts', () => {
       queued(envelope('m-1', MutationKind.GroupCreate, { name: 'Ravi', currency: 'INR' })),
     );
     expect(rows.map((row) => row.id)).toEqual([GROUP]);
+  });
+
+  it('exposes the same deleted-aware id set for child-row metadata filters', () => {
+    const mirror = mirrorWith([
+      { id: 'g-live', name: 'Goa', default_currency: 'INR', created_at: AT, archived_at: null },
+      { id: 'g-old', name: 'Old flat', default_currency: 'INR', created_at: AT, archived_at: AT },
+      {
+        id: 'g-gone',
+        name: 'Splitwise',
+        default_currency: 'INR',
+        created_at: AT,
+        archived_at: null,
+        deleted_at: AT,
+      },
+    ]);
+    const ids = materialiseLedgerGroupIds(
+      mirror,
+      queued(envelope('m-1', MutationKind.GroupCreate, { name: 'Ravi', currency: 'INR' })),
+    );
+
+    expect([...ids].sort()).toEqual([GROUP, 'g-live', 'g-old']);
   });
 });
 

--- a/packages/core/test/overlay.test.ts
+++ b/packages/core/test/overlay.test.ts
@@ -17,8 +17,10 @@ import {
   emptyMirror,
   enqueue,
   materialiseCaptures,
+  materialiseArchivedGroups,
   materialiseCategoryTags,
   materialiseGroups,
+  materialiseLedgerGroups,
   materialiseMemberBudgets,
   materialiseMembers,
   materialisePlanItems,
@@ -287,6 +289,105 @@ describe('groups', () => {
       },
     ]).state;
     expect(materialiseGroups(mirror, [])).toHaveLength(0);
+  });
+
+  it('keeps a deleted group out, tombstone and all', () => {
+    // A delete is a tombstone the sync pull carries (ADR-004), so the row does
+    // arrive and it is this filter, not its absence, that keeps it off every
+    // screen.
+    const mirror = reconcile(emptyMirror(), [
+      {
+        table: SyncTable.Groups,
+        groupId: GROUP,
+        seq: 1,
+        row: {
+          id: GROUP,
+          name: 'Splitwise',
+          default_currency: 'INR',
+          created_at: AT,
+          archived_at: null,
+          deleted_at: AT,
+        },
+      },
+    ]).state;
+    expect(materialiseGroups(mirror, [])).toHaveLength(0);
+    // Nor is it hiding in the archive: deleted is not a kind of archived.
+    expect(materialiseArchivedGroups(mirror, [])).toHaveLength(0);
+    // Nor in the set the Friends balances are summed from, which is the one
+    // that turns a stale row into a wrong number rather than a stale row.
+    expect(materialiseLedgerGroups(mirror, [])).toHaveLength(0);
+  });
+});
+
+/**
+ * Which groups still count as money.
+ *
+ * `materialiseGroups` answers "what is going on now" and drops an archived trip;
+ * `materialiseLedgerGroups` answers "what do I owe this person" and keeps it,
+ * because archiving a finished trip does not settle a debt. Both drop a deleted
+ * group. The Friends totals are read through the second one and the server's
+ * `waves_people_i_owe` draws the line in the same place — they have to agree, or
+ * the same question gets two answers depending on which side answered.
+ */
+describe('the groups whose ledger still counts', () => {
+  function mirrorWith(rows: Record<string, unknown>[]) {
+    return reconcile(
+      emptyMirror(),
+      rows.map((row, index) => ({
+        table: SyncTable.Groups,
+        groupId: String(row.id),
+        seq: index + 1,
+        row,
+      })),
+    ).state;
+  }
+
+  it('keeps an archived group in, unlike the dashboard list', () => {
+    const mirror = mirrorWith([
+      { id: 'g-live', name: 'Goa', default_currency: 'INR', created_at: AT, archived_at: null },
+      { id: 'g-old', name: 'Old flat', default_currency: 'INR', created_at: AT, archived_at: AT },
+    ]);
+
+    expect(materialiseGroups(mirror, []).map((row) => row.id)).toEqual(['g-live']);
+    expect(
+      materialiseLedgerGroups(mirror, [])
+        .map((row) => row.id)
+        .sort(),
+    ).toEqual(['g-live', 'g-old']);
+  });
+
+  it('drops a deleted group whether or not it was archived first', () => {
+    const mirror = mirrorWith([
+      {
+        id: 'g-gone',
+        name: 'Splitwise',
+        default_currency: 'INR',
+        created_at: AT,
+        archived_at: null,
+        deleted_at: AT,
+      },
+      {
+        id: 'g-gone-archived',
+        name: 'Splitwise 1',
+        default_currency: 'INR',
+        created_at: AT,
+        archived_at: AT,
+        deleted_at: AT,
+      },
+    ]);
+
+    expect(materialiseLedgerGroups(mirror, [])).toHaveLength(0);
+  });
+
+  it('shows a group started offline, before the server has ever seen it', () => {
+    // A queued `group.create` has no server row to carry a tombstone, so it is
+    // neither archived nor deleted and belongs in both lists — otherwise an
+    // add-person IOU made on a plane would owe nobody anything until it synced.
+    const rows = materialiseLedgerGroups(
+      emptyMirror(),
+      queued(envelope('m-1', MutationKind.GroupCreate, { name: 'Ravi', currency: 'INR' })),
+    );
+    expect(rows.map((row) => row.id)).toEqual([GROUP]);
   });
 });
 

--- a/packages/db/prisma/migrations/20260910100000_deleted_groups_out_of_balances/migration.sql
+++ b/packages/db/prisma/migrations/20260910100000_deleted_groups_out_of_balances/migration.sql
@@ -1,0 +1,892 @@
+-- A deleted group still counted towards what people owed each other.
+--
+-- Deleting a group is a tombstone, not an erasure (ADR-004, A49):
+-- `waves_delete_group` stamps `groups.deleted_at` and leaves everything
+-- underneath it exactly where it was — the expenses, the settlements, the
+-- `pairwise_balances` rows, and the `group_members` rows, whose `left_at` stays
+-- NULL because nobody left. That is deliberate, and it has to stay that way: the
+-- tombstone rides the sync pull so every device learns the group is gone, and it
+-- can only do that if the rows survive to carry it.
+--
+-- What nothing did was *read* the tombstone. Before this migration
+-- `groups.deleted_at` was written by exactly one statement and consulted by
+-- none: no RPC, no RLS policy, no trigger, no scheduled job. The soft delete was
+-- strictly weaker server-side than the archive, which at least three functions
+-- did check — backwards, since one means "put away" and the other means "gone".
+--
+-- A user found the sharp end of it: the same Splitwise export imported three
+-- times, two copies deleted, and a person screen reading "You owe ₹1,192.72 ·
+-- across 2 groups" over two identically-named rows, one of which was a link to
+-- "Group not found". The money was double-counted, not merely mis-listed.
+--
+-- This migration fixes the readers where a wrong answer reaches a person:
+--
+--   1. the two Friends balance RPCs, which is the reported bug;
+--   2. `waves_person_profile`'s "groups in common" count, which is also the gate
+--      on revealing somebody's email and phone — so this one is a privacy leak
+--      wearing a cosmetic bug's clothes;
+--   3. the three scheduled jobs that act on groups and then send mail or push —
+--      the weekly digest, the trip nudges, and the settlement auto-confirm;
+--   4. the auto-archive sweep, whose UPDATE bumps `updated_seq` and drags a dead
+--      group and its whole child set back through every ex-member's sync delta;
+--   5. the account-deletion preview, which warned about outstanding balances in
+--      groups that no longer exist;
+--   6. `waves_consume_invite`, so a durable join link (A47) for a deleted group
+--      stops letting people join it — and stops burning a guest's one-group
+--      ceiling on a group they will never see.
+--
+-- ────────────────────────────────────── why not fix it at the root instead ──
+--
+-- The obvious root fix is `is_group_member` / `is_group_admin`: they read
+-- `group_members` alone, never mention `public.groups`, and sit under roughly
+-- thirty RLS policies and forty-five RPCs. Teaching those two to require
+-- `deleted_at IS NULL` would close most of this in one edit. It was worked
+-- through and rejected, and the reasons are recorded so the next person does not
+-- have to rediscover them:
+--
+--   * `groups_select` is built on `is_group_member`. A member who cannot read
+--     the deleted group's own row never receives the tombstone, so the group
+--     never leaves their mirror — the delete would stop working on precisely the
+--     devices it exists to reach. The group's row must stay readable while its
+--     children stop counting, and one predicate cannot say both.
+--   * `waves_delete_group` is documented and tested as idempotent so a retried
+--     offline queue flush lands cleanly. Its admin gate runs *before* its
+--     already-deleted check, so a deleted-aware `is_group_admin` would turn the
+--     second delete into `NOT_ADMIN` instead of a no-op.
+--   * They are the hottest predicates in the schema. Adding a join to both, for
+--     a column that is NULL on virtually every row, is a large unmeasured change
+--     to make in the same breath as a correctness fix.
+--
+-- So the read side is fixed per caller. What that leaves — deliberately, and
+-- listed in the PR rather than quietly — is the write side: every group-scoped
+-- write RPC still accepts a deleted group, so a late-flushed offline mutation
+-- can still write into one, and `waves_touch_balances` will rebuild its
+-- `pairwise_balances` when it does. That wants its own change, its own test, and
+-- a decision about what a client should be told when its queued expense lands in
+-- a group that has since gone.
+--
+-- ─────────────────────────────────────── deleted is gone; archived is not ──
+--
+-- `archived_at` is not `deleted_at`, and they are treated differently here on
+-- purpose. The rule this migration settles on, in one sentence: **a deleted
+-- group is gone from everything; an archived group stays out of the surfaces
+-- about what is happening now, and stays in the ones about what two people owe
+-- each other.**
+--
+-- Archiving is offered as the calm way to clear a finished trip off the
+-- dashboard *without deleting its ledger*. Dropping its debts out of "what do I
+-- owe Hethu" would quietly break that promise: the money is real, nobody left,
+-- and the group is one tap of Unarchive away. So the balance RPCs below filter
+-- `deleted_at` only. The scheduled jobs keep their existing `archived_at`
+-- filters untouched, because they ask a different question — a trip that has
+-- been put away is not having a week to report and does not want a "what did you
+-- spend today?" push at nine in the morning.
+--
+-- That decision has a client half, made in the same change, because the server
+-- and the offline mirror disagreed about archived groups in *both* directions:
+-- the mirror dropped them from the Friends list while the server counted them on
+-- the person screen you reach by tapping a row in that list, so the same
+-- question had two answers. The mirror now counts an archived group's balance
+-- too, and the group screen — which refused to open an archived group, and would
+-- otherwise have made every archived row on the person screen a dead link — now
+-- opens one.
+--
+-- No signature and no return type changes anywhere here, so `CREATE OR REPLACE`
+-- is enough and there is no 42P13 to drop around. Grants are restated all the
+-- same: a replace keeps them, but this repo has been bitten by assuming that in
+-- the other direction, and restating them costs nothing.
+
+-- ══════════════════════════════════ 0. something to look the column up by ══
+--
+-- `archived_at` has had an index since the baseline; `deleted_at` never did,
+-- because until now nothing read it. Every function below has to prove a group
+-- is not a tombstone, which puts `deleted_at IS NULL` in about as many
+-- predicates as `archived_at IS NULL`, so it gets the twin of the index its
+-- sibling already has. Plain rather than partial, to match `groups_archived_at_idx`
+-- and to stay the shape Prisma's `@@index([deletedAt])` describes — a partial
+-- index here would be a permanent drift finding for a table this small.
+CREATE INDEX IF NOT EXISTS groups_deleted_at_idx ON public.groups USING btree (deleted_at);
+
+-- ═══════════════════════════ 1. who owes me, and who I owe, per person ══
+
+CREATE OR REPLACE FUNCTION public.waves_people_i_owe() RETURNS TABLE(person_key text, profile_id uuid, member_id uuid, display_name text, avatar_url text, is_ghost boolean, currency character, net bigint, group_count integer, only_group_id uuid, last_activity_at timestamp with time zone)
+    LANGUAGE sql STABLE
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+  WITH me AS (
+    -- The one gate, and it belongs here rather than at the end. `group_members`
+    -- alone cannot tell a live group from a tombstoned one — a delete does not
+    -- touch `left_at`, because nobody left — so the group row has to be
+    -- consulted, and everything downstream inherits the answer by joining back
+    -- to `me` on `group_id`: the edges, the sum, `group_count` and
+    -- `only_group_id` all follow, with no second filter to forget.
+    --
+    -- Archived groups are deliberately still here. The money in one is real and
+    -- the group is one tap of Unarchive away; it is the dashboard's list of
+    -- what is going on now that hides it, not the ledger.
+    SELECT gm.id AS member_id, gm.group_id
+      FROM public.group_members gm
+      JOIN public.groups g
+        ON g.id = gm.group_id
+       AND g.deleted_at IS NULL
+     WHERE gm.profile_id = public.waves_current_profile_id()
+       AND gm.left_at IS NULL
+  ),
+  edges AS (
+    SELECT pb.group_id, pb.to_member_id AS other_member_id, pb.currency, -pb.amount AS net
+      FROM public.pairwise_balances pb
+      JOIN me ON me.group_id = pb.group_id AND me.member_id = pb.from_member_id
+    UNION ALL
+    SELECT pb.group_id, pb.from_member_id, pb.currency, pb.amount
+      FROM public.pairwise_balances pb
+      JOIN me ON me.group_id = pb.group_id AND me.member_id = pb.to_member_id
+  ),
+  -- The newest activity per member, from every place a member leaves a
+  -- timestamp: expense versions they paid or shared, and settlements either way.
+  -- Deliberately not filtered by group: a member id belongs to exactly one
+  -- group, and only members reached through `edges` are ever looked up here, so
+  -- a dead group's timestamps have nothing to attach themselves to.
+  member_activity AS (
+    SELECT a.member_id, max(a.ts) AS last_activity_at
+      FROM (
+        SELECT epy.member_id, ev.created_at AS ts
+          FROM public.expense_payers epy
+          JOIN public.expense_versions ev ON ev.id = epy.expense_version_id
+          JOIN public.expenses ex ON ex.id = ev.expense_id AND ex.deleted_at IS NULL
+        UNION ALL
+        SELECT esh.member_id, ev.created_at
+          FROM public.expense_shares esh
+          JOIN public.expense_versions ev ON ev.id = esh.expense_version_id
+          JOIN public.expenses ex ON ex.id = ev.expense_id AND ex.deleted_at IS NULL
+        UNION ALL
+        SELECT s.from_member_id, s.created_at FROM public.settlements s
+        UNION ALL
+        SELECT s.to_member_id, s.created_at FROM public.settlements s
+      ) a(member_id, ts)
+      GROUP BY a.member_id
+  ),
+  named AS (
+    SELECT
+      e.group_id,
+      e.currency,
+      e.net,
+      gm.id            AS member_id,
+      gm.profile_id,
+      -- A profile id is proof of one human; a ghost merge is the caller's own
+      -- proof; failing both, a ghost stays keyed to its own group.
+      COALESCE(gm.profile_id::text, mrg.person_id::text, gm.id::text) AS person_key,
+      COALESCE(p.display_name, mrg.display_name, gm.ghost_name, 'Someone') AS display_name,
+      COALESCE(p.avatar_url, public.waves_gravatar_url(gm.invite_email)) AS avatar_url,
+      gm.profile_id IS NULL AS is_ghost,
+      ma.last_activity_at
+    FROM edges e
+    JOIN public.group_members gm ON gm.id = e.other_member_id
+    LEFT JOIN public.profiles p ON p.id = gm.profile_id
+    LEFT JOIN member_activity ma ON ma.member_id = gm.id
+    LEFT JOIN public.ghost_merges mrg
+      ON mrg.member_id = gm.id
+     AND mrg.owner = public.waves_current_profile_id()
+  )
+  SELECT
+    n.person_key,
+    max(n.profile_id::text)::uuid                       AS profile_id,
+    max(n.member_id::text)::uuid                        AS member_id,
+    max(n.display_name)                                 AS display_name,
+    max(n.avatar_url)                                   AS avatar_url,
+    bool_and(n.is_ghost)                                AS is_ghost,
+    n.currency,
+    sum(n.net)::bigint                                  AS net,
+    count(DISTINCT n.group_id)::int                     AS group_count,
+    CASE WHEN count(DISTINCT n.group_id) = 1
+         THEN max(n.group_id::text)::uuid END           AS only_group_id,
+    max(n.last_activity_at)                             AS last_activity_at
+  FROM named n
+  GROUP BY n.person_key, n.currency
+  HAVING sum(n.net) <> 0
+  ORDER BY abs(sum(n.net)) DESC, max(n.display_name);
+$$;
+
+GRANT EXECUTE ON FUNCTION public.waves_people_i_owe() TO authenticated, service_role;
+
+-- ─────────────────────────────── that same balance, un-collapsed per group ──
+
+CREATE OR REPLACE FUNCTION public.waves_person_group_balances(p_person_key text) RETURNS TABLE(group_id uuid, group_name text, cover_emoji text, currency character, net bigint, is_ghost boolean, display_name text)
+    LANGUAGE sql STABLE
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+  WITH me AS (
+    -- The same gate as `waves_people_i_owe`, and it has to be the same one: this
+    -- function exists to explain that function's total, so a group either counts
+    -- in both or in neither. The join at the bottom of this query already reads
+    -- `public.groups` for the name and the emoji, and would have been the
+    -- obvious place to filter — but filtering there would state the rule twice
+    -- in two different shapes, which is how two answers to one question start.
+    SELECT gm.id AS member_id, gm.group_id
+      FROM public.group_members gm
+      JOIN public.groups g
+        ON g.id = gm.group_id
+       AND g.deleted_at IS NULL
+     WHERE gm.profile_id = public.waves_current_profile_id()
+       AND gm.left_at IS NULL
+  ),
+  edges AS (
+    SELECT pb.group_id, pb.to_member_id AS other_member_id, pb.currency, -pb.amount AS net
+      FROM public.pairwise_balances pb
+      JOIN me ON me.group_id = pb.group_id AND me.member_id = pb.from_member_id
+    UNION ALL
+    SELECT pb.group_id, pb.from_member_id, pb.currency, pb.amount
+      FROM public.pairwise_balances pb
+      JOIN me ON me.group_id = pb.group_id AND me.member_id = pb.to_member_id
+  ),
+  named AS (
+    SELECT
+      e.group_id,
+      e.currency,
+      e.net,
+      -- The same key the list rolls people up under: a profile id is proof of
+      -- one human; a ghost merge is the caller's own proof; failing both, a
+      -- ghost stays keyed to its own group membership.
+      COALESCE(gm.profile_id::text, mrg.person_id::text, gm.id::text) AS person_key,
+      COALESCE(p.display_name, mrg.display_name, gm.ghost_name, 'Someone') AS display_name,
+      gm.profile_id IS NULL AS is_ghost
+    FROM edges e
+    JOIN public.group_members gm ON gm.id = e.other_member_id
+    LEFT JOIN public.profiles p ON p.id = gm.profile_id
+    LEFT JOIN public.ghost_merges mrg
+      ON mrg.member_id = gm.id
+     AND mrg.owner = public.waves_current_profile_id()
+  )
+  SELECT
+    n.group_id,
+    g.name         AS group_name,
+    g.cover_emoji,
+    n.currency,
+    sum(n.net)::bigint    AS net,
+    bool_and(n.is_ghost)  AS is_ghost,
+    max(n.display_name)   AS display_name
+  FROM named n
+  JOIN public.groups g ON g.id = n.group_id
+  WHERE n.person_key = p_person_key
+  GROUP BY n.group_id, g.name, g.cover_emoji, n.currency
+  HAVING sum(n.net) <> 0
+  ORDER BY g.name, n.currency;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.waves_person_group_balances(p_person_key text) TO authenticated, service_role;
+
+-- ═══════════ 2. "N groups in common", and what that number unlocks ══════
+--
+-- The same person screen carries a second count inflated the same way:
+-- `shared_groups`, rendered as "3 groups in common" under somebody's name.
+--
+-- It is not only a number. It is also the permission gate — a caller who shares
+-- nothing with the subject gets an empty result rather than a profile, which is
+-- what stops this function being an oracle for any uuid somebody cares to try —
+-- and passing it is what authorises the reveal further down of the other
+-- person's email, phone, payment rail, payment handle and country. A group both
+-- parties had deleted therefore went on unlocking a stranger's contact details.
+--
+-- Archived groups stay counted here, which is the one place this migration parts
+-- company with itself, because the question is a different one. The balance RPCs
+-- ask which ledgers are live enough to add up; this asks whether two people know
+-- each other. Putting a finished trip away does not make the people on it
+-- strangers, nobody left, and the answer feeds a sentence about acquaintance —
+-- not a sum of money and not a link to a screen.
+--
+-- Everything else in this function is 20260908090000_person_profile_and_discovery
+-- verbatim; the only changes are the three counting queries and these comments.
+CREATE OR REPLACE FUNCTION public.waves_person_profile(p_person_key text)
+RETURNS TABLE(
+  person_key       text,
+  display_name     text,
+  avatar_url       text,
+  is_ghost         boolean,
+  is_you           boolean,
+  shared_groups    integer,
+  email            text,
+  phone            text,
+  payment_rail     text,
+  payment_handle   text,
+  country_code     character(2),
+  -- The difference between "they have not told us" and "they have told us not
+  -- to tell you". A screen that cannot tell those apart has to write a weasel
+  -- sentence covering both; with this it can say the true one.
+  contact_withheld boolean
+)
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $fn$
+DECLARE
+  v_me      uuid := public.waves_current_profile_id();
+  v_profile uuid;
+  v_shared  integer := 0;
+  v_name    text;
+  v_avatar  text;
+  v_rail    text;
+  v_handle  text;
+  v_country character(2);
+  v_ghost   boolean := true;
+  v_visible boolean := false;
+  v_email   text;
+  v_phone   text;
+BEGIN
+  IF v_me IS NULL OR p_person_key IS NULL OR btrim(p_person_key) = '' THEN
+    RETURN;
+  END IF;
+
+  -- Case 1: the key is a real account.
+  IF p_person_key ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' THEN
+    SELECT p.id, p.display_name, p.avatar_url, p.payment_rail, p.payment_handle,
+           p.country_code, (p.contact_visibility = 'groups')
+      INTO v_profile, v_name, v_avatar, v_rail, v_handle, v_country, v_visible
+      FROM public.profiles p
+     WHERE p.id = p_person_key::uuid;
+  END IF;
+
+  IF v_profile IS NOT NULL THEN
+    v_ghost := false;
+
+    IF v_profile = v_me THEN
+      -- Looking at yourself: your own contact details are always yours to see,
+      -- and "shared groups" means every group you are in — every group that
+      -- still exists, that is.
+      v_shared := (SELECT count(*)::int
+                     FROM public.group_members gm
+                     JOIN public.groups g ON g.id = gm.group_id AND g.deleted_at IS NULL
+                    WHERE gm.profile_id = v_me AND gm.left_at IS NULL);
+      v_visible := true;
+    ELSE
+      -- The shared-group count doubles as the permission check.
+      SELECT count(DISTINCT mine.group_id)::int INTO v_shared
+        FROM public.group_members mine
+        JOIN public.groups g
+          ON g.id = mine.group_id
+         AND g.deleted_at IS NULL
+        JOIN public.group_members theirs
+          ON theirs.group_id = mine.group_id
+         AND theirs.left_at IS NULL
+         AND theirs.profile_id = v_profile
+       WHERE mine.profile_id = v_me
+         AND mine.left_at IS NULL;
+
+      IF coalesce(v_shared, 0) = 0 THEN
+        RETURN;
+      END IF;
+    END IF;
+
+  ELSE
+    -- Cases 2 and 3: a merged ghost (the caller's own merge) or a plain ghost.
+    -- Either way there is no account, so there is nothing to reveal and the
+    -- only question is whether the caller can see this person at all.
+    SELECT max(coalesce(mrg.display_name, gm.ghost_name, 'Someone')),
+           count(DISTINCT gm.group_id)::int
+      INTO v_name, v_shared
+      FROM public.group_members gm
+      JOIN public.groups g
+        ON g.id = gm.group_id
+       AND g.deleted_at IS NULL
+      JOIN public.group_members mine
+        ON mine.group_id = gm.group_id
+       AND mine.profile_id = v_me
+       AND mine.left_at IS NULL
+      LEFT JOIN public.ghost_merges mrg
+        ON mrg.member_id = gm.id
+       AND mrg.owner = v_me
+     WHERE gm.left_at IS NULL
+       AND gm.profile_id IS NULL
+       AND coalesce(mrg.person_id::text, gm.id::text) = p_person_key;
+
+    IF coalesce(v_shared, 0) = 0 THEN
+      RETURN;
+    END IF;
+  END IF;
+
+  -- The reveal. Guarded on a real `auth.users` for the same reason every other
+  -- read of it in this schema is: the DB test suite and the self-host stack run
+  -- these RPCs against a Postgres with no `auth` schema, or with a stub one,
+  -- where the right answer is "no contact on file", not an error.
+  IF NOT v_ghost AND v_visible AND public.waves_auth_contact_readable() THEN
+    SELECT nullif(btrim(lower(coalesce(u.email, ''))), ''),
+           -- Stored bare in `auth.users`; the '+' is put back so the number is
+           -- dialable and reads like every other number in the app.
+           CASE WHEN nullif(btrim(coalesce(u.phone, '')), '') IS NULL THEN NULL
+                ELSE '+' || regexp_replace(u.phone, '[^0-9]', '', 'g') END
+      INTO v_email, v_phone
+      FROM auth.users u
+     WHERE u.id = v_profile
+       AND u.deleted_at IS NULL;
+  END IF;
+
+  person_key       := p_person_key;
+  display_name     := coalesce(v_name, 'Someone');
+  avatar_url       := v_avatar;
+  is_ghost         := v_ghost;
+  is_you           := (v_profile IS NOT NULL AND v_profile = v_me);
+  shared_groups    := coalesce(v_shared, 0);
+  email            := v_email;
+  phone            := v_phone;
+  payment_rail     := CASE WHEN v_visible THEN v_rail ELSE NULL END;
+  payment_handle   := CASE WHEN v_visible THEN v_handle ELSE NULL END;
+  country_code     := CASE WHEN v_visible THEN v_country ELSE NULL END;
+  contact_withheld := (NOT v_ghost) AND (NOT v_visible);
+  RETURN NEXT;
+END
+$fn$;
+
+REVOKE ALL ON FUNCTION public.waves_person_profile(text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.waves_person_profile(text) TO authenticated, service_role;
+
+-- ═════════════════════ 3. the jobs that reach somebody's phone ══════════
+--
+-- A wrong number on a screen is a wrong number on a screen. These three send
+-- mail and push, and all were counting or acting on groups their recipients had
+-- deleted. Each keeps its existing `archived_at` filter unchanged — a trip put
+-- away really is not having a week and really does not want a nudge — and gains
+-- the `deleted_at` half that was never there.
+
+-- ───────────────────────────────────────────────── the Monday morning mail ──
+--
+-- Both halves were wrong, differently. The expense count is the gate — an
+-- account with a count of zero is skipped entirely — so a deleted group could be
+-- the whole reason somebody received mail at all. The net figure is the headline
+-- number inside it. Everything else is
+-- 20260907150000_weekly_digest_involved_people verbatim, restated because
+-- `CREATE OR REPLACE` replaces the whole body and a partial copy would silently
+-- drop the preference checks.
+CREATE OR REPLACE FUNCTION public.waves_enqueue_weekly_digest(p_now timestamp with time zone DEFAULT now()) RETURNS integer
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+DECLARE
+  v_since   timestamptz := p_now - interval '7 days';
+  v_week    text := to_char(date_trunc('week', p_now), 'IYYY-"W"IW');
+  v_person  record;
+  v_written integer := 0;
+  v_id      uuid;
+BEGIN
+  FOR v_person IN
+    SELECT p.id,
+           p.default_currency,
+           -- Expenses filed in the last seven days where this person actually
+           -- appears: the author/user, a payer/financer, or a share participant
+           -- (traveller/rider). A group bystander did not have a week to report.
+           (SELECT count(*)
+              FROM public.expenses e
+              JOIN public.expense_versions v ON v.id = e.current_version_id
+              JOIN public.group_members m
+                ON m.group_id = e.group_id
+               AND m.profile_id = p.id
+               AND m.left_at IS NULL
+              JOIN public.groups g
+                ON g.id = e.group_id
+               AND g.archived_at IS NULL
+               AND g.deleted_at IS NULL
+             WHERE e.deleted_at IS NULL
+               AND e.created_at > v_since
+               AND (
+                 v.author_member_id = m.id
+                 OR EXISTS (
+                   SELECT 1 FROM public.expense_payers ep
+                    WHERE ep.expense_version_id = v.id AND ep.member_id = m.id
+                 )
+                 OR EXISTS (
+                   SELECT 1 FROM public.expense_shares es
+                    WHERE es.expense_version_id = v.id AND es.member_id = m.id
+                 )
+               )) AS expense_count,
+           -- Net across every group, in their own currency only. Mixing
+           -- currencies into one number would be a lie, and picking a
+           -- "dominant" one would be a lie that changes week to week.
+           COALESCE((
+             SELECT SUM(CASE WHEN mine.side = 'to' THEN b.amount ELSE -b.amount END)
+             FROM public.pairwise_balances b
+             JOIN LATERAL (
+               SELECT 'to' AS side FROM public.group_members m
+                WHERE m.id = b.to_member_id AND m.profile_id = p.id
+               UNION ALL
+               SELECT 'from' FROM public.group_members m
+                WHERE m.id = b.from_member_id AND m.profile_id = p.id
+             ) mine ON TRUE
+             JOIN public.groups g
+               ON g.id = b.group_id
+              AND g.archived_at IS NULL
+              AND g.deleted_at IS NULL
+             WHERE b.currency = p.default_currency
+           ), 0) AS net_amount
+    FROM public.profiles p
+    WHERE NOT public.waves_is_guest(p.id)
+      -- No address, no digest. The claim would suppress it a minute later
+      -- anyway; not writing the row keeps the table honest about what was
+      -- actually sendable.
+      AND public.waves_email_for(p.id) IS NOT NULL
+      AND COALESCE((p.notification_prefs ->> 'email')::boolean, TRUE)
+      -- Opt-in, and the default is off. Settings → Notifications has carried
+      -- "Weekly email digest … Off by default" since before anything produced
+      -- one (`DEFAULT_NOTIFICATION_PREFS.weeklyEmail` is false), so a digest
+      -- that shipped to everybody would make that screen a lie on the day it
+      -- started working. Note the default here is FALSE, unlike every other
+      -- preference in this file.
+      AND COALESCE((p.notification_prefs ->> 'weeklyEmail')::boolean, FALSE)
+  LOOP
+    -- Nothing happened: say nothing. This is the whole difference between a
+    -- digest people read and a digest people filter.
+    CONTINUE WHEN v_person.expense_count = 0;
+
+    v_id := public.waves_notify(
+      v_person.id,
+      NULL,
+      'digest_weekly',
+      'Your week on Waves',
+      v_person.expense_count::text || ' expenses',
+      'waves://activity',
+      jsonb_build_object(
+        'count', v_person.expense_count::text,
+        'amount', v_person.net_amount::text,
+        'currency', v_person.default_currency
+      ),
+      'digest_weekly:' || v_person.id::text || ':' || v_week
+    );
+
+    IF v_id IS NOT NULL THEN
+      v_written := v_written + 1;
+    END IF;
+  END LOOP;
+
+  RETURN v_written;
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.waves_enqueue_weekly_digest(timestamp with time zone) FROM PUBLIC;
+GRANT ALL ON FUNCTION public.waves_enqueue_weekly_digest(timestamp with time zone) TO service_role;
+
+-- ────────────────────────────────────── "Anything from yesterday?", forever ──
+--
+-- The nudges sweep every group whose trip dates bracket today. A deleted trip
+-- whose dates still do went on pushing twice a day to every member, carrying a
+-- deep link — `waves://group/<id>/add-expense` — into a screen the app correctly
+-- refuses to show. Deleting a trip did not stop its reminders, which is about
+-- the least forgivable shape this bug could take.
+CREATE OR REPLACE FUNCTION public.waves_trip_nudges(p_now timestamp with time zone DEFAULT now()) RETURNS integer
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+DECLARE
+  v_group    record;
+  v_member   record;
+  v_local    timestamp;
+  v_today    date;
+  v_slot     text;
+  v_subject  date;
+  v_written  integer := 0;
+  v_id       uuid;
+BEGIN
+  FOR v_group IN
+    SELECT id, name, time_zone, start_date, end_date,
+           remind_morning_at, remind_evening_at
+    FROM public.groups
+    WHERE remind_daily
+      AND archived_at IS NULL
+      AND deleted_at IS NULL
+      AND start_date IS NOT NULL
+      AND end_date   IS NOT NULL
+  LOOP
+    v_local := p_now AT TIME ZONE v_group.time_zone;
+    v_today := v_local::date;
+
+    -- Inclusive of both ends: the last day of a trip is the day with the most
+    -- unrecorded spending on it.
+    CONTINUE WHEN v_today < v_group.start_date OR v_today > v_group.end_date;
+
+    -- Both slots are considered on every run rather than only the latest one.
+    -- If cron is down all morning, the breakfast reminder should still go out
+    -- late rather than not at all, and the dedupe key is what stops it going
+    -- out twice.
+    FOREACH v_slot IN ARRAY ARRAY['morning', 'evening']
+    LOOP
+    IF v_slot = 'morning' THEN
+      CONTINUE WHEN v_local::time < v_group.remind_morning_at;
+      -- At breakfast the interesting day is the one that just ended. On the
+      -- first morning of a trip there is no yesterday worth asking about.
+      v_subject := v_today - 1;
+      CONTINUE WHEN v_subject < v_group.start_date;
+    ELSE
+      CONTINUE WHEN v_local::time < v_group.remind_evening_at;
+      v_subject := v_today;
+    END IF;
+
+    FOR v_member IN
+      SELECT m.id AS member_id, m.profile_id
+      FROM public.group_members m
+      JOIN public.profiles p ON p.id = m.profile_id
+      WHERE m.group_id = v_group.id
+        AND m.profile_id IS NOT NULL
+        AND m.left_at IS NULL
+        -- Somebody who turned nudges off has answered this question already.
+        AND COALESCE((p.notification_prefs ->> 'nudges')::boolean, TRUE)
+    LOOP
+      -- Nobody is asked about a day they already recorded. This is the whole
+      -- difference between a useful reminder and the kind people mute.
+      CONTINUE WHEN EXISTS (
+        SELECT 1
+        FROM public.expenses e
+        JOIN public.expense_versions v ON v.id = e.current_version_id
+        WHERE e.group_id = v_group.id
+          AND e.deleted_at IS NULL
+          AND v.author_member_id = v_member.member_id
+          AND v.expense_date = v_subject
+      );
+
+      v_id := public.waves_notify(
+        v_member.profile_id,
+        v_group.id,
+        CASE v_slot WHEN 'morning' THEN 'trip_nudge_morning' ELSE 'trip_nudge_evening' END,
+        CASE v_slot
+          WHEN 'morning' THEN 'Anything from yesterday?'
+          ELSE 'Add today before you forget'
+        END,
+        CASE v_slot
+          WHEN 'morning' THEN 'Add what you spent yesterday while you still remember it'
+          ELSE 'What did you pay for today?'
+        END,
+        'waves://group/' || v_group.id::text || '/add-expense',
+        jsonb_build_object('group', v_group.name, 'date', v_subject::text, 'slot', v_slot),
+        'trip_nudge:' || v_group.id::text || ':' || v_subject::text || ':' || v_slot
+          || ':' || v_member.profile_id::text
+      );
+
+      IF v_id IS NOT NULL THEN
+        v_written := v_written + 1;
+      END IF;
+    END LOOP;
+    END LOOP;
+  END LOOP;
+
+  RETURN v_written;
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.waves_trip_nudges(p_now timestamp with time zone) FROM PUBLIC;
+GRANT ALL ON FUNCTION public.waves_trip_nudges(p_now timestamp with time zone) TO service_role;
+
+-- ────────────────────────────── settling up inside a group that is not there ──
+--
+-- A settlement left unanswered for a week is confirmed on the payer's behalf and
+-- both people are told. In a deleted group that is two pushes about a payment
+-- nobody can open, pointing at `waves://group/<id>`, plus a row written into the
+-- dead group's feed. The join to `groups` was already there for the name; it now
+-- also decides whether there is anything to confirm.
+CREATE OR REPLACE FUNCTION public.waves_auto_confirm_settlements(p_now timestamp with time zone DEFAULT now(), p_window interval DEFAULT '7 days'::interval) RETURNS integer
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+DECLARE
+  v_row     record;
+  v_count   integer := 0;
+  v_amount  text;
+BEGIN
+  FOR v_row IN
+    SELECT s.id,
+           s.group_id,
+           s.amount,
+           s.currency,
+           s.from_member_id,
+           s.to_member_id,
+           g.name                AS group_name,
+           payer.profile_id      AS payer_profile,
+           -- A member is either a real profile or a ghost standing in for
+           -- somebody who has not joined; the name lives in whichever it is.
+           COALESCE(payer_profile.display_name, payer.ghost_name) AS payer_name,
+           payee.profile_id      AS payee_profile,
+           COALESCE(payee_profile.display_name, payee.ghost_name) AS payee_name
+    FROM public.settlements s
+    JOIN public.groups g            ON g.id = s.group_id AND g.deleted_at IS NULL
+    JOIN public.group_members payer ON payer.id = s.from_member_id
+    JOIN public.group_members payee ON payee.id = s.to_member_id
+    LEFT JOIN public.profiles payer_profile ON payer_profile.id = payer.profile_id
+    LEFT JOIN public.profiles payee_profile ON payee_profile.id = payee.profile_id
+    WHERE s.status = 'initiated'
+      AND s.initiated_at <= p_now - p_window
+    -- Locked so two overlapping runs of the job cannot both claim the same
+    -- settlement; the second simply finds nothing to do.
+    FOR UPDATE OF s SKIP LOCKED
+  LOOP
+    UPDATE public.settlements
+       SET status = 'auto_confirmed'
+     WHERE id = v_row.id;
+
+    INSERT INTO public.activity_log
+      (group_id, actor_member_id, verb, object_type, object_id, payload)
+    VALUES
+      (v_row.group_id, NULL, 'auto_confirmed', 'settlement', v_row.id,
+       jsonb_build_object('amount', v_row.amount::text, 'currency', v_row.currency,
+                          'reason', 'no_response_in_window'));
+
+    v_amount := v_row.amount::text;
+
+    -- Both people are told, and the wording differs because their positions
+    -- do. The payee is the one who might want to dispute it.
+    PERFORM public.waves_notify(
+      v_row.payee_profile, v_row.group_id, 'settlement_confirmed',
+      'Settled automatically',
+      COALESCE(v_row.payer_name, 'Someone') || ' paid you, and nobody said otherwise for a week',
+      'waves://group/' || v_row.group_id::text,
+      jsonb_build_object('settlementId', v_row.id, 'amount', v_amount,
+                         'currency', v_row.currency, 'role', 'payee',
+                         'counterparty', v_row.payer_name, 'group', v_row.group_name),
+      'auto_confirm:' || v_row.id::text || ':payee'
+    );
+
+    PERFORM public.waves_notify(
+      v_row.payer_profile, v_row.group_id, 'settlement_confirmed',
+      'Settled automatically',
+      'Your payment to ' || COALESCE(v_row.payee_name, 'them') || ' was confirmed after a week',
+      'waves://group/' || v_row.group_id::text,
+      jsonb_build_object('settlementId', v_row.id, 'amount', v_amount,
+                         'currency', v_row.currency, 'role', 'payer',
+                         'counterparty', v_row.payee_name, 'group', v_row.group_name),
+      'auto_confirm:' || v_row.id::text || ':payer'
+    );
+
+    v_count := v_count + 1;
+  END LOOP;
+
+  RETURN v_count;
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.waves_auto_confirm_settlements(p_now timestamp with time zone, p_window interval) FROM PUBLIC;
+GRANT ALL ON FUNCTION public.waves_auto_confirm_settlements(p_now timestamp with time zone, p_window interval) TO service_role;
+
+-- ═════════════ 4. the sweep that dragged dead groups back into sync ═════
+--
+-- Eighteen months of quiet archives a group. A deleted group is quiet by
+-- definition, so the sweep would eventually stamp `archived_at` on one — and
+-- that UPDATE fires `groups_stamp_seq`, which bumps `updated_seq` and pushes the
+-- dead group, and the whole child set hanging off it, back through every
+-- ex-member's next sync delta. Archiving something already deleted is also
+-- simply meaningless: there is no dashboard left to take it off.
+CREATE OR REPLACE FUNCTION public.waves_auto_archive_stale_groups(p_now timestamp with time zone DEFAULT now(), p_age interval DEFAULT '1 year 6 mons'::interval) RETURNS integer
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+DECLARE
+  v_row   record;
+  v_count integer := 0;
+BEGIN
+  FOR v_row IN
+    SELECT g.id
+      FROM public.groups g
+     WHERE g.archived_at IS NULL
+       AND g.deleted_at IS NULL
+       -- The last thing anyone did here. GREATEST ignores NULL arguments, so a
+       -- group with no expenses/settlements/activity falls back to its own
+       -- creation time — which correctly leaves a brand-new empty group alone.
+       AND GREATEST(
+             g.created_at,
+             (SELECT max(e.created_at) FROM public.expenses e     WHERE e.group_id = g.id),
+             (SELECT max(s.created_at) FROM public.settlements s  WHERE s.group_id = g.id),
+             (SELECT max(a.created_at) FROM public.activity_log a WHERE a.group_id = g.id)
+           ) <= p_now - p_age
+     -- Locked so two overlapping runs cannot both claim the same group; the
+     -- second simply finds nothing to do.
+     FOR UPDATE OF g SKIP LOCKED
+  LOOP
+    UPDATE public.groups
+       SET archived_at = p_now
+     WHERE id = v_row.id;
+
+    -- A line in the feed so the archive is explained rather than mysterious.
+    -- actor NULL = "the system did this", the same convention the auto-confirm
+    -- job uses.
+    INSERT INTO public.activity_log
+      (group_id, actor_member_id, verb, object_type, object_id, payload)
+    VALUES
+      (v_row.id, NULL, 'auto_archived', 'group', v_row.id,
+       jsonb_build_object('reason', 'inactive', 'after', p_age::text));
+
+    v_count := v_count + 1;
+  END LOOP;
+
+  RETURN v_count;
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.waves_auto_archive_stale_groups(p_now timestamp with time zone, p_age interval) FROM PUBLIC;
+GRANT ALL ON FUNCTION public.waves_auto_archive_stale_groups(p_now timestamp with time zone, p_age interval) TO service_role;
+
+-- ═════════ 5. what deleting your account is said to cost you ════════════
+--
+-- The pre-deletion screen tells somebody how many groups they are in and warns
+-- them if they still have money outstanding. Both numbers were read straight off
+-- `group_members` with no idea whether the groups still existed, so an account
+-- whose only unsettled balance was in a group deleted months ago was warned it
+-- had an outstanding balance in INR — about a ledger that is gone, on the one
+-- screen where somebody is deciding whether to go through with something
+-- irreversible.
+--
+-- `left_at` is deliberately still not filtered here, which is a separate
+-- question this migration does not answer: a group you left still holds the
+-- expenses you wrote, so whether it belongs in "what you are about to lose" is a
+-- product call, not a bug. Only the tombstone is fixed.
+CREATE OR REPLACE FUNCTION public.waves_my_erasure_preview() RETURNS TABLE(groups_count bigint, expenses_authored bigint, settlements_involved bigint, outstanding_currencies text[])
+    LANGUAGE sql STABLE SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+  WITH me AS (
+    SELECT gm.id
+      FROM public.group_members gm
+      JOIN public.groups g
+        ON g.id = gm.group_id
+       AND g.deleted_at IS NULL
+     WHERE gm.profile_id = public.waves_current_profile_id()
+  )
+  SELECT
+    (SELECT count(*) FROM me),
+    (SELECT count(*) FROM public.expenses e
+      WHERE e.created_by IN (SELECT id FROM me) AND e.deleted_at IS NULL),
+    (SELECT count(*) FROM public.settlements s
+      WHERE s.from_member_id IN (SELECT id FROM me)
+         OR s.to_member_id IN (SELECT id FROM me)),
+    COALESCE(
+      (SELECT array_agg(DISTINCT b.currency::text)
+         FROM public.group_balances b
+        WHERE b.member_id IN (SELECT id FROM me) AND b.balance <> 0),
+      ARRAY[]::text[]
+    );
+$$;
+
+REVOKE ALL ON FUNCTION public.waves_my_erasure_preview() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.waves_my_erasure_preview() TO authenticated, service_role;
+
+-- ═════════════ 6. a join link into a group that is not there ════════════
+--
+-- A durable group join link (A47) is a long-lived invite row, and consuming one
+-- checked only the invite: not revoked, not expired, uses left. It never asked
+-- about the group. So a QR code or a WhatsApp link for a group somebody has
+-- since deleted still worked — it added the person to a group they will never
+-- see, and if they were a guest it spent their one-group ceiling on it (ADR-006
+-- addendum), which is the version of this that cannot be undone by the person it
+-- happened to.
+--
+-- A refusal here surfaces exactly as a revoked invite already does, so the join
+-- screen has nothing new to say.
+CREATE OR REPLACE FUNCTION public.waves_consume_invite(p_invite_id uuid) RETURNS boolean
+    LANGUAGE sql SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+  UPDATE public.invites i
+  SET use_count = use_count + 1
+  WHERE i.id = p_invite_id
+    AND i.revoked_at IS NULL
+    AND i.expires_at > now()
+    AND i.use_count < i.max_uses
+    AND EXISTS (
+      SELECT 1 FROM public.groups g
+       WHERE g.id = i.group_id
+         AND g.deleted_at IS NULL
+    )
+  RETURNING true;
+$$;
+
+REVOKE ALL ON FUNCTION public.waves_consume_invite(p_invite_id uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.waves_consume_invite(p_invite_id uuid) TO service_role;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -304,6 +304,10 @@ model Group {
   storageObjects     StorageObject[]
 
   @@index([archivedAt])
+  /// The twin of the one above, and it earned its place the same way: every
+  /// sweep and every balance read now has to prove the group is not a tombstone,
+  /// so `deleted_at IS NULL` appears in as many predicates as `archived_at` does.
+  @@index([deletedAt])
   /// The nudge job only ever looks at groups that have said when they are
   /// happening, which is a small minority of them.
   @@index([startDate, endDate], map: "groups_reminder_window_idx")

--- a/packages/db/test/people.test.ts
+++ b/packages/db/test/people.test.ts
@@ -278,7 +278,7 @@ describe('direction', () => {
 });
 
 /**
- * A group that has been deleted or archived is out of the money entirely.
+ * A deleted group owes nobody anything. An archived one still does.
  *
  * Deleting a group is a tombstone, not an erasure (ADR-004): `deleted_at` is
  * stamped and every row underneath — the expenses, the `pairwise_balances`, the
@@ -288,11 +288,10 @@ describe('direction', () => {
  * physically holds. Both used to let it through: one joined `groups` without
  * ever looking at `deleted_at`, the other never joined `groups` at all.
  *
- * Archived is the same test for a different reason. No route in this app opens
- * an archived group's ledger, and the offline mirror has always dropped archived
- * groups out of these same sums (`materialiseGroups`), so a server that counted
- * them handed the person screen a number the Friends list it was reached from
- * disagreed with — and a row that opens nothing.
+ * Archived goes the other way and is tested here beside it so the two cannot be
+ * conflated by the next person to read this file. A trip put away has not
+ * settled up; the ledger is intact, nobody left, and one tap of Unarchive brings
+ * it back. It leaves the dashboard, not the money.
  */
 describe('a dead group owes nobody anything', () => {
   async function personGroups(profileId: string, personKey: string) {
@@ -355,20 +354,40 @@ describe('a dead group owes nobody anything', () => {
     expect(await personGroups(asha, ghost)).toHaveLength(0);
   });
 
-  it('drops an archived group too, and gives it back when it is unarchived', async () => {
+  it('goes on counting an archived group, because the money is still owed', async () => {
+    // The line this migration draws: deleted is gone, archived is put away.
+    // Archiving is offered as the way to clear a finished trip off the dashboard
+    // *without deleting its ledger*, so dropping its debts out of "what do I owe
+    // Ravi" would break that promise quietly — nobody left, the group is one tap
+    // of Unarchive away, and the money is real.
     const asha = await profile('Asha');
     const { groupId, ghost } = await owing(asha, 100000n);
 
     await client.query(`UPDATE groups SET archived_at = now() WHERE id = $1`, [groupId]);
-    expect(await people(asha)).toHaveLength(0);
-    expect(await personGroups(asha, ghost)).toHaveLength(0);
 
-    // Nothing was destroyed by that: the ledger is intact and one Unarchive puts
-    // the balance back into every total at once.
-    await client.query(`UPDATE groups SET archived_at = NULL WHERE id = $1`, [groupId]);
     const rows = await people(asha);
     expect(rows).toHaveLength(1);
     expect(BigInt(rows[0].net)).toBe(50000n);
+    // And the per-group row that explains that total is still there, which it
+    // has to be: it is the only place the archived group's share of the figure
+    // is shown, and the group screen opens an archived group now, so it leads
+    // somewhere.
+    expect(await personGroups(asha, ghost)).toHaveLength(1);
+  });
+
+  it('stops counting an archived group once it is deleted as well', async () => {
+    // Archived is not a weaker delete and delete is not a stronger archive:
+    // whichever order they happen in, the tombstone is what decides.
+    const asha = await profile('Asha');
+    const { groupId, ghost } = await owing(asha, 100000n);
+
+    await client.query(`UPDATE groups SET archived_at = now() WHERE id = $1`, [groupId]);
+    expect(await people(asha)).toHaveLength(1);
+
+    await asUser(asha, () => client.query(`SELECT waves_delete_group($1)`, [groupId]));
+
+    expect(await people(asha)).toHaveLength(0);
+    expect(await personGroups(asha, ghost)).toHaveLength(0);
   });
 
   it('leaves a live group alone', async () => {

--- a/packages/db/test/people.test.ts
+++ b/packages/db/test/people.test.ts
@@ -276,3 +276,110 @@ describe('direction', () => {
     expect(BigInt(rows[0].net)).toBe(-50000n);
   });
 });
+
+/**
+ * A group that has been deleted or archived is out of the money entirely.
+ *
+ * Deleting a group is a tombstone, not an erasure (ADR-004): `deleted_at` is
+ * stamped and every row underneath — the expenses, the `pairwise_balances`, the
+ * memberships, whose `left_at` stays NULL because nobody left — survives to
+ * carry that tombstone out over the sync pull. Which means these two RPCs are
+ * the only thing standing between a deleted group and the balances it still
+ * physically holds. Both used to let it through: one joined `groups` without
+ * ever looking at `deleted_at`, the other never joined `groups` at all.
+ *
+ * Archived is the same test for a different reason. No route in this app opens
+ * an archived group's ledger, and the offline mirror has always dropped archived
+ * groups out of these same sums (`materialiseGroups`), so a server that counted
+ * them handed the person screen a number the Friends list it was reached from
+ * disagreed with — and a row that opens nothing.
+ */
+describe('a dead group owes nobody anything', () => {
+  async function personGroups(profileId: string, personKey: string) {
+    return asUser(profileId, async () => {
+      const { rows } = await client.query(`SELECT * FROM waves_person_group_balances($1)`, [
+        personKey,
+      ]);
+      return rows;
+    });
+  }
+
+  /** Asha and one ghost called Ravi, with Ravi owing her half of `amount`. */
+  async function owing(asha: string, amount: bigint): Promise<{ groupId: string; ghost: string }> {
+    const groupId = await makeGroup(asha);
+    const ghost = await addGhost(asha, groupId, 'Ravi');
+    await expense(asha, groupId, await myMember(groupId, asha), ghost, amount);
+    return { groupId, ghost };
+  }
+
+  it('drops a deleted group out of the total and out of the group count', async () => {
+    const asha = await profile('Asha');
+    const live = await owing(asha, 100000n); // Ravi owes 500
+    const dead = await owing(asha, 40000n); //  Ravi owes 200, until this goes
+
+    // Two ghosts called Ravi are two people (nothing proves otherwise), so what
+    // is checked here is that a row disappears, not that a sum shrinks.
+    expect(await people(asha)).toHaveLength(2);
+
+    await asUser(asha, () => client.query(`SELECT waves_delete_group($1)`, [dead.groupId]));
+
+    const rows = await people(asha);
+    expect(rows).toHaveLength(1);
+    expect(BigInt(rows[0].net)).toBe(50000n);
+    expect(rows[0].only_group_id).toBe(live.groupId);
+  });
+
+  it('keeps a deleted group off the person screen it used to dead-link from', async () => {
+    const asha = await profile('Asha');
+    const { groupId, ghost } = await owing(asha, 100000n);
+
+    expect(await personGroups(asha, ghost)).toHaveLength(1);
+
+    await asUser(asha, () => client.query(`SELECT waves_delete_group($1)`, [groupId]));
+
+    // The row was what was wrong, not the refusal it led to: the client mirror
+    // has always declined to open a tombstoned group, so this row was a link to
+    // "Group not found".
+    expect(await personGroups(asha, ghost)).toHaveLength(0);
+  });
+
+  it('counts a deleted group in neither RPC, so the two still agree', async () => {
+    // The per-group RPC exists to un-collapse the list's total. If one of them
+    // filtered and the other did not, the person screen would contradict the
+    // Friends row that was tapped to reach it.
+    const asha = await profile('Asha');
+    const { groupId, ghost } = await owing(asha, 100000n);
+    await asUser(asha, () => client.query(`SELECT waves_delete_group($1)`, [groupId]));
+
+    expect(await people(asha)).toHaveLength(0);
+    expect(await personGroups(asha, ghost)).toHaveLength(0);
+  });
+
+  it('drops an archived group too, and gives it back when it is unarchived', async () => {
+    const asha = await profile('Asha');
+    const { groupId, ghost } = await owing(asha, 100000n);
+
+    await client.query(`UPDATE groups SET archived_at = now() WHERE id = $1`, [groupId]);
+    expect(await people(asha)).toHaveLength(0);
+    expect(await personGroups(asha, ghost)).toHaveLength(0);
+
+    // Nothing was destroyed by that: the ledger is intact and one Unarchive puts
+    // the balance back into every total at once.
+    await client.query(`UPDATE groups SET archived_at = NULL WHERE id = $1`, [groupId]);
+    const rows = await people(asha);
+    expect(rows).toHaveLength(1);
+    expect(BigInt(rows[0].net)).toBe(50000n);
+  });
+
+  it('leaves a live group alone', async () => {
+    const asha = await profile('Asha');
+    const { groupId, ghost } = await owing(asha, 100000n);
+
+    const rows = await people(asha);
+    expect(rows).toHaveLength(1);
+    expect(BigInt(rows[0].net)).toBe(50000n);
+    expect(rows[0].group_count).toBe(1);
+    expect(rows[0].only_group_id).toBe(groupId);
+    expect(await personGroups(asha, ghost)).toHaveLength(1);
+  });
+});

--- a/packages/db/test/person-profile.test.ts
+++ b/packages/db/test/person-profile.test.ts
@@ -97,6 +97,56 @@ describe('waves_person_profile', () => {
     expect(Number(row?.shared_groups)).toBe(2);
   });
 
+  it('stops counting a group once it has been deleted', async () => {
+    // A delete is a tombstone (ADR-004) and leaves both memberships in place, so
+    // "2 groups in common" survived the group itself until this was filtered.
+    const first = await seedGroup(client, { memberCount: 2, name: 'Goa' });
+    const [me, them] = first.profileIds;
+
+    const groupId = randomUUID();
+    await client.query(
+      `INSERT INTO groups (id, name, type, default_currency, created_by)
+       VALUES ($1, 'Flat', 'home', 'INR', $2)`,
+      [groupId, me],
+    );
+    for (const profileId of [me, them]) {
+      await client.query(
+        `INSERT INTO group_members (id, group_id, profile_id, role, joined_via)
+         VALUES ($1, $2, $3, 'member', 'invite')`,
+        [randomUUID(), groupId, profileId],
+      );
+    }
+    expect(Number((await profileOf(me!, them!))?.shared_groups)).toBe(2);
+
+    await client.query(`UPDATE groups SET deleted_at = now() WHERE id = $1`, [groupId]);
+    expect(Number((await profileOf(me!, them!))?.shared_groups)).toBe(1);
+  });
+
+  it('goes on counting an archived group, because nobody left it', async () => {
+    // The one place this parts company with the balance RPCs, which drop an
+    // archived group. That question is about which ledgers are live enough to
+    // add up and to open; this one is about whether two people know each other,
+    // and putting a finished trip away does not make them strangers.
+    const group = await seedGroup(client, { memberCount: 2 });
+    const [me, them] = group.profileIds;
+
+    await client.query(`UPDATE groups SET archived_at = now() WHERE id = $1`, [group.groupId]);
+
+    expect(Number((await profileOf(me!, them!))?.shared_groups)).toBe(1);
+  });
+
+  it('will not show a stranger whose only shared group is deleted', async () => {
+    // The count doubles as the permission gate, so filtering tightens the gate
+    // too — and correctly: a group that no longer exists must not be the sole
+    // reason somebody's name, face and phone number come back.
+    const group = await seedGroup(client, { memberCount: 2 });
+    const [me, them] = group.profileIds;
+
+    await client.query(`UPDATE groups SET deleted_at = now() WHERE id = $1`, [group.groupId]);
+
+    expect(await profileOf(me!, them!)).toBeUndefined();
+  });
+
   it('returns nothing at all for somebody you share no group with', async () => {
     const mine = await seedGroup(client, { memberCount: 1 });
     const theirs = await seedGroup(client, { memberCount: 1 });

--- a/supabase/functions/invite-accept/index.ts
+++ b/supabase/functions/invite-accept/index.ts
@@ -73,11 +73,24 @@ serveWithCors(async (request) => {
       throw new HttpError(404, 'INVITE_INVALID', 'This invite link is no longer valid');
     }
 
+    // `service` is the service role, so RLS is not doing any filtering here and
+    // the tombstone has to be asked about by name. A group somebody deleted
+    // (A49) keeps its rows — that is how the delete travels to other devices —
+    // so without this a QR code or a WhatsApp link for a group that no longer
+    // exists still previewed with its name and member count, and still let
+    // people in.
     const { data: group } = await service
       .from('groups')
       .select('id, name, cover_emoji, default_currency')
       .eq('id', invite.group_id)
-      .single();
+      .is('deleted_at', null)
+      .maybeSingle();
+
+    // The same answer as a revoked or expired link, deliberately: a caller
+    // learns that the link does not work, not which groups have been deleted.
+    if (!group) {
+      throw new HttpError(404, 'INVITE_INVALID', 'This invite link is no longer valid');
+    }
 
     const { data: members } = await service
       .from('group_members')


### PR DESCRIPTION
Follow-up to #751, which carries the security half of the same finding. This is the correctness half. The two are independent — different functions, different migration — and can land in either order.

## The bug

A user opened a person's profile from Friends and saw **"You owe ₹1,192.72 · across 2 groups"** over **two rows both named "Splitwise", ₹596.36 each**. Tapping one landed on **"Group not found"**.

On prod, three groups carry identical balances — the same Splitwise export imported three times:

| id | name | deleted_at |
|---|---|---|
| `777e5b7d…` | Splitwise | null |
| `c8a9aa5f…` | Splitwise | 2026-09-09 16:46 |
| `38214d33…` | Splitwise 1 | 2026-09-09 16:45 |

Deleting a group is a tombstone, not an erasure (ADR-004, A49): `waves_delete_group` stamps `deleted_at` and leaves the expenses, the settlements, the `pairwise_balances` and the `group_members` rows where they are — `left_at` stays NULL because nobody left. That is deliberate and has to stay: the tombstone rides the sync pull so every device learns the group is gone, and it can only do that if the rows survive to carry it.

What nothing did was **read** it.

## The audit — the true blast radius

`groups.deleted_at` was written by one statement and consulted by **none**. Across all ~17,700 lines of SQL in `packages/db/prisma/migrations/**` (and there is no `.sql` anywhere else in the repo) the only four references were inside `waves_delete_group` itself. Zero RPCs, zero RLS policies, zero triggers, zero cron jobs. There are **no views or matviews anywhere** in the schema, so the "check views too" question has a short answer: there are none. By contrast `archived_at` was filtered in three functions.

So this was never two bugs. It was a schema-wide omission with two visible symptoms.

`BASE` below = `packages/db/prisma/migrations/20260904000000_waves_baseline/migration.sql`.

### Fixed here

| Object | Where | Reads | What went wrong |
|---|---|---|---|
| `waves_people_i_owe` | `BASE:4849` | `group_members` → `pairwise_balances` | Never joined `groups` at all. Every total it produced — the web Friends list, the developer API's `/v1/people`, the person screen's per-currency sum — carried deleted groups. Also fed a wrong `group_count` / `only_group_id`. |
| `waves_person_group_balances` | `BASE:4969` | same, plus `groups` for name/emoji | Joined `groups` without checking `deleted_at`. The dead rows on the person screen. |
| `waves_person_profile` | `20260908090000:179,202` | `group_members` | `shared_groups` counted deleted groups **and that count is the permission gate** (`IF v_shared = 0 THEN RETURN`). A group both parties had deleted still authorised the reveal of the other person's email, phone, payment rail, payment handle and country. Privacy, not cosmetics. |
| `waves_enqueue_weekly_digest` | `20260907150000:51,78` | expenses + `pairwise_balances` | Filtered `archived_at`, not `deleted_at`. The count is the send gate, so a deleted group could be the whole reason somebody got mail; the net was the headline figure in it. |
| `waves_trip_nudges` | `BASE:6914` | `groups` sweep | A deleted trip whose dates still bracket today pushed twice a day to every member, deep-linking `waves://group/<id>/add-expense` into a screen the app refuses to open. Deleting a trip did not stop its reminders. |
| `waves_auto_confirm_settlements` | `BASE:1559` | `settlements` + `groups` | Auto-confirmed pending settle-ups inside deleted groups, fired two pushes with a dead link, and wrote an `activity_log` row into the dead group. |
| `waves_auto_archive_stale_groups` | `BASE:1496` | `groups` sweep | Would stamp `archived_at` on a deleted group; that UPDATE fires `groups_stamp_seq`, so the dead group and its whole child set re-entered every ex-member's sync delta. |
| `waves_my_erasure_preview` | `BASE:4280` | `group_members`, `group_balances` | The pre-account-deletion screen warned "you still have an outstanding balance in INR" from a group deleted months ago — on the one screen where somebody is deciding something irreversible. |
| `waves_consume_invite` | `BASE:2272` | `invites` only | A durable A47 join link for a deleted group still worked, and burned a guest's one-group ceiling on a group they would never see. `invite-accept` also previewed the group by id with no filter; both fixed. |
| `useRecentActivity` | `apps/mobile/src/data/hooks.ts` | mirrored `activity_log` | The feed went on listing what happened in deleted groups, each row linking to "Group not found". |
| `Overview` hero | `apps/web/src/components/Overview.tsx:117` | `group_balances` | Read with no join to `groups` at all, so the web hero totalled deleted **and** archived groups that were not in the list beneath it. |
| `myGroups` / `allGroups` / `groupRow` / `group` | `packages/api-client/src/client.ts` | `groups` | No `deleted_at` filter, so a deleted group came back looking exactly like a live one. |
| `GET /v1/groups`, `GET /v1/groups/:id` | `apps/api/src/routes/v1/groups.ts:74,144` | `groups` | Same. The list has an `include_archived` flag and deliberately gains no `include_deleted` twin — archiving is reversible and a script has reason to ask for those rows; a delete is a tombstone whose rows survive only so the delete can travel. |

### Found, deliberately not fixed here

- **`is_group_member` (`BASE:219`) and `is_group_admin` (`BASE:200`)** — the root. They read `group_members` alone and sit under ~30 RLS policies and ~45 RPCs, so to the whole authorization layer a deleted group is indistinguishable from a live one. **Why not fixed at the root** (this is the trap, and it is written into the migration too):
  - `groups_select` is built on `is_group_member`. A member who cannot read the deleted group's own row never receives the tombstone, so the group never leaves their mirror — the delete would stop working on exactly the devices it exists to reach. **The group's row must stay readable while its children stop counting, and one predicate cannot say both.**
  - `waves_delete_group` is documented and tested as idempotent so a retried offline queue flush lands cleanly. Its admin gate runs *before* the already-deleted check, so a deleted-aware `is_group_admin` turns the second delete into `NOT_ADMIN` instead of a no-op.
  - They are the hottest predicates in the schema; adding a join to both for a column that is NULL on virtually every row is a large unmeasured change to make beside a correctness fix.
- **Every group-scoped write RPC** (~45 of them, all gated on those two predicates: `waves_apply_expense BASE:1037`, `waves_add_ghost_member:308`, `waves_record_settlement`, `waves_set_group_budget:6038`, …). A late-flushed offline mutation can still write into a deleted group, and `waves_touch_balances BASE:6864` → `waves_refresh_group_balances BASE:5472` will rebuild its `pairwise_balances` when it does. This wants its own change plus a decision about what a client is *told* when its queued expense lands in a group that has since gone — dropping a rejected mutation from the queue deletes what it made locally, which this repo has been bitten by before.
- **RLS SELECT on 23 group-scoped tables** (`groups_select BASE:10731`, `group_members_select:10684`, `pairwise_balances_select:10806`, `expenses_select:10591`, `settlements_select:11015`, storage policies at `BASE:13110`/`13164`, …) all resolve to `is_group_member(group_id)`, so a deleted group's rows stay fully readable and keep syncing forever. Arguably intended — the tombstone is advisory and the client filters — but it is the reason the client half of this PR exists.
- **`profiles_select_co_members` (`BASE:10839`)**, `waves_shares_a_group_with (BASE:6365)`, `waves_profiles_share_group (BASE:5003)` — a deleted shared group keeps granting SELECT on the other person's profile row and, via the avatar storage policy `BASE:13211`, their avatar file. Same shape as the `waves_person_profile` leak, one layer down.
- **`waves_nudge_to_settle` (`BASE:4725`)** — joins `groups` for the name, reads `pairwise_balances`, no filter. Left alone because it is reached only from the Friends "remind" glyph on rows this PR stops producing, so it is now unreachable with a deleted group; worth closing when someone is next in that file.
- **Admin aggregates** — `waves_admin_overview BASE:876/877`, `waves_admin_daily:677`, `waves_admin_geo:763/766`, `waves_admin_money:841`, `waves_admin_flag_results:724` all count deleted groups while filtering `expenses.deleted_at` meticulously. Internal dashboards, no user-facing number, so out of scope here.
- **Storage quota** — `waves_my_storage_usage BASE:4407` counts bytes in deleted groups against the 10 MB free cap with no way to free them. Possibly intended (the objects still exist); flagging it rather than deciding it.
- **`waves_my_member_claims BASE:4310`**, **`waves_find_person`'s `already_shared`** — cosmetic.
- **`knownContacts.ts`** — still reads only active groups, so somebody visible in Friends via an archived group is not offered as a contact suggestion. Not a number, so not chased.

## Archived — the decision, and why

**A deleted group is gone from everything. An archived group stays out of the surfaces about what is happening now, and stays in the ones about what two people owe each other.**

The tempting alternative was to hide archived debts too, because that is what the client already did. What ruled it out is that archiving is *offered* as the calm way to clear a finished trip off the dashboard **without deleting its ledger**. Dropping its debts out of "what do I owe Hethu" quietly breaks that promise: the money is real, nobody left, and it is one tap of Unarchive away.

**Then I checked whether the app can open an archived group, as asked. It could not** — and that is what made this a two-sided fix rather than a one-line filter:

- `useGroup` (`hooks.ts`) explicitly resolved an archived group to `null`, so the group screen showed the same "Group not found — It may have been archived, or you are no longer a member" state the bug report ends on.
- `apps/mobile/src/app/settings/archived.tsx` listed archived groups with an **Unarchive button and no navigation** — the row went nowhere.
- So the only thing you could do with a finished trip was put it back on the dashboard you had deliberately cleared it off. "Archiving does not delete the ledger" was a technicality if you could not read the ledger.

**The screen gave, not the list.** `useGroup` now opens an archived group (still refusing a deleted one), the archive shelf's rows open the group, and the group's own settings row flips to **Unarchive** when it is already archived — otherwise arriving there from a Friends balance would offer "Archive" on something already archived, a control that visibly does nothing.

And the mirror and the server disagreed in **both** directions, which is its own bug: the mirror dropped archived groups from the Friends list while the RPC counted them on the person screen you reach by tapping a row in that list. Same question, two answers, depending on which side answered. Both now count archived and neither counts deleted.

Two places deliberately keep the old line and say so in the code:

- **`waves_person_profile.shared_groups`** counts archived groups. It asks whether two people know each other, not which ledgers are live; putting a trip away does not make the people on it strangers. It excludes deleted, because a group that no longer exists must not be the sole reason a stranger's contact details come back.
- **The dashboard hero** (mobile and web) is still the sum of the group cards under it, archived excluded. It answers "what is going on now" and the cards are right there to check it against.

## Did the mirror need fixing?

Yes, twice, and the answer is the interesting part of this PR.

The Friends list is **not** the RPC — it is `usePeopleBalances`, computed on the device from the mirror (ADR-005). It summed over `materialiseGroups`, which already excluded deleted groups, so **the deleted-group half was already correct locally**. A server-only fix would have been invisible on the mobile Friends tab and would have left the person screen behind it disagreeing.

What was wrong locally was archived, in the opposite direction. So `packages/core` gains `materialiseLedgerGroups` — every group whose ledger still counts, archived included, deleted not — beside the existing `materialiseGroups` ("what is going on now"). `usePeopleBalances`, `useKnownPeopleCount` (the empty-state disambiguator on the same screen) and `useMergeCandidates` read through it. Unit-tested in `packages/core`, where the sums are pure.

## Testing

- **`packages/core/test/overlay.test.ts`** — a deleted group is out of all three lists; `materialiseLedgerGroups` keeps an archived group that `materialiseGroups` drops; a deleted group is dropped whether or not it was archived first; a group created offline (no server row, so no tombstone) is in both. **These run and pass.**
- **`packages/db/test/people.test.ts`** — a deleted group leaves both the total and the group count; the per-group RPC stops returning the row it used to dead-link from; the two RPCs agree; an archived group is still counted, and unarchiving restores it; a live group is untouched.
- **`packages/db/test/person-profile.test.ts`** — the count stops including a deleted group; still includes an archived one; somebody whose only shared group is deleted is no longer visible at all.

**Unverified locally**: this worktree has no Postgres on `localhost:54330`, so all 67 `@waves/db` suites fail to connect here — not only these. Everything else is green: `pnpm format:check`, `pnpm lint` (all projects, `--max-warnings 0`), `pnpm typecheck`, and `core` 961 / `mobile` 1217 / `web` 53 / `edge` 254 / `api` 63 / `api-client` 12 / `admin` 40 / `agent-mcp` 25.

The hook-level wiring in `hooks.ts` has no unit test, consistent with the rest of that file; the logic it wires is tested in `packages/core`.

## Index

`groups_deleted_at_idx` added, plus the matching `@@index([deletedAt])` in `schema.prisma` so the drift check stays clean. Plain btree to match `groups_archived_at_idx` rather than partial — a partial index would be a permanent drift finding on a table this size.

## What a person with an already-inflated total sees

**It corrects itself. Nothing needs recomputing.**

Both RPCs read `pairwise_balances` live at query time; there is no materialised total anywhere. The moment the migration is applied, the next call returns the right number. On web and in the developer API that is the next page load.

On mobile the Friends list is computed on the device — and the deleted-group half was **already** correct there, so the number on that tab has been right all along. What changes on mobile is the person screen behind it (server-side, right immediately) and archived groups now being included on both sides. No re-sync, no cache bust, no backfill.

The one thing that is *not* self-correcting is the mirror's own copy of deleted groups' child rows: they stay on the device forever, because RLS keeps serving them and nothing tombstones each child individually. They are inert — every read is scoped by group and every group list filters the tombstone — and the activity-feed filter in this PR closes the last place they were visible.

## Not built, but worth saying

The user imported the same export three times and deleted two of them. The import always makes a fresh group and records no fingerprint of what it ingested, so nothing can notice a repeat. The cheap version of a guard is not deduplication: at the point `waves_import_ledger` has resolved the file's people to members, the caller already knows the person set, the expense count and the total. A live group of the same name with the same member set and the same expense count is a near-certain re-import, and the import screen could say "You already have a Splitwise with these 4 people and 37 expenses — import anyway?" before writing anything. One query, one confirm, no schema. Out of scope here.

## Deploy

Migration written, **not applied** — no prod changes made. Note that the mobile half is JS-only (OTA), and the web half needs a Vercel deploy of the web project.
