### PR TITLE
Sentry's token belongs in the environment, not in .env.local

### DIFF
--- a/docs/play-release.md
+++ b/docs/play-release.md
@@ -80,7 +80,7 @@ already installed against the old one stop hearing about updates for good.
 ```sh
 cd apps/mobile
 npx expo prebuild --clean          # regenerates android/ with every plugin applied
-export SENTRY_AUTH_TOKEN=$(grep '^SENTRY_AUTH_TOKEN=' .env.local | cut -d= -f2-)
+export SENTRY_AUTH_TOKEN=...        # only if it is not already in your environment
 cd android
 ./gradlew bundleRelease            # → app/build/outputs/bundle/release/app-release.aab
 ```
@@ -91,15 +91,21 @@ prebuild, and an `android/` directory generated before a plugin was added simply
 does not have it. That is the whole of the "Sentry native configuration is
 missing" warning.
 
-The `export` is not optional once `SENTRY_ORG` and `SENTRY_PROJECT` are set.
-Those two switch on a source-map upload task in the release build, and that task
-is `sentry-cli`, run by Gradle — which never sees `.env.local`, because loading
-that file is Expo's doing and Gradle is not Expo. Without it the build dies at
+`SENTRY_AUTH_TOKEN` has to be in the _environment_, not only in `.env.local`.
+Once `SENTRY_ORG` and `SENTRY_PROJECT` are set, the release build gains a
+source-map upload task; that task is `sentry-cli`, run by Gradle, and Gradle
+never reads `.env.local` — loading that file is Expo's doing, and Gradle is not
+Expo. Without the token the build compiles everything and _then_ dies at
 `:app:…_SentryUpload_…` with
 
 > error: Auth token is required for this request. Please run `sentry-cli login`
 
-after several minutes of work, having compiled everything first.
+On the machine this is built from it is set once as a user environment variable
+(`setx`, or `[Environment]::SetEnvironmentVariable(..., 'User')`), so a plain
+`./gradlew bundleRelease` in a new terminal works with no preamble. The `export`
+line above is only for a shell that does not already have it — including any
+terminal opened _before_ the variable was set, since a process inherits its
+environment at birth and does not notice later changes.
 
 An AAB cannot be installed on a phone. To test the exact artefact Play will
 serve, use [bundletool](https://github.com/google/bundletool) to build APKs from


### PR DESCRIPTION
Docs only.

Three release builds in a row died at `:app:…_SentryUpload_…` on

```
error: Auth token is required for this request. Please run `sentry-cli login`
```

after compiling everything first. The cause is that the source-map upload is `sentry-cli` run by Gradle, and Gradle does not read `.env.local` — loading that file is Expo's doing, and Gradle is not Expo. The token being present in `apps/mobile/.env.local` looks like it should be enough and is not.

It is now set once as a user environment variable on the build machine, so `./gradlew bundleRelease` works from a fresh terminal with no preamble. `docs/play-release.md` says so, and keeps the `export` line for a shell that lacks it — including any terminal opened *before* the variable was set, since a process inherits its environment at birth and never hears about later changes.

No code change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Play release instructions to require the Sentry authentication token from the process environment.
  * Added guidance for persistent user-level configuration and terminal environment inheritance.
  * Documented the upload failure that occurs when the token is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->