### PR TITLE
Adding an expense looks like editing one, and says where the currency is

### DIFF
--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -1652,58 +1652,19 @@ export default function AddExpenseScreen() {
           keyboardShouldPersistTaps="handled"
           showsVerticalScrollIndicator={false}
         >
-          {/* "How much" and "what for" are the whole of the common case. The
-            amount is in the hero above; the note follows it directly, with
-            nothing between the two fields somebody came here to fill and the
-            split below them. The names are handed to the recogniser as hints; a
-            general model guesses at Indian names and the note is where they turn
-            up. */}
-          <DescriptionField
-            value={description}
-            onChange={setDescription}
-            placeholder={t.expense.descriptionPlaceholder}
-            accessibilityLabel={t.description}
-            hints={nameHints}
-            multiline
-          />
+          {/* The bill, first — the order the expense screen reads in.
 
-          {/* When it happened, on the common path rather than behind the fold.
-            The day is not an advanced setting: an expense filed on the wrong one
-            lands in the wrong month, the wrong trip and the wrong place in the
-            feed, and somebody correcting a date should not have to guess that it
-            lives under "More details" — which is exactly what happened when it
-            did. It sits beside the note rather than above the fold for the same
-            reason: split, payers and participants fill the first screenful, so
-            anything after them is still a scroll away. What, when, then who.
-            Untouched it still inherits the day it always had, so editing a note
-            never moves a three-week-old dinner. */}
-          <Card style={{ paddingVertical: theme.spacing.xs, gap: 0 }}>
-            <SettingRow
-              label={t.captures.date}
-              value={showDate(expenseDate, locale)}
-              leading={
-                <Ionicons
-                  name="calendar-outline"
-                  size={iconSize.md}
-                  color={theme.color.textMuted}
-                />
-              }
-              onPress={() => setEditingDate(true)}
-            />
-          </Card>
+            Viewing a bill puts its receipts at the top, above the card of facts
+            and above the split; the form used to put them third, after the note
+            and the day, so the same expense told its story in two different
+            orders depending on whether you were reading it or writing it. The
+            bill is also the thing a person is most often holding when they open
+            this screen, and scanning it fills in the amount and the note below —
+            so it belongs before the fields it populates, not after them.
 
-          {editingDate ? (
-            <DateTimePicker
-              value={dateFrom(expenseDate)}
-              mode="date"
-              display={Platform.OS === 'ios' ? 'inline' : 'default'}
-              onChange={applyDate}
-            />
-          ) : null}
-
-          {/* The bill is a shortcut, not the screen: two small actions rather
-            than a card that makes this look like a receipt scanner. Scan is
-            metered and gives way when the group is capped; Add photo keeps an
+            The bill is still a shortcut, not the screen: two small actions
+            rather than a card that makes this look like a receipt scanner. Scan
+            is metered and gives way when the group is capped; Add photo keeps an
             image on the device and never records a receipt server-side, so it
             is offered even at the cap.
 
@@ -1798,6 +1759,91 @@ export default function AddExpenseScreen() {
               </Pressable>
             ) : null}
           </View>
+
+          {/* "How much" and "what for" are the whole of the common case. The
+            amount is in the hero above and the note is here, with only the bill
+            between them — and the bill is what fills both in when it is scanned,
+            so it is on the way to the note rather than in front of it. The names
+            are handed to the recogniser as hints; a general model guesses at
+            Indian names and the note is where they turn up. */}
+          <DescriptionField
+            value={description}
+            onChange={setDescription}
+            placeholder={t.expense.descriptionPlaceholder}
+            accessibilityLabel={t.description}
+            hints={nameHints}
+            multiline
+          />
+
+          {/* The bill's facts, as one labelled card — the same card the expense
+            screen shows under its receipts, with the answers editable instead of
+            printed.
+
+            These four are all the same kind of question: a short answer, already
+            filled in, changed from a sheet. They used to be spread across three
+            places — the day in a card of its own here, the category and the rail
+            behind the "More details" fold, and the currency only as a pill in
+            the header — so a form that could have said what it knew in four
+            lines instead made you find three different controls to read it.
+
+            None of them is an advanced setting. An expense filed on the wrong
+            day lands in the wrong month, the wrong trip and the wrong place in
+            the feed; a bill paid on a card recorded as cash is wrong on the
+            statement it is checked against; and a total in the wrong currency is
+            simply a different number. Untouched, the day still inherits whatever
+            it always had, so editing a note never moves a three-week-old dinner.
+
+            Category is here as well as on the hero badge above: the badge shows
+            the guess, which is what you want while typing the note, but it is
+            not a control — this row is where the guess is overruled. */}
+          <Card style={{ paddingVertical: theme.spacing.xs, gap: 0 }}>
+            <SettingRow
+              label={t.captures.date}
+              value={showDate(expenseDate, locale)}
+              leading={
+                <Ionicons
+                  name="calendar-outline"
+                  size={iconSize.md}
+                  color={theme.color.textMuted}
+                />
+              }
+              onPress={() => setEditingDate(true)}
+            />
+            <Divider />
+            <CategoryRow
+              value={category}
+              meta={categoryMeta}
+              onPress={() => setPickingCategory(true)}
+            />
+            <Divider />
+            <PaymentMethodRow value={paymentMethod} onPress={() => setPickingPayment(true)} />
+            <Divider />
+            {/* What it was paid in, as a named row rather than only as the pill
+              in the header. The pill is still there and still works — but it is
+              a hairline outline on a gradient beside a large amount, and "there
+              is no currency selection" is what somebody looking for one
+              reported. This names the field and opens the same sheet. */}
+            <SettingRow
+              label={t.captures.currencyLabel}
+              value={`${currencySymbol(currency)} ${currency}`}
+              leading={
+                // Not `cash-outline`: the rail row directly above wears that
+                // glyph whenever the answer is cash, which is the default — two
+                // rows with the same icon read as one repeated question.
+                <Ionicons name="globe-outline" size={iconSize.md} color={theme.color.textMuted} />
+              }
+              onPress={() => setPickingCurrency(true)}
+            />
+          </Card>
+
+          {editingDate ? (
+            <DateTimePicker
+              value={dateFrom(expenseDate)}
+              mode="date"
+              display={Platform.OS === 'ios' ? 'inline' : 'default'}
+              onChange={applyDate}
+            />
+          ) : null}
 
           {/* "How is this split" as one block instead of three.
 
@@ -2207,10 +2253,16 @@ export default function AddExpenseScreen() {
             />
           </Card>
 
-          {/* Everything most expenses never need — the category (already guessed
-            from the note), how it was paid, where, and a foreign rate — folded
-            off the common path. It opens itself the moment one of them carries a
-            value, so an edit or a foreign currency is never hidden behind it. */}
+          {/* What is genuinely optional: where it happened, and — once the
+            currency is not the group's — the rate that converts it.
+
+            The category and the rail used to live down here too. They are not
+            optional in the same sense: both are always set (the category is
+            guessed from the note, the rail defaults to cash), so the fold was
+            hiding two answers the form had already given rather than two
+            questions nobody had asked. They are up in the facts card now, beside
+            the day and the currency, and this keeps the two that really can be
+            left empty. */}
           <Pressable
             accessibilityRole="button"
             accessibilityState={{ expanded: showDetails }}
@@ -2230,53 +2282,13 @@ export default function AddExpenseScreen() {
           </Pressable>
 
           <View style={{ gap: theme.spacing.xl, display: showDetails ? 'flex' : 'none' }}>
-            {/* The two tags an expense carries, as a list rather than two lanes
-              of chips.
-
-              Both are questions with one short answer, and both are already
-              answered when the fold opens — the category is guessed from the
-              note (a menu between somebody and saving a dinner is how a column
-              ends up empty, and an empty column is a spending chart nobody can
-              draw, TDR §8), and the rail defaults to cash. Two rows of chips
-              spent a screenful showing every answer that was *not* chosen; two
-              rows name the field, say what it is set to, and keep the options
-              behind a sheet for the times somebody wants to change one. The same
-              card of divided rows the capture screen uses for its meta. */}
-            <Card style={{ paddingVertical: theme.spacing.xs, gap: 0 }}>
-              <CategoryRow
-                value={category}
-                meta={categoryMeta}
-                onPress={() => setPickingCategory(true)}
-              />
-              <Divider />
-              <PaymentMethodRow value={paymentMethod} onPress={() => setPickingPayment(true)} />
-              <Divider />
-              {/* What it was paid in, as a named row rather than only as the pill
-                  in the header. The pill is still there and still works — but it
-                  is a hairline outline on a gradient beside a large amount, and
-                  "there is no currency selection" is what somebody looking for
-                  one reported. A row spells the field out by name, in the card
-                  where the other two short answers already live, and opens the
-                  same sheet the pill does. */}
-              <SettingRow
-                label={t.captures.currencyLabel}
-                value={`${currencySymbol(currency)} ${currency}`}
-                leading={
-                  // Not `cash-outline`: the rail row directly above wears that
-                  // glyph whenever the answer is cash, which is the default —
-                  // two rows with the same icon read as one repeated question.
-                  <Ionicons name="globe-outline" size={iconSize.md} color={theme.color.textMuted} />
-                }
-                onPress={() => setPickingCurrency(true)}
-              />
-            </Card>
-
             {/* Where it happened (A43) — optional, opt-in, never a background track. */}
             <LocationField value={location} onChange={setLocation} />
 
-            {/* Currency is chosen from the header pill; this collapses to the FX
-              rate alone — nothing while the expense is in the group's currency,
-              the rate methods once it is foreign (ADR-003). */}
+            {/* Currency is chosen from the facts card above (and from the header
+              pill); this collapses to the FX rate alone — nothing while the
+              expense is in the group's currency, the rate methods once it is
+              foreign (ADR-003). */}
             <CurrencyRate
               groupCurrency={groupCurrency}
               currency={currency}

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -93,6 +93,7 @@ import { resolveDraftCurrency, resolveDraftFx } from '@/lib/expenseDraft';
 import { dateFrom, isoDate, showDate } from '@/lib/expenseDay';
 import {
   expenseDateFor,
+  expenseDetailsVisible,
   planCollapseToOne,
   planEvenly,
   planToggle,
@@ -1565,8 +1566,11 @@ export default function AddExpenseScreen() {
   //
   // A foreign currency still forces it open over a collapse: the rate card lives
   // inside the fold and the expense cannot be saved without a rate.
-  const rateNeeded = currency !== groupCurrency;
-  const showDetails = rateNeeded || (detailsChoice ?? true);
+  const showDetails = expenseDetailsVisible({
+    choice: detailsChoice,
+    currency,
+    groupCurrency,
+  });
 
   // The bottom-bar sub-line. When an equal split lands the same amount on every
   // head, say it in money — "3 people owe ₹200 each" — which is the number

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -1552,11 +1552,21 @@ export default function AddExpenseScreen() {
   const canSave =
     amount > 0n && participants.length > 0 && splitIssue === null && payerProblem === null;
 
-  // A foreign currency must show its rate card (it cannot be saved without one),
-  // and any detail somebody has already set is a decision that must not hide.
-  const detailsNonDefault =
-    currency !== groupCurrency || location !== null || paymentMethod !== 'cash' || categoryChosen;
-  const showDetails = detailsChoice ?? detailsNonDefault;
+  // The fold starts open, and starts open the same way whether this is a new
+  // expense or an edit.
+  //
+  // It used to derive its default from whether anything inside carried a
+  // non-default value — and `categoryChosen` was one of those. Every saved
+  // expense has a category, so that flag is true on essentially every edit and
+  // false on every new one: the fold stood open on the edit form and shut on the
+  // add form, and one screen quietly had two layouts. Worse, it shut in exactly
+  // the case where the rows are most use — a new expense, where the day, the
+  // rail and the currency have not been set by anybody yet.
+  //
+  // A foreign currency still forces it open over a collapse: the rate card lives
+  // inside the fold and the expense cannot be saved without a rate.
+  const rateNeeded = currency !== groupCurrency;
+  const showDetails = rateNeeded || (detailsChoice ?? true);
 
   // The bottom-bar sub-line. When an equal split lands the same amount on every
   // head, say it in money — "3 people owe ₹200 each" — which is the number
@@ -2240,6 +2250,25 @@ export default function AddExpenseScreen() {
               />
               <Divider />
               <PaymentMethodRow value={paymentMethod} onPress={() => setPickingPayment(true)} />
+              <Divider />
+              {/* What it was paid in, as a named row rather than only as the pill
+                  in the header. The pill is still there and still works — but it
+                  is a hairline outline on a gradient beside a large amount, and
+                  "there is no currency selection" is what somebody looking for
+                  one reported. A row spells the field out by name, in the card
+                  where the other two short answers already live, and opens the
+                  same sheet the pill does. */}
+              <SettingRow
+                label={t.captures.currencyLabel}
+                value={`${currencySymbol(currency)} ${currency}`}
+                leading={
+                  // Not `cash-outline`: the rail row directly above wears that
+                  // glyph whenever the answer is cash, which is the default —
+                  // two rows with the same icon read as one repeated question.
+                  <Ionicons name="globe-outline" size={iconSize.md} color={theme.color.textMuted} />
+                }
+                onPress={() => setPickingCurrency(true)}
+              />
             </Card>
 
             {/* Where it happened (A43) — optional, opt-in, never a background track. */}

--- a/apps/mobile/src/lib/expenseForm.ts
+++ b/apps/mobile/src/lib/expenseForm.ts
@@ -65,6 +65,22 @@ export interface PayerPlan {
 const NO_LOCKS: ReadonlySet<MemberId> = new Set<MemberId>();
 
 /**
+ * Whether the optional details fold is visible.
+ *
+ * The form starts open on both add and edit so the two routes do not present two
+ * different layouts for the same expense. A person's explicit toggle is still
+ * honoured — except when a foreign currency is selected, because the FX rate
+ * lives in the fold and the expense cannot be saved without it.
+ */
+export function expenseDetailsVisible(input: {
+  readonly choice: boolean | null;
+  readonly currency: string;
+  readonly groupCurrency: string;
+}): boolean {
+  return input.currency !== input.groupCurrency || (input.choice ?? true);
+}
+
+/**
  * Tapping a member's face.
  *
  * One-payer mode is a radio: the tap replaces whoever was there and hands them

--- a/apps/mobile/test/expenseForm.test.ts
+++ b/apps/mobile/test/expenseForm.test.ts
@@ -13,6 +13,7 @@ import { rebalancePayers, type PayerMap } from '@waves/core';
 
 import {
   expenseDateFor,
+  expenseDetailsVisible,
   planCollapseToOne,
   planEvenly,
   planToggle,
@@ -84,6 +85,31 @@ describe('expenseDateFor', () => {
 
   it('writes a plain UTC day, never a timestamp', () => {
     expect(todayIso(new Date('2026-09-01T22:45:00.000Z'))).toBe('2026-09-01');
+  });
+});
+
+describe('expenseDetailsVisible', () => {
+  it('starts open when nobody has toggled it, so add and edit share one layout', () => {
+    // The bug was deriving the default from saved facts: ordinary edits opened
+    // because a category existed, while a new bill opened shut. Users, riders and
+    // travellers saw two versions of the same form for the same kind of expense.
+    expect(expenseDetailsVisible({ choice: null, currency: 'INR', groupCurrency: 'INR' })).toBe(
+      true,
+    );
+  });
+
+  it('honours an explicit collapse for a same-currency expense', () => {
+    expect(expenseDetailsVisible({ choice: false, currency: 'INR', groupCurrency: 'INR' })).toBe(
+      false,
+    );
+  });
+
+  it('keeps a foreign-currency expense open so the required rate is reachable', () => {
+    // A traveller's hotel bill or a financer reconciling USD in an INR group must
+    // not be allowed to hide the FX rate card behind a collapsed fold.
+    expect(expenseDetailsVisible({ choice: false, currency: 'USD', groupCurrency: 'INR' })).toBe(
+      true,
+    );
   });
 });
 


### PR DESCRIPTION
Three reports off the add-expense form, and the first two share a cause.

### One form, two layouts

`showDetails` derived its default from `detailsNonDefault`, which included `categoryChosen`. Every saved expense has a category, so on an edit that flag is true and the "More details" fold opens; on a new expense it is false and the fold shuts. Same screen, two layouts — and shut in the case where the rows are most use, since a new expense is the one where nobody has set the day, the rail or the currency yet.

Now it starts open on both, with the toggle unchanged. A foreign currency still forces it open over a collapse: the rate card is inside the fold and the expense cannot be saved without a rate.

### "There is no currency selection"

There was — the pill in the gradient header. It is a hairline outline sitting beside the large amount, so it reads as an annotation on the number rather than a control. It stays and still works. A **Currency** row now names the field and opens the same sheet, with `globe-outline` rather than `cash-outline` (the rail row shows that glyph whenever the answer is cash).

### The form now reads in the expense screen's order

The expense screen reads *bill → one labelled card of facts → how the money splits*. The form read *note → day → bill → split*, so the same expense told its story two different ways depending on whether you were reading it or writing it.

| | before | after |
|---|---|---|
| 1 | note | **receipts** (gallery on an edit, scan/add-photo on a new one) |
| 2 | day | note |
| 3 | receipts | **facts card — day · category · paid with · currency** |
| 4 | split | split |
| 5 | who paid | who paid |
| 6 | split with | split with |
| 7 | fold: category, rail, location, FX | fold: **location, FX** |

Receipts go first because the bill is what somebody is holding when they open this screen, and scanning it fills in the amount and the note below — it belongs before the fields it populates.

The four short answers become one card because they are one kind of question, and were spread across three places. What stays folded is what can genuinely be left empty; the category and the rail never could be (both are always set), so the fold had been hiding two answers the form had already given.

No new controls, no behaviour change to saving, and nothing was removed — the header pill, the fold and its toggle are all still there.

Gates: tsc, lint, 1273 tests green. Not device-verified.