### PR TITLE
A sheet with a field in it stands above the keyboard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,21 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    # React Native is pinned by the Expo SDK, not by us, and its 0.x numbering
+    # makes a breaking release look like a minor one — so it lands in the
+    # "routine noise" group and is merged on a green CI that cannot see the
+    # problem. This has already happened once: 0.86 to 0.87 went in as #199 and
+    # came straight back out as #200, because Expo SDK 57 cannot build it
+    # natively (AGP/Kotlin/Gradle break the autolinking plugin, and worklets
+    # 0.12 breaks reanimated 4.5.3). CI is JS-only, so nothing caught it until
+    # somebody ran `gradlew`.
+    #
+    # These move when the Expo SDK moves, deliberately and with an APK built to
+    # prove it. `expo install --check` is the tool for that, not Dependabot.
+    ignore:
+      - dependency-name: react-native
+      - dependency-name: react-native-worklets
+      - dependency-name: '@react-native/*'
     groups:
       # One PR for the routine patch/minor noise instead of dozens; majors still
       # come as their own reviewable PRs.

--- a/packages/ui/src/components/Overlay.tsx
+++ b/packages/ui/src/components/Overlay.tsx
@@ -29,7 +29,9 @@ import { useEffect, useRef, useState, type ReactNode } from 'react';
 import {
   AccessibilityInfo,
   Animated,
+  Keyboard,
   Modal,
+  Platform,
   Pressable,
   StyleSheet,
   useWindowDimensions,
@@ -194,6 +196,36 @@ function SheetCard({
  * swallows the tap so a press inside never dismisses. Rounded top corners, a
  * grab handle, and the safe-area inset folded into the bottom padding.
  */
+/**
+ * How much of the screen the keyboard is currently covering.
+ *
+ * A `Modal` on Android is its own native window, and `adjustResize` — which the
+ * app sets for its main window — does not reach it. So the keyboard opens
+ * *over* a bottom-anchored sheet and hides the field being typed into along
+ * with both of its buttons. (iOS does not resize a modal either; it just tends
+ * to hurt less, because sheets there are usually shorter.)
+ *
+ * `will` events on iOS so the lift runs with the keyboard rather than after it;
+ * Android only emits the `did` pair, and emits them early enough to look right.
+ */
+function useKeyboardInset(): number {
+  const [inset, setInset] = useState(0);
+  useEffect(() => {
+    const ios = Platform.OS === 'ios';
+    const show = Keyboard.addListener(ios ? 'keyboardWillShow' : 'keyboardDidShow', (event) =>
+      setInset(event.endCoordinates.height),
+    );
+    const hide = Keyboard.addListener(ios ? 'keyboardWillHide' : 'keyboardDidHide', () =>
+      setInset(0),
+    );
+    return () => {
+      show.remove();
+      hide.remove();
+    };
+  }, []);
+  return inset;
+}
+
 export function Sheet({
   visible,
   onClose,
@@ -207,6 +239,7 @@ export function Sheet({
   const reduceMotion = useReduceMotion();
   const { width: screenWidth, height: screenHeight } = useWindowDimensions();
   const { mounted, progress } = useOverlay(visible);
+  const keyboard = useKeyboardInset();
   // The sheet's own height, measured on layout, so it travels exactly its own
   // distance rather than a guess. Until the first measure a screen-height
   // fallback keeps the first frame off-screen instead of flashing in place.
@@ -264,7 +297,19 @@ export function Sheet({
             accessibilityLabel={closeLabel}
             style={StyleSheet.absoluteFill}
           />
-          <View pointerEvents="box-none" style={{ flex: 1, justifyContent: 'flex-end' }}>
+          <View
+            pointerEvents="box-none"
+            style={{
+              flex: 1,
+              justifyContent: 'flex-end',
+              // Lift the card clear of the keyboard. The card already reserves
+              // the navigation bar at its foot, and the keyboard covers that
+              // bar — so padding by the raw keyboard height would leave a strip
+              // of scrim the width of the nav bar under the card. Subtracting
+              // what is already reserved lands the card exactly on the keyboard.
+              paddingBottom: keyboard > 0 ? Math.max(keyboard - insets.bottom, 0) : 0,
+            }}
+          >
             <Animated.View style={{ transform: [{ translateY }] }}>
               <SheetCard handle={handle} padded={padded} style={style} onLayout={setHeight}>
                 {children}


### PR DESCRIPTION
Found on a device — the screen recording shows it plainly.

Tapping **Address** on the account screen opens the editor, then the keyboard opens straight over it. The field, its hint and both buttons are all hidden; there is nothing on screen to say where the typing is going.

## Why

`Modal` on Android is its own native window, and the `adjustResize` the app sets on its **main** window does not reach it. A bottom-anchored sheet therefore stays exactly where it is and the keyboard covers it. iOS does not resize a modal either — it has simply been hurting less, because until this week no sheet had a text field in it.

## The fix

`Sheet` watches the keyboard and pads its anchoring column by the keyboard's height, lifting the card to sit on top of it.

The padding subtracts the bottom inset the card already reserves for the navigation bar: the keyboard covers that bar, so padding by the raw height would leave a strip of scrim the width of the nav bar underneath the card.

`keyboardWillShow`/`Hide` on iOS so the lift travels with the keyboard; Android only emits the `did` pair, and emits them early enough to look right.

Fixed in `Sheet`, not in the screen that found it — every sheet that ever grows a field wants this, and none of them should have to remember it. `Popup` is deliberately untouched: it is centred rather than anchored, and nothing in it takes typing.

## Testing

Nothing in the suite could have caught this: mobile's vitest has no renderer by design, and this is a native window manager's behaviour, not a decision in JS. It wants the same device check that found it.

Gates: tsc (ui + mobile), lint, filename check, 1296 tests.