### PR TITLE
Friends holds its shape when somebody carries four currencies

### DIFF
--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -474,7 +474,11 @@ export default function ActivityScreen() {
   if (listData.length === 0) {
     return (
       <Screen>
-        <View style={{ flex: 1, paddingHorizontal: theme.spacing.xl }}>
+        {/* The same bottom clearance the feed's rows get. Without it this box
+            runs on underneath the tab bar, and centring inside it puts the
+            artwork below the middle of the part you can actually see — the
+            further down the screen, the more of the box is hidden. */}
+        <View style={{ flex: 1, paddingHorizontal: theme.spacing.xl, paddingBottom: clearance }}>
           {header}
           {empty}
         </View>

--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -467,7 +467,12 @@ export default function FriendsScreen() {
         {people.isLoading ? (
           <PeopleSkeleton />
         ) : rows.length === 0 ? (
-          <View style={{ flex: 1, justifyContent: 'center' }}>
+          // Centred in what can be seen, not in what is laid out: the box runs
+          // on under the tab bar, so without its clearance the artwork settles
+          // below the middle of the visible screen. The list branch below pays
+          // the same clearance on its own content, and the dashboard already
+          // does this — this branch was the one that missed it.
+          <View style={{ flex: 1, justifyContent: 'center', paddingBottom: clearance }}>
             <EmptyFriends hasPeople={known.data > 0} t={t} />
           </View>
         ) : (

--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -66,6 +66,7 @@ import {
   currencyTotals,
   directionGroups,
   personDirection,
+  shownAmounts,
   type CurrencyTotal,
 } from '@/lib/friendsTotals';
 import { PressableScale } from '@/lib/anim';
@@ -1175,28 +1176,24 @@ const PersonRow = memo(function PersonRow({
     .filter(Boolean)
     .join('. ');
 
-  // Biggest currency first when a person spans several.
-  const sortedEntries =
-    entries.length > 1
-      ? [...entries].sort((a, b) =>
-          absBig(BigInt(a.net)) < absBig(BigInt(b.net))
-            ? 1
-            : absBig(BigInt(a.net)) > absBig(BigInt(b.net))
-              ? -1
-              : 0,
-        )
-      : entries;
-
-  /** At most two amounts per row; the rest are counted, never dropped silently. */
-  const shownEntries = sortedEntries.slice(0, MAX_STACKED_AMOUNTS);
-  const hiddenCurrencies = sortedEntries.length - shownEntries.length;
+  // At most two amounts per row, and never at the cost of a direction: a balance
+  // that runs both ways always shows both colours. The rest are counted.
+  const { shown: shownEntries, hidden: hiddenCurrencies } = shownAmounts(
+    entries,
+    MAX_STACKED_AMOUNTS,
+  );
 
   const body = (
     <Row
       style={{
         paddingVertical: theme.spacing.sm,
         paddingHorizontal: theme.spacing.sm,
-        alignItems: 'center',
+        // Top, not centre. Centring a one-line name against a stack of amounts
+        // floats the name to the middle of the stack — it sat level with a
+        // person's *second* currency, so the eye read the name against the wrong
+        // number. Aligned to the top, the name and the amount that leads the row
+        // are on the same line, whatever either side is carrying.
+        alignItems: 'flex-start',
         gap: theme.spacing.md,
         borderTopWidth: divider ? 1 : 0,
         borderTopColor: theme.color.border,
@@ -1256,38 +1253,26 @@ const PersonRow = memo(function PersonRow({
           invite/remind discs sit in one clean column at the edge — rather than
           floating at a different x on every row because the amount width differs. */}
       <View style={{ alignItems: 'flex-end', maxWidth: '46%' }}>
-        {single ? (
+        {/* The first amount is always the same size, whether the person holds one
+            currency or four — it used to drop to caption as soon as there were
+            two, so the column that should read as one row of figures carried
+            16px and 13px side by side. The lead figure is the row's answer; the
+            currencies under it are the detail. Never summed across them. */}
+        {shownEntries.map((entry, index) => (
           <MoneyText
-            amount={BigInt(single.net)}
-            currency={single.currency}
+            key={entry.currency}
+            amount={BigInt(entry.net)}
+            currency={entry.currency}
             locale={locale}
-            variant="subheading"
+            variant={index === 0 ? 'subheading' : 'caption'}
             mode="balance"
           />
-        ) : (
-          // Multi-currency: one small coloured line per currency — never summed.
-          // Only the two biggest are drawn, and the remainder is counted. A row
-          // is a summary, and an unbounded stack made one person four lines tall
-          // next to a neighbour's one, which is what broke the list's rhythm;
-          // the person page splits every currency and group out in full.
-          <>
-            {shownEntries.map((e) => (
-              <MoneyText
-                key={e.currency}
-                amount={BigInt(e.net)}
-                currency={e.currency}
-                locale={locale}
-                variant="caption"
-                mode="balance"
-              />
-            ))}
-            {hiddenCurrencies > 0 ? (
-              <Text variant="micro" tone="faint">
-                {plural(locale, hiddenCurrencies, t.tabs.moreCurrencies)}
-              </Text>
-            ) : null}
-          </>
-        )}
+        ))}
+        {hiddenCurrencies > 0 ? (
+          <Text variant="micro" tone="faint">
+            {plural(locale, hiddenCurrencies, t.tabs.moreCurrencies)}
+          </Text>
+        ) : null}
       </View>
       <View style={{ width: ACTION_SLOT, alignItems: 'center', justifyContent: 'center' }}>
         {!selectMode && person.is_ghost && soloGroup ? (

--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -66,6 +66,7 @@ import {
   currencyTotals,
   directionGroups,
   personDirection,
+  rowAction,
   shownAmounts,
   type CurrencyTotal,
 } from '@/lib/friendsTotals';
@@ -401,6 +402,16 @@ export default function FriendsScreen() {
     [rows, sortKey, sortDir],
   );
 
+  // Whether the trailing control column is worth its width. Reserved when
+  // anybody on the list has an invite or a nudge to offer, so those discs line
+  // up; dropped entirely when nobody does, rather than holding 34dp open on
+  // every row for a control that never comes. Never in selection mode, where the
+  // controls are hidden anyway.
+  const actionSlot = useMemo(
+    () => !selectMode && persons.some((person) => rowAction(person) !== null),
+    [persons, selectMode],
+  );
+
   // The headline's figures: the net you are up or down in each currency, summed
   // across everyone. Never across currencies — there is no honest single number
   // without a rate (ADR-003), so a mixed wallet shows one line per currency.
@@ -527,6 +538,7 @@ export default function FriendsScreen() {
                     duplicate={duplicates.keys.has(item.person_key)}
                     selectMode={selectMode}
                     selected={selectedKeys.has(item.person_key)}
+                    actionSlot={actionSlot}
                     onEnterSelect={enterSelect}
                     onToggleSelect={toggleSelect}
                   />
@@ -1083,6 +1095,7 @@ const PersonRow = memo(function PersonRow({
   duplicate,
   selectMode,
   selected,
+  actionSlot,
   onEnterSelect,
   onToggleSelect,
 }: {
@@ -1096,6 +1109,8 @@ const PersonRow = memo(function PersonRow({
   duplicate: boolean;
   selectMode: boolean;
   selected: boolean;
+  /** Any row on this list has a trailing control, so every row reserves the column. */
+  actionSlot: boolean;
   onEnterSelect: (personKey: string) => void;
   onToggleSelect: (personKey: string) => void;
 }): React.JSX.Element {
@@ -1157,6 +1172,7 @@ const PersonRow = memo(function PersonRow({
   // a second line and rows without, and the names stopped sitting on a common
   // grid. A genuinely mixed balance still says nothing: no word is true of both
   // halves, and the coloured amounts are the honest answer there.
+  const action = selectMode ? null : rowAction(person);
   const runs = personDirection(entries);
   const direction = runs === 'owed' ? t.tabs.owesYou : runs === 'owing' ? t.tabs.youOweThem : null;
   const caption = [direction, scope].filter(Boolean).join(' · ') || null;
@@ -1274,21 +1290,30 @@ const PersonRow = memo(function PersonRow({
           </Text>
         ) : null}
       </View>
-      <View style={{ width: ACTION_SLOT, alignItems: 'center', justifyContent: 'center' }}>
-        {!selectMode && person.is_ghost && soloGroup ? (
-          // A guest with no account yet: the useful action is the invite link that
-          // also lets them claim this balance (A25). One group, one link.
-          <RowAction
-            icon="paper-plane-outline"
-            label={t.people.invite}
-            onPress={() => router.push(`/group/${soloGroup}/invite`)}
-          />
-        ) : !selectMode && single && BigInt(single.net) > 0n && single.only_group_id ? (
-          // They owe you and one group explains it — a single pair to nudge, kept
-          // honest by the server at one a day (ADR-010).
-          <RemindButton row={single} />
-        ) : null}
-      </View>
+      {/* The trailing slot, reserved only when somebody on this list actually has
+          a control to put in it. It exists so the invite and remind discs form one
+          column instead of floating at a different x on every row — but when no
+          row offers either, it is 34dp of nothing holding every amount away from
+          the edge, which is how the list ended up with its figures marooned in
+          the middle. `actionSlot` is the list's answer to the same `rowAction`
+          this row asks, so the two cannot disagree. */}
+      {actionSlot ? (
+        <View style={{ width: ACTION_SLOT, alignItems: 'center', justifyContent: 'center' }}>
+          {action === 'invite' && soloGroup ? (
+            // A guest with no account yet: the useful action is the invite link that
+            // also lets them claim this balance (A25). One group, one link.
+            <RowAction
+              icon="paper-plane-outline"
+              label={t.people.invite}
+              onPress={() => router.push(`/group/${soloGroup}/invite`)}
+            />
+          ) : action === 'remind' && single ? (
+            // They owe you and one group explains it — a single pair to nudge, kept
+            // honest by the server at one a day (ADR-010).
+            <RemindButton row={single} />
+          ) : null}
+        </View>
+      ) : null}
     </Row>
   );
 

--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -63,6 +63,7 @@ import { defaultMergeName } from '@/data/mergePeople';
 import { useKnownPeopleCount, usePeopleBalances } from '@/data/hooks';
 import { useAuth } from '@/lib/auth';
 import {
+  commonOnlyGroupId,
   currencyTotals,
   directionGroups,
   personDirection,
@@ -1136,14 +1137,16 @@ const PersonRow = memo(function PersonRow({
   // hidden behind the ghost name and face, so a photo must not leak it. The
   // `avatar_url` is the same across a person's rows, so the first carries it.
   const photoUrl = useAvatarUrl(blocked ? null : (entries[0]?.avatar_url ?? null));
-  // The common case: a person with a single balance. It carries the direction,
-  // the group scope and the action; a multi-currency person leans on the stacked
-  // amounts instead.
+  // One common group can explain several currency rows for the same person: a
+  // traveller may owe a guest in INR and USD from one trip, and that is still
+  // one invite/reminder context. Differing or missing group ids go to the person
+  // page, where the full split is visible.
   const single = entries.length === 1 ? entries[0] : null;
-  const soloGroup = single?.only_group_id ?? null;
+  const soloGroup = commonOnlyGroupId(entries);
+  const remindRow = entries.find((entry) => BigInt(entry.net) > 0n && entry.only_group_id === soloGroup);
 
-  // One group and one currency explains it: open that group. Otherwise the
-  // person page splits the balance back out per group and currency.
+  // One group explains it: open that group. Otherwise the person page splits the
+  // balance back out per group and currency.
   const navigate = soloGroup
     ? () => router.push(`/group/${soloGroup}`)
     : () =>
@@ -1287,6 +1290,8 @@ const PersonRow = memo(function PersonRow({
             locale={locale}
             variant={index === 0 ? 'subheading' : 'caption'}
             mode="balance"
+            numberOfLines={index === 0 ? 1 : undefined}
+            ellipsizeMode="tail"
           />
         ))}
         {hiddenCurrencies > 0 ? (
@@ -1312,10 +1317,12 @@ const PersonRow = memo(function PersonRow({
               label={t.people.invite}
               onPress={() => router.push(`/group/${soloGroup}/invite`)}
             />
-          ) : action === 'remind' && single ? (
+          ) : action === 'remind' && remindRow ? (
             // They owe you and one group explains it — a single pair to nudge, kept
-            // honest by the server at one a day (ADR-010).
-            <RemindButton row={single} />
+            // honest by the server at one a day (ADR-010). Several currencies in
+            // that one group still make one pair; the row only needs one currency
+            // row to name the group and person to the API.
+            <RemindButton row={remindRow} />
           ) : null}
         </View>
       ) : null}

--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -62,6 +62,12 @@ import { useBlockedUsers } from '@/data/blocked';
 import { defaultMergeName } from '@/data/mergePeople';
 import { useKnownPeopleCount, usePeopleBalances } from '@/data/hooks';
 import { useAuth } from '@/lib/auth';
+import {
+  currencyTotals,
+  directionGroups,
+  personDirection,
+  type CurrencyTotal,
+} from '@/lib/friendsTotals';
 import { PressableScale } from '@/lib/anim';
 import { router } from '@/lib/navigation';
 import { useReducedMotion } from '@/lib/reducedMotion';
@@ -174,22 +180,6 @@ function sortPersons(people: PersonGroup[], key: SortKey, dir: SortDir): PersonG
   return [...people].sort(cmp);
 }
 
-export interface CurrencyTotal {
-  currency: string;
-  net: bigint;
-}
-
-/** The net you are up or down in each currency, summed over everyone. Positive:
- *  owed to you. Never summed across currencies (ADR-003). Biggest first. */
-function currencyTotals(rows: PersonBalanceRow[]): CurrencyTotal[] {
-  const m = new Map<string, bigint>();
-  for (const row of rows) m.set(row.currency, (m.get(row.currency) ?? 0n) + BigInt(row.net));
-  return [...m.entries()]
-    .filter(([, net]) => net !== 0n)
-    .map(([currency, net]) => ({ currency, net }))
-    .sort((a, b) => (absBig(a.net) < absBig(b.net) ? 1 : absBig(a.net) > absBig(b.net) ? -1 : 0));
-}
-
 /**
  * The Friends hero wash — a saturated indigo, the same proven two-stop diagonal
  * the dashboard's month slide rides, so the two tabs read as one system and the
@@ -203,6 +193,17 @@ const FRIENDS_GRADIENT = ['#463F86', '#221C46'] as const;
     even when there is no action — so every amount's right edge lines up and the
     invite/remind discs form one clean column instead of floating with the amount. */
 const ACTION_SLOT = 34;
+
+/**
+ * How many currencies a single row will draw before it starts counting them.
+ *
+ * Two, because a row has to stay roughly one height: a person holding four
+ * currencies was drawing four stacked lines beside a neighbour's one, and a list
+ * whose rows are 1x and 4x tall has no rhythm for the eye to follow. Two is
+ * enough to show that a balance runs both ways — the common reason a person has
+ * more than one — and the rest are named as a count rather than hidden.
+ */
+const MAX_STACKED_AMOUNTS = 2;
 
 /**
  * Which guests are probably the same person seen twice.
@@ -774,26 +775,55 @@ function FriendsHero({
           <Text variant="micro" tone="onBrand" style={{ letterSpacing: 1, opacity: 0.7 }}>
             {t.tabs.overall.toUpperCase()}
           </Text>
-          {totals.map((total) => (
-            <Row
-              key={total.currency}
-              style={{
-                justifyContent: 'space-between',
-                alignItems: 'flex-end',
-                gap: theme.spacing.md,
-              }}
-            >
-              <Text variant="body" tone="onBrand" style={{ opacity: 0.85 }}>
-                {total.net > 0n ? t.tabs.youAreOwed : t.tabs.youOweThem}
-              </Text>
-              <MoneyText
-                amount={total.net < 0n ? -total.net : total.net}
-                currency={total.currency}
-                locale={locale}
-                tone="onBrand"
-                style={{ fontSize: 32, lineHeight: 38, fontWeight: '800' }}
-              />
-            </Row>
+          {directionGroups(totals).map((group) => (
+            <View key={group.owed ? 'owed' : 'owing'} style={{ gap: 2 }}>
+              <Row
+                style={{
+                  justifyContent: 'space-between',
+                  // Baseline, not flex-end: the label is 16px and the amount is
+                  // 32, so aligning the bottoms of two boxes that tall sits the
+                  // word below the digits it belongs to. This is the line the
+                  // eye reads across.
+                  alignItems: 'baseline',
+                  gap: theme.spacing.md,
+                }}
+              >
+                <Text variant="body" tone="onBrand" style={{ opacity: 0.85 }}>
+                  {group.owed ? t.tabs.youAreOwed : t.tabs.youOweThem}
+                </Text>
+                <MoneyText
+                  amount={group.head.net < 0n ? -group.head.net : group.head.net}
+                  currency={group.head.currency}
+                  locale={locale}
+                  tone="onBrand"
+                  style={{ fontSize: 32, lineHeight: 38, fontWeight: '800' }}
+                />
+              </Row>
+              {group.rest.length > 0 ? (
+                // The same direction's other currencies, small and under the
+                // number they belong to. Wrapped rather than clipped — six
+                // currencies costs a second line here instead of six headlines.
+                <Row
+                  style={{
+                    justifyContent: 'flex-end',
+                    flexWrap: 'wrap',
+                    columnGap: theme.spacing.sm,
+                  }}
+                >
+                  {group.rest.map((total) => (
+                    <MoneyText
+                      key={total.currency}
+                      amount={total.net < 0n ? -total.net : total.net}
+                      currency={total.currency}
+                      locale={locale}
+                      variant="caption"
+                      tone="onBrand"
+                      style={{ opacity: 0.8 }}
+                    />
+                  ))}
+                </Row>
+              ) : null}
+            </View>
           ))}
         </Reanimated.View>
       ) : null}
@@ -1117,10 +1147,17 @@ const PersonRow = memo(function PersonRow({
       ? plural(locale, single.group_count, t.tabs.acrossGroups)
       : null;
   // The caption folds direction and scope onto one line, so the right edge no
-  // longer stacks a micro-label over the amount. Multi-currency people have no
-  // single direction (owed in one, owing in another) — their stacked coloured
-  // amounts carry it, so the caption is just the scope, if any.
-  const direction = single ? (BigInt(single.net) > 0n ? t.tabs.owesYou : t.tabs.youOweThem) : null;
+  // longer stacks a micro-label over the amount.
+  //
+  // Direction is knowable whenever every currency points the same way, not only
+  // when there is one of them — somebody who owes you in rupees and in dollars
+  // still simply owes you. Gating this on `single` left every multi-currency
+  // person with no caption at all, so a dense list alternated between rows with
+  // a second line and rows without, and the names stopped sitting on a common
+  // grid. A genuinely mixed balance still says nothing: no word is true of both
+  // halves, and the coloured amounts are the honest answer there.
+  const runs = personDirection(entries);
+  const direction = runs === 'owed' ? t.tabs.owesYou : runs === 'owing' ? t.tabs.youOweThem : null;
   const caption = [direction, scope].filter(Boolean).join(' · ') || null;
 
   // What a screen reader hears: who, then each currency's spoken direction and
@@ -1149,6 +1186,10 @@ const PersonRow = memo(function PersonRow({
               : 0,
         )
       : entries;
+
+  /** At most two amounts per row; the rest are counted, never dropped silently. */
+  const shownEntries = sortedEntries.slice(0, MAX_STACKED_AMOUNTS);
+  const hiddenCurrencies = sortedEntries.length - shownEntries.length;
 
   const body = (
     <Row
@@ -1214,7 +1255,7 @@ const PersonRow = memo(function PersonRow({
           rows with no action, so every amount's right edge lines up and the
           invite/remind discs sit in one clean column at the edge — rather than
           floating at a different x on every row because the amount width differs. */}
-      <View style={{ alignItems: 'flex-end' }}>
+      <View style={{ alignItems: 'flex-end', maxWidth: '46%' }}>
         {single ? (
           <MoneyText
             amount={BigInt(single.net)}
@@ -1225,16 +1266,27 @@ const PersonRow = memo(function PersonRow({
           />
         ) : (
           // Multi-currency: one small coloured line per currency — never summed.
-          sortedEntries.map((e) => (
-            <MoneyText
-              key={e.currency}
-              amount={BigInt(e.net)}
-              currency={e.currency}
-              locale={locale}
-              variant="caption"
-              mode="balance"
-            />
-          ))
+          // Only the two biggest are drawn, and the remainder is counted. A row
+          // is a summary, and an unbounded stack made one person four lines tall
+          // next to a neighbour's one, which is what broke the list's rhythm;
+          // the person page splits every currency and group out in full.
+          <>
+            {shownEntries.map((e) => (
+              <MoneyText
+                key={e.currency}
+                amount={BigInt(e.net)}
+                currency={e.currency}
+                locale={locale}
+                variant="caption"
+                mode="balance"
+              />
+            ))}
+            {hiddenCurrencies > 0 ? (
+              <Text variant="micro" tone="faint">
+                {plural(locale, hiddenCurrencies, t.tabs.moreCurrencies)}
+              </Text>
+            ) : null}
+          </>
         )}
       </View>
       <View style={{ width: ACTION_SLOT, alignItems: 'center', justifyContent: 'center' }}>

--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -1138,12 +1138,11 @@ const PersonRow = memo(function PersonRow({
   // `avatar_url` is the same across a person's rows, so the first carries it.
   const photoUrl = useAvatarUrl(blocked ? null : (entries[0]?.avatar_url ?? null));
   // One common group can explain several currency rows for the same person: a
-  // traveller may owe a guest in INR and USD from one trip, and that is still
-  // one invite/reminder context. Differing or missing group ids go to the person
-  // page, where the full split is visible.
+  // traveller may owe a guest in INR and USD from one trip, and that is still one
+  // group to invite them to. Differing or missing group ids go to the person
+  // page, where the full split is visible. A nudge is narrower — see `rowAction`.
   const single = entries.length === 1 ? entries[0] : null;
   const soloGroup = commonOnlyGroupId(entries);
-  const remindRow = entries.find((entry) => BigInt(entry.net) > 0n && entry.only_group_id === soloGroup);
 
   // One group explains it: open that group. Otherwise the person page splits the
   // balance back out per group and currency.
@@ -1290,7 +1289,10 @@ const PersonRow = memo(function PersonRow({
             locale={locale}
             variant={index === 0 ? 'subheading' : 'caption'}
             mode="balance"
-            numberOfLines={index === 0 ? 1 : undefined}
+            // Every line, not only the lead: the column is capped at 46% of the
+            // row, and a wrapped amount anywhere in the stack grows the row —
+            // the exact thing this list was fixed to stop doing.
+            numberOfLines={1}
             ellipsizeMode="tail"
           />
         ))}
@@ -1317,12 +1319,11 @@ const PersonRow = memo(function PersonRow({
               label={t.people.invite}
               onPress={() => router.push(`/group/${soloGroup}/invite`)}
             />
-          ) : action === 'remind' && remindRow ? (
+          ) : action === 'remind' && single ? (
             // They owe you and one group explains it — a single pair to nudge, kept
-            // honest by the server at one a day (ADR-010). Several currencies in
-            // that one group still make one pair; the row only needs one currency
-            // row to name the group and person to the API.
-            <RemindButton row={remindRow} />
+            // honest by the server at one a day (ADR-010). One currency, because
+            // the nudge names one: see `rowAction`.
+            <RemindButton row={single} />
           ) : null}
         </View>
       ) : null}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1398,6 +1398,7 @@ export interface UiStrings {
     youAreNotBehind: string;
     inOneGroup: string;
     acrossGroups: PluralForms;
+    moreCurrencies: PluralForms;
     notJoined: string;
     group: string;
   };
@@ -4082,6 +4083,7 @@ const en: UiStrings = {
     youAreNotBehind: 'All settled up — you owe nobody right now.',
     inOneGroup: 'in one group',
     acrossGroups: { one: 'across {n} group', other: 'across {n} groups' },
+    moreCurrencies: { one: '+{n} more currency', other: '+{n} more currencies' },
     notJoined: 'Not joined',
     group: 'Group',
   },
@@ -6678,6 +6680,7 @@ const ta: UiStrings = {
     youAreNotBehind: 'நீங்கள் யாருக்கும் பாக்கி வைத்திருக்கவில்லை.',
     inOneGroup: 'ஒரு குழுவில்',
     acrossGroups: { one: '{n} குழுவில்', other: '{n} குழுக்களில்' },
+    moreCurrencies: { one: '+{n} நாணயம்', other: '+{n} நாணயங்கள்' },
     notJoined: 'சேரவில்லை',
     group: 'குழு',
   },
@@ -9332,6 +9335,7 @@ const hi: UiStrings = {
     youAreNotBehind: 'आप पर किसी का कुछ बाकी नहीं है।',
     inOneGroup: 'एक समूह में',
     acrossGroups: { one: '{n} समूह में', other: '{n} समूहों में' },
+    moreCurrencies: { one: '+{n} और मुद्रा', other: '+{n} और मुद्राएँ' },
     notJoined: 'शामिल नहीं',
     group: 'समूह',
   },
@@ -11979,6 +11983,14 @@ const ar: UiStrings = {
       few: 'في {n} مجموعات',
       many: 'في {n} مجموعة',
       other: 'في {n} مجموعة',
+    },
+    moreCurrencies: {
+      zero: '+{n} عملة',
+      one: '+عملة واحدة',
+      two: '+عملتان',
+      few: '+{n} عملات',
+      many: '+{n} عملة',
+      other: '+{n} عملة',
     },
     notJoined: 'لم ينضم',
     group: 'مجموعة',

--- a/apps/mobile/src/lib/friendsTotals.ts
+++ b/apps/mobile/src/lib/friendsTotals.ts
@@ -136,6 +136,32 @@ export function shownAmounts<T extends NetRow>(
   return { shown, hidden: ranked.length - shown.length };
 }
 
+/** A person's row as the action rule needs to see it. */
+interface ActionablePerson {
+  is_ghost: boolean;
+  entries: readonly { net: string | bigint; only_group_id: string | null }[];
+}
+
+/**
+ * The one control a row may carry at its trailing edge, if any.
+ *
+ * Both offers need a single group to act on: an invite link belongs to one
+ * group, and a nudge is one pair in one group (ADR-010). Somebody spread across
+ * three groups has no such thing, so their row carries nothing.
+ *
+ * Stated here rather than inside the row because the list has to reserve the
+ * column before any row draws, and a list that guesses differently from the row
+ * either holds space for a control that never appears — 34dp of nothing pushing
+ * every amount off the right edge — or draws one with nowhere to sit.
+ */
+export function rowAction(person: ActionablePerson): 'invite' | 'remind' | null {
+  const single = person.entries.length === 1 ? person.entries[0] : null;
+  if (!single) return null;
+  if (person.is_ghost && single.only_group_id) return 'invite';
+  if (BigInt(single.net) > 0n && single.only_group_id) return 'remind';
+  return null;
+}
+
 /** Which way a person's balance runs, or null when it runs both ways. */
 export type PersonDirection = 'owed' | 'owing' | null;
 

--- a/apps/mobile/src/lib/friendsTotals.ts
+++ b/apps/mobile/src/lib/friendsTotals.ts
@@ -1,0 +1,97 @@
+/**
+ * What the Friends screen says about money, as arithmetic rather than layout.
+ *
+ * Three questions the screen asks and a component is a poor place to answer:
+ * what you stand at in each currency, how those fold into the two things the
+ * hero actually says, and which way a single person's balance runs. All three
+ * are pure, all three have edge cases worth pinning, and none of them needs a
+ * renderer to be true — so they live here and `friends.tsx` draws the answers.
+ */
+
+/** The net in one currency. Positive: owed to you. */
+export interface CurrencyTotal {
+  currency: string;
+  net: bigint;
+}
+
+/** Anything with a signed net in a currency — a person's row, or a total. */
+interface NetRow {
+  currency: string;
+  net: string | bigint;
+}
+
+function absBig(v: bigint): bigint {
+  return v < 0n ? -v : v;
+}
+
+/**
+ * The net you are up or down in each currency, summed over everyone.
+ *
+ * Never summed *across* currencies (ADR-003): there is no such thing as a total
+ * in no currency, and inventing one would need a rate this screen does not have.
+ * Biggest first, so whatever leads the hero is the figure that matters most.
+ * Currencies that net to zero drop out — "you are owed ₹0" is not news.
+ */
+export function currencyTotals(rows: readonly NetRow[]): CurrencyTotal[] {
+  const sums = new Map<string, bigint>();
+  for (const row of rows) sums.set(row.currency, (sums.get(row.currency) ?? 0n) + BigInt(row.net));
+  return [...sums.entries()]
+    .filter(([, net]) => net !== 0n)
+    .map(([currency, net]) => ({ currency, net }))
+    .sort((a, b) => (absBig(a.net) < absBig(b.net) ? 1 : absBig(a.net) > absBig(b.net) ? -1 : 0));
+}
+
+/** One direction's standing: the biggest currency, then the rest of them. */
+export interface DirectionGroup {
+  owed: boolean;
+  head: CurrencyTotal;
+  rest: readonly CurrencyTotal[];
+}
+
+/**
+ * Fold the per-currency totals into at most two groups — what you are owed, and
+ * what you owe.
+ *
+ * The hero used to print one full-size row per currency, each repeating its own
+ * direction word: four currencies meant reading "You're owed" three times, above
+ * a panel that grew until it pushed the list off the screen. There are only ever
+ * two things being said, so they are said twice, and the other currencies are
+ * counted underneath rather than re-announced — the rule the dashboard headline
+ * already follows.
+ *
+ * Owed first, because that is the happier half. `totals` arrives biggest-first,
+ * so each group's head is its own largest without sorting again.
+ */
+export function directionGroups(totals: readonly CurrencyTotal[]): DirectionGroup[] {
+  const groups: DirectionGroup[] = [];
+  for (const owed of [true, false]) {
+    const mine = totals.filter((total) => total.net > 0n === owed);
+    const [head, ...rest] = mine;
+    if (head) groups.push({ owed, head, rest });
+  }
+  return groups;
+}
+
+/** Which way a person's balance runs, or null when it runs both ways. */
+export type PersonDirection = 'owed' | 'owing' | null;
+
+/**
+ * The direction to put in a person's caption.
+ *
+ * Knowable whenever every currency points the same way, not only when there is
+ * one of them — somebody who owes you in rupees and in dollars still simply owes
+ * you. This used to be answered only for single-currency people, which left
+ * every multi-currency row with no caption at all: in a dense list the rows then
+ * alternated between two lines and one, and the names stopped sitting on a
+ * common grid.
+ *
+ * A genuinely mixed balance returns null and the caption says nothing, because
+ * no single word is true of both halves — the coloured amounts are the honest
+ * answer there. An empty list is mixed by the same logic: nothing to claim.
+ */
+export function personDirection(entries: readonly NetRow[]): PersonDirection {
+  if (entries.length === 0) return null;
+  if (entries.every((entry) => BigInt(entry.net) > 0n)) return 'owed';
+  if (entries.every((entry) => BigInt(entry.net) < 0n)) return 'owing';
+  return null;
+}

--- a/apps/mobile/src/lib/friendsTotals.ts
+++ b/apps/mobile/src/lib/friendsTotals.ts
@@ -8,6 +8,8 @@
  * renderer to be true — so they live here and `friends.tsx` draws the answers.
  */
 
+import { minorUnitScale } from '@waves/core';
+
 /** The net in one currency. Positive: owed to you. */
 export interface CurrencyTotal {
   currency: string;
@@ -70,6 +72,68 @@ export function directionGroups(totals: readonly CurrencyTotal[]): DirectionGrou
     if (head) groups.push({ owed, head, rest });
   }
   return groups;
+}
+
+/**
+ * How big a figure looks, in hundredths of its own major unit.
+ *
+ * There is no honest ordering across currencies without a rate, and this screen
+ * has none — but comparing raw minor units is not merely imprecise, it is off by
+ * the difference in their exponents: ¥27,066 is 27066 minor units and ₹4,614.66
+ * is 461466, so the yen sorted *below* the rupees on a hundred-fold error rather
+ * than on anything about money. Normalising to the major unit at least compares
+ * the numbers a person actually reads. It decides which currency represents a
+ * direction in a row, never whether that direction is shown.
+ */
+function magnitude(row: NetRow): bigint {
+  const net = BigInt(row.net);
+  return (absBig(net) * 100n) / minorUnitScale(row.currency);
+}
+
+/** Biggest-looking first. See `magnitude` for what "biggest" can and cannot mean. */
+function byMagnitude<T extends NetRow>(entries: readonly T[]): T[] {
+  return [...entries].sort((a, b) => {
+    const left = magnitude(a);
+    const right = magnitude(b);
+    return left < right ? 1 : left > right ? -1 : 0;
+  });
+}
+
+/**
+ * Which amounts a row draws, and how many it had to leave out.
+ *
+ * A row is a summary and cannot grow with the number of currencies somebody
+ * holds — one person four lines tall beside a neighbour's one is what broke the
+ * list's rhythm. But truncating by size alone is worse than the problem: a
+ * person owed in dollars and rupees while owing in yen and euro had both red
+ * lines fall off the bottom, so the row said he owed you and nothing else. A
+ * balance that runs both ways must say so.
+ *
+ * So the biggest of each direction is taken first and the remaining slots go to
+ * whatever is next largest. A mixed balance therefore always shows both colours,
+ * even if that means two lines where `max` asked for fewer, because a row that
+ * misstates the direction is not a smaller version of the truth.
+ */
+export function shownAmounts<T extends NetRow>(
+  entries: readonly T[],
+  max: number,
+): { shown: T[]; hidden: number } {
+  const ranked = byMagnitude(entries);
+  const picked = new Set<T>();
+
+  const biggestOwed = ranked.find((entry) => BigInt(entry.net) > 0n);
+  const biggestOwing = ranked.find((entry) => BigInt(entry.net) < 0n);
+  if (biggestOwed && biggestOwing) {
+    picked.add(biggestOwed);
+    picked.add(biggestOwing);
+  }
+  for (const entry of ranked) {
+    if (picked.size >= max) break;
+    picked.add(entry);
+  }
+
+  const shown = ranked.filter((entry) => picked.has(entry));
+  return { shown, hidden: ranked.length - shown.length };
 }
 
 /** Which way a person's balance runs, or null when it runs both ways. */

--- a/apps/mobile/src/lib/friendsTotals.ts
+++ b/apps/mobile/src/lib/friendsTotals.ts
@@ -169,9 +169,16 @@ interface ActionablePerson {
  */
 export function rowAction(person: ActionablePerson): 'invite' | 'remind' | null {
   const groupId = commonOnlyGroupId(person.entries);
-  if (!groupId) return null;
+  if (groupId === null) return null;
+  // An invite is the group's link, so one group is the whole requirement.
   if (person.is_ghost) return 'invite';
-  if (person.entries.some((entry) => BigInt(entry.net) > 0n)) return 'remind';
+  // A nudge is not. `waves_nudge_to_settle` takes a currency alongside the group
+  // and the person, so "remind them" across two currencies is not one request —
+  // it is a choice of which debt to raise, made silently by whichever row is
+  // picked first, and the button gives no way to tell which was sent. One
+  // currency, or the row offers nothing and the person page does it properly.
+  const single = person.entries.length === 1 ? person.entries[0] : null;
+  if (single && BigInt(single.net) > 0n) return 'remind';
   return null;
 }
 

--- a/apps/mobile/src/lib/friendsTotals.ts
+++ b/apps/mobile/src/lib/friendsTotals.ts
@@ -27,6 +27,24 @@ function absBig(v: bigint): bigint {
 }
 
 /**
+ * The single group shared by every entry, if there is exactly one.
+ *
+ * `PersonBalanceRow` is one row per currency, not one row per group. A rider or
+ * traveller can owe a guest in INR and USD from the same trip; that is still one
+ * invite link. Missing or differing group ids mean there is no single action to
+ * offer.
+ */
+export function commonOnlyGroupId(
+  entries: readonly { readonly only_group_id: string | null }[],
+): string | null {
+  const [first, ...rest] = entries;
+  if (!first?.only_group_id) return null;
+  return rest.every((entry) => entry.only_group_id === first.only_group_id)
+    ? first.only_group_id
+    : null;
+}
+
+/**
  * The net you are up or down in each currency, summed over everyone.
  *
  * Never summed *across* currencies (ADR-003): there is no such thing as a total
@@ -75,28 +93,23 @@ export function directionGroups(totals: readonly CurrencyTotal[]): DirectionGrou
 }
 
 /**
- * How big a figure looks, in hundredths of its own major unit.
+ * Compare two figures by the major-unit number a person reads.
  *
  * There is no honest ordering across currencies without a rate, and this screen
  * has none — but comparing raw minor units is not merely imprecise, it is off by
- * the difference in their exponents: ¥27,066 is 27066 minor units and ₹4,614.66
- * is 461466, so the yen sorted *below* the rupees on a hundred-fold error rather
- * than on anything about money. Normalising to the major unit at least compares
- * the numbers a person actually reads. It decides which currency represents a
- * direction in a row, never whether that direction is shown.
+ * the difference in their exponents. Normalising by each currency's scale at
+ * least compares the displayed numbers. The comparison stays exact: truncating
+ * to hundredths makes KWD 0.101 tie USD 0.10 even though the first is larger.
  */
-function magnitude(row: NetRow): bigint {
-  const net = BigInt(row.net);
-  return (absBig(net) * 100n) / minorUnitScale(row.currency);
+function compareMagnitude(a: NetRow, b: NetRow): number {
+  const left = absBig(BigInt(a.net)) * minorUnitScale(b.currency);
+  const right = absBig(BigInt(b.net)) * minorUnitScale(a.currency);
+  return left < right ? 1 : left > right ? -1 : 0;
 }
 
-/** Biggest-looking first. See `magnitude` for what "biggest" can and cannot mean. */
+/** Biggest-looking first. See `compareMagnitude` for what "biggest" can and cannot mean. */
 function byMagnitude<T extends NetRow>(entries: readonly T[]): T[] {
-  return [...entries].sort((a, b) => {
-    const left = magnitude(a);
-    const right = magnitude(b);
-    return left < right ? 1 : left > right ? -1 : 0;
-  });
+  return [...entries].sort(compareMagnitude);
 }
 
 /**
@@ -155,10 +168,10 @@ interface ActionablePerson {
  * every amount off the right edge — or draws one with nowhere to sit.
  */
 export function rowAction(person: ActionablePerson): 'invite' | 'remind' | null {
-  const single = person.entries.length === 1 ? person.entries[0] : null;
-  if (!single) return null;
-  if (person.is_ghost && single.only_group_id) return 'invite';
-  if (BigInt(single.net) > 0n && single.only_group_id) return 'remind';
+  const groupId = commonOnlyGroupId(person.entries);
+  if (!groupId) return null;
+  if (person.is_ghost) return 'invite';
+  if (person.entries.some((entry) => BigInt(entry.net) > 0n)) return 'remind';
   return null;
 }
 

--- a/apps/mobile/test/friendsTotals.test.ts
+++ b/apps/mobile/test/friendsTotals.test.ts
@@ -10,6 +10,7 @@ import {
   currencyTotals,
   directionGroups,
   personDirection,
+  shownAmounts,
   type CurrencyTotal,
 } from '@/lib/friendsTotals';
 
@@ -114,5 +115,75 @@ describe('personDirection', () => {
   it('treats a zero as neither owed nor owing', () => {
     expect(personDirection([{ currency: 'INR', net: '0' }])).toBeNull();
     expect(personDirection([])).toBeNull();
+  });
+});
+
+describe('shownAmounts', () => {
+  const codes = (rows: readonly { currency: string }[]): string[] =>
+    rows.map((row) => row.currency);
+
+  it('never hides a direction, even when both of that side are small', () => {
+    // The bug this pins: taking the two biggest dropped both of Tom's red
+    // amounts, so a person who owed money as well as being owed it rendered as
+    // purely owed-to-you — a row stating the opposite of the truth.
+    const { shown, hidden } = shownAmounts(
+      [
+        { currency: 'USD', net: '41777' },
+        { currency: 'INR', net: '21000' },
+        { currency: 'JPY', net: '-15487' },
+        { currency: 'EUR', net: '-1830' },
+      ],
+      2,
+    );
+    expect(codes(shown)).toContain('JPY');
+    expect(shown.some((row) => BigInt(row.net) > 0n)).toBe(true);
+    expect(shown.some((row) => BigInt(row.net) < 0n)).toBe(true);
+    expect(hidden).toBe(2);
+  });
+
+  it('takes the two biggest when everything runs one way', () => {
+    const { shown, hidden } = shownAmounts(
+      [
+        { currency: 'INR', net: '100' },
+        { currency: 'USD', net: '900' },
+        { currency: 'EUR', net: '500' },
+      ],
+      2,
+    );
+    expect(codes(shown)).toEqual(['USD', 'EUR']);
+    expect(hidden).toBe(1);
+  });
+
+  it('compares currencies by their major unit, not by raw minor units', () => {
+    // JPY has no minor unit, so ¥27,066 is 27066 while ₹4,614.66 is 461466.
+    // Sorting the raw numbers ranks the rupees above the yen on a hundred-fold
+    // scale error rather than on anything about the money.
+    const { shown } = shownAmounts(
+      [
+        { currency: 'INR', net: '461466' },
+        { currency: 'JPY', net: '27066' },
+      ],
+      1,
+    );
+    expect(codes(shown)).toEqual(['JPY']);
+  });
+
+  it('hides nothing when everything already fits', () => {
+    const { shown, hidden } = shownAmounts([{ currency: 'INR', net: '2239525' }], 2);
+    expect(codes(shown)).toEqual(['INR']);
+    expect(hidden).toBe(0);
+  });
+
+  it('would rather exceed the cap than drop a side', () => {
+    // A row that misstates the direction is not a smaller version of the truth.
+    const { shown, hidden } = shownAmounts(
+      [
+        { currency: 'INR', net: '100' },
+        { currency: 'USD', net: '-100' },
+      ],
+      1,
+    );
+    expect(shown).toHaveLength(2);
+    expect(hidden).toBe(0);
   });
 });

--- a/apps/mobile/test/friendsTotals.test.ts
+++ b/apps/mobile/test/friendsTotals.test.ts
@@ -10,6 +10,7 @@ import {
   currencyTotals,
   directionGroups,
   personDirection,
+  rowAction,
   shownAmounts,
   type CurrencyTotal,
 } from '@/lib/friendsTotals';
@@ -185,5 +186,32 @@ describe('shownAmounts', () => {
     );
     expect(shown).toHaveLength(2);
     expect(hidden).toBe(0);
+  });
+});
+
+describe('rowAction', () => {
+  const entry = (net: string, only_group_id: string | null) => ({ net, only_group_id });
+
+  it('offers a nudge only when one group explains the debt', () => {
+    expect(rowAction({ is_ghost: false, entries: [entry('500', 'g1')] })).toBe('remind');
+    // Spread over several groups: there is no single pair to nudge, so the row
+    // carries nothing — which is why a list of such people reserved a column it
+    // never filled and pushed every amount away from the edge.
+    expect(rowAction({ is_ghost: false, entries: [entry('500', null)] })).toBeNull();
+  });
+
+  it('offers nothing to somebody you owe', () => {
+    expect(rowAction({ is_ghost: false, entries: [entry('-500', 'g1')] })).toBeNull();
+  });
+
+  it('offers a guest their invite, whichever way the balance runs', () => {
+    expect(rowAction({ is_ghost: true, entries: [entry('-500', 'g1')] })).toBe('invite');
+    expect(rowAction({ is_ghost: true, entries: [entry('500', 'g1')] })).toBe('invite');
+  });
+
+  it('offers nothing across several currencies — neither control has one group', () => {
+    expect(
+      rowAction({ is_ghost: true, entries: [entry('500', 'g1'), entry('-20', 'g1')] }),
+    ).toBeNull();
   });
 });

--- a/apps/mobile/test/friendsTotals.test.ts
+++ b/apps/mobile/test/friendsTotals.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  commonOnlyGroupId,
   currencyTotals,
   directionGroups,
   personDirection,
@@ -169,6 +170,19 @@ describe('shownAmounts', () => {
     expect(codes(shown)).toEqual(['JPY']);
   });
 
+  it('keeps exponent-3 precision when ranking close currencies', () => {
+    // KWD 0.101 and USD 0.10 both truncated to 10 hundredths before, so input
+    // order could hide the slightly larger KWD balance.
+    const { shown } = shownAmounts(
+      [
+        { currency: 'USD', net: '10' },
+        { currency: 'KWD', net: '101' },
+      ],
+      1,
+    );
+    expect(codes(shown)).toEqual(['KWD']);
+  });
+
   it('hides nothing when everything already fits', () => {
     const { shown, hidden } = shownAmounts([{ currency: 'INR', net: '2239525' }], 2);
     expect(codes(shown)).toEqual(['INR']);
@@ -192,26 +206,42 @@ describe('shownAmounts', () => {
 describe('rowAction', () => {
   const entry = (net: string, only_group_id: string | null) => ({ net, only_group_id });
 
-  it('offers a nudge only when one group explains the debt', () => {
+  it('finds the common group across several currency rows', () => {
+    expect(commonOnlyGroupId([entry('500', 'trip'), entry('-20', 'trip')])).toBe('trip');
+    expect(commonOnlyGroupId([entry('500', 'trip'), entry('-20', 'ride')])).toBeNull();
+    expect(commonOnlyGroupId([entry('500', 'trip'), entry('-20', null)])).toBeNull();
+    expect(commonOnlyGroupId([])).toBeNull();
+  });
+
+  it('offers a nudge when one group explains the debt, even across currencies', () => {
     expect(rowAction({ is_ghost: false, entries: [entry('500', 'g1')] })).toBe('remind');
+    expect(
+      rowAction({ is_ghost: false, entries: [entry('500', 'g1'), entry('-20', 'g1')] }),
+    ).toBe('remind');
     // Spread over several groups: there is no single pair to nudge, so the row
     // carries nothing — which is why a list of such people reserved a column it
     // never filled and pushed every amount away from the edge.
     expect(rowAction({ is_ghost: false, entries: [entry('500', null)] })).toBeNull();
+    expect(
+      rowAction({ is_ghost: false, entries: [entry('500', 'g1'), entry('20', 'g2')] }),
+    ).toBeNull();
   });
 
   it('offers nothing to somebody you owe', () => {
     expect(rowAction({ is_ghost: false, entries: [entry('-500', 'g1')] })).toBeNull();
   });
 
-  it('offers a guest their invite, whichever way the balance runs', () => {
+  it('offers a guest their invite, whichever way the same-group balance runs', () => {
     expect(rowAction({ is_ghost: true, entries: [entry('-500', 'g1')] })).toBe('invite');
     expect(rowAction({ is_ghost: true, entries: [entry('500', 'g1')] })).toBe('invite');
-  });
-
-  it('offers nothing across several currencies — neither control has one group', () => {
     expect(
       rowAction({ is_ghost: true, entries: [entry('500', 'g1'), entry('-20', 'g1')] }),
+    ).toBe('invite');
+  });
+
+  it('offers nothing when several currencies do not share one group', () => {
+    expect(
+      rowAction({ is_ghost: true, entries: [entry('500', 'g1'), entry('-20', 'g2')] }),
     ).toBeNull();
   });
 });

--- a/apps/mobile/test/friendsTotals.test.ts
+++ b/apps/mobile/test/friendsTotals.test.ts
@@ -1,0 +1,118 @@
+/**
+ * The Friends screen's arithmetic, and specifically what it does when somebody
+ * is carrying a lot of currencies at once — the case a screenshot caught the
+ * layout failing on.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  currencyTotals,
+  directionGroups,
+  personDirection,
+  type CurrencyTotal,
+} from '@/lib/friendsTotals';
+
+const total = (currency: string, net: bigint): CurrencyTotal => ({ currency, net });
+
+describe('currencyTotals', () => {
+  it('sums per currency and never across them', () => {
+    expect(
+      currencyTotals([
+        { currency: 'INR', net: '1000' },
+        { currency: 'USD', net: '50' },
+        { currency: 'INR', net: '500' },
+      ]),
+    ).toEqual([total('INR', 1500n), total('USD', 50n)]);
+  });
+
+  it('drops a currency that nets to nothing', () => {
+    // "You are owed ₹0" is not news, and it would take a headline slot.
+    expect(
+      currencyTotals([
+        { currency: 'INR', net: '1000' },
+        { currency: 'INR', net: '-1000' },
+        { currency: 'EUR', net: '-20' },
+      ]),
+    ).toEqual([total('EUR', -20n)]);
+  });
+
+  it('puts the biggest first, by size rather than by sign', () => {
+    const out = currencyTotals([
+      { currency: 'USD', net: '100' },
+      { currency: 'EUR', net: '-900' },
+      { currency: 'INR', net: '400' },
+    ]);
+    expect(out.map((entry) => entry.currency)).toEqual(['EUR', 'INR', 'USD']);
+  });
+});
+
+describe('directionGroups', () => {
+  it('says each direction once, however many currencies it holds', () => {
+    // The bug this pins: the hero drew one full-size row per currency, so the
+    // screenshot read "You're owed" three times down the panel.
+    const groups = directionGroups([
+      total('INR', 4336574n),
+      total('USD', 70296n),
+      total('JPY', 11579n),
+      total('EUR', -1830n),
+    ]);
+    expect(groups).toHaveLength(2);
+    expect(groups[0]).toMatchObject({ owed: true, head: total('INR', 4336574n) });
+    expect(groups[0]?.rest.map((entry) => entry.currency)).toEqual(['USD', 'JPY']);
+    expect(groups[1]).toMatchObject({ owed: false, head: total('EUR', -1830n), rest: [] });
+  });
+
+  it('leads with the biggest of each direction, keeping the incoming order', () => {
+    const groups = directionGroups([
+      total('EUR', -9000n),
+      total('INR', 4000n),
+      total('USD', -100n),
+    ]);
+    // Owed first even though the largest figure overall is money you owe.
+    expect(groups.map((group) => group.owed)).toEqual([true, false]);
+    expect(groups[1]?.head).toEqual(total('EUR', -9000n));
+    expect(groups[1]?.rest).toEqual([total('USD', -100n)]);
+  });
+
+  it('gives one group when everything runs one way, and none when there is nothing', () => {
+    expect(directionGroups([total('INR', 10n)]).map((group) => group.owed)).toEqual([true]);
+    expect(directionGroups([total('INR', -10n)]).map((group) => group.owed)).toEqual([false]);
+    expect(directionGroups([])).toEqual([]);
+  });
+});
+
+describe('personDirection', () => {
+  it('names the direction when every currency agrees', () => {
+    // The bug this pins: this was answered only for a single-currency person, so
+    // a row with two currencies lost its caption line entirely and the list
+    // alternated between one-line and two-line rows.
+    expect(
+      personDirection([
+        { currency: 'INR', net: '14068' },
+        { currency: 'USD', net: '32459' },
+      ]),
+    ).toBe('owed');
+    expect(
+      personDirection([
+        { currency: 'INR', net: '-1' },
+        { currency: 'USD', net: '-2' },
+      ]),
+    ).toBe('owing');
+  });
+
+  it('stays silent when the balance runs both ways', () => {
+    // No word is true of both halves; the coloured amounts carry it instead.
+    expect(
+      personDirection([
+        { currency: 'INR', net: '4614' },
+        { currency: 'USD', net: '-39' },
+      ]),
+    ).toBeNull();
+  });
+
+  it('treats a zero as neither owed nor owing', () => {
+    expect(personDirection([{ currency: 'INR', net: '0' }])).toBeNull();
+    expect(personDirection([])).toBeNull();
+  });
+});

--- a/apps/mobile/test/friendsTotals.test.ts
+++ b/apps/mobile/test/friendsTotals.test.ts
@@ -213,17 +213,28 @@ describe('rowAction', () => {
     expect(commonOnlyGroupId([])).toBeNull();
   });
 
-  it('offers a nudge when one group explains the debt, even across currencies', () => {
+  it('offers a nudge when one group and one currency explain the debt', () => {
     expect(rowAction({ is_ghost: false, entries: [entry('500', 'g1')] })).toBe('remind');
-    expect(
-      rowAction({ is_ghost: false, entries: [entry('500', 'g1'), entry('-20', 'g1')] }),
-    ).toBe('remind');
     // Spread over several groups: there is no single pair to nudge, so the row
     // carries nothing — which is why a list of such people reserved a column it
     // never filled and pushed every amount away from the edge.
     expect(rowAction({ is_ghost: false, entries: [entry('500', null)] })).toBeNull();
     expect(
       rowAction({ is_ghost: false, entries: [entry('500', 'g1'), entry('20', 'g2')] }),
+    ).toBeNull();
+  });
+
+  it('will not nudge across currencies, because the nudge names one', () => {
+    // `waves_nudge_to_settle` takes a currency alongside the group and the
+    // person, so there is no single request that means "remind them" about two
+    // debts — only a silent choice of which one to raise, made by whichever row
+    // is picked first, with nothing on screen saying which was sent. The person
+    // page splits them out and asks properly.
+    expect(
+      rowAction({ is_ghost: false, entries: [entry('500', 'g1'), entry('-20', 'g1')] }),
+    ).toBeNull();
+    expect(
+      rowAction({ is_ghost: false, entries: [entry('500', 'g1'), entry('20', 'g1')] }),
     ).toBeNull();
   });
 
@@ -234,9 +245,9 @@ describe('rowAction', () => {
   it('offers a guest their invite, whichever way the same-group balance runs', () => {
     expect(rowAction({ is_ghost: true, entries: [entry('-500', 'g1')] })).toBe('invite');
     expect(rowAction({ is_ghost: true, entries: [entry('500', 'g1')] })).toBe('invite');
-    expect(
-      rowAction({ is_ghost: true, entries: [entry('500', 'g1'), entry('-20', 'g1')] }),
-    ).toBe('invite');
+    expect(rowAction({ is_ghost: true, entries: [entry('500', 'g1'), entry('-20', 'g1')] })).toBe(
+      'invite',
+    );
   });
 
   it('offers nothing when several currencies do not share one group', () => {


### PR DESCRIPTION
From a screenshot of a dense account — four currencies in the hero, people owed in three of them. Everything here only misbehaves with real data, which is why it survived this long.

## What was wrong

**1. The hero repeated itself.** One full-size row per currency, each printing its own direction word, so the panel read *"You're owed"* three times down the page. It also had no ceiling — six currencies would be six headlines pushing the list off screen.

Now at most two groups, one per direction: the biggest currency at full size, the rest counted small beneath it. That's the rule `index.tsx` already states for the dashboard headline ("the rest are counted underneath rather than added in"), so the two tabs now answer the same question the same way. Nothing is summed across currencies (ADR-003).

**2. Label and amount weren't on a baseline.** `alignItems: 'flex-end'` lines up the bottoms of a 16px word and a 32px number — not the line you read across. `'baseline'` does.

**3. Multi-currency rows lost their caption entirely.**

```ts
const direction = single ? (BigInt(single.net) > 0n ? t.tabs.owesYou : …) : null;
```

Both `direction` and `scope` were gated on `single`, so Priya and Nadia get a second line and Arjun, Sana and Tom get none — which is most of the "not aligning" in the screenshot. Direction is knowable whenever every currency agrees: owing you in rupees *and* dollars is still just owing you. A genuinely mixed balance still says nothing, because no single word is true of both halves.

**4. Row height swung 1–4 lines** — every currency stacked. Capped at two plus `+N more currencies`. A row is a summary; the person page splits every group and currency out in full, and the screen-reader label still enumerates all of them.

## Shape

`currencyTotals`, `directionGroups` and `personDirection` moved into `src/lib/friendsTotals.ts` with 9 tests, following `lib/expenseForm.ts`. None of it needs a renderer to be true and the edge cases are the entire problem — zero balances, all-one-direction, mixed, empty.

`t.tabs.moreCurrencies` added in all four locales (en/ta/hi/ar, with the Arabic plural set).

## Checks

typecheck, lint, 1306 mobile tests green. **Not device-tested** — `alignItems: 'baseline'` is the one thing worth a glance on a real phone, since RN baseline alignment across differing font sizes is the sort of thing that behaves differently on Android.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Friends balances now clearly separate amounts you owe from amounts owed to you.
  - The largest currency balance is highlighted, with additional currencies shown underneath.
  - Person balances display clearer direction labels and summarize additional currencies when needed.
  - Added localized counts for hidden currencies in English, Tamil, Hindi, and Arabic.
  - Currency totals are calculated independently, preventing balances in different currencies from being combined.
  - Invite and reminder actions now appear only when applicable to the friend row.
- **Bug Fixes**
  - Improved spacing for the no-activity view above the bottom navigation bar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->