### PR TITLE
The photo sheet, and the account screen that opens it

### DIFF
--- a/apps/mobile/src/app/group/[id]/member/[memberId].tsx
+++ b/apps/mobile/src/app/group/[id]/member/[memberId].tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useLocalSearchParams } from 'expo-router';
-import { ScrollView, TextInput, View } from 'react-native';
+import { ScrollView, View } from 'react-native';
 
-import { currencyExposure, isValidVpa } from '@waves/core';
+import { currencyExposure, format, isValidVpa, money, type CurrencyCode } from '@waves/core';
 import {
   Avatar,
   Badge,
@@ -23,6 +23,9 @@ import {
   useTheme,
 } from '@waves/ui';
 
+import { EditTextSheet } from '@/components/EditTextSheet';
+import { ProfileAvatar } from '@/components/ProfileAvatar';
+import { SettingsSection, type SettingsRow } from '@/components/SettingsSection';
 import { useGroup, useGroupLedger, useSetMemberRole, useUpdateMember } from '@/data/hooks';
 import { friendlyError } from '@/lib/errors';
 import { expenseTitle } from '@/data/expenseTitle';
@@ -57,6 +60,8 @@ export default function MemberScreen() {
   const [name, setName] = useState(member?.ghost_name ?? '');
   const [vpa, setVpa] = useState(member?.vpa ?? '');
   const [status, setStatus] = useState<string | null>(null);
+  /** Which editable row has its sheet open, or null. */
+  const [editing, setEditing] = useState<'name' | 'vpa' | null>(null);
 
   // Seed the editors from the member the moment the query resolves, and again
   // if the row identity changes — synced in render (the app's idiom for
@@ -84,7 +89,6 @@ export default function MemberScreen() {
   // action. Blocking is display-only; it never touches the balance shown here.
   const shownName = displayName(member, profile?.id, blockedIds, t.misc.someone);
   const realName = member.profile?.display_name ?? member.ghost_name ?? t.misc.someone;
-  const vpaValid = vpa.trim() === '' || isValidVpa(vpa.trim());
 
   const confirmBlock = async (): Promise<void> => {
     if (!member.profile_id) return;
@@ -106,6 +110,52 @@ export default function MemberScreen() {
   // pair keeps the amount readable on the tint.
   const heroTint = balance > 0n ? 'mint' : balance < 0n ? 'pink' : 'lilac';
   const heroInk = theme.tint[heroTint].ink;
+
+  /**
+   * Promote, demote, block, unblock — whichever of them apply to this person.
+   *
+   * Built as a list so the section can be omitted entirely when none apply,
+   * rather than drawing a heading over nothing. That is the case for yourself,
+   * and for a ghost seen by a non-admin.
+   */
+  const manageRows: SettingsRow[] = [
+    ...(iAmAdmin && !isMe
+      ? [
+          {
+            icon: (member.role === 'admin' ? 'shield-outline' : 'shield-checkmark-outline') as
+              'shield-outline' | 'shield-checkmark-outline',
+            label: member.role === 'admin' ? t.people.removeAdmin : t.people.makeAdmin,
+            hint: ghost ? t.people.adminNeedsAccount : t.people.adminNote,
+            onPress:
+              ghost || setRole.isPending
+                ? undefined
+                : () =>
+                    setRole.mutate(
+                      {
+                        memberId: member.id,
+                        role: member.role === 'admin' ? 'member' : 'admin',
+                      },
+                      {
+                        onSuccess: () => setStatus(t.account.saved),
+                        onError: (caught) =>
+                          setStatus(friendlyError(caught, t.couldNotSave, 'member.setRole')),
+                      },
+                    ),
+          },
+        ]
+      : []),
+    ...(!isMe && !ghost && member.profile_id
+      ? [
+          {
+            icon: (blocked ? 'eye-outline' : 'ban-outline') as 'eye-outline' | 'ban-outline',
+            label: blocked ? t.blocked.unblock : t.blocked.action,
+            hint: t.blocked.note,
+            destructive: !blocked,
+            onPress: blocked ? () => unblock(member.profile_id!) : () => void confirmBlock(),
+          },
+        ]
+      : []),
+  ];
 
   // Expenses this person is actually part of.
   const involved = expenses.rows.filter((expense) =>
@@ -168,6 +218,20 @@ export default function MemberScreen() {
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
+        {/* Who, how much, and which way round.
+            
+            The amount used to stand alone: a number in a tinted card with no
+            word next to it, so "¥58,039" could as easily have been money owed
+            to this person as money they owe. The colour said which — and colour
+            alone is the one thing a balance must never rely on (ADR-009 and the
+            #191 regression this app already had once). Splitwise puts the
+            direction in words above the figure; bunq labels the hero outright.
+            So does this now, in the same words the Friends tab already uses.
+
+            The portrait is `ProfileAvatar`, so a member who has a photo shows
+            it. `Avatar` drew initials and nothing else, which meant the one
+            screen entirely about a person was the one screen that never showed
+            their face. */}
         <TintCard
           tint={heroTint}
           style={{
@@ -177,7 +241,16 @@ export default function MemberScreen() {
             padding: theme.spacing.xl,
           }}
         >
-          <Avatar name={shownName} ghost={ghost || blocked} size={78} />
+          <ProfileAvatar
+            name={shownName}
+            avatarUrl={ghost || blocked ? null : (member.profile?.avatar_url ?? null)}
+            size={78}
+          />
+          {balance !== 0n ? (
+            <Text variant="caption" style={{ color: heroInk, opacity: 0.85 }}>
+              {balance > 0n ? t.tabs.owesYou : t.tabs.youOweThem}
+            </Text>
+          ) : null}
           <MoneyText
             amount={balance}
             currency={currency}
@@ -187,167 +260,113 @@ export default function MemberScreen() {
             tone="default"
             style={{ color: heroInk }}
           />
-          <Row style={{ gap: theme.spacing.sm }}>
+          {balance === 0n ? (
+            <Text variant="caption" style={{ color: heroInk, opacity: 0.85 }}>
+              {t.tabs.allSquare}
+            </Text>
+          ) : null}
+          <Row style={{ gap: theme.spacing.sm, flexWrap: 'wrap', justifyContent: 'center' }}>
             {ghost ? <Badge label={t.notJoinedYet} /> : null}
             {blocked ? <Badge label={t.blocked.badge} /> : null}
             {member.role === 'admin' ? <Badge label={t.people.admin} tone="brand" /> : null}
             {isMe ? <Badge label={t.people.you} tone="positive" /> : null}
           </Row>
           {balance !== 0n && !isMe ? (
-            <Button label={t.settleUp} onPress={() => router.push(`/group/${groupId}/settle`)} />
+            // Full width, and the only filled button on the screen. It was a
+            // content-width pill sitting against the leading edge of a centred
+            // card, which read as an afterthought rather than as the thing this
+            // screen is for.
+            <Button
+              label={t.settleUp}
+              fullWidth
+              onPress={() => router.push(`/group/${groupId}/settle`)}
+            />
           ) : null}
         </TintCard>
 
-        {paidExposure.length > 0 ? (
-          <Card style={{ gap: theme.spacing.sm }}>
-            <Text variant="caption" tone="muted">
-              {t.people.paidAcross}
-            </Text>
-            <View
-              style={{
-                flexDirection: 'row',
-                flexWrap: 'wrap',
-                alignItems: 'center',
-                gap: theme.spacing.md,
-              }}
-            >
-              {paidExposure.map((entry) => (
-                <MoneyText
-                  key={entry.currency}
-                  amount={entry.amountMinor}
-                  currency={entry.currency}
-                  locale={locale}
-                  variant="subheading"
-                  mode="plain"
-                />
-              ))}
-            </View>
-          </Card>
-        ) : null}
-
-        {ghost ? (
-          <Card style={{ gap: theme.spacing.md }}>
-            <Text variant="caption" tone="muted">
-              {t.common.name}
-            </Text>
-            <Row>
-              <TextInput
-                value={name}
-                onChangeText={setName}
-                accessibilityLabel={t.people.memberName}
-                placeholderTextColor={theme.color.textFaint}
-                style={{
-                  flex: 1,
-                  fontSize: 18,
-                  fontWeight: '600',
-                  color: theme.color.text,
-                  paddingVertical: theme.spacing.sm,
-                }}
-              />
-              <Button
-                label={t.common.save}
-                size="sm"
-                variant="secondary"
-                disabled={!name.trim() || name.trim() === member.ghost_name}
-                onPress={() => save({ ghost_name: name.trim() })}
-              />
-            </Row>
-            <Text variant="micro" tone="muted">
-              {t.people.ghostNote}
-            </Text>
-          </Card>
-        ) : null}
-
-        {isMe ? (
-          <Card style={{ gap: theme.spacing.md }}>
-            <Text variant="caption" tone="muted">
-              {t.people.upiForGroup}
-            </Text>
-            <Row>
-              <TextInput
-                value={vpa}
-                onChangeText={setVpa}
-                autoCapitalize="none"
-                accessibilityLabel={t.people.upiForGroup}
-                placeholder={profile?.default_vpa ?? 'you@bank'}
-                placeholderTextColor={theme.color.textFaint}
-                style={{
-                  flex: 1,
-                  fontSize: 18,
-                  fontWeight: '600',
-                  color: vpaValid ? theme.color.text : theme.color.negative,
-                  paddingVertical: theme.spacing.sm,
-                }}
-              />
-              <Button
-                label={t.common.save}
-                size="sm"
-                variant="secondary"
-                disabled={!vpaValid || vpa.trim() === (member.vpa ?? '')}
-                onPress={() => save({ vpa: vpa.trim() === '' ? null : vpa.trim() })}
-              />
-            </Row>
-            <Text variant="micro" tone="muted">
-              {t.people.upiForGroupNote}
-            </Text>
-          </Card>
-        ) : null}
-
-        {/* An admin can make another member an admin, or take it back — for
-            anyone but themselves. A ghost still shows the card, but disabled
-            with the reason: no account means nothing to act as an admin with,
-            which the server enforces (GHOST_CANNOT_ADMIN). Showing it greyed
-            beats hiding it, so the capability is discoverable rather than a
-            secret. The server refuses demoting the last admin — the button
-            offers it, the RPC is what actually keeps the rule. */}
-        {iAmAdmin && !isMe ? (
-          <Card style={{ gap: theme.spacing.sm }}>
-            <Text variant="caption" tone="muted">
-              {t.people.role}
-            </Text>
-            <Button
-              label={member.role === 'admin' ? t.people.removeAdmin : t.people.makeAdmin}
-              variant="secondary"
-              disabled={ghost || setRole.isPending}
-              onPress={() =>
-                setRole.mutate(
+        {/* What this person has actually put in, as rows rather than a card per
+            figure. Two facts read down a column in the time it takes to read
+            one sentence, which is the bunq and Wanderlog shape. Paid stays
+            per-currency and unsummed (ADR-004): a trip that touched yen and
+            dollars has no single true total. */}
+        <SettingsSection
+          title={t.people.inThisGroup}
+          rows={[
+            ...(paidExposure.length > 0
+              ? [
                   {
-                    memberId: member.id,
-                    role: member.role === 'admin' ? 'member' : 'admin',
+                    icon: 'card-outline' as const,
+                    label: t.people.paidAcross,
+                    value: paidExposure
+                      .map((entry) =>
+                        format(money(entry.amountMinor, entry.currency as CurrencyCode), {
+                          locale,
+                          compactFraction: true,
+                        }),
+                      )
+                      .join(' · '),
                   },
-                  {
-                    onSuccess: () => setStatus(t.account.saved),
-                    onError: (caught) =>
-                      setStatus(friendlyError(caught, t.couldNotSave, 'member.setRole')),
-                  },
-                )
-              }
-            />
-            <Text variant="micro" tone="muted">
-              {ghost ? t.people.adminNeedsAccount : t.people.adminNote}
-            </Text>
-          </Card>
+                ]
+              : []),
+            {
+              icon: 'receipt-outline' as const,
+              label: t.people.expensesLabel,
+              value: String(involved.length),
+            },
+          ]}
+        />
+
+        {/* The two editable facts, as rows that open a sheet — the same pattern
+            the account screen uses, so a field is one line until somebody wants
+            to change it. A ghost's name is editable by anyone in the group; the
+            UPI override is yours alone. */}
+        {ghost || isMe ? (
+          <SettingsSection
+            rows={[
+              ...(ghost
+                ? [
+                    {
+                      icon: 'person-outline' as const,
+                      label: t.people.memberName,
+                      hint: t.people.ghostNote,
+                      value: name.trim() || t.misc.someone,
+                      valueMuted: !name.trim(),
+                      onPress: () => setEditing('name'),
+                    },
+                  ]
+                : []),
+              ...(isMe
+                ? [
+                    {
+                      icon: 'wallet-outline' as const,
+                      label: t.people.upiForGroup,
+                      hint: t.people.upiForGroupNote,
+                      value: vpa.trim() || (profile?.default_vpa ?? 'you@bank'),
+                      valueMuted: !vpa.trim(),
+                      onPress: () => setEditing('vpa'),
+                    },
+                  ]
+                : []),
+            ]}
+          />
         ) : null}
 
-        {/* Block or unblock this person. Only offered for a real account that is
-            not you: a ghost has no cross-group identity to block, and blocking
-            yourself is meaningless. It only changes how they are shown — the
-            balance above is untouched — so it lives here as a quiet control
-            rather than a destructive headline. */}
-        {!isMe && !ghost && member.profile_id ? (
-          <Card style={{ gap: theme.spacing.sm }}>
-            <Text variant="caption" tone="muted">
-              {t.blocked.title}
-            </Text>
-            <Button
-              label={blocked ? t.blocked.unblock : t.blocked.action}
-              variant={blocked ? 'secondary' : 'ghostDanger'}
-              onPress={blocked ? () => unblock(member.profile_id!) : () => void confirmBlock()}
-            />
-            <Text variant="micro" tone="muted">
-              {t.blocked.note}
-            </Text>
-          </Card>
+        {/* Managing this person: one section of rows rather than a card each.
+            
+            These were two cards, each a caption over a button over a note, at
+            two different weights — a soft lavender "Make admin" and a red
+            "Block" — for two things that are both just controls. GoPay files
+            exactly this under one "More action" heading of icon rows, and the
+            note each one carried becomes the row's second line, which is where
+            a sentence explaining a control belongs.
+
+            An admin can promote or demote anyone but themselves. A ghost shows
+            the row disabled with the reason rather than hiding it, so the
+            capability stays discoverable — the server enforces the rule either
+            way (GHOST_CANNOT_ADMIN, and the last admin cannot be demoted).
+            Blocking is display-only and never touches the balance above. */}
+        {manageRows.length > 0 ? (
+          <SettingsSection title={t.people.manageTitle} rows={manageRows} />
         ) : null}
 
         {status ? (
@@ -402,6 +421,44 @@ export default function MemberScreen() {
           </Card>
         </View>
       </ScrollView>
+
+      {/* The editors, over the list rather than inside it — see the account
+          screen for why a row beats a field with a Save button beside it. */}
+      <EditTextSheet
+        visible={editing === 'name'}
+        title={t.people.memberName}
+        hint={t.people.ghostNote}
+        value={name}
+        saving={updateMember.isPending}
+        onSave={(next) => {
+          setName(next);
+          save({ ghost_name: next });
+          setEditing(null);
+        }}
+        onClose={() => setEditing(null)}
+      />
+      <EditTextSheet
+        visible={editing === 'vpa'}
+        title={t.people.upiForGroup}
+        hint={t.people.upiForGroupNote}
+        value={vpa}
+        placeholder={profile?.default_vpa ?? 'you@bank'}
+        autoCapitalize="none"
+        saving={updateMember.isPending}
+        onSave={(next) => {
+          // An empty field clears the override rather than storing a blank —
+          // and an unparseable handle is refused here, since the sheet is the
+          // only door and the ledger should never hold one.
+          if (next.trim() !== '' && !isValidVpa(next.trim())) {
+            setStatus(t.people.upiInvalid);
+            return;
+          }
+          setVpa(next);
+          save({ vpa: next.trim() === '' ? null : next.trim() });
+          setEditing(null);
+        }}
+        onClose={() => setEditing(null)}
+      />
     </Screen>
   );
 }

--- a/apps/mobile/src/app/profile.tsx
+++ b/apps/mobile/src/app/profile.tsx
@@ -30,7 +30,7 @@ import { isRtlLanguage, LANGUAGE_NAMES, plural, useStrings } from '@/i18n';
 import { useLanguage } from '@/i18n/language';
 import { useAuth } from '@/lib/auth';
 import { useDialog } from '@/lib/dialog';
-import { pickAvatarPhoto } from '@/lib/image';
+import { pickAvatarPhoto, type PhotoSource } from '@/lib/image';
 import { router } from '@/lib/navigation';
 import { r2Enabled } from '@/lib/storage';
 import { describeGrace, useLock } from '@/lib/lock';
@@ -273,9 +273,9 @@ function ProfileForm() {
    * writes `avatar_url` itself; this repeats it through `updateProfile` so the
    * copy held in context matches without a round trip.
    */
-  const choosePhoto = async (): Promise<void> => {
+  const choosePhoto = async (source: PhotoSource = 'library'): Promise<void> => {
     if (!profile) return;
-    const picked = await pickAvatarPhoto();
+    const picked = await pickAvatarPhoto(source);
     if (!picked) return;
 
     setStatus(null);
@@ -307,10 +307,28 @@ function ProfileForm() {
     }
   };
 
-  // Three ways forward, so a sheet rather than a dialog — the shape Nextdoor
-  // and Instacart use for a short list of actions, and the one a thumb can
-  // reach. There is nothing to choose between when no photo is set yet, so that
-  // case skips the question entirely and opens the picker.
+  /**
+   * The photo sheet: where it comes from, and how to take it away.
+   *
+   * It used to ask one vague question — "Choose a new one" — and draw the three
+   * rows at three different weights: a filled pill, a line of red text and a
+   * line of brand text, for three things that are all just choices. Against the
+   * sheets this pattern has settled into elsewhere (Linktree, Flighty, Yubo,
+   * Beli), two things were missing and one was wrong.
+   *
+   * Missing, first: the camera and the library are separate choices everywhere
+   * it is done well, because a profile photo is usually taken there and then,
+   * and "choose a new one" makes somebody open a picker to find out it was not
+   * the door they wanted. Missing, second: a glyph per row, which is what lets
+   * three short rows be told apart without reading all three.
+   *
+   * Wrong: the weights. These are peers. The dialog draws them as peers now,
+   * with the one that takes something away in red — its own glyph included, so
+   * it does not look like the other two until the words are read.
+   *
+   * Still no question when there is no photo yet: there is nothing to remove
+   * and nothing to replace, so a first tap opens the library directly.
+   */
   const photoOptions = async (): Promise<void> => {
     if (!profile?.avatar_url) {
       void choosePhoto();
@@ -319,11 +337,18 @@ function ProfileForm() {
     const picked = await choose({
       title: t.account.yourPhoto,
       options: [
-        { id: 'replace', label: t.account.chooseNewPhoto },
-        { id: 'remove', label: t.common.remove, tone: 'danger' },
+        { id: 'camera', label: t.account.takeNewPhoto, icon: 'camera-outline' },
+        { id: 'library', label: t.account.chooseFromLibrary, icon: 'images-outline' },
+        {
+          id: 'remove',
+          label: t.account.removePhoto,
+          icon: 'trash-outline',
+          tone: 'danger',
+        },
       ],
     });
-    if (picked === 'replace') void choosePhoto();
+    if (picked === 'camera') void choosePhoto('camera');
+    else if (picked === 'library') void choosePhoto('library');
     else if (picked === 'remove') void clearPhoto();
   };
 

--- a/apps/mobile/src/app/profile.tsx
+++ b/apps/mobile/src/app/profile.tsx
@@ -5,32 +5,27 @@ import { ScrollView, View } from 'react-native';
 import {
   Badge,
   Button,
-  Card,
   directionalIcon,
   EmptyState,
   IconButton,
   iconSize,
-  ListRow,
   MoneyText,
   Row,
   Screen,
-  SectionHeader,
   Text,
   useTabBarClearance,
   useTheme,
 } from '@waves/ui';
 
 import { ProfileAvatar } from '@/components/ProfileAvatar';
+import { SettingsSection } from '@/components/SettingsSection';
 import { SignOutSheet } from '@/components/SignOutSheet';
-import { friendlyError } from '@/lib/errors';
 import { SkeletonList } from '@/components/Skeletons';
-import { removeAvatar, uploadAvatar } from '@/data/api';
 import { useSettledTotals } from '@/data/hooks';
 import { isRtlLanguage, LANGUAGE_NAMES, plural, useStrings } from '@/i18n';
 import { useLanguage } from '@/i18n/language';
 import { useAuth } from '@/lib/auth';
-import { useDialog } from '@/lib/dialog';
-import { pickAvatarPhoto, type PhotoSource } from '@/lib/image';
+import { useAvatarEditor } from '@/lib/avatarEditor';
 import { router } from '@/lib/navigation';
 import { r2Enabled } from '@/lib/storage';
 import { describeGrace, useLock } from '@/lib/lock';
@@ -63,82 +58,6 @@ import { useThemePreference } from '@/lib/theme';
  * the same delete ended up a quiet list row on one screen and a red card on
  * this one.
  */
-interface SettingsRow {
-  icon: keyof typeof Ionicons.glyphMap;
-  label: string;
-  hint?: string;
-  route?: string;
-  onPress?: () => void;
-  /** Ends something. Red title, red icon. */
-  destructive?: boolean;
-}
-
-function SettingsSection({ title, rows }: { title?: string; rows: SettingsRow[] }) {
-  const theme = useTheme();
-  return (
-    <View>
-      {title ? <SectionHeader title={title} /> : null}
-      <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
-        {rows.map((item, index) => {
-          const live = Boolean(item.route ?? item.onPress);
-          return (
-            <View key={item.label}>
-              <ListRow
-                title={item.label}
-                subtitle={item.hint}
-                destructive={item.destructive}
-                onPress={
-                  item.onPress ?? (item.route ? () => router.push(item.route as never) : undefined)
-                }
-                leading={
-                  <View
-                    style={{
-                      width: 40,
-                      height: 40,
-                      borderRadius: theme.radius.pill,
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      backgroundColor: item.destructive
-                        ? theme.color.negativeSoft
-                        : live
-                          ? theme.color.brandSoft
-                          : theme.color.surfaceMuted,
-                    }}
-                  >
-                    <Ionicons
-                      name={item.icon}
-                      size={iconSize.md}
-                      color={
-                        item.destructive
-                          ? theme.color.negative
-                          : live
-                            ? theme.color.brand
-                            : theme.color.textMuted
-                      }
-                    />
-                  </View>
-                }
-                trailing={
-                  item.route ? (
-                    <Ionicons
-                      name={directionalIcon('chevron-forward')}
-                      size={iconSize.md}
-                      color={theme.color.textFaint}
-                    />
-                  ) : null
-                }
-              />
-              {index < rows.length - 1 ? (
-                <View style={{ height: 1, backgroundColor: theme.color.border }} />
-              ) : null}
-            </View>
-          );
-        })}
-      </Card>
-    </View>
-  );
-}
-
 /**
  * What has actually changed hands through you.
  *
@@ -239,8 +158,7 @@ function ProfileForm() {
   const theme = useTheme();
   const clearance = useTabBarClearance();
   const { t, locale } = useStrings();
-  const { session, profile, isGuest, updateProfile, signOut } = useAuth();
-  const { choose } = useDialog();
+  const { session, profile, isGuest, signOut } = useAuth();
   // A Google/Apple sign-in carries a photo in the session's user metadata, but
   // the profile row only holds one if a trigger copied it across — older
   // accounts have a null `avatar_url` and so showed initials here. Fall back to
@@ -264,8 +182,9 @@ function ProfileForm() {
   const { preference: themePreference, overridden: themeOverridden } = useThemePreference();
   const { language, stored: languageChosen, restartNeeded } = useLanguage();
 
-  const [status, setStatus] = useState<string | null>(null);
-  const [photoBusy, setPhotoBusy] = useState(false);
+  // The portrait, its sheet and its spinner are one behaviour shared with the
+  // account screen — see `lib/avatarEditor`.
+  const photo = useAvatarEditor();
   const [signingOut, setSigningOut] = useState(false);
 
   /**
@@ -273,85 +192,6 @@ function ProfileForm() {
    * writes `avatar_url` itself; this repeats it through `updateProfile` so the
    * copy held in context matches without a round trip.
    */
-  const choosePhoto = async (source: PhotoSource = 'library'): Promise<void> => {
-    if (!profile) return;
-    const picked = await pickAvatarPhoto(source);
-    if (!picked) return;
-
-    setStatus(null);
-    setPhotoBusy(true);
-    try {
-      const path = await uploadAvatar({
-        profileId: profile.id,
-        base64: picked.base64,
-        mimeType: picked.mimeType,
-      });
-      await updateProfile({ avatar_url: path });
-    } catch (caught) {
-      setStatus(friendlyError(caught, t.couldNotSave, 'profile.uploadPhoto'));
-    } finally {
-      setPhotoBusy(false);
-    }
-  };
-
-  const clearPhoto = async (): Promise<void> => {
-    if (!profile) return;
-    setPhotoBusy(true);
-    try {
-      await removeAvatar(profile.id, profile.avatar_url);
-      await updateProfile({ avatar_url: null });
-    } catch (caught) {
-      setStatus(friendlyError(caught, t.couldNotSave, 'profile.removePhoto'));
-    } finally {
-      setPhotoBusy(false);
-    }
-  };
-
-  /**
-   * The photo sheet: where it comes from, and how to take it away.
-   *
-   * It used to ask one vague question — "Choose a new one" — and draw the three
-   * rows at three different weights: a filled pill, a line of red text and a
-   * line of brand text, for three things that are all just choices. Against the
-   * sheets this pattern has settled into elsewhere (Linktree, Flighty, Yubo,
-   * Beli), two things were missing and one was wrong.
-   *
-   * Missing, first: the camera and the library are separate choices everywhere
-   * it is done well, because a profile photo is usually taken there and then,
-   * and "choose a new one" makes somebody open a picker to find out it was not
-   * the door they wanted. Missing, second: a glyph per row, which is what lets
-   * three short rows be told apart without reading all three.
-   *
-   * Wrong: the weights. These are peers. The dialog draws them as peers now,
-   * with the one that takes something away in red — its own glyph included, so
-   * it does not look like the other two until the words are read.
-   *
-   * Still no question when there is no photo yet: there is nothing to remove
-   * and nothing to replace, so a first tap opens the library directly.
-   */
-  const photoOptions = async (): Promise<void> => {
-    if (!profile?.avatar_url) {
-      void choosePhoto();
-      return;
-    }
-    const picked = await choose({
-      title: t.account.yourPhoto,
-      options: [
-        { id: 'camera', label: t.account.takeNewPhoto, icon: 'camera-outline' },
-        { id: 'library', label: t.account.chooseFromLibrary, icon: 'images-outline' },
-        {
-          id: 'remove',
-          label: t.account.removePhoto,
-          icon: 'trash-outline',
-          tone: 'danger',
-        },
-      ],
-    });
-    if (picked === 'camera') void choosePhoto('camera');
-    else if (picked === 'library') void choosePhoto('library');
-    else if (picked === 'remove') void clearPhoto();
-  };
-
   /**
    * The row says the language in its own script. It is the one settings row
    * whose subtitle has to be legible to somebody who cannot read the rest of
@@ -436,8 +276,8 @@ function ProfileForm() {
             name={profile?.display_name ?? t.account.you}
             avatarUrl={profile?.avatar_url || oauthAvatar}
             size={92}
-            onPress={profile ? () => void photoOptions() : undefined}
-            busy={photoBusy}
+            onPress={profile ? photo.open : undefined}
+            busy={photo.busy}
           />
           <View style={{ alignItems: 'center', gap: theme.spacing.sm }}>
             <Row style={{ gap: theme.spacing.sm }}>
@@ -451,9 +291,9 @@ function ProfileForm() {
             </Row>
             <SettledPill profileId={profile?.id ?? null} locale={locale} />
             {/* Photo errors have nowhere else to land now the form is gone. */}
-            {status ? (
+            {photo.status ? (
               <Text variant="caption" tone="negative">
-                {status}
+                {photo.status}
               </Text>
             ) : null}
           </View>

--- a/apps/mobile/src/app/settings/account.tsx
+++ b/apps/mobile/src/app/settings/account.tsx
@@ -29,11 +29,20 @@ import {
   useTheme,
 } from '@waves/ui';
 
-import { currencyForCountry, currencySymbol, dialingCodeForCountry } from '@waves/core';
+import {
+  countryFlag,
+  countryName,
+  currencyForCountry,
+  currencySymbol,
+  dialingCodeForCountry,
+} from '@waves/core';
 
 import { CountryCodePicker } from '@/components/CountryCodePicker';
-import { CountryRow } from '@/components/CountryPicker';
+import { EditTextSheet } from '@/components/EditTextSheet';
 import { ProfileAvatar } from '@/components/ProfileAvatar';
+import { SettingsSection } from '@/components/SettingsSection';
+import { useAvatarEditor } from '@/lib/avatarEditor';
+import { requestCountry } from '@/lib/countryPickerBridge';
 import { friendlyError } from '@/lib/errors';
 import { confirmContact, startAddingContact, ContactChannel } from '@/data/api';
 import { deviceCountry, useStrings } from '@/i18n';
@@ -91,6 +100,11 @@ function AccountForm() {
   // profile; the key on this screen's owner keeps it honest across a swap.
   const [name, setName] = useState(profile?.display_name ?? '');
   const [nameStatus, setNameStatus] = useState<string | null>(null);
+  /** Which row's editor is open, or null. */
+  const [editing, setEditing] = useState<'name' | 'address' | null>(null);
+  const [rowSaving, setRowSaving] = useState(false);
+  // The portrait's sheet, shared with Settings so the two cannot drift.
+  const photo = useAvatarEditor();
 
   // Region: the country decides the default currency (and settle rails) and,
   // optionally, a postal address. Seeded from the profile, falling back to the
@@ -103,6 +117,12 @@ function AccountForm() {
   const [addressStatus, setAddressStatus] = useState<string | null>(null);
   // The country drives this: it is what every new group and expense starts on.
   const currency = currencyForCountry(country) ?? profile?.default_currency ?? 'INR';
+  // The list has one place to say something went wrong, so the three writes
+  // behind it share one line rather than each owning a slot in a layout that no
+  // longer has slots.
+  const rowStatus = [nameStatus, regionStatus, addressStatus].find(
+    (line) => line && line !== t.account.saved,
+  );
 
   const [channel, setChannel] = useState<ContactChannel>(ContactChannel.Email);
   const [value, setValue] = useState('');
@@ -170,16 +190,21 @@ function AccountForm() {
     }
   };
 
-  const nameDirty = name.trim() !== (profile?.display_name ?? '');
-
-  const saveName = async (): Promise<void> => {
+  const saveName = async (next: string): Promise<void> => {
     setNameStatus(null);
+    setRowSaving(true);
     try {
       // Only the name. The empty name falls back to "You" so nobody is nameless.
-      await updateProfile({ display_name: name.trim() || t.account.you });
+      await updateProfile({ display_name: next.trim() || t.account.you });
+      setName(next.trim());
       setNameStatus(t.account.saved);
+      // Closed only once the write landed: a sheet that shuts on tap and fails
+      // behind the person's back is how a name silently does not change.
+      setEditing(null);
     } catch (caught) {
       setNameStatus(friendlyError(caught, t.couldNotSave, 'account.saveName'));
+    } finally {
+      setRowSaving(false);
     }
   };
 
@@ -209,15 +234,19 @@ function AccountForm() {
     }
   };
 
-  const addressDirty = address.trim() !== (profile?.address ?? '');
-  const saveAddress = async (): Promise<void> => {
+  const saveAddress = async (next: string): Promise<void> => {
     setAddressStatus(null);
+    setRowSaving(true);
     try {
       // Empty clears it to null rather than storing a blank string.
-      await updateProfile({ address: address.trim() || null });
+      await updateProfile({ address: next.trim() || null });
+      setAddress(next.trim());
       setAddressStatus(t.account.saved);
+      setEditing(null);
     } catch (caught) {
       setAddressStatus(friendlyError(caught, t.couldNotSave, 'account.saveAddress'));
+    } finally {
+      setRowSaving(false);
     }
   };
 
@@ -301,13 +330,14 @@ function AccountForm() {
         }}
         keyboardShouldPersistTaps="handled"
       >
-        {/* A calm identity header: the avatar and name give the screen a focal
-            point that names whose account this is (Mobbin — Slopes, Tesla, Me+,
-            Vivino: a centred portrait over the name and contact). It is a
-            portrait, not a control — the name is edited in the field just below,
-            and the photo owner is (tabs)/profile, so there is no camera badge
-            here. `ProfileAvatar` shows the uploaded photo, or the provider
-            photo, and falls back to initials only when there is neither. */}
+        {/* Who this account is, and the one control the header carries.
+            
+            The portrait is tappable now. Every edit-profile screen worth
+            copying makes it so — Beli, Lyft, BeReal, Binance, Instagram,
+            Shopee all put a camera badge on the avatar right here — and the
+            reason is simply that this is where somebody looks for it. It opens
+            the same sheet the Settings portrait does (`useAvatarEditor`), so
+            there is one behaviour and not two that drift. */}
         <View
           style={{
             alignItems: 'center',
@@ -315,7 +345,13 @@ function AccountForm() {
             paddingTop: theme.spacing.sm,
           }}
         >
-          <ProfileAvatar name={displayName} avatarUrl={avatarUrl} size={96} />
+          <ProfileAvatar
+            name={displayName}
+            avatarUrl={avatarUrl}
+            size={96}
+            onPress={photo.open}
+            busy={photo.busy}
+          />
           <View style={{ alignItems: 'center', gap: theme.spacing.xs }}>
             <Row style={{ gap: theme.spacing.sm }}>
               <Text variant="title">{displayName}</Text>
@@ -330,104 +366,82 @@ function AccountForm() {
                 {accountContact}
               </Text>
             ) : null}
+            {photo.status ? (
+              <Text variant="caption" tone="negative">
+                {photo.status}
+              </Text>
+            ) : null}
           </View>
         </View>
 
-        {/* Your name, and how you appear to everyone else. Folded in from the
-            old "You" screen so the whole account lives on one page. Save appears
-            only once the name has changed, so the resting screen is calm. */}
-        <View style={{ gap: theme.spacing.md }}>
-          <GroupLabel icon="person-outline" title={t.account.displayName} />
-          <Card style={{ gap: theme.spacing.lg }}>
-            <TextInput
-              value={name}
-              onChangeText={setName}
-              accessibilityLabel={t.account.displayName}
-              placeholder={t.common.yourName}
-              placeholderTextColor={theme.color.textFaint}
-              style={fieldStyle}
-            />
-            {nameDirty ? (
-              <Button label={t.common.save} fullWidth onPress={() => void saveName()} />
-            ) : null}
-            {nameStatus ? (
-              <Text
-                variant="caption"
-                tone={nameStatus === t.account.saved ? 'positive' : 'negative'}
-              >
-                {nameStatus}
-              </Text>
-            ) : null}
-          </Card>
-        </View>
+        {/* What you have set, as a list you can read rather than a stack of
+            forms you have to scroll.
 
-        {/* Where you are: the country sets the currency every new group and
-            expense starts on, and the settle rails you are offered. Required —
-            an address may follow, but it never has to. */}
-        <View style={{ gap: theme.spacing.md }}>
-          <GroupLabel icon="location-outline" title={t.account.regionTitle} />
-          <Card style={{ gap: theme.spacing.lg }}>
-            <CountryRow countryCode={country} onChange={(next) => void saveCountry(next)} />
+            This was four cards, each holding one text field and a Save button
+            that appeared when it was dirty, under a label of its own — so the
+            page was mostly the space between things, and you could not see what
+            your details *were* without reading four inputs. Every edit-profile
+            screen on the reference boards is a dense list of label-and-value
+            rows instead, and the value is the point: "Name · Madan" answers the
+            question the screen is open for, at a glance.
 
-            {country ? (
-              <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
-                <View>
-                  <Text variant="caption" tone="muted">
-                    {t.account.currencyLabel}
-                  </Text>
-                  <Text variant="caption" tone="muted">
-                    {t.account.currencyFromCountry}
-                  </Text>
-                </View>
-                <Text variant="subheading">{`${currencySymbol(currency)} ${currency}`}</Text>
-              </Row>
-            ) : (
-              <Text variant="caption" tone="negative">
-                {t.account.countryRequired}
-              </Text>
-            )}
+            The rows are the same component Settings uses (`SettingsSection`),
+            which is the other half of the ask — two lists one tap apart should
+            not be two designs. Each one opens a focused editor: a sheet for the
+            free text, the existing picker for the country.
 
-            {regionStatus ? (
-              <Text
-                variant="caption"
-                tone={regionStatus === t.account.saved ? 'positive' : 'negative'}
-              >
-                {regionStatus}
-              </Text>
-            ) : null}
+            Currency is the exception and has no press: it is derived from the
+            country above it and is shown because people look for it, not
+            because it can be set. */}
+        <SettingsSection
+          title={t.account.detailsTitle}
+          rows={[
+            {
+              icon: 'person-outline',
+              label: t.account.displayName,
+              value: name.trim() || t.common.yourName,
+              valueMuted: !name.trim(),
+              onPress: () => setEditing('name'),
+            },
+            {
+              icon: 'location-outline',
+              label: t.pickers.country,
+              value: country
+                ? `${countryFlag(country) ?? ''} ${countryName(country) ?? country}`.trim()
+                : t.account.countryRequired,
+              valueMuted: !country,
+              onPress: () => {
+                requestCountry({
+                  initial: country,
+                  onPicked: (next: string | null) => void saveCountry(next),
+                });
+                router.push('/country');
+              },
+            },
+            {
+              icon: 'cash-outline',
+              label: t.account.currencyLabel,
+              hint: t.account.currencyFromCountry,
+              value: `${currencySymbol(currency)} ${currency}`,
+            },
+            {
+              icon: 'home-outline',
+              label: t.account.addressTitle,
+              value: address.trim() || t.account.addressOptional,
+              valueMuted: !address.trim(),
+              onPress: () => setEditing('address'),
+            },
+          ]}
+        />
 
-            <View style={{ gap: theme.spacing.xs }}>
-              <Row style={{ gap: theme.spacing.xs, alignItems: 'center' }}>
-                <Text variant="caption" tone="muted">
-                  {t.account.addressTitle}
-                </Text>
-                <Text variant="caption" tone="faint">
-                  {`· ${t.account.addressOptional}`}
-                </Text>
-              </Row>
-              <TextInput
-                value={address}
-                onChangeText={setAddress}
-                multiline
-                accessibilityLabel={t.account.addressTitle}
-                placeholder={t.account.addressPlaceholder}
-                placeholderTextColor={theme.color.textFaint}
-                style={[fieldStyle, { minHeight: 72, textAlignVertical: 'top' }]}
-              />
-              {addressDirty ? (
-                <Button label={t.common.save} fullWidth onPress={() => void saveAddress()} />
-              ) : null}
-              {addressStatus ? (
-                <Text
-                  variant="caption"
-                  tone={addressStatus === t.account.saved ? 'positive' : 'negative'}
-                >
-                  {addressStatus}
-                </Text>
-              ) : null}
-            </View>
-          </Card>
-        </View>
+        {/* One line of bad news for the rows above, which have no room for their
+            own. Silent when a save worked: the row already shows the new value,
+            and a "Saved" that has to be dismissed is a second thing to read. */}
+        {rowStatus ? (
+          <Text variant="caption" tone="negative">
+            {rowStatus}
+          </Text>
+        ) : null}
 
         {/* The signed-in reassurance is gone: for a member it said nothing they
             did not already know. A guest, or somebody sent here by a limit, gets
@@ -624,6 +638,32 @@ function AccountForm() {
           {t.contact.footnote}
         </Text>
       </ScrollView>
+
+      {/* The editors, over the list. Outside the ScrollView so a sheet is
+          anchored to the screen rather than to a scroll position, and so the
+          keyboard it raises does not push the list it came from. */}
+      <EditTextSheet
+        visible={editing === 'name'}
+        title={t.account.displayName}
+        hint={t.account.displayNameHint}
+        value={name}
+        placeholder={t.common.yourName}
+        saving={rowSaving}
+        onSave={(next) => void saveName(next)}
+        onClose={() => setEditing(null)}
+      />
+      <EditTextSheet
+        visible={editing === 'address'}
+        title={t.account.addressTitle}
+        hint={t.account.addressHint}
+        value={address}
+        placeholder={t.account.addressPlaceholder}
+        multiline
+        autoCapitalize="sentences"
+        saving={rowSaving}
+        onSave={(next) => void saveAddress(next)}
+        onClose={() => setEditing(null)}
+      />
     </Screen>
   );
 }

--- a/apps/mobile/src/components/AppDialog.tsx
+++ b/apps/mobile/src/components/AppDialog.tsx
@@ -271,6 +271,19 @@ function DialogContent({
             key={action.id}
             label={action.label}
             variant={variantFor(action)}
+            icon={
+              action.icon ? (
+                <Ionicons
+                  name={action.icon as keyof typeof Ionicons.glyphMap}
+                  size={iconSize.md}
+                  // The glyph belongs to its row, so it takes the row's colour:
+                  // red on the one that takes something away, brand on a peer.
+                  // A single neutral grey across all three would make the
+                  // destructive row look like the others until you read it.
+                  color={action.tone === 'dangerQuiet' ? theme.color.negative : theme.color.brand}
+                />
+              ) : undefined
+            }
             fullWidth
             onPress={() => onChoose(action.id)}
           />

--- a/apps/mobile/src/components/EditTextSheet.tsx
+++ b/apps/mobile/src/components/EditTextSheet.tsx
@@ -1,0 +1,146 @@
+/**
+ * Change one field, in a sheet over the list it came from.
+ *
+ * The account screen reads as a list of what you have set, which only works if
+ * the list is short — and a list is short when each row is one line rather than
+ * a card wrapped around a text input. So the input lives here instead: tap the
+ * row, type, save, and the row shows the new value.
+ *
+ * It keeps its own draft. Editing straight into the caller's state means a
+ * cancelled edit has already been applied to everything watching it, and the
+ * caller has to remember what the value was to put it back. The draft is seeded
+ * each time the sheet opens, so re-opening after a cancel shows the saved value
+ * and not the abandoned one.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { Platform, TextInput, View } from 'react-native';
+
+import { Button, Row, Sheet, Text, useTheme } from '@waves/ui';
+
+import { useStrings } from '@/i18n';
+
+export function EditTextSheet({
+  visible,
+  title,
+  hint,
+  value,
+  placeholder,
+  multiline = false,
+  autoCapitalize = 'words',
+  saving = false,
+  onSave,
+  onClose,
+}: {
+  visible: boolean;
+  title: string;
+  /** One line under the title: what this is for, when that is not obvious. */
+  hint?: string;
+  value: string;
+  placeholder?: string;
+  multiline?: boolean;
+  autoCapitalize?: 'none' | 'words' | 'sentences';
+  /** A write is in flight — the field and both doors hold still until it lands. */
+  saving?: boolean;
+  onSave: (next: string) => void;
+  onClose: () => void;
+}): React.JSX.Element {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const [draft, setDraft] = useState(value);
+  const field = useRef<TextInput>(null);
+
+  /**
+   * Seeded once per opening, during render rather than from an effect.
+   *
+   * It has to be once per *opening* and not on every render: the saved value
+   * arrives from the mirror while somebody is still typing, and re-seeding on
+   * it would overwrite their edit with the value they are in the middle of
+   * changing. And it is done in render because seeding from an effect means a
+   * first frame drawn with the previous field's text, then a second with this
+   * one — the cascading render the lint rule is about. A `setState` during a
+   * component's own render is React's sanctioned way to say "this is derived
+   * from a prop change", and it re-renders before anything is committed.
+   */
+  const [openedWith, setOpenedWith] = useState<string | null>(null);
+  if (visible && openedWith === null) {
+    setOpenedWith(value);
+    setDraft(value);
+  }
+  if (!visible && openedWith !== null) setOpenedWith(null);
+
+  // The keyboard comes up with the sheet. Somebody who tapped a row to change
+  // a value has already decided to type; making them tap again is a tap this
+  // screen exists to remove. Delayed a frame so the field is laid out first —
+  // focusing a view that has not been measured is a no-op on Android.
+  useEffect(() => {
+    if (!visible) return;
+    const id = setTimeout(() => field.current?.focus(), 150);
+    return () => clearTimeout(id);
+  }, [visible]);
+
+  const trimmed = draft.trim();
+  const changed = trimmed !== value.trim();
+
+  return (
+    <Sheet visible={visible} onClose={onClose} closeLabel={t.common.close}>
+      <View style={{ gap: theme.spacing.lg }}>
+        <View style={{ gap: theme.spacing.xs }}>
+          <Text variant="title">{title}</Text>
+          {hint ? (
+            <Text variant="caption" tone="muted">
+              {hint}
+            </Text>
+          ) : null}
+        </View>
+
+        <TextInput
+          ref={field}
+          value={draft}
+          onChangeText={setDraft}
+          editable={!saving}
+          multiline={multiline}
+          autoCapitalize={autoCapitalize}
+          autoCorrect={false}
+          accessibilityLabel={title}
+          placeholder={placeholder}
+          placeholderTextColor={theme.color.textFaint}
+          // Enter saves a single-line field, the way a search or a rename does
+          // everywhere else. A multiline field keeps Enter as a newline.
+          returnKeyType={multiline ? 'default' : 'done'}
+          onSubmitEditing={() => {
+            if (!multiline && changed && !saving) onSave(trimmed);
+          }}
+          style={{
+            borderWidth: 1,
+            borderColor: theme.color.border,
+            borderRadius: theme.radius.lg,
+            paddingHorizontal: theme.spacing.md,
+            paddingVertical: Platform.OS === 'ios' ? theme.spacing.md : theme.spacing.sm,
+            fontSize: 16,
+            color: theme.color.text,
+            backgroundColor: theme.color.surface,
+            ...(multiline ? { minHeight: 96, textAlignVertical: 'top' as const } : null),
+          }}
+        />
+
+        <Row style={{ gap: theme.spacing.sm }}>
+          <View style={{ flex: 1 }}>
+            <Button label={t.common.cancel} variant="secondary" fullWidth onPress={onClose} />
+          </View>
+          <View style={{ flex: 1 }}>
+            {/* Disabled until something actually changed: a Save that writes the
+                value already saved is a request, a spinner and a "Saved" for
+                nothing. */}
+            <Button
+              label={saving ? t.common.loading : t.common.save}
+              fullWidth
+              disabled={!changed || saving}
+              onPress={() => onSave(trimmed)}
+            />
+          </View>
+        </Row>
+      </View>
+    </Sheet>
+  );
+}

--- a/apps/mobile/src/components/SettingsSection.tsx
+++ b/apps/mobile/src/components/SettingsSection.tsx
@@ -1,0 +1,147 @@
+/**
+ * The app's settings list: a titled group of rows in one card.
+ *
+ * Extracted from the Settings screen, which is where it grew up, because the
+ * account screen needed the same thing and the alternative was a second one.
+ * Two list styles for two screens a tap apart is how an app starts to look like
+ * it was assembled rather than designed — and it is the specific request this
+ * was pulled out for.
+ *
+ * A row is a glyph in a soft circle, a title, an optional second line, and one
+ * of two things at the end: a chevron when it leads somewhere, or the value it
+ * currently holds when it is a setting you can read off the list. The value is
+ * what makes this usable for an account screen: "Name · Madan" says what it is
+ * set to without opening anything, which is the whole point of a list over a
+ * page of form fields.
+ */
+
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { View } from 'react-native';
+
+import {
+  Card,
+  directionalIcon,
+  iconSize,
+  ListRow,
+  Row,
+  SectionHeader,
+  Text,
+  useTheme,
+} from '@waves/ui';
+
+import { router } from '@/lib/navigation';
+
+export interface SettingsRow {
+  icon: keyof typeof Ionicons.glyphMap;
+  label: string;
+  hint?: string;
+  /**
+   * What this setting is set to, drawn at the end of its own row.
+   *
+   * Distinct from `hint`, which explains the row; this *is* the answer. A row
+   * with neither reads as a door and gets a chevron instead.
+   */
+  value?: string;
+  /** Say a value is missing in the muted voice — "Add one" rather than a blank. */
+  valueMuted?: boolean;
+  route?: string;
+  onPress?: () => void;
+  /** Ends something. Red title, red icon. */
+  destructive?: boolean;
+}
+
+export function SettingsSection({ title, rows }: { title?: string; rows: SettingsRow[] }) {
+  const theme = useTheme();
+  return (
+    <View>
+      {title ? <SectionHeader title={title} /> : null}
+      <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+        {rows.map((item, index) => {
+          const live = Boolean(item.route ?? item.onPress);
+          return (
+            <View key={item.label}>
+              <ListRow
+                title={item.label}
+                subtitle={item.hint}
+                destructive={item.destructive}
+                onPress={
+                  item.onPress ?? (item.route ? () => router.push(item.route as never) : undefined)
+                }
+                leading={
+                  <View
+                    style={{
+                      width: 40,
+                      height: 40,
+                      borderRadius: theme.radius.pill,
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      backgroundColor: item.destructive
+                        ? theme.color.negativeSoft
+                        : live
+                          ? theme.color.brandSoft
+                          : theme.color.surfaceMuted,
+                    }}
+                  >
+                    <Ionicons
+                      name={item.icon}
+                      size={iconSize.md}
+                      color={
+                        item.destructive
+                          ? theme.color.negative
+                          : live
+                            ? theme.color.brand
+                            : theme.color.textMuted
+                      }
+                    />
+                  </View>
+                }
+                trailing={
+                  item.value !== undefined ? (
+                    // The value shares the row with the title, so it takes only
+                    // what is left: `flexShrink` with a zero `minWidth` lets a
+                    // long answer clip rather than push the chevron off the
+                    // edge. A chevron still follows a value when the row opens
+                    // something — a value alone would read as unchangeable.
+                    <Row
+                      style={{
+                        gap: theme.spacing.xs,
+                        flexShrink: 1,
+                        minWidth: 0,
+                        alignItems: 'center',
+                      }}
+                    >
+                      <Text
+                        variant="caption"
+                        tone={item.valueMuted ? 'faint' : 'muted'}
+                        numberOfLines={1}
+                        style={{ flexShrink: 1, minWidth: 0 }}
+                      >
+                        {item.value}
+                      </Text>
+                      {live ? (
+                        <Ionicons
+                          name={directionalIcon('chevron-forward')}
+                          size={iconSize.md}
+                          color={theme.color.textFaint}
+                        />
+                      ) : null}
+                    </Row>
+                  ) : item.route ? (
+                    <Ionicons
+                      name={directionalIcon('chevron-forward')}
+                      size={iconSize.md}
+                      color={theme.color.textFaint}
+                    />
+                  ) : null
+                }
+              />
+              {index < rows.length - 1 ? (
+                <View style={{ height: 1, backgroundColor: theme.color.border }} />
+              ) : null}
+            </View>
+          );
+        })}
+      </Card>
+    </View>
+  );
+}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1994,6 +1994,14 @@ export interface UiStrings {
     memberName: string;
     /** Member detail: label over their per-currency outlay (currency exposure). */
     paidAcross: string;
+    /** Heading over what this person put into this group. */
+    inThisGroup: string;
+    /** How many expenses they are part of. */
+    expensesLabel: string;
+    /** Heading over role and blocking. */
+    manageTitle: string;
+    /** Said when a typed UPI handle is not a handle. */
+    upiInvalid: string;
     ghostNote: string;
     upiForGroup: string;
     upiForGroupNote: string;
@@ -4586,6 +4594,10 @@ const en: UiStrings = {
     you: 'you',
     memberName: 'Member name',
     paidAcross: 'Paid',
+    inThisGroup: 'In this group',
+    expensesLabel: 'Expenses',
+    manageTitle: 'Manage',
+    upiInvalid: 'That does not look like a UPI ID.',
     ghostNote: 'This person holds real balances. When they join, they can claim this history.',
     upiForGroup: 'UPI ID for this group',
     upiForGroupNote:
@@ -7205,6 +7217,10 @@ const ta: UiStrings = {
     you: 'நீங்கள்',
     memberName: 'உறுப்பினர் பெயர்',
     paidAcross: 'செலுத்தியது',
+    inThisGroup: 'இந்தக் குழுவில்',
+    expensesLabel: 'செலவுகள்',
+    manageTitle: 'நிர்வகி',
+    upiInvalid: 'இது UPI ஐடி போலத் தெரியவில்லை.',
     ghostNote:
       'இவருக்கு உண்மையான இருப்புகள் உள்ளன. அவர்கள் சேரும்போது இந்த வரலாற்றைத் தங்களுடையதாக்கிக் கொள்ளலாம்.',
     upiForGroup: 'இந்தக் குழுவுக்கான UPI ID',
@@ -9829,6 +9845,10 @@ const hi: UiStrings = {
     you: 'आप',
     memberName: 'सदस्य का नाम',
     paidAcross: 'चुकाया',
+    inThisGroup: 'इस ग्रुप में',
+    expensesLabel: 'खर्च',
+    manageTitle: 'प्रबंधित करें',
+    upiInvalid: 'यह UPI आईडी जैसी नहीं लगती।',
     ghostNote: 'इस व्यक्ति का असली हिसाब है। जुड़ने पर वे यह इतिहास अपने नाम कर सकते हैं।',
     upiForGroup: 'इस समूह के लिए UPI ID',
     upiForGroupNote:
@@ -12538,6 +12558,10 @@ const ar: UiStrings = {
     you: 'أنت',
     memberName: 'اسم العضو',
     paidAcross: 'دفع',
+    inThisGroup: 'في هذه المجموعة',
+    expensesLabel: 'المصاريف',
+    manageTitle: 'إدارة',
+    upiInvalid: 'لا يبدو هذا معرّف UPI صالحًا.',
     ghostNote: 'لهذا الشخص أرصدة حقيقية. حين ينضم يمكنه أن يطالب بهذا السجل.',
     upiForGroup: 'معرّف الدفع لهذه المجموعة',
     upiForGroupNote: 'يتجاوز معرّف حسابك هنا فقط — مفيد حين تُسوّى مجموعة إلى حساب مختلف.',

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -852,6 +852,12 @@ export interface UiStrings {
     otherCurrencies: PluralForms;
     saved: string;
     displayName: string;
+    /** One line in the name editor: who sees it. */
+    displayNameHint: string;
+    /** The heading over the account list. */
+    detailsTitle: string;
+    /** One line in the address editor: why it is asked for. */
+    addressHint: string;
     regionTitle: string;
     currencyLabel: string;
     currencyFromCountry: string;
@@ -3637,6 +3643,9 @@ const en: UiStrings = {
     otherCurrencies: { one: 'and {n} other currency', other: 'and {n} other currencies' },
     saved: 'Saved',
     displayName: 'Display name',
+    displayNameHint: 'Everyone you share a group with sees this.',
+    detailsTitle: 'Your details',
+    addressHint: 'Never posted to. Kept for your own records.',
     regionTitle: 'Region',
     currencyLabel: 'Currency',
     currencyFromCountry: 'Set from your country',
@@ -6206,6 +6215,9 @@ const ta: UiStrings = {
     otherCurrencies: { one: 'மேலும் {n} நாணயம்', other: 'மேலும் {n} நாணயங்கள்' },
     saved: 'சேமிக்கப்பட்டது',
     displayName: 'காட்டப்படும் பெயர்',
+    displayNameHint: 'நீங்கள் குழு பகிரும் அனைவரும் இதைப் பார்ப்பார்கள்.',
+    detailsTitle: 'உங்கள் விவரங்கள்',
+    addressHint: 'இதற்கு எதுவும் அனுப்பப்படாது. உங்கள் பதிவுக்காக மட்டும்.',
     regionTitle: 'பகுதி',
     currencyLabel: 'நாணயம்',
     currencyFromCountry: 'உங்கள் நாட்டிலிருந்து அமைக்கப்படுகிறது',
@@ -8873,6 +8885,9 @@ const hi: UiStrings = {
     otherCurrencies: { one: 'और {n} अन्य मुद्रा', other: 'और {n} अन्य मुद्राएँ' },
     saved: 'सेव हो गया',
     displayName: 'दिखने वाला नाम',
+    displayNameHint: 'जिन ग्रुप में आप हैं, उनमें सब यही देखते हैं।',
+    detailsTitle: 'आपकी जानकारी',
+    addressHint: 'यहाँ कुछ नहीं भेजा जाता। सिर्फ़ आपके रिकॉर्ड के लिए।',
     regionTitle: 'क्षेत्र',
     currencyLabel: 'मुद्रा',
     currencyFromCountry: 'आपके देश से सेट',
@@ -11508,6 +11523,9 @@ const ar: UiStrings = {
     },
     saved: 'تم الحفظ',
     displayName: 'الاسم الظاهر',
+    displayNameHint: 'يراه كل من تشاركه مجموعة.',
+    detailsTitle: 'بياناتك',
+    addressHint: 'لا يُرسل إليه شيء. محفوظ لسجلك فقط.',
     regionTitle: 'المنطقة',
     currencyLabel: 'العملة',
     currencyFromCountry: 'يُضبط حسب بلدك',

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -865,6 +865,12 @@ export interface UiStrings {
     addYourDetails: string;
     yourPhoto: string;
     chooseNewPhoto: string;
+    /** Take a new one with the camera, rather than picking a saved one. */
+    takeNewPhoto: string;
+    /** Pick one already on the phone. */
+    chooseFromLibrary: string;
+    /** Take the current photo away, leaving initials. */
+    removePhoto: string;
     howPeoplePayYou: string;
     yourRailDetails: string;
     handleWrong: string;
@@ -3645,6 +3651,9 @@ const en: UiStrings = {
     addYourDetails: 'Add your details',
     yourPhoto: 'Your photo',
     chooseNewPhoto: 'Choose a new one',
+    takeNewPhoto: 'Take a photo',
+    chooseFromLibrary: 'Choose from library',
+    removePhoto: 'Remove photo',
     howPeoplePayYou: 'How people pay you',
     yourRailDetails: 'Your {rail} details',
     handleWrong: 'That does not look like {hint}.',
@@ -6212,6 +6221,9 @@ const ta: UiStrings = {
     addYourDetails: 'உங்கள் விவரங்களைச் சேர்',
     yourPhoto: 'உங்கள் புகைப்படம்',
     chooseNewPhoto: 'புதிதாக ஒன்றைத் தேர்ந்தெடு',
+    takeNewPhoto: 'புகைப்படம் எடு',
+    chooseFromLibrary: 'கேலரியில் இருந்து தேர்ந்தெடு',
+    removePhoto: 'புகைப்படத்தை நீக்கு',
     howPeoplePayYou: 'உங்களுக்கு எப்படிப் பணம் தருவது',
     yourRailDetails: 'உங்கள் {rail} விவரங்கள்',
     handleWrong: 'இது {hint} போல் தெரியவில்லை.',
@@ -8875,6 +8887,9 @@ const hi: UiStrings = {
     addYourDetails: 'अपनी जानकारी जोड़ें',
     yourPhoto: 'आपकी फ़ोटो',
     chooseNewPhoto: 'नई चुनें',
+    takeNewPhoto: 'फ़ोटो लें',
+    chooseFromLibrary: 'गैलरी से चुनें',
+    removePhoto: 'फ़ोटो हटाएँ',
     howPeoplePayYou: 'लोग आपको कैसे भुगतान करें',
     yourRailDetails: 'आपकी {rail} जानकारी',
     handleWrong: 'यह {hint} जैसा नहीं लगता।',
@@ -11507,6 +11522,9 @@ const ar: UiStrings = {
     addYourDetails: 'أضف بياناتك',
     yourPhoto: 'صورتك',
     chooseNewPhoto: 'اختر صورة جديدة',
+    takeNewPhoto: 'التقط صورة',
+    chooseFromLibrary: 'اختر من المعرض',
+    removePhoto: 'إزالة الصورة',
     howPeoplePayYou: 'كيف يدفع لك الناس',
     yourRailDetails: 'بيانات {rail} الخاصة بك',
     handleWrong: 'هذا لا يبدو مثل {hint}.',

--- a/apps/mobile/src/lib/avatarActions.ts
+++ b/apps/mobile/src/lib/avatarActions.ts
@@ -1,0 +1,27 @@
+import type { ChooseOption } from '@/lib/dialog';
+
+export type AvatarPhotoAction = 'camera' | 'library' | 'remove';
+
+export function avatarPhotoActions(
+  labels: {
+    readonly takeNewPhoto: string;
+    readonly chooseFromLibrary: string;
+    readonly removePhoto: string;
+  },
+  hasStoredPhoto: boolean,
+): ChooseOption[] {
+  return [
+    { id: 'camera', label: labels.takeNewPhoto, icon: 'camera-outline' },
+    { id: 'library', label: labels.chooseFromLibrary, icon: 'images-outline' },
+    ...(hasStoredPhoto
+      ? [
+          {
+            id: 'remove',
+            label: labels.removePhoto,
+            icon: 'trash-outline',
+            tone: 'danger' as const,
+          },
+        ]
+      : []),
+  ];
+}

--- a/apps/mobile/src/lib/avatarEditor.ts
+++ b/apps/mobile/src/lib/avatarEditor.ts
@@ -1,0 +1,111 @@
+/**
+ * Changing your photo, as one behaviour two screens can both call.
+ *
+ * Settings shows the portrait and so does the account screen, and both are
+ * places somebody expects to be able to tap it. Two copies of this would be two
+ * sheets that drift — one offering the camera, the other not; one clearing the
+ * stored file on remove, the other only the column. So it lives here once, and
+ * the screens own nothing but the avatar they draw.
+ *
+ * `busy` is for the spinner over the portrait, and `status` is the one line of
+ * bad news, which the caller places where its own layout wants it.
+ */
+
+import { useCallback, useState } from 'react';
+
+import { removeAvatar, uploadAvatar } from '@/data/api';
+import { useStrings } from '@/i18n';
+import { useAuth } from '@/lib/auth';
+import { useDialog } from '@/lib/dialog';
+import { friendlyError } from '@/lib/errors';
+import { pickAvatarPhoto, type PhotoSource } from '@/lib/image';
+
+export interface AvatarEditor {
+  /** Open the sheet — or, with no photo set, go straight to the library. */
+  readonly open: () => void;
+  /** A picture is uploading or being removed. */
+  readonly busy: boolean;
+  /** What went wrong, in words, or null. */
+  readonly status: string | null;
+}
+
+export function useAvatarEditor(): AvatarEditor {
+  const { profile, updateProfile } = useAuth();
+  const { t } = useStrings();
+  const { choose } = useDialog();
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState<string | null>(null);
+
+  const choosePhoto = useCallback(
+    async (source: PhotoSource): Promise<void> => {
+      if (!profile) return;
+      const picked = await pickAvatarPhoto(source);
+      if (!picked) return;
+
+      setStatus(null);
+      setBusy(true);
+      try {
+        const path = await uploadAvatar({
+          profileId: profile.id,
+          base64: picked.base64,
+          mimeType: picked.mimeType,
+        });
+        await updateProfile({ avatar_url: path });
+      } catch (caught) {
+        setStatus(friendlyError(caught, t.couldNotSave, 'profile.uploadPhoto'));
+      } finally {
+        setBusy(false);
+      }
+    },
+    [profile, updateProfile, t.couldNotSave],
+  );
+
+  const clearPhoto = useCallback(async (): Promise<void> => {
+    if (!profile) return;
+    setBusy(true);
+    try {
+      // The stored object goes too, not just the column pointing at it.
+      await removeAvatar(profile.id, profile.avatar_url);
+      await updateProfile({ avatar_url: null });
+    } catch (caught) {
+      setStatus(friendlyError(caught, t.couldNotSave, 'profile.removePhoto'));
+    } finally {
+      setBusy(false);
+    }
+  }, [profile, updateProfile, t.couldNotSave]);
+
+  /**
+   * The sheet: where the photo comes from, and how to take it away.
+   *
+   * The camera and the library are separate rows because a profile photo is
+   * usually taken there and then, and one vague "choose a new one" makes
+   * somebody open a picker to find out it was not the door they wanted. Each
+   * row carries a glyph, which is what lets three short rows be told apart
+   * without reading all three, and the row that takes something away carries a
+   * red one — so it reads as destructive before the words do.
+   *
+   * No question at all when there is no photo yet: nothing to remove, nothing
+   * to replace, so a first tap opens the library.
+   */
+  const open = useCallback((): void => {
+    void (async () => {
+      if (!profile?.avatar_url) {
+        await choosePhoto('library');
+        return;
+      }
+      const picked = await choose({
+        title: t.account.yourPhoto,
+        options: [
+          { id: 'camera', label: t.account.takeNewPhoto, icon: 'camera-outline' },
+          { id: 'library', label: t.account.chooseFromLibrary, icon: 'images-outline' },
+          { id: 'remove', label: t.account.removePhoto, icon: 'trash-outline', tone: 'danger' },
+        ],
+      });
+      if (picked === 'camera') await choosePhoto('camera');
+      else if (picked === 'library') await choosePhoto('library');
+      else if (picked === 'remove') await clearPhoto();
+    })();
+  }, [profile?.avatar_url, choose, choosePhoto, clearPhoto, t.account]);
+
+  return { open, busy, status };
+}

--- a/apps/mobile/src/lib/avatarEditor.ts
+++ b/apps/mobile/src/lib/avatarEditor.ts
@@ -18,10 +18,11 @@ import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { useDialog } from '@/lib/dialog';
 import { friendlyError } from '@/lib/errors';
+import { avatarPhotoActions, type AvatarPhotoAction } from '@/lib/avatarActions';
 import { pickAvatarPhoto, type PhotoSource } from '@/lib/image';
 
 export interface AvatarEditor {
-  /** Open the sheet — or, with no photo set, go straight to the library. */
+  /** Open the sheet that asks where the photo should come from. */
   readonly open: () => void;
   /** A picture is uploading or being removed. */
   readonly busy: boolean;
@@ -83,24 +84,13 @@ export function useAvatarEditor(): AvatarEditor {
    * row carries a glyph, which is what lets three short rows be told apart
    * without reading all three, and the row that takes something away carries a
    * red one — so it reads as destructive before the words do.
-   *
-   * No question at all when there is no photo yet: nothing to remove, nothing
-   * to replace, so a first tap opens the library.
    */
   const open = useCallback((): void => {
     void (async () => {
-      if (!profile?.avatar_url) {
-        await choosePhoto('library');
-        return;
-      }
-      const picked = await choose({
+      const picked = (await choose({
         title: t.account.yourPhoto,
-        options: [
-          { id: 'camera', label: t.account.takeNewPhoto, icon: 'camera-outline' },
-          { id: 'library', label: t.account.chooseFromLibrary, icon: 'images-outline' },
-          { id: 'remove', label: t.account.removePhoto, icon: 'trash-outline', tone: 'danger' },
-        ],
-      });
+        options: avatarPhotoActions(t.account, Boolean(profile?.avatar_url)),
+      })) as AvatarPhotoAction | null;
       if (picked === 'camera') await choosePhoto('camera');
       else if (picked === 'library') await choosePhoto('library');
       else if (picked === 'remove') await clearPhoto();

--- a/apps/mobile/src/lib/dialog.tsx
+++ b/apps/mobile/src/lib/dialog.tsx
@@ -138,6 +138,8 @@ export interface ChooseOption {
   readonly label: string;
   /** Marks the one that takes something away, so it is not drawn as a peer. */
   readonly tone?: 'danger';
+  /** An Ionicons glyph before the label — see `DialogAction.icon`. */
+  readonly icon?: string;
 }
 
 /** More than two ways forward — an action list, drawn as a bottom sheet. */
@@ -273,6 +275,7 @@ export function DialogProvider({ children }: { children: ReactNode }) {
           ...options.options.map((option) => ({
             id: `${OPTION_PREFIX}${option.id}`,
             label: option.label,
+            icon: option.icon,
             tone: option.tone === 'danger' ? ('dangerQuiet' as const) : ('quiet' as const),
           })),
           { id: DIALOG_CANCEL, label: options.cancelLabel ?? t.common.cancel, tone: 'ghost' },

--- a/apps/mobile/src/lib/dialogQueue.ts
+++ b/apps/mobile/src/lib/dialogQueue.ts
@@ -86,6 +86,19 @@ export interface DialogAction {
   readonly id: string;
   readonly label: string;
   readonly tone?: DialogActionTone;
+  /**
+   * An Ionicons glyph name, drawn before the label.
+   *
+   * For a *menu* rather than a question. Three soft rows of the same weight are
+   * told apart by reading all three; a glyph says which is which at a glance,
+   * and it is the difference between "Take a photo" and "Choose from library"
+   * being one decision instead of two lines of prose. A confirmation's doors
+   * take none — there the words are the whole content.
+   *
+   * Typed loosely on purpose: this module is the queue, and it must not import
+   * a vector-icon package to name a string that the renderer resolves.
+   */
+  readonly icon?: string;
 }
 
 /**

--- a/apps/mobile/src/lib/image.ts
+++ b/apps/mobile/src/lib/image.ts
@@ -264,17 +264,38 @@ async function readUnshrunk(
   return { base64, uri, mimeType: undefined };
 }
 
+/** Where a square photo comes from. The camera is the answer for a face. */
+export type PhotoSource = 'library' | 'camera';
+
 /**
  * Ask for a square photo — a profile picture or a group cover.
  *
  * Returns null when the person changes their mind or declines access. Both are
  * ordinary answers, not errors to report.
+ *
+ * `source` is asked for by name rather than guessed. A profile photo is most
+ * often taken there and then, and the sheet that calls this now offers the
+ * camera and the library as two separate choices — which is what every app
+ * whose photo sheet is worth copying does, because "choose a new one" makes
+ * somebody open a picker to find out it is not the one they wanted.
+ *
+ * A declined camera falls back to nothing rather than silently opening the
+ * library: they asked for the camera, and quietly showing them their photo roll
+ * instead is answering a question nobody put.
  */
-export async function pickSquarePhoto(maxEdge: number): Promise<PickedImage | null> {
-  const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+export async function pickSquarePhoto(
+  maxEdge: number,
+  source: PhotoSource = 'library',
+): Promise<PickedImage | null> {
+  const permission =
+    source === 'camera'
+      ? await ImagePicker.requestCameraPermissionsAsync()
+      : await ImagePicker.requestMediaLibraryPermissionsAsync();
   if (!permission.granted) return null;
 
-  const result = await ImagePicker.launchImageLibraryAsync({
+  const launch =
+    source === 'camera' ? ImagePicker.launchCameraAsync : ImagePicker.launchImageLibraryAsync;
+  const result = await launch({
     mediaTypes: ['images'],
     allowsEditing: true,
     aspect: [1, 1],
@@ -299,7 +320,8 @@ export async function pickSquarePhoto(maxEdge: number): Promise<PickedImage | nu
   return { base64: shrunk.base64, mimeType: shrunk.mimeType ?? 'image/jpeg', uri: shrunk.uri };
 }
 
-export const pickAvatarPhoto = () => pickSquarePhoto(AVATAR_MAX_EDGE);
+export const pickAvatarPhoto = (source: PhotoSource = 'library') =>
+  pickSquarePhoto(AVATAR_MAX_EDGE, source);
 export const pickGroupPhoto = () => pickSquarePhoto(COVER_MAX_EDGE);
 
 /** Longest edge for an album photo — big enough to look good full-screen,

--- a/apps/mobile/test/avatarEditor.test.ts
+++ b/apps/mobile/test/avatarEditor.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { avatarPhotoActions } from '@/lib/avatarActions';
+
+const labels = {
+  takeNewPhoto: 'Take a photo',
+  chooseFromLibrary: 'Choose from library',
+  removePhoto: 'Remove photo',
+};
+
+describe('avatarPhotoActions', () => {
+  it('offers camera and library when a person is setting their first photo', () => {
+    // The first avatar tap is often for a face taken right now. Silently opening
+    // the library leaves the user, rider, traveller or financer to back out and
+    // hunt for the camera door that the sheet says should exist.
+    expect(avatarPhotoActions(labels, false)).toEqual([
+      { id: 'camera', label: 'Take a photo', icon: 'camera-outline' },
+      { id: 'library', label: 'Choose from library', icon: 'images-outline' },
+    ]);
+  });
+
+  it('adds the destructive remove row only when there is a stored photo to remove', () => {
+    expect(avatarPhotoActions(labels, true)).toEqual([
+      { id: 'camera', label: 'Take a photo', icon: 'camera-outline' },
+      { id: 'library', label: 'Choose from library', icon: 'images-outline' },
+      {
+        id: 'remove',
+        label: 'Remove photo',
+        icon: 'trash-outline',
+        tone: 'danger',
+      },
+    ]);
+  });
+});

--- a/docs/play-release.md
+++ b/docs/play-release.md
@@ -80,7 +80,7 @@ already installed against the old one stop hearing about updates for good.
 ```sh
 cd apps/mobile
 npx expo prebuild --clean          # regenerates android/ with every plugin applied
-export SENTRY_AUTH_TOKEN=$(grep '^SENTRY_AUTH_TOKEN=' .env.local | cut -d= -f2-)
+export SENTRY_AUTH_TOKEN=...        # only if it is not already in your environment
 cd android
 ./gradlew bundleRelease            # → app/build/outputs/bundle/release/app-release.aab
 ```
@@ -91,15 +91,21 @@ prebuild, and an `android/` directory generated before a plugin was added simply
 does not have it. That is the whole of the "Sentry native configuration is
 missing" warning.
 
-The `export` is not optional once `SENTRY_ORG` and `SENTRY_PROJECT` are set.
-Those two switch on a source-map upload task in the release build, and that task
-is `sentry-cli`, run by Gradle — which never sees `.env.local`, because loading
-that file is Expo's doing and Gradle is not Expo. Without it the build dies at
+`SENTRY_AUTH_TOKEN` has to be in the _environment_, not only in `.env.local`.
+Once `SENTRY_ORG` and `SENTRY_PROJECT` are set, the release build gains a
+source-map upload task; that task is `sentry-cli`, run by Gradle, and Gradle
+never reads `.env.local` — loading that file is Expo's doing, and Gradle is not
+Expo. Without the token the build compiles everything and _then_ dies at
 `:app:…_SentryUpload_…` with
 
 > error: Auth token is required for this request. Please run `sentry-cli login`
 
-after several minutes of work, having compiled everything first.
+On the machine this is built from it is set once as a user environment variable
+(`setx`, or `[Environment]::SetEnvironmentVariable(..., 'User')`), so a plain
+`./gradlew bundleRelease` in a new terminal works with no preamble. The `export`
+line above is only for a shell that does not already have it — including any
+terminal opened _before_ the variable was set, since a process inherits its
+environment at birth and does not notice later changes.
 
 An AAB cannot be installed on a phone. To test the exact artefact Play will
 serve, use [bundletool](https://github.com/google/bundletool) to build APKs from


### PR DESCRIPTION
Two changes to the same corner of the app, in order.

## 1. The photo sheet says where the photo comes from

The "Your photo" sheet drew three choices at three different weights — a filled pill, a line of red text, a line of brand text — and the first of them, "Choose a new one", did not say which door it opened.

Checked against [Linktree](https://mobbin.com/screens/91797c43-569d-417d-b2dc-fc10b0a32baf), [Flighty](https://mobbin.com/screens/c9ad8fe9-0154-4339-920f-83abb47c89ba), [Yubo](https://mobbin.com/screens/a54f60b4-2a25-4b2d-b1d3-f3b7ec0558da), [Beli](https://mobbin.com/screens/feeadc9e-91c6-4336-bdef-2cf202c6e238), [Gentler Streak](https://mobbin.com/screens/687d5774-148e-43bc-a1c7-f1d7395ad5b3). Every one splits camera from library, gives each row a glyph, and draws the rows as peers with the destructive one red.

| before | after |
|---|---|
| **Choose a new one** (filled pill) | 📷 Take a photo |
| Remove (red text) | 🖼 Choose from library |
| Cancel (brand text) | 🗑 Remove photo *(red)* |

`pickSquarePhoto` takes a `PhotoSource`. A declined camera returns null rather than falling back to the library — they asked for the camera, and quietly showing them their photo roll answers a question nobody put.

Icons went into the primitive, not the screen: `DialogAction` and `ChooseOption` gained an optional `icon`, so every action sheet in the app can use it. Each glyph takes its row's colour, so the destructive row reads as destructive before the words are read.

## 2. The account screen is a list of what you have set

It was four cards, each holding one text field and a Save button that appeared when dirty, each under its own label. The page was mostly the space between things, and you could not see what your details *were* without reading four inputs.

Every edit-profile screen on the boards is the same shape instead — avatar with a camera badge, then dense label-and-value rows: [Beli](https://mobbin.com/screens/0d58befe-d949-4c16-aff3-64c5f8e7eb04), [Lyft](https://mobbin.com/screens/32dae9be-c4a3-42cc-b633-1ce9f7a842f7), [BeReal](https://mobbin.com/screens/2f17b497-238f-41e1-b42a-87486715de33), [Binance](https://mobbin.com/screens/f595fc41-758f-4a9f-a64a-cf73973caad3), [Instagram](https://mobbin.com/screens/968761ca-7201-48ba-a822-06e3f5c6620a), [Shopee](https://mobbin.com/screens/4da2e535-f0f7-4423-a037-fbe6b5ab2bb2), [Telegram](https://mobbin.com/screens/53079779-93aa-4d60-bf67-b6d09c1978ea), [Pangea](https://mobbin.com/screens/714810a5-e289-49e2-b8d3-41dbe8d69049), [Polarsteps](https://mobbin.com/screens/347a9b4e-d9ed-4778-b0c5-861565d37795), [X](https://mobbin.com/screens/766c9852-1c75-406e-9c40-d36a4e827f23).

**The rows are literally the Settings rows.** `SettingsSection` moved out of `profile.tsx` into `components/`, so the two lists one tap apart are one component instead of two designs that drift — which was the ask. It gained an optional `value` drawn at the end of the row, plus a muted spelling for "not set yet".

**The portrait is a control.** It was deliberately inert here; the old comment said the photo belongs to Settings. But this is where people look for it, and every reference puts a camera badge exactly here. It opens the *same* sheet: `useAvatarEditor` owns that behaviour for both screens now, so there is one upload path and one remove that clears the stored object rather than only the column. Settings lost ~40 lines to the move and behaves identically.

**Editing moved into a sheet** (`EditTextSheet`), which is what lets a row be one line. It keeps its own draft, so cancelling leaves the saved value alone, and it closes only once the write lands — a sheet that shuts on tap and fails behind you is how a name silently does not change. Seeded during render rather than from an effect, so there is no frame showing the previous field's text.

Currency keeps a row but takes no tap: derived from the country above it, shown because people look for it.

## Gates

tsc, lint, filename check, 1294 tests. Strings added in all four locales.

Not device-verified — the camera path and the keyboard-over-sheet behaviour both want a real phone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added camera, photo-library, and remove-photo options for profile pictures.
  - Added reusable settings sections and edit sheets for account and member details.
  - Added clearer member balances, settlement actions, and management options.
  - Added icons to menu actions and improved localized labels and validation messages.

- **Bug Fixes**
  - Improved photo editing feedback by showing loading and error states during updates.
  - Prevented saving unchanged text and validated payment details before submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->