### PR TITLE
Let EAS sign its own builds, and tell the web about the key it made

### DIFF
--- a/apps/mobile/plugins/withReleaseSigning.js
+++ b/apps/mobile/plugins/withReleaseSigning.js
@@ -160,6 +160,21 @@ function patchBuildGradle(contents) {
 }
 
 module.exports = function withReleaseSigning(config) {
+  // On EAS Build, signing is not ours to arrange.
+  //
+  // EAS holds the keystore, hands it to the builder, and patches the stock
+  // `signingConfigs.release` to point at it. Ours is the block it would be
+  // patching — wrapped in `if (wavesHasUploadKey)`, which is false there
+  // because the key never arrives as `WAVES_UPLOAD_STORE_FILE` in
+  // `~/.gradle/gradle.properties`. The guard then reads that same false and
+  // stops `bundleRelease` with a message about properties nobody can set on a
+  // hosted builder. That is what failed build 2362155a.
+  //
+  // `expo prebuild` runs on the builder too, so this is decided at the same
+  // moment there as it is here, and the generated `build.gradle` is simply
+  // Expo's own — which is exactly what EAS knows how to sign.
+  if (process.env.EAS_BUILD === 'true') return config;
+
   return withAppBuildGradle(config, (gradleConfig) => {
     gradleConfig.modResults.contents = patchBuildGradle(gradleConfig.modResults.contents);
     return gradleConfig;

--- a/apps/mobile/test/releaseSigning.test.ts
+++ b/apps/mobile/test/releaseSigning.test.ts
@@ -16,9 +16,12 @@
 import { describe, expect, it } from 'vitest';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const { patchBuildGradle } = require('../plugins/withReleaseSigning.js') as {
+const withReleaseSigning = require('../plugins/withReleaseSigning.js') as ((
+  config: object,
+) => object) & {
   patchBuildGradle: (contents: string) => string;
 };
+const { patchBuildGradle } = withReleaseSigning;
 
 const TEMPLATE = `android {
     namespace 'app.waves.mobile'
@@ -112,6 +115,25 @@ describe('the release signing patch', () => {
 
   it('is idempotent, because prebuild is not guaranteed to run once', () => {
     expect(patchBuildGradle(patched)).toBe(patched);
+  });
+
+  it('stands down on EAS, where the keystore is not ours to install', () => {
+    // The bug this pins: EAS holds the key and patches the stock
+    // `signingConfigs.release` to reach it. Patch the file first and that block
+    // is ours, guarded by a `wavesHasUploadKey` that is false on a hosted
+    // builder — so the guard stopped `bundleRelease` with a message about
+    // gradle properties nobody can set there. Build 2362155a died exactly that
+    // way. On EAS the plugin returns the config untouched, leaving Expo's own
+    // template for EAS to sign.
+    const config = { name: 'Waves' };
+    const before = process.env.EAS_BUILD;
+    try {
+      process.env.EAS_BUILD = 'true';
+      expect(withReleaseSigning(config)).toBe(config);
+    } finally {
+      if (before === undefined) delete process.env.EAS_BUILD;
+      else process.env.EAS_BUILD = before;
+    }
   });
 
   it('refuses to patch a template it does not recognise', () => {

--- a/apps/web/src/app/.well-known/assetlinks.json/route.ts
+++ b/apps/web/src/app/.well-known/assetlinks.json/route.ts
@@ -49,6 +49,14 @@ const CERT_FINGERPRINTS = [
   // builds are the one place an invite link still opens the browser, which is
   // exactly where a link is most likely to be tested.
   'CD:72:24:BE:46:44:D1:0F:BC:11:31:04:B8:CD:96:2F:60:12:02:52:1D:03:07:B1:E2:31:43:6D:02:4D:EA:3E',
+  // The EAS-managed upload key, generated when the first cloud production build
+  // ran and now the key that signs what goes to Play. It is listed alongside the
+  // one above rather than instead of it: release APKs built locally are still
+  // signed with `~/keys/waves-upload.jks`, and those installs stay on phones.
+  // Both are upload certificates, so neither is what a Play install presents —
+  // but both are what a sideloaded build presents, and a link has to open in
+  // either.
+  'AE:F2:B8:46:40:A1:61:AA:3B:42:F0:FF:B1:7B:A3:20:34:38:9F:5A:06:8B:D3:F5:93:0F:BA:20:A3:B5:DE:F1',
 ];
 
 export const runtime = 'nodejs';


### PR DESCRIPTION
The first `eas build --profile production --platform android` failed at `bundleRelease` (build `2362155a`). The cause was `withReleaseSigning.js`, not Expo or Gradle.

## What went wrong

The plugin patches the generated `build.gradle` so the release variant signs with a real upload key read from `~/.gradle/gradle.properties`, and guards `bundleRelease` against running debug-signed:

```groovy
if (!wavesHasUploadKey && graph.allTasks.any { it.name.startsWith('bundleRelease') }) {
    throw new GradleException('No upload key: set WAVES_UPLOAD_STORE_FILE, ...')
}
```

On EAS the keystore arrives through EAS credentials, never as `WAVES_UPLOAD_STORE_FILE`, so `wavesHasUploadKey` is false — and the `signingConfigs.release` block EAS wants to patch is ours, wrapped in a condition false for the same reason. The guard stopped the build with a message naming four gradle properties nobody can set on a hosted builder.

## The fix

`expo prebuild` runs on the builder too, so the plugin declines there:

```js
if (process.env.EAS_BUILD === 'true') return config;
```

EAS then signs Expo's own template, which is the shape it knows how to patch. Local behaviour is unchanged — the guard still fails a keyless `bundleRelease`, and a keyless `assembleRelease` still warns and ships debug-signed for sideloading. A test pins the escape hatch.

## The certificate

That build generated its own keystore and we are keeping it as the Play upload key, so its SHA-256 joins `assetlinks.json`:

```
AE:F2:B8:46:40:A1:61:AA:3B:42:F0:FF:B1:7B:A3:20:34:38:9F:5A:06:8B:D3:F5:93:0F:BA:20:A3:B5:DE:F1
```

Added, not swapped, per the rule the file already states. Release APKs built locally are still signed with `~/keys/waves-upload.jks` and those installs stay on phones; both are upload certificates, so neither is what a Play install presents, but either is what a sideload presents and a join link has to open the app on both.

## Checks

`expo-doctor` 21/21, typecheck, lint, mobile + web tests green. **`apps/web` needs a deploy after merge** for the new fingerprint to be served.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Android release builds on EAS so they use EAS-managed signing without being blocked by local signing configuration.
  * Preserved local release signing behavior for development and prebuild workflows.

* **Improvements**
  * Added support for Android app links signed with the EAS-managed certificate, alongside the existing local certificate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->