### PR TITLE
Adding someone leads with the two ways in, not with two blank fields

### DIFF
--- a/apps/mobile/src/app/group/[id]/members.tsx
+++ b/apps/mobile/src/app/group/[id]/members.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useLocalSearchParams } from 'expo-router';
-import { ActivityIndicator, ScrollView, TextInput, View } from 'react-native';
+import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react-native';
 
 import {
   Avatar,
@@ -303,56 +303,113 @@ export default function MembersScreen() {
           ))}
         </Card>
 
-        {/* ADR-006: a name is enough to start splitting with someone. */}
-        <Card style={{ gap: theme.spacing.md }}>
+        {/* Adding somebody, with the two doors first and the typing second.
+            
+            It used to be two bare text fields stacked on top of each other —
+            neither labelled, only placeheld — with a small Add beside the first
+            that also committed the second, and "Browse my contacts" as a ghost
+            button underneath them both. So the fastest way in was the last thing
+            you saw, and the invite link was a text link in a different card
+            further down the page, shown only once a ghost already existed.
+
+            Every add-members screen worth copying puts the doors at the top as
+            a row of tiles — Teams (share link / QR / camera), Discord (share /
+            copy link / Messages / Gmail), GroupMe, Abode. Typing a name is the
+            fallback, under a divider, which is what it actually is: ADR-006
+            says a name alone is enough, not that a name alone is the first
+            thing to reach for.
+
+            Two tiles rather than the three or four those apps show, because our
+            link and our QR are the same screen. A third tile pointing at the
+            same place would be the second door that this app keeps deciding not
+            to build. */}
+        <Card style={{ gap: theme.spacing.lg }}>
           <Text variant="caption" tone="muted">
             {t.people.addSomeone}
           </Text>
-          <Row>
-            <TextInput
-              value={ghostName}
-              onChangeText={setGhostName}
-              placeholder={t.people.namePlaceholder}
-              placeholderTextColor={theme.color.textFaint}
-              accessibilityLabel={t.common.name}
-              onSubmitEditing={add}
-              style={{
-                flex: 1,
-                fontSize: 17,
-                fontWeight: '600',
-                color: theme.color.text,
-                paddingVertical: theme.spacing.sm,
-              }}
+
+          <Row style={{ gap: theme.spacing.sm }}>
+            <AddTile
+              icon="people-outline"
+              label={t.people.browseContacts}
+              onPress={openContactPicker}
             />
-            <Button
-              label={t.add}
-              size="sm"
-              variant="secondary"
-              disabled={(!ghostName.trim() && !ghostContact.trim()) || addGhost.isPending}
-              onPress={add}
+            <AddTile
+              icon="link-outline"
+              label={t.people.shareInvite}
+              onPress={() => router.push(`/group/${groupId}/invite`)}
             />
           </Row>
 
-          <TextInput
-            value={ghostContact}
-            onChangeText={setGhostContact}
-            autoCapitalize="none"
-            keyboardType="email-address"
-            placeholder={t.people.contactPlaceholder}
-            placeholderTextColor={theme.color.textFaint}
-            accessibilityLabel={t.common.emailOrPhone}
-            onSubmitEditing={add}
-            style={{
-              fontSize: 15,
-              color: theme.color.text,
-              paddingVertical: theme.spacing.sm,
-            }}
-          />
+          {/* A rule with the alternative written into it, so the fields below
+              read as the other way rather than as the only way. */}
+          <Row style={{ alignItems: 'center', gap: theme.spacing.md }}>
+            <View style={{ flex: 1, height: 1, backgroundColor: theme.color.border }} />
+            <Text variant="micro" tone="faint">
+              {t.people.orByName}
+            </Text>
+            <View style={{ flex: 1, height: 1, backgroundColor: theme.color.border }} />
+          </Row>
 
-          <Button label={t.people.browseContacts} variant="ghost" onPress={openContactPicker} />
-          <Text variant="micro" tone="muted">
-            {t.misc.nameAloneBody}
-          </Text>
+          <View style={{ gap: theme.spacing.sm }}>
+            <Row style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
+              <TextInput
+                value={ghostName}
+                onChangeText={setGhostName}
+                placeholder={t.people.namePlaceholder}
+                placeholderTextColor={theme.color.textFaint}
+                accessibilityLabel={t.common.name}
+                onSubmitEditing={add}
+                returnKeyType="done"
+                style={{
+                  flex: 1,
+                  fontSize: 17,
+                  fontWeight: '600',
+                  color: theme.color.text,
+                  borderWidth: 1,
+                  borderColor: theme.color.border,
+                  borderRadius: theme.radius.lg,
+                  paddingHorizontal: theme.spacing.md,
+                  paddingVertical: theme.spacing.sm,
+                }}
+              />
+              <Button
+                label={t.add}
+                size="sm"
+                disabled={(!ghostName.trim() && !ghostContact.trim()) || addGhost.isPending}
+                onPress={add}
+              />
+            </Row>
+
+            {/* The contact is optional and looked compulsory: a second field of
+                the same weight directly under the first reads as the rest of the
+                form. It is a quieter, smaller row now, and says so in its own
+                placeholder. */}
+            <TextInput
+              value={ghostContact}
+              onChangeText={setGhostContact}
+              autoCapitalize="none"
+              keyboardType="email-address"
+              placeholder={t.people.contactPlaceholder}
+              placeholderTextColor={theme.color.textFaint}
+              accessibilityLabel={t.common.emailOrPhone}
+              onSubmitEditing={add}
+              returnKeyType="done"
+              style={{
+                fontSize: 15,
+                color: theme.color.text,
+                borderWidth: 1,
+                borderColor: theme.color.border,
+                borderRadius: theme.radius.lg,
+                paddingHorizontal: theme.spacing.md,
+                paddingVertical: theme.spacing.sm,
+              }}
+            />
+            <Text variant="micro" tone="muted">
+              {t.misc.nameAloneBody}
+            </Text>
+          </View>
+
           {addGhost.isPending || adding ? <ActivityIndicator color={theme.color.brand} /> : null}
           {error ? <Callout tone="negative">{error}</Callout> : null}
         </Card>
@@ -371,5 +428,47 @@ export default function MembersScreen() {
         ) : null}
       </ScrollView>
     </Screen>
+  );
+}
+
+/**
+ * One of the ways in, as a tile rather than a line of text.
+ *
+ * Half the width each and the same weight as each other, because they are two
+ * answers to one question and neither is the recommended one — which is the
+ * shape the reference boards all use for this row. A glyph over a label, so the
+ * pair reads as a choice at a glance instead of two sentences to compare.
+ */
+function AddTile({
+  icon,
+  label,
+  onPress,
+}: {
+  icon: keyof typeof Ionicons.glyphMap;
+  label: string;
+  onPress: () => void;
+}) {
+  const theme = useTheme();
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      onPress={onPress}
+      style={({ pressed }) => ({
+        flex: 1,
+        alignItems: 'center',
+        gap: theme.spacing.xs,
+        paddingVertical: theme.spacing.md,
+        paddingHorizontal: theme.spacing.sm,
+        borderRadius: theme.radius.lg,
+        backgroundColor: theme.color.brandSoft,
+        opacity: pressed ? 0.7 : 1,
+      })}
+    >
+      <Ionicons name={icon} size={iconSize.lg} color={theme.color.brand} />
+      <Text variant="caption" tone="brand" numberOfLines={1} style={{ fontWeight: '700' }}>
+        {label}
+      </Text>
+    </Pressable>
   );
 }

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -2027,6 +2027,8 @@ export interface UiStrings {
     emailSubject: string;
     hideContacts: string;
     browseContacts: string;
+    /** The rule between the invite tiles and the by-name fields. */
+    orByName: string;
     /** Short label for the phone-contacts entry point. */
     contacts: string;
     /** Reminding somebody who owes you to settle, gently (ADR-010). */
@@ -4619,6 +4621,7 @@ const en: UiStrings = {
     emailSubject: 'Join {group} on Waves',
     hideContacts: 'Hide contacts',
     browseContacts: 'Browse my contacts',
+    orByName: 'or add by name',
     contacts: 'Contacts',
     remind: 'Remind',
     reminded: 'Reminded',
@@ -7247,6 +7250,7 @@ const ta: UiStrings = {
     emailSubject: 'Waves-ல் {group} குழுவில் சேரவும்',
     hideContacts: 'தொடர்புகளை மறை',
     browseContacts: 'என் தொடர்புகளைப் பார்',
+    orByName: 'அல்லது பெயரால் சேர்',
     contacts: 'தொடர்புகள்',
     remind: 'நினைவூட்டு',
     reminded: 'நினைவூட்டப்பட்டது',
@@ -9874,6 +9878,7 @@ const hi: UiStrings = {
     emailSubject: 'Waves पर {group} में शामिल हों',
     hideContacts: 'संपर्क छिपाएँ',
     browseContacts: 'मेरे संपर्क देखें',
+    orByName: 'या नाम से जोड़ें',
     contacts: 'संपर्क',
     remind: 'याद दिलाएँ',
     reminded: 'याद दिला दिया',
@@ -12589,6 +12594,7 @@ const ar: UiStrings = {
     emailSubject: 'انضم إلى {group} على Waves',
     hideContacts: 'إخفاء جهات الاتصال',
     browseContacts: 'تصفّح جهات اتصالي',
+    orByName: 'أو أضف بالاسم',
     contacts: 'جهات الاتصال',
     remind: 'ذكّر',
     reminded: 'تم التذكير',


### PR DESCRIPTION
### Before

Two bare text inputs stacked on each other — neither labelled, only placeheld — with a small **Add** beside the first that also committed the second, and **Browse my contacts** as a ghost button underneath them both. So the fastest way in was the last thing you saw.

The invite link was not even in this card: a line of tappable text in a different block further down the page, shown only once a ghost already existed.

### After

```
Add someone
┌───────────────────┬───────────────────┐
│        👥         │        🔗         │
│ Browse my contacts│   Share invite    │
└───────────────────┴───────────────────┘
      ──────  or add by name  ──────
[ Name                              ] [ Add ]
[ Email or phone (optional)                 ]
A name is enough to start splitting.
```

### Why

Every add-members screen on the boards puts the doors first, as a row of equal-weight tiles: [Microsoft Teams](https://mobbin.com/screens/747d2570-e5fd-414a-b5b6-01ec1bdeaed8) (share link / QR / camera import), [Discord](https://mobbin.com/screens/35287404-a271-43d1-ac4a-5ccabf20b23b) (share invite / copy link / Messages / Gmail), [GroupMe](https://mobbin.com/screens/a6f302a5-9a0a-4521-9e94-bc6588437907), [Abode](https://mobbin.com/screens/c4f8a5a9-caa1-479e-b942-5fa369422b4e), [WhatsApp](https://mobbin.com/screens/90354546-8acc-4aa6-89ce-b068e3dfe257), [GoPay](https://mobbin.com/screens/71be92d0-3f4a-43a0-b1e7-50fae72b8298). Typing a name is the fallback, under a rule that says so.

That ordering is also truer to the rule it implements: ADR-006 says a name alone is *enough* to start splitting with somebody — not that a name alone is the first thing to reach for.

**Two tiles, not three or four.** Our invite link and our QR are the same screen, so a third tile would point where the second already does — the second door this app keeps deciding not to build.

The fields are bordered now, so a text input looks like one; the optional contact is visibly quieter than the name instead of sitting at equal weight beneath it and reading as the rest of a required form; and **Add** is filled, because it is the one thing the block is for.

Strings added in all four locales. Gates: tsc, lint, filename check, 1296 tests. Not device-verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned the add-members experience with two clear options: browse contacts or share an invite.
  - Added a separate “or by name” section for entering member details.
  - Improved the layout and emphasis of name and contact fields, with a more prominent Add button.
  - Added translations for the new section label in English, Tamil, Hindi, and Arabic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->