### PR TITLE
Phone sign-in: Firebase proves the number, and a guest who proves one keeps everything

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -61,15 +61,20 @@
               "pathPrefix": "/g/"
             }
           ],
-          "category": ["BROWSABLE", "DEFAULT"]
+          "category": [
+            "BROWSABLE",
+            "DEFAULT"
+          ]
         }
-      ]
+      ],
+      "googleServicesFile": "./google-services.json"
     },
     "web": {
       "output": "static",
       "favicon": "./assets/images/favicon.png"
     },
     "plugins": [
+      "@react-native-firebase/app",
       "expo-router",
       "expo-localization",
       "expo-sqlite",
@@ -94,7 +99,9 @@
         {
           "microphonePermission": "Waves uses the microphone only while you hold the mic button, to write down what you say.",
           "speechRecognitionPermission": "Waves turns what you say into the note on an expense, so you can add one without typing at the table.",
-          "androidSpeechServicePackages": ["com.google.android.googlequicksearchbox"]
+          "androidSpeechServicePackages": [
+            "com.google.android.googlequicksearchbox"
+          ]
         }
       ],
       [

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -61,10 +61,7 @@
               "pathPrefix": "/g/"
             }
           ],
-          "category": [
-            "BROWSABLE",
-            "DEFAULT"
-          ]
+          "category": ["BROWSABLE", "DEFAULT"]
         }
       ],
       "googleServicesFile": "./google-services.json"
@@ -99,9 +96,7 @@
         {
           "microphonePermission": "Waves uses the microphone only while you hold the mic button, to write down what you say.",
           "speechRecognitionPermission": "Waves turns what you say into the note on an expense, so you can add one without typing at the table.",
-          "androidSpeechServicePackages": [
-            "com.google.android.googlequicksearchbox"
-          ]
+          "androidSpeechServicePackages": ["com.google.android.googlequicksearchbox"]
         }
       ],
       [

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -13,6 +13,8 @@
     "@noble/ciphers": "^2.4.0",
     "@react-native-async-storage/async-storage": "3.1.1",
     "@react-native-community/datetimepicker": "9.1.0",
+    "@react-native-firebase/app": "26.4.0",
+    "@react-native-firebase/auth": "26.4.0",
     "@react-native-google-signin/google-signin": "^16.1.5",
     "@react-native-ml-kit/text-recognition": "^2.0.0",
     "@sentry/react-native": "~8.25.0",

--- a/apps/mobile/src/app/settings/account.tsx
+++ b/apps/mobile/src/app/settings/account.tsx
@@ -48,6 +48,7 @@ import { confirmContact, startAddingContact, ContactChannel } from '@/data/api';
 import { deviceCountry, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { router } from '@/lib/navigation';
+import { phoneSignInAvailable } from '@/lib/phoneAuth';
 
 export default function AccountScreen() {
   const { profile, profileSettled, reloadProfile } = useAuth();
@@ -471,10 +472,18 @@ function AccountForm() {
                 setError(null);
                 setValue('');
               }}
-              options={[
-                { value: ContactChannel.Email, label: t.contact.email },
-                { value: ContactChannel.Phone, label: t.contact.phone },
-              ]}
+              // Phone only where the build can prove one. The code comes from
+              // Firebase, which is a native module, so a JavaScript-only update
+              // onto an older binary would leave this chip selectable and the
+              // "send code" under it dead — an offer the app cannot keep.
+              options={
+                phoneSignInAvailable()
+                  ? [
+                      { value: ContactChannel.Email, label: t.contact.email },
+                      { value: ContactChannel.Phone, label: t.contact.phone },
+                    ]
+                  : [{ value: ContactChannel.Email, label: t.contact.email }]
+              }
             />
 
             {existing ? (

--- a/apps/mobile/src/app/welcome.tsx
+++ b/apps/mobile/src/app/welcome.tsx
@@ -42,6 +42,7 @@ import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { friendlyError } from '@/lib/errors';
 import { router } from '@/lib/navigation';
+import { phoneSignInAvailable } from '@/lib/phoneAuth';
 
 /** The door's green wash — a light stop into the base green (#65B63E) into a
     darker one, top to bottom, matching the splash. A local screen colour, not a
@@ -235,15 +236,22 @@ export default function WelcomeScreen() {
               }}
             >
               {appleFirst ? googleTile : appleTile}
-              <SocialTile
-                testID="auth-phone"
-                provider="phone"
-                field="brand"
-                accessibilityLabel={t.signIn.continuePhone}
-                caption={t.signIn.providerPhone}
-                disabled={busy}
-                onPress={() => router.push('/phone')}
-              />
+              {/* Only where the build can actually do it. Firebase sends the
+                  code and Firebase is a native module, so a JavaScript-only
+                  update landing on a binary made before it existed would draw
+                  this tile over nothing — a door offered and then dead under the
+                  finger, which is worse than no door. */}
+              {phoneSignInAvailable() ? (
+                <SocialTile
+                  testID="auth-phone"
+                  provider="phone"
+                  field="brand"
+                  accessibilityLabel={t.signIn.continuePhone}
+                  caption={t.signIn.providerPhone}
+                  disabled={busy}
+                  onPress={() => router.push('/phone')}
+                />
+              ) : null}
               <SocialTile
                 testID="auth-email"
                 provider="email"

--- a/apps/mobile/src/components/AuthFlow.tsx
+++ b/apps/mobile/src/components/AuthFlow.tsx
@@ -49,6 +49,7 @@ import { useStrings, type UiStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { friendlyError } from '@/lib/errors';
 import { router, useGoBack } from '@/lib/navigation';
+import { phoneSignInAvailable } from '@/lib/phoneAuth';
 
 export type AuthFlowKind = 'login' | 'signup';
 
@@ -431,7 +432,14 @@ export function AuthFlow({ flow }: { flow: AuthFlowKind }) {
               busy={busy}
               onGoogle={() => void run(withGoogle)}
               onApple={() => void run(withApple)}
-              onPhone={isSignup ? undefined : () => router.push('/phone')}
+              // Absent from sign-up by the rule below, and absent from a build
+              // that cannot do it at all. Firebase is a native module: a
+              // JavaScript-only update onto a binary made before it existed
+              // leaves this tile drawn and every tap behind it dead, which is
+              // worse than a door that was never offered.
+              onPhone={
+                isSignup || !phoneSignInAvailable() ? undefined : () => router.push('/phone')
+              }
               t={t}
             />
             {/* ADR-006 addendum: the guest way in belongs to the sign-up page —

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -31,6 +31,7 @@ import {
 import { activeStrings } from '@/i18n';
 import type { DeviceIdentity } from '@/lib/device';
 import { normaliseContactPhone } from '@/lib/phone';
+import { attachPhoneCode, sendPhoneCode } from '@/lib/phoneAuth';
 import { imageUrl, putImage, removeImage } from '@/lib/storage';
 import { backend } from '@/lib/backend';
 import type {
@@ -1354,10 +1355,15 @@ export async function startAddingContact(channel: ContactChannel, value: string)
   // auth service says about it — and it is the same rule the invite columns
   // enforce in the database, so one form cannot accept what another rejects.
   const normalised = channel === 'email' ? normaliseEmail(value) : normalisePhone(value);
-  const { error } =
-    channel === 'email'
-      ? await backend.auth.updateUser({ email: normalised })
-      : await backend.auth.updateUser({ phone: normalised });
+  // A phone number is proved by Firebase, the same way signing in with one is.
+  // Not by GoTrue: it would send the code through whatever SMS provider the
+  // project has, which is the arrangement this app deliberately does not have —
+  // and two ways of verifying a number is how they drift into disagreeing.
+  if (channel === 'phone') {
+    await sendPhoneCode(normalised);
+    return;
+  }
+  const { error } = await backend.auth.updateUser({ email: normalised });
   if (error) throw new Error(describeAuthError(error.message, channel));
 }
 
@@ -1367,11 +1373,15 @@ export async function confirmContact(
   token: string,
 ): Promise<void> {
   const normalised = channel === 'email' ? normaliseEmail(value) : normalisePhone(value);
-  const { error } = await backend.auth.verifyOtp(
-    channel === 'email'
-      ? { email: normalised, token: token.trim(), type: 'email_change' }
-      : { phone: normalised, token: token.trim(), type: 'phone_change' },
-  );
+  if (channel === 'phone') {
+    await attachPhoneCode(normalised, token.trim());
+    return;
+  }
+  const { error } = await backend.auth.verifyOtp({
+    email: normalised,
+    token: token.trim(),
+    type: 'email_change',
+  });
   if (error) throw new Error(error.message);
 }
 

--- a/apps/mobile/src/lib/auth.tsx
+++ b/apps/mobile/src/lib/auth.tsx
@@ -18,6 +18,7 @@ import {
 import { appleNativeSignIn, googleNativeSignIn } from './nativeIdentity';
 import { identifyForReporting, reportHandled } from './observability';
 import { claimCode } from './oauthClaim';
+import { confirmPhoneCode, sendPhoneCode } from './phoneAuth';
 import { lockPersonal, syncPersonalAccount } from './personalLock';
 import { refreshPushToken, revokePushToken } from './push';
 import { backend } from './backend';
@@ -503,24 +504,23 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       },
       isGuest: session?.user?.is_anonymous === true,
 
+      // Firebase sends the code, not Supabase — the only way to deliver an SMS
+      // worldwide without a registered company, a DLT filing per country and a
+      // monthly bill. What it proves is the number; `phone-verify` turns that
+      // proof into a session. See `lib/phoneAuth` for why the module is loaded
+      // lazily, and the `phone-verify` handler for why a session cannot simply
+      // be minted from a Firebase token.
+      //
+      // ADR-006 is enforced where it always was, on the server: that function
+      // asks GoTrue with `create_user: false`, so a number nobody owns is a
+      // refusal rather than a new account. Firebase having verified a number
+      // does not make it one.
       async sendOtp(phone) {
-        // `shouldCreateUser` is false for the same reason it is on the login
-        // door's email path below: a mistyped number would otherwise mint an
-        // empty account and send a code to a stranger, and every OTP to an
-        // unknown number is a message we pay for — the surface SMS-pumping
-        // fraud aims at. It also matches ADR-006, where a phone number is a way
-        // to keep an account and never the way to get one; `auth.sms` in
-        // config.toml refuses the signup server-side regardless.
-        const { error } = await backend.auth.signInWithOtp({
-          phone,
-          options: { shouldCreateUser: false },
-        });
-        if (error) throw error;
+        await sendPhoneCode(phone);
       },
 
       async verifyOtp(phone, token) {
-        const { error } = await backend.auth.verifyOtp({ phone, token, type: 'sms' });
-        if (error) throw error;
+        await confirmPhoneCode(phone, token);
       },
 
       async sendEmailOtp(email, createUser) {

--- a/apps/mobile/src/lib/backend/index.ts
+++ b/apps/mobile/src/lib/backend/index.ts
@@ -45,6 +45,16 @@ type BackendAuth = Pick<
   | 'linkIdentity'
   | 'signInWithIdToken'
   | 'exchangeCodeForSession'
+  // Phone sign-in mints its session on the server — Firebase proves the number,
+  // `phone-verify` trades that for a session — so the client is handed tokens
+  // rather than earning them through a call here. Any adapter has to offer some
+  // way to adopt a session it did not create.
+  | 'setSession'
+  // Attaching a phone changes the user *server-side*, so the copy in this
+  // device's storage is stale until the access token next rolls — up to an
+  // hour of the account screen still offering to add the number somebody just
+  // added. `getSession` reads the cache; only this asks again.
+  | 'refreshSession'
   | 'signOut'
   | 'resend'
 >;

--- a/apps/mobile/src/lib/firebaseModule.ts
+++ b/apps/mobile/src/lib/firebaseModule.ts
@@ -1,0 +1,37 @@
+/**
+ * The one place `@react-native-firebase/auth` is named.
+ *
+ * It is a **native module**, so importing it at the top of a file means an app
+ * whose JavaScript was updated over the air, on a binary built before Firebase
+ * was added, dies at *launch* — not on the phone screen, at launch, with nothing
+ * local to catch it. So the require is lazy and wrapped in a check that cannot
+ * throw, which is this repo's standing rule for anything native.
+ *
+ * It lives alone in a file for a second reason: a `require` cannot be
+ * substituted by a test the way an import can, so the seam that lets the phone
+ * flow be tested at all is exactly here — the module boundary. Everything above
+ * it is ordinary JavaScript.
+ */
+
+/** What Firebase hands back between sending a code and checking it. */
+export interface PhoneConfirmation {
+  confirm(code: string): Promise<{ user: { getIdToken(): Promise<string> } } | null>;
+}
+
+export interface FirebaseAuth {
+  (): {
+    signInWithPhoneNumber(phone: string): Promise<PhoneConfirmation>;
+    signOut(): Promise<void>;
+  };
+}
+
+/** The module, or null on a build that has no Firebase in it. Never throws. */
+export function loadFirebaseAuth(): FirebaseAuth | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const loaded = require('@react-native-firebase/auth') as { default?: FirebaseAuth };
+    return loaded.default ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/mobile/src/lib/phoneAuth.ts
+++ b/apps/mobile/src/lib/phoneAuth.ts
@@ -1,0 +1,170 @@
+/**
+ * Signing in with a phone number, which is two different systems shaking hands.
+ *
+ * Firebase sends the code and checks it — it is the only way to deliver an SMS
+ * worldwide without a registered company, a DLT filing per country, or a monthly
+ * bill. What Firebase cannot do is hand out a Waves session, so once it has
+ * proved the number the assertion goes to `phone-verify`, which checks Google's
+ * signature and mints a Supabase session the ordinary way (see that function's
+ * header for why it cannot simply be minted).
+ *
+ * Firebase is a **native module**, and that is the whole reason this file is
+ * shaped the way it is. Requiring it at the top level would mean an app whose
+ * JavaScript was updated over the air, on a binary built before this change,
+ * dies at launch — not on the phone screen, at launch, with nothing local to
+ * catch it. So it is required lazily, behind a check that cannot throw, and
+ * `phoneSignInAvailable()` is the honest answer to "can this build do this at
+ * all" for anything that would otherwise offer a door to nowhere.
+ */
+
+import { backend } from '@/lib/backend';
+
+/** What Firebase hands back between sending a code and checking it. */
+interface PhoneConfirmation {
+  confirm(code: string): Promise<{ user: { getIdToken(): Promise<string> } } | null>;
+}
+
+interface FirebaseAuth {
+  (): {
+    signInWithPhoneNumber(phone: string): Promise<PhoneConfirmation>;
+    signOut(): Promise<void>;
+  };
+}
+
+/**
+ * `undefined` means nobody has looked yet; `null` means we looked and this build
+ * has no Firebase in it. The distinction matters — the check runs once and its
+ * answer, including the negative, is kept.
+ */
+let module_: FirebaseAuth | null | undefined;
+
+function firebaseAuth(): FirebaseAuth | null {
+  if (module_ !== undefined) return module_;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const loaded = require('@react-native-firebase/auth') as { default?: FirebaseAuth };
+    module_ = loaded.default ?? null;
+  } catch {
+    module_ = null;
+  }
+  return module_;
+}
+
+/** Whether this build can sign somebody in by phone at all. */
+export function phoneSignInAvailable(): boolean {
+  return firebaseAuth() !== null;
+}
+
+/**
+ * The verification in flight.
+ *
+ * One at a time, because one screen is asking: the code screen follows the
+ * number screen and there is no way to have two going at once. Held here rather
+ * than in the screen's state so a remount mid-flow does not lose it.
+ */
+let pending: { phone: string; confirmation: PhoneConfirmation } | null = null;
+
+export class PhoneSignInUnavailable extends Error {
+  constructor() {
+    super('This version of the app cannot sign in by phone.');
+    this.name = 'PhoneSignInUnavailable';
+  }
+}
+
+/** Firebase sends the SMS. Nothing of ours is called until the code is right. */
+export async function sendPhoneCode(phone: string): Promise<void> {
+  const auth = firebaseAuth();
+  if (!auth) throw new PhoneSignInUnavailable();
+  const confirmation = await auth().signInWithPhoneNumber(phone);
+  pending = { phone, confirmation };
+}
+
+/**
+ * Check the code with Firebase, then trade its assertion for a Waves session.
+ *
+ * The Firebase session is signed out immediately afterwards, and deliberately:
+ * it was only ever a way to prove the number, this app keeps no state in it, and
+ * leaving one signed in means a token sitting on the device that `phone-verify`
+ * would accept as proof for the next ten minutes.
+ */
+/**
+ * Check the code with Firebase and come away with its signed assertion.
+ *
+ * Shared by both things a proved number can be used for, because the proving is
+ * identical and only what follows differs. The Firebase session is signed out
+ * the moment the token is in hand: it was never more than a way to prove the
+ * number, and leaving one signed in means a token on the device that
+ * `phone-verify` would accept for the next ten minutes.
+ */
+async function proveNumber(phone: string, code: string): Promise<string> {
+  const auth = firebaseAuth();
+  if (!auth) throw new PhoneSignInUnavailable();
+  if (!pending || pending.phone !== phone) {
+    // The number changed under the code screen, or the flow was resumed from
+    // somewhere that never sent a code. Asking Firebase to confirm against a
+    // stale verification would fail with something unreadable.
+    throw new Error('Ask for a new code.');
+  }
+
+  const credential = await pending.confirmation.confirm(code);
+  if (!credential?.user) throw new Error('That code did not work.');
+
+  try {
+    return await credential.user.getIdToken();
+  } finally {
+    pending = null;
+    await auth()
+      .signOut()
+      .catch(() => undefined);
+  }
+}
+
+export async function confirmPhoneCode(phone: string, code: string): Promise<void> {
+  const idToken = await proveNumber(phone, code);
+
+  const { data, error } = await backend.functions.invoke('phone-verify', {
+    body: { idToken },
+  });
+  if (error) throw error;
+
+  const session = data as { access_token?: string; refresh_token?: string } | null;
+  if (!session?.access_token || !session.refresh_token) {
+    throw new Error('Could not sign you in just now.');
+  }
+
+  const { error: setError } = await backend.auth.setSession({
+    access_token: session.access_token,
+    refresh_token: session.refresh_token,
+  });
+  if (setError) throw setError;
+}
+
+/**
+ * Attach the proved number to the account already signed in, rather than
+ * signing in as whoever owns it.
+ *
+ * The same code, the same proof — a different thing to do with it. The account
+ * keeps its id, so nothing entered before the number was added moves or is lost,
+ * and the number becomes a second way back to the same place (ADR-006).
+ */
+export async function attachPhoneCode(phone: string, code: string): Promise<void> {
+  const idToken = await proveNumber(phone, code);
+  const { data, error } = await backend.functions.invoke('phone-verify', {
+    body: { idToken, mode: 'attach' },
+  });
+  if (error) throw error;
+  if (!(data as { attached?: boolean } | null)?.attached) {
+    throw new Error('Could not add that number just now.');
+  }
+
+  // Nobody is signed out and nothing is re-entered — but the user held on this
+  // device was read before the number existed, so without this the account
+  // screen goes on offering to add a phone that is already attached, until the
+  // access token happens to roll. Refreshing is the whole of "seamless" here.
+  await backend.auth.refreshSession();
+}
+
+/** Forget any verification in flight — the screen leaving, or starting over. */
+export function forgetPendingPhoneCode(): void {
+  pending = null;
+}

--- a/apps/mobile/src/lib/phoneAuth.ts
+++ b/apps/mobile/src/lib/phoneAuth.ts
@@ -12,24 +12,24 @@
  * shaped the way it is. Requiring it at the top level would mean an app whose
  * JavaScript was updated over the air, on a binary built before this change,
  * dies at launch — not on the phone screen, at launch, with nothing local to
- * catch it. So it is required lazily, behind a check that cannot throw, and
+ * catch it. So it is required lazily (in `lib/firebaseModule`, which exists to
+ * hold that one require), behind a check that cannot throw, and
  * `phoneSignInAvailable()` is the honest answer to "can this build do this at
- * all" for anything that would otherwise offer a door to nowhere.
+ * all" for anything that would otherwise offer a door to nowhere. Every screen
+ * that offers the door asks it: the welcome tiles, the sign-in tiles, and the
+ * phone chip on the account screen.
+ *
+ * Which of the two things a proved number becomes is not decided here either.
+ * `planAuth` has decided that for every door since ADR-006, and it says the same
+ * thing for all of them: somebody already holding an account — a guest very much
+ * included — is *adding* a way in, never trading the account they are holding
+ * for the one that owns the number.
  */
 
+import { AuthMethod, planAuth, type Viewer } from '@waves/core';
+
 import { backend } from '@/lib/backend';
-
-/** What Firebase hands back between sending a code and checking it. */
-interface PhoneConfirmation {
-  confirm(code: string): Promise<{ user: { getIdToken(): Promise<string> } } | null>;
-}
-
-interface FirebaseAuth {
-  (): {
-    signInWithPhoneNumber(phone: string): Promise<PhoneConfirmation>;
-    signOut(): Promise<void>;
-  };
-}
+import { loadFirebaseAuth, type FirebaseAuth, type PhoneConfirmation } from '@/lib/firebaseModule';
 
 /**
  * `undefined` means nobody has looked yet; `null` means we looked and this build
@@ -40,13 +40,7 @@ let module_: FirebaseAuth | null | undefined;
 
 function firebaseAuth(): FirebaseAuth | null {
   if (module_ !== undefined) return module_;
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const loaded = require('@react-native-firebase/auth') as { default?: FirebaseAuth };
-    module_ = loaded.default ?? null;
-  } catch {
-    module_ = null;
-  }
+  module_ = loadFirebaseAuth();
   return module_;
 }
 
@@ -80,14 +74,6 @@ export async function sendPhoneCode(phone: string): Promise<void> {
 }
 
 /**
- * Check the code with Firebase, then trade its assertion for a Waves session.
- *
- * The Firebase session is signed out immediately afterwards, and deliberately:
- * it was only ever a way to prove the number, this app keeps no state in it, and
- * leaving one signed in means a token sitting on the device that `phone-verify`
- * would accept as proof for the next ten minutes.
- */
-/**
  * Check the code with Firebase and come away with its signed assertion.
  *
  * Shared by both things a proved number can be used for, because the proving is
@@ -119,13 +105,61 @@ async function proveNumber(phone: string, code: string): Promise<string> {
   }
 }
 
+/**
+ * What `phone-verify` actually said.
+ *
+ * `functions.invoke` collapses every non-2xx into one sentence about a non-2xx
+ * status code, so without this a number already on somebody else's account, a
+ * code already used and a database outage all reach the screen as the same
+ * unreadable line — and two of those three are things the person can act on.
+ * The body is ours and its `message` is written to be read.
+ */
+async function explain(error: unknown, fallback: string): Promise<Error> {
+  const response = (error as { context?: unknown })?.context;
+  if (response instanceof Response) {
+    try {
+      const body = (await response.clone().json()) as { message?: unknown };
+      if (typeof body.message === 'string' && body.message) return new Error(body.message);
+    } catch {
+      // A body that is not our JSON says nothing worth showing.
+    }
+  }
+  return new Error(fallback);
+}
+
+/** Who is holding the phone right now, in the shape `planAuth` reads. */
+async function currentViewer(): Promise<Viewer> {
+  const { data } = await backend.auth.getSession();
+  const user = data.session?.user;
+  if (!user) return { kind: 'nobody' };
+  return user.is_anonymous === true
+    ? { kind: 'guest', userId: user.id }
+    : { kind: 'user', userId: user.id };
+}
+
 export async function confirmPhoneCode(phone: string, code: string): Promise<void> {
+  // Which call a proved number turns into is never the screen's decision —
+  // `planAuth` has decided it for every other door since ADR-006, and this is
+  // the door that was making the decision itself.
+  //
+  // The case that matters is a guest. They are *already signed in*, to an
+  // anonymous account holding a trip, and `setSession` would quietly swap it for
+  // whoever owns the number: everything entered as a guest is still on the
+  // server, under an account with no way back into it. So for anybody already
+  // holding an account the number is an addition to it, and only somebody
+  // holding nothing is signed in by it.
+  const plan = planAuth(await currentViewer(), AuthMethod.PhoneOtp);
+  if (plan.call === 'updateUser') {
+    await attachProof(await proveNumber(phone, code));
+    return;
+  }
+
   const idToken = await proveNumber(phone, code);
 
   const { data, error } = await backend.functions.invoke('phone-verify', {
-    body: { idToken },
+    body: { idToken, mode: 'signin' },
   });
-  if (error) throw error;
+  if (error) throw await explain(error, 'Could not sign you in just now.');
 
   const session = data as { access_token?: string; refresh_token?: string } | null;
   if (!session?.access_token || !session.refresh_token) {
@@ -148,11 +182,20 @@ export async function confirmPhoneCode(phone: string, code: string): Promise<voi
  * and the number becomes a second way back to the same place (ADR-006).
  */
 export async function attachPhoneCode(phone: string, code: string): Promise<void> {
-  const idToken = await proveNumber(phone, code);
+  await attachProof(await proveNumber(phone, code));
+}
+
+/**
+ * The attach half, once the number is proved.
+ *
+ * Split out because a guest signing in by phone lands here too: the proving is
+ * identical and the account they keep is the whole point.
+ */
+async function attachProof(idToken: string): Promise<void> {
   const { data, error } = await backend.functions.invoke('phone-verify', {
     body: { idToken, mode: 'attach' },
   });
-  if (error) throw error;
+  if (error) throw await explain(error, 'Could not add that number just now.');
   if (!(data as { attached?: boolean } | null)?.attached) {
     throw new Error('Could not add that number just now.');
   }
@@ -161,6 +204,11 @@ export async function attachPhoneCode(phone: string, code: string): Promise<void
   // device was read before the number existed, so without this the account
   // screen goes on offering to add a phone that is already attached, until the
   // access token happens to roll. Refreshing is the whole of "seamless" here.
+  //
+  // It carries the other half of the upgrade too. A guest who attaches a number
+  // stops being one, and `is_anonymous` lives in the access token: until it is
+  // reissued the app goes on drawing the ceilings — one group, ten days — around
+  // somebody who has just lifted them.
   await backend.auth.refreshSession();
 }
 

--- a/apps/mobile/test/phoneAuth.test.ts
+++ b/apps/mobile/test/phoneAuth.test.ts
@@ -1,0 +1,161 @@
+/**
+ * The client half of signing in with a phone — which of the two things a proved
+ * number can do, and whether the door is offered at all.
+ *
+ * Two defects live here and neither one shows up as an error anywhere:
+ *
+ *   * **A guest signing in by phone lost everything.** They are already signed
+ *     in, to an anonymous account holding a trip, and `setSession` would swap it
+ *     for whoever owns the number. The data stays on the server under an account
+ *     with no door left into it — no failure, no message, just a person whose
+ *     trip is gone. ADR-006 says an anonymous session upgrades *in place*, and
+ *     `planAuth` is where every other door already asks.
+ *   * **`phoneSignInAvailable()` was written and never called.** Firebase is a
+ *     native module. A JavaScript-only update onto a binary built before it
+ *     existed leaves the tile drawn and dead, so the check has to answer — and
+ *     answer without throwing, because the thing it is checking for is exactly
+ *     the thing that throws.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/** The Supabase side: what the screen would have done to the session. */
+const world = vi.hoisted(() => ({
+  /** Null for nobody, or the user the device is currently holding. */
+  user: null as { id: string; is_anonymous: boolean } | null,
+  invoked: [] as { name: string; body: Record<string, unknown> }[],
+  /** What `phone-verify` answers. Its shape decides which branch is taken. */
+  answer: { data: {} as unknown, error: null as unknown },
+  setSession: vi.fn(async () => ({ error: null })),
+  refreshSession: vi.fn(async () => ({ error: null })),
+}));
+
+vi.mock('@/lib/backend', () => ({
+  backend: {
+    auth: {
+      getSession: async () => ({ data: { session: world.user ? { user: world.user } : null } }),
+      setSession: world.setSession,
+      refreshSession: world.refreshSession,
+    },
+    functions: {
+      invoke: async (name: string, options: { body: Record<string, unknown> }) => {
+        world.invoked.push({ name, body: options.body });
+        return world.answer;
+      },
+    },
+  },
+}));
+
+/**
+ * Firebase, standing in for the native module this build may or may not have.
+ *
+ * Mocked at `lib/firebaseModule` rather than at the package, because the package
+ * is reached by a `require` and a `require` cannot be substituted — which is the
+ * reason that one line lives in a file of its own.
+ */
+vi.mock('@/lib/firebaseModule', () => ({
+  loadFirebaseAuth: () => () => ({
+    signInWithPhoneNumber: async () => ({
+      confirm: async () => ({ user: { getIdToken: async () => 'id-token' } }),
+    }),
+    signOut: async () => undefined,
+  }),
+}));
+
+const { confirmPhoneCode, phoneSignInAvailable, sendPhoneCode } = await import('@/lib/phoneAuth');
+
+beforeEach(() => {
+  world.user = null;
+  world.invoked = [];
+  world.answer = { data: { access_token: 'access', refresh_token: 'refresh' }, error: null };
+  world.setSession.mockClear();
+  world.refreshSession.mockClear();
+});
+
+describe('whether this build can do it at all', () => {
+  it('answers rather than throwing, which is the whole point of asking', async () => {
+    // The check exists because requiring the module can blow up; a check that
+    // blows up in the same circumstances is no check. Called twice because the
+    // answer is cached and the cached path must not throw either.
+    expect(() => phoneSignInAvailable()).not.toThrow();
+    expect(typeof phoneSignInAvailable()).toBe('boolean');
+    expect(() => phoneSignInAvailable()).not.toThrow();
+  });
+});
+
+describe('a guest who signs in by phone', () => {
+  it('keeps the account they are holding instead of being handed another', async () => {
+    // The defect this pins: `setSession` swaps the anonymous account for
+    // whoever owns the number, and everything entered as a guest is left on the
+    // server under an id nobody can reach again. ADR-006 makes this an addition.
+    world.user = { id: 'guest-1', is_anonymous: true };
+    world.answer = { data: { attached: true }, error: null };
+
+    await sendPhoneCode('+919876543210');
+    await confirmPhoneCode('+919876543210', '123456');
+
+    expect(world.invoked).toHaveLength(1);
+    expect(world.invoked[0]?.body.mode).toBe('attach');
+    expect(world.setSession).not.toHaveBeenCalled();
+    // The ceiling lifts in the access token, so the session has to be reissued
+    // before the app stops drawing it.
+    expect(world.refreshSession).toHaveBeenCalled();
+  });
+});
+
+describe('somebody with nothing to lose', () => {
+  it('is signed in, and asks for that by name', async () => {
+    world.user = null;
+
+    await sendPhoneCode('+919876543210');
+    await confirmPhoneCode('+919876543210', '123456');
+
+    // Spelled out rather than left to a default: the server refuses a mode it
+    // does not recognise, and silence is the one spelling that could drift.
+    expect(world.invoked[0]?.body.mode).toBe('signin');
+    expect(world.setSession).toHaveBeenCalled();
+  });
+});
+
+describe('an account that already exists', () => {
+  it('gains the number rather than being swapped for another account', async () => {
+    // Same rule as the guest, and for the same reason: somebody holding an
+    // account who proves a number is adding a way in, never trading one account
+    // for another. If the number belongs elsewhere the server says so.
+    world.user = { id: 'user-1', is_anonymous: false };
+    world.answer = { data: { attached: true }, error: null };
+
+    await sendPhoneCode('+919876543210');
+    await confirmPhoneCode('+919876543210', '123456');
+
+    expect(world.invoked[0]?.body.mode).toBe('attach');
+    expect(world.setSession).not.toHaveBeenCalled();
+  });
+});
+
+describe('what the person is told when it fails', () => {
+  it('reads the sentence the function wrote rather than the one invoke made up', async () => {
+    // `functions.invoke` collapses every non-2xx into one line about a non-2xx
+    // status code. "That number is already on another Waves account" is
+    // actionable; "Edge Function returned a non-2xx status code" is not, and
+    // both used to reach the screen as the latter.
+    world.user = { id: 'user-1', is_anonymous: false };
+    world.answer = {
+      data: null,
+      error: Object.assign(new Error('Edge Function returned a non-2xx status code'), {
+        context: new Response(
+          JSON.stringify({
+            code: 'PHONE_TAKEN',
+            message: 'That number is already on another Waves account',
+          }),
+          { status: 409 },
+        ),
+      }),
+    };
+
+    await sendPhoneCode('+919876543210');
+    await expect(confirmPhoneCode('+919876543210', '123456')).rejects.toThrow(
+      'That number is already on another Waves account',
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "devDependencies": {
     "@vitest/coverage-v8": "4.1.10",
+    "@xmldom/xmldom": "^0.8.15",
     "prettier": "^3.4.2",
     "typescript": "~5.9.2",
     "vitest": "^4.1.10"

--- a/packages/db/prisma/migrations/20260912150000_phone_assertion_and_guest_upgrade/migration.sql
+++ b/packages/db/prisma/migrations/20260912150000_phone_assertion_and_guest_upgrade/migration.sql
@@ -1,0 +1,191 @@
+-- ═══════════ One proof, used once — and a guest who proves a number is done ═══
+--
+-- Three things the phone door was missing, and each of them is a way the same
+-- feature breaks rather than three separate features.
+--
+--   1. **A Firebase assertion is single use.** The token is good for ten
+--      minutes, and inside that window the *same* token could be replayed: to
+--      sign in as the number's owner, and then, from a second account, to attach
+--      that number to it. One proof, two irreversible outcomes. What is recorded
+--      is `(uid, auth_time)` rather than the token, because an ID token is
+--      refreshable — a fresh token minted from the same Firebase session carries
+--      the same `auth_time`, so keying on the token itself would pin nothing.
+--   2. **A failure that was ours gives the attempt back.** The daily allowance
+--      exists to stop somebody spending money on SMS. A relay that timed out or
+--      a GoTrue that answered 502 spent no money, and charging the person for it
+--      means three of our own failures lock them out for the day.
+--   3. **A guest who attaches a number stops being a guest.** ADR-006 makes an
+--      anonymous session upgrade *in place* — the account keeps its id and
+--      everything in it. That upgrade is `is_anonymous` going false, and the
+--      GoTrue admin API that attaches the number does not do it. Without this,
+--      somebody with a real, proved contact would still be held to one group and
+--      a ten-day read-only trial, which is the ceiling for an account nobody has
+--      claimed.
+
+-- ───────────────────────────────────── a proof is worth exactly one use ──
+
+-- One row per Firebase sign-in that has been spent. Small, short-lived, and
+-- never read by anything but the functions below: it holds no number and no
+-- token, only "this sign-in has already been traded in".
+CREATE TABLE public.firebase_assertions (
+  uid       text        NOT NULL,
+  auth_time bigint      NOT NULL,
+  used_at   timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT firebase_assertions_pkey PRIMARY KEY (uid, auth_time)
+);
+
+COMMENT ON TABLE public.firebase_assertions IS
+  'Firebase sign-ins already traded for a session or an attachment. A proof is worth one use.';
+
+CREATE INDEX firebase_assertions_used_at_idx ON public.firebase_assertions (used_at);
+
+ALTER TABLE public.firebase_assertions ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE public.firebase_assertions FROM PUBLIC, anon, authenticated;
+
+-- True the first time and false every time after. `ON CONFLICT DO NOTHING` with
+-- the row count is the whole of it: two requests racing with one token both
+-- reach the insert, exactly one row appears, and the loser is told so rather
+-- than both coming away believing they proved something.
+--
+-- The prune rides along instead of needing a cron. A token older than the
+-- verifier's ten-minute ceiling is refused before this is ever called, so an
+-- hour of history is already far more than is useful.
+CREATE FUNCTION public.waves_firebase_assertion_use(p_uid text, p_auth_time bigint)
+RETURNS boolean
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_rows integer;
+BEGIN
+  IF p_uid IS NULL OR p_uid = '' OR p_auth_time IS NULL OR p_auth_time <= 0 THEN
+    RAISE EXCEPTION 'waves_firebase_assertion_use needs a uid and an auth_time';
+  END IF;
+
+  DELETE FROM public.firebase_assertions WHERE used_at < now() - interval '1 hour';
+
+  INSERT INTO public.firebase_assertions (uid, auth_time)
+  VALUES (p_uid, p_auth_time)
+  ON CONFLICT (uid, auth_time) DO NOTHING;
+
+  GET DIAGNOSTICS v_rows = ROW_COUNT;
+  RETURN v_rows > 0;
+END;
+$$;
+
+COMMENT ON FUNCTION public.waves_firebase_assertion_use(text, bigint) IS
+  'Claims a Firebase sign-in. True the first time, false for every replay of the same proof.';
+
+REVOKE ALL ON FUNCTION public.waves_firebase_assertion_use(text, bigint) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.waves_firebase_assertion_use(text, bigint) TO service_role;
+
+-- Gives the proof back, and only ever for a failure on our side of the wire: a
+-- database that could not be reached, a relay that never filled, a GoTrue that
+-- answered 502. Somebody whose sign-in fell over on our infrastructure should be
+-- able to press the button again with the code they already typed, rather than
+-- being sent back to Firebase for a second SMS.
+--
+-- Never called after anything the person did — a number already on another
+-- account, a blocked one, a request with nobody signed in. Those are answers,
+-- and an answer has been given for the proof.
+CREATE FUNCTION public.waves_firebase_assertion_release(p_uid text, p_auth_time bigint)
+RETURNS void
+LANGUAGE sql SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+  DELETE FROM public.firebase_assertions WHERE uid = p_uid AND auth_time = p_auth_time;
+$$;
+
+REVOKE ALL ON FUNCTION public.waves_firebase_assertion_release(text, bigint) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.waves_firebase_assertion_release(text, bigint) TO service_role;
+
+-- ──────────────────────────────── an attempt nobody spent anything on ──
+
+-- Hands back one of the day's three, for the same failures the release above
+-- covers. Deliberately not `waves_phone_verified`: that clears the whole day
+-- because somebody *proved* they were a person, and using it here would let
+-- three failed exchanges wipe a day of genuine evidence that a script is
+-- hammering the number.
+--
+-- The row goes when the count reaches zero rather than sitting at zero, so a day
+-- that was only ever refunded looks exactly like a day nothing happened on —
+-- which is what it is, and which keeps it off the strike count.
+CREATE FUNCTION public.waves_phone_gate_refund(p_phone text)
+RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_today date := (now() AT TIME ZONE 'utc')::date;
+BEGIN
+  UPDATE public.phone_otp_strikes
+     SET hits = GREATEST(0, hits - 1)
+   WHERE phone = p_phone
+     AND day = v_today;
+
+  DELETE FROM public.phone_otp_strikes
+   WHERE phone = p_phone
+     AND day = v_today
+     AND hits <= 0;
+END;
+$$;
+
+COMMENT ON FUNCTION public.waves_phone_gate_refund(text) IS
+  'Gives back one of the day''s codes after a failure on our side. Never after a refusal the person caused.';
+
+REVOKE ALL ON FUNCTION public.waves_phone_gate_refund(text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.waves_phone_gate_refund(text) TO service_role;
+
+-- ──────────────────────────────────── the guest who now has a contact ──
+
+-- ADR-006's in-place upgrade, in the one place it was not happening. Attaching
+-- an email goes through GoTrue's own change-verification, which clears
+-- `is_anonymous` as part of the flow; attaching a phone goes through the admin
+-- API, which does not — it sets the number and nothing else. So the same person,
+-- doing the same thing through the other door, stayed a guest: one group, ten
+-- days, read-only after, with a proved contact sitting on the account.
+--
+-- Only ever called for an account that has just had a confirmed contact put on
+-- it, and it re-checks that here rather than trusting the caller: a promotion
+-- that could be asked for without a proved contact would be a way to lift the
+-- ceiling on any anonymous account at all.
+--
+-- plpgsql and guarded exactly like `waves_is_guest`: CI runs these migrations
+-- against a stub `auth` schema whose users table has no `is_anonymous` column,
+-- and a SQL body naming a missing column fails at CREATE. Where there is no such
+-- column there are no anonymous users, so there is nothing to promote and false
+-- is the true answer.
+CREATE FUNCTION public.waves_promote_guest(p_user uuid)
+RETURNS boolean
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_rows integer;
+BEGIN
+  IF to_regclass('auth.users') IS NULL
+     OR NOT EXISTS (
+       SELECT 1 FROM information_schema.columns
+       WHERE table_schema = 'auth'
+         AND table_name = 'users'
+         AND column_name = 'is_anonymous'
+     ) THEN
+    RETURN FALSE;
+  END IF;
+
+  UPDATE auth.users
+     SET is_anonymous = false
+   WHERE id = p_user
+     AND is_anonymous
+     AND (phone_confirmed_at IS NOT NULL OR email_confirmed_at IS NOT NULL);
+  GET DIAGNOSTICS v_rows = ROW_COUNT;
+
+  RETURN v_rows > 0;
+END;
+$$;
+
+COMMENT ON FUNCTION public.waves_promote_guest(uuid) IS
+  'ADR-006 in-place upgrade: an anonymous account with a confirmed contact is no longer a guest.';
+
+REVOKE ALL ON FUNCTION public.waves_promote_guest(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.waves_promote_guest(uuid) TO service_role;

--- a/packages/db/prisma/migrations/20260912160000_refuse_concurrent_phone_relay/migration.sql
+++ b/packages/db/prisma/migrations/20260912160000_refuse_concurrent_phone_relay/migration.sql
@@ -1,0 +1,32 @@
+-- A second live Firebase→GoTrue phone exchange for the same number must not
+-- replace the first one. Replacement lets one device claim or close another
+-- device's code, and can make the newer request fall through to ordinary SMS
+-- delivery. Stale rows are still replaced so an abandoned exchange does not pin
+-- the number forever.
+
+CREATE OR REPLACE FUNCTION public.waves_otp_relay_open(p_phone text)
+RETURNS uuid
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_exchange uuid := gen_random_uuid();
+BEGIN
+  INSERT INTO public.otp_relay (phone, exchange, code, requested_at)
+  VALUES (p_phone, v_exchange, NULL, now())
+  ON CONFLICT (phone) DO UPDATE
+    SET exchange = EXCLUDED.exchange, code = NULL, requested_at = now()
+    WHERE public.otp_relay.requested_at <= now() - interval '30 seconds'
+  RETURNING exchange INTO v_exchange;
+
+  IF v_exchange IS NULL THEN
+    RAISE EXCEPTION 'OTP_RELAY_BUSY: an exchange is already open for this phone'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  RETURN v_exchange;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.waves_otp_relay_open(text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.waves_otp_relay_open(text) TO service_role;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1731,6 +1731,24 @@ model AppConfig {
   @@schema("public")
 }
 
+/// A Firebase sign-in already traded for a session or an attachment.
+///
+/// One proof, one use. Keyed on the Firebase user and the moment they actually
+/// entered the code rather than on the token, because an ID token is
+/// refreshable: a fresh one minted from the same sign-in is the same proof, and
+/// without this a single captured token buys both a session as the number's
+/// owner and an attachment of that number to a second account.
+model FirebaseAssertion {
+  uid      String
+  authTime BigInt   @map("auth_time")
+  usedAt   DateTime @default(now()) @map("used_at") @db.Timestamptz(6)
+
+  @@id([uid, authTime])
+  @@index([usedAt])
+  @@map("firebase_assertions")
+  @@schema("public")
+}
+
 /// A sign-in code in flight between `phone-verify` and `otp-send`.
 ///
 /// Firebase can prove somebody holds a number but cannot mint a Supabase

--- a/packages/db/test/phoneRelay.test.ts
+++ b/packages/db/test/phoneRelay.test.ts
@@ -173,33 +173,38 @@ describe('the exchange, from the gate to a session', () => {
 });
 
 describe('two devices on one number', () => {
-  it('does not let the displaced exchange take the newcomer’s code', async () => {
-    // The defect the exchange id exists for. One row per number, so the second
-    // `open` replaces the first's — and without an id to match on, the first
-    // caller claims a code minted for the second and signs in with it.
+  it('refuses a second exchange while the first is still live', async () => {
+    // Two devices, one number, at the same moment. The exchange id already stops
+    // the loser *stealing* a code, but displacement left a subtler mess: the
+    // second open replaced the first's row, so the code GoTrue minted for the
+    // first request was parked into the second's and signed the second device
+    // in on it. Same account either way, so never a breach — but a code answering
+    // a request nobody made. Refusing the overlap removes the question.
     const phone = aNumber();
     const first = await open(phone);
-    const second = await open(phone);
-    expect(first).not.toBe(second);
+    expect(first).toBeTruthy();
 
+    await expect(open(phone)).rejects.toThrow(/OTP_RELAY_BUSY/);
+
+    // And the first exchange is untouched by the attempt — it still owns its row.
     await park(phone, '222222');
-
-    expect(await claim(phone, first)).toBeNull();
-    expect(await claim(phone, second)).toBe('222222');
+    expect(await claim(phone, first)).toBe('222222');
   });
 
-  it('does not let the displaced exchange delete the newcomer’s row', async () => {
-    // The same defect in the other direction, and the more expensive one: the
-    // loser's `finally` tidies up, takes the winner's row with it, and the code
-    // GoTrue minted goes out as an SMS to somebody who was never sent one.
+  it('lets the next device through the moment the first is done', async () => {
+    // The cost of refusing an overlap is a door that stays shut too long, so the
+    // close has to open it again immediately — a person whose first attempt died
+    // is the most likely caller of the second.
     const phone = aNumber();
     const first = await open(phone);
-    const second = await open(phone);
-
     await close(phone, first);
 
-    await park(phone, '222222');
-    expect(await claim(phone, second)).toBe('222222');
+    const second = await open(phone);
+    expect(second).toBeTruthy();
+    expect(second).not.toBe(first);
+
+    await park(phone, '333333');
+    expect(await claim(phone, second)).toBe('333333');
   });
 
   it('hands the code to exactly one of two callers racing for it', async () => {

--- a/packages/db/test/phoneRelay.test.ts
+++ b/packages/db/test/phoneRelay.test.ts
@@ -1,0 +1,476 @@
+/**
+ * The phone door, end to end, against a real Postgres — which is as close to an
+ * end-to-end test as this feature can get without a device and a live SMS.
+ *
+ * Everything the exchange actually depends on is a race or a window, and neither
+ * survives being unit-tested with a mock: the relay is keyed on a phone number,
+ * so two devices signing in on one number meet in the same row; a Firebase proof
+ * is good for ten minutes, so two requests can carry the same one; and a
+ * refunded attempt is a subtraction that must not turn into a resurrection. All
+ * of those are exercised here over real connections, in parallel where parallel
+ * is the point.
+ *
+ * What each block is standing guard over:
+ *
+ *   * **The handshake.** Open, park, claim, verify — the four calls `phone-verify`
+ *     and `otp-send` make between them, in the order they make them, with the
+ *     code surviving exactly one hop and nothing left behind afterwards.
+ *   * **The exchange id.** Without it one number is one row: the second sign-in
+ *     overwrites the first's, and the first then either claims a code minted for
+ *     somebody else or deletes the second's on its way out — sending a stranger's
+ *     code to an SMS nobody asked for.
+ *   * **One proof, one use.** A Firebase ID token is refreshable, so the same
+ *     sign-in can arrive twice wearing two signatures. One proof buying both a
+ *     session *and* an attachment to a second account is two irreversible things
+ *     from one SMS.
+ *   * **A refund is a subtraction, not an amnesty.** Handing back an attempt we
+ *     wasted must not clear the day's evidence that somebody is hammering the
+ *     number, and must not leave a phantom row that counts as a spent day.
+ *
+ * Unrun as written: Docker was not available on the machine this was written on,
+ * so the suite has never been executed. CI provides the database.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { connect } from './helpers.js';
+
+let client: Client;
+
+/** Distinct per test, so nothing leaks between them through a shared number. */
+let seq = 0;
+function aNumber(): string {
+  seq += 1;
+  return `+4477008${String(seq).padStart(5, '0')}`;
+}
+
+let uidSeq = 0;
+function aFirebaseUid(): string {
+  uidSeq += 1;
+  return `firebase-uid-${uidSeq}`;
+}
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client?.end();
+});
+
+afterEach(async () => {
+  await client.query('DELETE FROM public.otp_relay');
+  await client.query('DELETE FROM public.firebase_assertions');
+  await client.query('DELETE FROM public.phone_otp_strikes');
+  await client.query('DELETE FROM public.phone_blocks');
+});
+
+async function one<T>(sql: string, params: unknown[] = []): Promise<T> {
+  const { rows } = await client.query(sql, params);
+  return Object.values(rows[0] as Record<string, unknown>)[0] as T;
+}
+
+const open = (phone: string) => one<string>('SELECT public.waves_otp_relay_open($1)', [phone]);
+const park = (phone: string, code: string) =>
+  one<boolean>('SELECT public.waves_otp_relay_park($1, $2)', [phone, code]);
+const claim = (phone: string, exchange: string) =>
+  one<string | null>('SELECT public.waves_otp_relay_claim($1, $2)', [phone, exchange]);
+const close = (phone: string, exchange: string) =>
+  client.query('SELECT public.waves_otp_relay_close($1, $2)', [phone, exchange]);
+
+interface Verdict {
+  allowed: boolean;
+  reason: 'ok' | 'spent' | 'blocked';
+  remaining?: number;
+}
+const gate = (phone: string) => one<Verdict>('SELECT public.waves_phone_gate($1)', [phone]);
+const refund = (phone: string) =>
+  client.query('SELECT public.waves_phone_gate_refund($1)', [phone]);
+const useProof = (uid: string, authTime: number) =>
+  one<boolean>('SELECT public.waves_firebase_assertion_use($1, $2)', [uid, authTime]);
+const releaseProof = (uid: string, authTime: number) =>
+  client.query('SELECT public.waves_firebase_assertion_release($1, $2)', [uid, authTime]);
+
+/** How many rows the day is currently standing at, or null for no row at all. */
+async function hitsToday(phone: string): Promise<number | null> {
+  const { rows } = await client.query<{ hits: number }>(
+    `SELECT hits FROM public.phone_otp_strikes
+      WHERE phone = $1 AND day = (now() AT TIME ZONE 'utc')::date`,
+    [phone],
+  );
+  return rows[0]?.hits ?? null;
+}
+
+/** Backdate an open exchange, which is the only way to reach the TTL in a test. */
+async function ageExchange(phone: string, seconds: number): Promise<void> {
+  await client.query(
+    `UPDATE public.otp_relay SET requested_at = now() - make_interval(secs => $2) WHERE phone = $1`,
+    [phone, seconds],
+  );
+}
+
+describe('the exchange, from the gate to a session', () => {
+  it('carries the code one hop and leaves nothing behind', async () => {
+    // The whole handshake in the order the two functions make it. Every step is
+    // covered on its own elsewhere; what this pins is that they compose — an
+    // earlier draft had the claim matching on the number alone, which passed
+    // every individual test and handed the wrong code to the wrong caller.
+    const phone = aNumber();
+
+    expect((await gate(phone)).allowed).toBe(true);
+    const exchange = await open(phone);
+    expect(await park(phone, '123456')).toBe(true);
+    expect(await claim(phone, exchange)).toBe('123456');
+
+    // Claimed means gone: a live sign-in credential does not get to sit around
+    // waiting for whoever finds it next.
+    const { rows } = await client.query('SELECT * FROM public.otp_relay WHERE phone = $1', [phone]);
+    expect(rows).toHaveLength(0);
+
+    // A code was used, so the day is cleared and nothing can accrue a strike.
+    await client.query('SELECT public.waves_phone_verified($1)', [phone]);
+    expect(await hitsToday(phone)).toBeNull();
+  });
+
+  it('parks nothing when nobody is waiting, which is the ordinary SMS path', async () => {
+    // `otp-send` reads false as "this is a real code somebody is sitting waiting
+    // for" and goes on to send it. If this ever answered true with no exchange
+    // open, every ordinary phone sign-in would silently stop receiving its SMS.
+    expect(await park(aNumber(), '123456')).toBe(false);
+  });
+
+  it('refuses a code parked after the window has gone by', async () => {
+    // The window is what stops an abandoned exchange sitting there fillable. A
+    // request that went astray half a minute ago is not an exchange any more,
+    // and a code parked into it is a live credential nobody is coming back for.
+    const phone = aNumber();
+    await open(phone);
+    await ageExchange(phone, 120);
+
+    expect(await park(phone, '123456')).toBe(false);
+  });
+
+  it('refuses a second code over one already parked', async () => {
+    // Two codes and one row: the second would overwrite a code the caller is
+    // about to claim, so the caller verifies with a code GoTrue has already
+    // superseded and the sign-in fails for no visible reason.
+    const phone = aNumber();
+    const exchange = await open(phone);
+    expect(await park(phone, '111111')).toBe(true);
+    expect(await park(phone, '222222')).toBe(false);
+    expect(await claim(phone, exchange)).toBe('111111');
+  });
+
+  it('refuses to claim a code that has aged past the window', async () => {
+    const phone = aNumber();
+    const exchange = await open(phone);
+    await park(phone, '123456');
+    await ageExchange(phone, 120);
+
+    expect(await claim(phone, exchange)).toBeNull();
+  });
+});
+
+describe('two devices on one number', () => {
+  it('does not let the displaced exchange take the newcomer’s code', async () => {
+    // The defect the exchange id exists for. One row per number, so the second
+    // `open` replaces the first's — and without an id to match on, the first
+    // caller claims a code minted for the second and signs in with it.
+    const phone = aNumber();
+    const first = await open(phone);
+    const second = await open(phone);
+    expect(first).not.toBe(second);
+
+    await park(phone, '222222');
+
+    expect(await claim(phone, first)).toBeNull();
+    expect(await claim(phone, second)).toBe('222222');
+  });
+
+  it('does not let the displaced exchange delete the newcomer’s row', async () => {
+    // The same defect in the other direction, and the more expensive one: the
+    // loser's `finally` tidies up, takes the winner's row with it, and the code
+    // GoTrue minted goes out as an SMS to somebody who was never sent one.
+    const phone = aNumber();
+    const first = await open(phone);
+    const second = await open(phone);
+
+    await close(phone, first);
+
+    await park(phone, '222222');
+    expect(await claim(phone, second)).toBe('222222');
+  });
+
+  it('hands the code to exactly one of two callers racing for it', async () => {
+    // Read-then-delete is the shape that lets both come away holding a live
+    // credential. This is the one case that cannot be written with a single
+    // connection, because a single connection cannot race itself.
+    const phone = aNumber();
+    const exchange = await open(phone);
+    await park(phone, '123456');
+
+    const [a, b] = await Promise.all([connect(), connect()]);
+    try {
+      const results = await Promise.all(
+        [a, b].map(async (c) => {
+          const { rows } = await c.query<{ waves_otp_relay_claim: string | null }>(
+            'SELECT public.waves_otp_relay_claim($1, $2)',
+            [phone, exchange],
+          );
+          return rows[0]!.waves_otp_relay_claim;
+        }),
+      );
+      expect(results.filter((code) => code === '123456')).toHaveLength(1);
+      expect(results.filter((code) => code === null)).toHaveLength(1);
+    } finally {
+      await a.end();
+      await b.end();
+    }
+  });
+});
+
+/**
+ * A Firebase proof is good for ten minutes and is refreshable, so "present the
+ * same token twice" is not the only replay: a second token minted from the same
+ * Firebase session is the same sign-in wearing a different signature. Both are
+ * refused after the first, because one proof must not buy both a session and an
+ * attachment to a different account.
+ */
+describe('one proof, one use', () => {
+  it('is true the first time and false every time after', async () => {
+    const uid = aFirebaseUid();
+    expect(await useProof(uid, 1_770_000_000)).toBe(true);
+    expect(await useProof(uid, 1_770_000_000)).toBe(false);
+    expect(await useProof(uid, 1_770_000_000)).toBe(false);
+  });
+
+  it('is keyed on the sign-in, so a refreshed token is the same proof', async () => {
+    // Nothing here carries the token: two different tokens from one Firebase
+    // sign-in agree on `auth_time`, and that is what makes them the same proof.
+    // Keyed on anything derived from the token itself, this would pin nothing.
+    const uid = aFirebaseUid();
+    expect(await useProof(uid, 1_770_000_100)).toBe(true);
+    expect(await useProof(uid, 1_770_000_100)).toBe(false);
+
+    // A genuinely new sign-in — they typed a second code — is a new proof.
+    expect(await useProof(uid, 1_770_000_200)).toBe(true);
+  });
+
+  it('keeps one person’s sign-in apart from another’s', async () => {
+    const authTime = 1_770_000_300;
+    expect(await useProof(aFirebaseUid(), authTime)).toBe(true);
+    expect(await useProof(aFirebaseUid(), authTime)).toBe(true);
+  });
+
+  it('is claimed by exactly one of two requests carrying it at once', async () => {
+    // The whole attack in one line: sign in with the token on one device while
+    // attaching it to a second account on another. Both arrive inside the ten
+    // minutes, and only a race-safe claim decides between them.
+    const uid = aFirebaseUid();
+    const [a, b] = await Promise.all([connect(), connect()]);
+    try {
+      const results = await Promise.all(
+        [a, b].map(async (c) => {
+          const { rows } = await c.query<{ waves_firebase_assertion_use: boolean }>(
+            'SELECT public.waves_firebase_assertion_use($1, $2)',
+            [uid, 1_770_000_400],
+          );
+          return rows[0]!.waves_firebase_assertion_use;
+        }),
+      );
+      expect(results.filter(Boolean)).toHaveLength(1);
+    } finally {
+      await a.end();
+      await b.end();
+    }
+  });
+
+  it('can be handed back, so a failure of ours is not a second SMS', async () => {
+    // Released only when the exchange fell over on our side. The person is
+    // holding a code they typed correctly; sending them back to Firebase for
+    // another one is charging them for our outage.
+    const uid = aFirebaseUid();
+    expect(await useProof(uid, 1_770_000_500)).toBe(true);
+    await releaseProof(uid, 1_770_000_500);
+    expect(await useProof(uid, 1_770_000_500)).toBe(true);
+  });
+
+  it('refuses a proof with nothing in it rather than recording one', async () => {
+    await expect(useProof('', 1)).rejects.toThrow(/uid and an auth_time/);
+    await expect(useProof(aFirebaseUid(), 0)).rejects.toThrow(/uid and an auth_time/);
+  });
+});
+
+/**
+ * The allowance pays for messages. A relay that never filled and a GoTrue that
+ * answered 502 sent nothing, and three of our own bad minutes must not be the
+ * thing that locks somebody out for the day.
+ */
+describe('an attempt handed back', () => {
+  it('lets the next ask through instead of refusing it', async () => {
+    const phone = aNumber();
+    await gate(phone);
+    await gate(phone);
+    expect((await gate(phone)).allowed).toBe(true);
+    // The fourth would be refused — unless one of the three was never spent.
+    await refund(phone);
+    expect((await gate(phone)).allowed).toBe(true);
+  });
+
+  it('leaves no day behind when every ask was given back', async () => {
+    // A row sitting at zero is a day that happened, and a day that happened at
+    // the cap is a strike. A day that was entirely refunded did not happen.
+    const phone = aNumber();
+    await gate(phone);
+    await refund(phone);
+    expect(await hitsToday(phone)).toBeNull();
+  });
+
+  it('never goes below zero, and never invents a day that was not spent', async () => {
+    const phone = aNumber();
+    await refund(phone);
+    expect(await hitsToday(phone)).toBeNull();
+  });
+
+  it('subtracts one attempt rather than pardoning the day', async () => {
+    // Deliberately not `waves_phone_verified`, which clears the whole day
+    // because somebody proved they were a person. Using that here would let
+    // three failed exchanges erase a day of genuine evidence that a script is
+    // working through the number.
+    const phone = aNumber();
+    await gate(phone);
+    await gate(phone);
+    await refund(phone);
+    expect(await hitsToday(phone)).toBe(1);
+  });
+
+  it('does not reach back into yesterday', async () => {
+    const phone = aNumber();
+    await client.query(
+      `INSERT INTO public.phone_otp_strikes (phone, day, hits)
+       VALUES ($1, (now() AT TIME ZONE 'utc')::date - 1, 3)`,
+      [phone],
+    );
+    await refund(phone);
+
+    const { rows } = await client.query<{ hits: number }>(
+      `SELECT hits FROM public.phone_otp_strikes WHERE phone = $1`,
+      [phone],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.hits).toBe(3);
+  });
+});
+
+/**
+ * ADR-006's in-place upgrade, in the one place it was not happening.
+ *
+ * Attaching an email runs through GoTrue's own change-verification, which clears
+ * `is_anonymous` on the way past. Attaching a phone runs through the admin API,
+ * which sets the number and nothing else — so the same person, through the other
+ * door, kept the guest ceilings (one group, ten days, read-only after) while
+ * holding a proved contact.
+ */
+describe('the guest ceiling a proved contact lifts', () => {
+  it('answers false rather than throwing where auth.users has no such column', async () => {
+    // The shape CI runs in: `auth` is a stub here and the stub has no
+    // `is_anonymous`. Where the column does not exist there are no anonymous
+    // users, so there is nothing to promote — and the guard is the difference
+    // between that and an attachment that fails with a missing-column error.
+    const { rows } = await client.query<{ promoted: boolean }>(
+      'SELECT public.waves_promote_guest(gen_random_uuid()) AS promoted',
+    );
+    expect(rows[0]!.promoted).toBe(false);
+  });
+
+  it('promotes an anonymous account that now has a confirmed contact', async () => {
+    // The columns are added inside a transaction that is rolled back, because
+    // the stub `auth.users` this suite runs against does not have them and the
+    // rule being proved is a rule about them. Nothing survives the test.
+    await client.query(`CREATE SCHEMA IF NOT EXISTS auth`);
+    await client.query(`CREATE TABLE IF NOT EXISTS auth.users (id uuid PRIMARY KEY)`);
+
+    await client.query('BEGIN');
+    try {
+      await client.query(`
+        ALTER TABLE auth.users
+          ADD COLUMN IF NOT EXISTS is_anonymous boolean NOT NULL DEFAULT false,
+          ADD COLUMN IF NOT EXISTS phone_confirmed_at timestamptz,
+          ADD COLUMN IF NOT EXISTS email_confirmed_at timestamptz
+      `);
+
+      const { rows: made } = await client.query<{ id: string }>(
+        `INSERT INTO auth.users (id) VALUES (gen_random_uuid()) RETURNING id`,
+      );
+      const guest = made[0]!.id;
+      await client.query(`UPDATE auth.users SET is_anonymous = true WHERE id = $1`, [guest]);
+
+      // No contact yet: the ceiling stays, because a promotion that can be asked
+      // for without a proved contact is a way to lift it on any account at all.
+      const { rows: early } = await client.query<{ promoted: boolean }>(
+        'SELECT public.waves_promote_guest($1) AS promoted',
+        [guest],
+      );
+      expect(early[0]!.promoted).toBe(false);
+
+      await client.query(`UPDATE auth.users SET phone_confirmed_at = now() WHERE id = $1`, [guest]);
+
+      const { rows: now } = await client.query<{ promoted: boolean }>(
+        'SELECT public.waves_promote_guest($1) AS promoted',
+        [guest],
+      );
+      expect(now[0]!.promoted).toBe(true);
+
+      const { rows: after } = await client.query<{ is_anonymous: boolean }>(
+        'SELECT is_anonymous FROM auth.users WHERE id = $1',
+        [guest],
+      );
+      expect(after[0]!.is_anonymous).toBe(false);
+
+      // Twice is a no-op, not a second promotion: the attach path is retried
+      // whenever a connection drops mid-answer.
+      const { rows: again } = await client.query<{ promoted: boolean }>(
+        'SELECT public.waves_promote_guest($1) AS promoted',
+        [guest],
+      );
+      expect(again[0]!.promoted).toBe(false);
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  });
+});
+
+describe('who can reach any of this', () => {
+  async function asRole(role: 'anon' | 'authenticated', sql: string): Promise<unknown> {
+    await client.query(`SET ROLE ${role}`);
+    try {
+      return await client.query(sql);
+    } finally {
+      await client.query('RESET ROLE');
+    }
+  }
+
+  it.each(['anon', 'authenticated'] as const)('is closed to %s', async (role) => {
+    // A live sign-in credential and a list of proofs already spent. Neither is
+    // anything a signed-in caller has business reading, and `authenticated` is
+    // the role a guest session carries — a REVOKE that named only `anon` would
+    // leave this open to every account in the app.
+    await expect(asRole(role, 'SELECT * FROM public.otp_relay')).rejects.toThrow(/permission/i);
+    await expect(asRole(role, 'SELECT * FROM public.firebase_assertions')).rejects.toThrow(
+      /permission/i,
+    );
+    await expect(
+      asRole(role, `SELECT public.waves_firebase_assertion_use('u', 1)`),
+    ).rejects.toThrow(/permission/i);
+    await expect(
+      asRole(role, `SELECT public.waves_firebase_assertion_release('u', 1)`),
+    ).rejects.toThrow(/permission/i);
+    await expect(
+      asRole(role, `SELECT public.waves_phone_gate_refund('+447700900123')`),
+    ).rejects.toThrow(/permission/i);
+    await expect(
+      asRole(role, `SELECT public.waves_promote_guest(gen_random_uuid())`),
+    ).rejects.toThrow(/permission/i);
+  });
+});

--- a/packages/db/test/phoneRelaySql.test.ts
+++ b/packages/db/test/phoneRelaySql.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Static guards for the phone OTP relay migrations.
+ *
+ * The live DB integration suite covers these rules when Postgres is available,
+ * but this audit environment may not have the local service. These assertions
+ * keep the migration text from regressing on the concurrency contract: one phone
+ * may have only one live Firebase→GoTrue exchange, and every claim/close must
+ * name the exchange it owns.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const originalRelayMigration = readFileSync(
+  join(__dirname, '../prisma/migrations/20260912120000_otp_relay/migration.sql'),
+  'utf8',
+);
+const concurrentRelayMigration = readFileSync(
+  join(__dirname, '../prisma/migrations/20260912160000_refuse_concurrent_phone_relay/migration.sql'),
+  'utf8',
+);
+
+describe('phone OTP relay SQL', () => {
+  it('refuses a second live exchange instead of replacing it', () => {
+    expect(concurrentRelayMigration).toContain('CREATE OR REPLACE FUNCTION public.waves_otp_relay_open');
+    expect(concurrentRelayMigration).toContain("LANGUAGE plpgsql SECURITY DEFINER");
+    expect(concurrentRelayMigration).toContain(
+      "WHERE public.otp_relay.requested_at <= now() - interval '30 seconds'",
+    );
+    expect(concurrentRelayMigration).toContain(
+      'OTP_RELAY_BUSY: an exchange is already open for this phone',
+    );
+  });
+
+  it('keeps claim and close scoped to the exchange owner', () => {
+    expect(originalRelayMigration).toContain(
+      'CREATE FUNCTION public.waves_otp_relay_claim(p_phone text, p_exchange uuid)',
+    );
+    expect(originalRelayMigration).toContain('AND exchange = p_exchange');
+    expect(originalRelayMigration).toContain(
+      'CREATE FUNCTION public.waves_otp_relay_close(p_phone text, p_exchange uuid)',
+    );
+    expect(originalRelayMigration).toContain(
+      'DELETE FROM public.otp_relay WHERE phone = p_phone AND exchange = p_exchange',
+    );
+  });
+});

--- a/packages/db/test/phoneRelaySql.test.ts
+++ b/packages/db/test/phoneRelaySql.test.ts
@@ -18,14 +18,19 @@ const originalRelayMigration = readFileSync(
   'utf8',
 );
 const concurrentRelayMigration = readFileSync(
-  join(__dirname, '../prisma/migrations/20260912160000_refuse_concurrent_phone_relay/migration.sql'),
+  join(
+    __dirname,
+    '../prisma/migrations/20260912160000_refuse_concurrent_phone_relay/migration.sql',
+  ),
   'utf8',
 );
 
 describe('phone OTP relay SQL', () => {
   it('refuses a second live exchange instead of replacing it', () => {
-    expect(concurrentRelayMigration).toContain('CREATE OR REPLACE FUNCTION public.waves_otp_relay_open');
-    expect(concurrentRelayMigration).toContain("LANGUAGE plpgsql SECURITY DEFINER");
+    expect(concurrentRelayMigration).toContain(
+      'CREATE OR REPLACE FUNCTION public.waves_otp_relay_open',
+    );
+    expect(concurrentRelayMigration).toContain('LANGUAGE plpgsql SECURITY DEFINER');
     expect(concurrentRelayMigration).toContain(
       "WHERE public.otp_relay.requested_at <= now() - interval '30 seconds'",
     );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 4.1.10
         version: 4.1.10(vitest@4.1.10)
+      '@xmldom/xmldom':
+        specifier: ^0.8.15
+        version: 0.8.15
       prettier:
         specifier: ^3.4.2
         version: 3.9.6
@@ -242,6 +245,12 @@ importers:
       '@react-native-community/datetimepicker':
         specifier: 9.1.0
         version: 9.1.0(expo@57.0.21)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      '@react-native-firebase/app':
+        specifier: 26.4.0
+        version: 26.4.0(@react-native-async-storage/async-storage@3.1.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(expo@57.0.21)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      '@react-native-firebase/auth':
+        specifier: 26.4.0
+        version: 26.4.0(@react-native-firebase/app@26.4.0(@react-native-async-storage/async-storage@3.1.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(expo@57.0.21)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(expo@57.0.21)
       '@react-native-google-signin/google-signin':
         specifier: ^16.1.5
         version: 16.1.5(expo@57.0.21)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
@@ -2469,6 +2478,234 @@ packages:
     resolution: {integrity: sha512-R11tGE6yIFwqpaIqcfkcg7AICXzFg14+5h5v0TfF/9+RMDL6jhzCy/pxHVOfbALGdtVYdt6JdR21tuxEgl34dw==}
     deprecated: Please update to a newer version.
 
+  '@firebase/ai@2.14.0':
+    resolution: {integrity: sha512-TYEQqCQUTyVHuG/HVi9vau6F9kvEaS49o/hmdn/yUuN6ZXQkwIml2nNJTIBfjNl/r9LOxwUNILgcOY16nxObug==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@firebase/app-types': 0.x
+
+  '@firebase/analytics-compat@0.2.29':
+    resolution: {integrity: sha512-allztvCvCUlItZzD97TiRAtGoFJzR1FQFmLxbaLc6PvgscqD9cl5NdKPTtka6keShVYXvCZJpzWcRoH4TME8rw==}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@firebase/app-compat': 0.x
+
+  '@firebase/analytics-types@0.8.4':
+    resolution: {integrity: sha512-zQ+XTgkwH6CY/eUSHJRP7e4LxM30RCxlCmob5sy2axs25GE3Ny0XdgpDscMTHHQIGqWkxPXad4w2Mw9sCgT8zQ==}
+
+  '@firebase/analytics@0.10.23':
+    resolution: {integrity: sha512-34ALWXzWA6PTRUA5hipZmsm1RKzeecw5J1+qTCXsiMzwLqONC+GuTIQSdmm91MmTAEA+wG1Q5t0IFahcYQOqAA==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/app-check-compat@0.4.6':
+    resolution: {integrity: sha512-2pzNEZEkX84jSqy6TH6FI1HSLA1lc7kakRUybBbKjg9YhIttPlW/XX3N9CDtChji2PTTPWVPZiWhB10exHfA+A==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@firebase/app-compat': 0.x
+
+  '@firebase/app-check-interop-types@0.3.4':
+    resolution: {integrity: sha512-zz3i6e13B8BfWiLy8MABtTh8aGIACgKbf9UVnyHcWs+yQzJXgQcl8A46b0zfaiJHdQ+niF0ouAfcpuf+3LMPQg==}
+
+  '@firebase/app-check-types@0.5.4':
+    resolution: {integrity: sha512-xV7JsIyzVr15aA7f3Pi0rB9gdBuVubs89FGA8VkRYA4g0l78poADgdfrScgf7NndSg9mm7cR7PJyY0+t22KaGw==}
+
+  '@firebase/app-check@0.13.0':
+    resolution: {integrity: sha512-AbMttBKazQvGVXBZhQdVAdPzRhwHyJAY3Ghu5y2C7IZKIDIppzNYz0shTZ1mP4FBJa+28BuC4t+5h1Q6pT3Asg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/app-compat@0.5.16':
+    resolution: {integrity: sha512-shQq37O8qELDzvsVwYPlDXwD1zlcrZ0m2bpBF5ov2HSbY8x+AHsnL5TtJ2e1JAfkQN05qHao1AfabS69PN6GiA==}
+    engines: {node: '>=20.0.0'}
+
+  '@firebase/app-types@0.9.5':
+    resolution: {integrity: sha512-YevqTjvo7Iujsa9Dwowmd6dSoElhzmD63ZSrq6bzjvQ6POjYgNjOFHLmNIgJs48eNO093NCERibuFnxbfOvU7A==}
+
+  '@firebase/app@0.16.0':
+    resolution: {integrity: sha512-G+ZGEyVP8YTb3ay6A+XpcYgFH3sTESHcnHU/EyTktodqhz2BHkLq+QEP7IVwjiMX0cxYwpVKip0/wC0KZcn9vQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@firebase/auth-compat@0.6.9':
+    resolution: {integrity: sha512-/hHeTBmQ61+N5J1RECls+WfskZTY78JXr7aO5EMOfUpqJvDqvoS+568k0rp6Ss/4UWwBjadILs+H+SGy1zCS3A==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@firebase/app-compat': 0.x
+
+  '@firebase/auth-interop-types@0.2.5':
+    resolution: {integrity: sha512-1Li/YuBDBAXcKv7BzY4U28gontUmAaw53sYiqbaVOMCFb2lFKK/c3CGMUWqtwe7+TXrl3poWnTCL5umYBg85Eg==}
+
+  '@firebase/auth-types@0.13.1':
+    resolution: {integrity: sha512-0c1Mnid0uMDfGJHeUS4zfvBa4/CedJXotGy/n/NZJnBjwiJawt0ZYU+wH2VAVLiRCEfG2ncCkAX3yd1/2nrB7g==}
+    peerDependencies:
+      '@firebase/app-types': 0.x
+      '@firebase/util': 1.x
+
+  '@firebase/auth@1.13.4':
+    resolution: {integrity: sha512-s+NS1aV0DDyyfoIMeSz53HXnVTv7ufJjJfrP63XyaWHweJ5vOoxKWrTm5tO7S7PDqvyOa/Wi3oP0dgAo6JTMMA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@react-native-async-storage/async-storage': ^2.2.0 || ^3.0.0
+    peerDependenciesMeta:
+      '@react-native-async-storage/async-storage':
+        optional: true
+
+  '@firebase/component@0.7.4':
+    resolution: {integrity: sha512-tLpOaaCol9ugUIYp2R3CbWPPA8Ajg/papX/XHEy8U52b/QXH3BbX8tTJX9aShDCjp+9sMAxMLD94i7lresdugQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@firebase/data-connect@0.7.3':
+    resolution: {integrity: sha512-nHBFk3Ntl+NZCRIUG2d5j7I69P0otjyQ/duhVKLbw4+5cNke/F6RK1pdE5Jnf831/QOTs2Bd00LlxlZ+jNsb9w==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/database-compat@2.1.6':
+    resolution: {integrity: sha512-mu7S/75UIajB1A5M9Vfojk69LttW55uABp9nHEtWrV/mIaSEwvoaIe9GySsEzS2EKFK5/3f5okcAuUbihhYeJg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@firebase/app-compat': 0.x
+    peerDependenciesMeta:
+      '@firebase/app':
+        optional: true
+      '@firebase/app-compat':
+        optional: true
+
+  '@firebase/database-types@1.0.21':
+    resolution: {integrity: sha512-SX1jUqhttKgg/m9dYRTvqU9QvucBooziWfA986r4cpsbi4zlsvewe424j3Vpduwd6DG1MSAMfBVT2VqA61FnkA==}
+
+  '@firebase/database@1.1.4':
+    resolution: {integrity: sha512-D+j4+8uhGtNd1tVD+X+c8JrC4ppStGJKyujSQt2NPwdN26QcCk0BeIxue+UqspHkHiFHyQOimwlzjLewGq6S+A==}
+    engines: {node: '>=20.0.0'}
+
+  '@firebase/firestore-compat@0.4.12':
+    resolution: {integrity: sha512-k2uX81Ao/S0jnFcWGPOQpKK1cPlJHvD9WIqh/RE1XBDP2yg5zhE4rHhSg1rtB11k39q3nKon9XLNDDrPjGclag==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@firebase/app-compat': 0.x
+
+  '@firebase/firestore-types@3.0.4':
+    resolution: {integrity: sha512-jGn+JSS4X9zZsrfu7Yw66v5YRdOLD1oyQh4USR0xWl4CUqV/DA6bNIXRPpxH/cUl3iVTNiP6MN7g+EL42A4qfA==}
+    peerDependencies:
+      '@firebase/app-types': 0.x
+      '@firebase/util': 1.x
+
+  '@firebase/firestore@4.17.0':
+    resolution: {integrity: sha512-P9tof6pyO1bnLlMWbux+5O7WFJqlb7OTPMKxxOiXKYiQl7mxykAvxr1BFCgWeEXUU7DZxQncyJ040B0IhFVZCg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/functions-compat@0.4.6':
+    resolution: {integrity: sha512-dj9sOet+FIU91jeU4A3vGJoXHty7NqkSfjRLCwLgJXPDk1m72KFuxD3nlFgw/yXx/Fr7UjqzbxZ0LrIOdpx7+w==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@firebase/app-compat': 0.x
+
+  '@firebase/functions-types@0.6.4':
+    resolution: {integrity: sha512-zV6kgqtduR4rUAdC/ilS7kmb93XD7bEZoJDlVBZqlOw2uGGGCNBQBuleww2rr0Ulr3L9o2TDjumEt68/l1f9DQ==}
+
+  '@firebase/functions@0.13.6':
+    resolution: {integrity: sha512-9obLnzeQUivK5lmtGFOU2ucQ38BjTp+jpPtbfFp/mDsdVCvEpRqdWNvMMQ6aQwR4vcVc/utsvngm5BRkXbc7ZA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/installations-compat@0.2.23':
+    resolution: {integrity: sha512-isaXmjb9roM83eVeXAe+ZRNKYNsSo2s0aNM+cy04AAGEyVL/d8Aa11GwEXovRFeYjl9+1yRAOxRDTOukZRwTxA==}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@firebase/app-compat': 0.x
+
+  '@firebase/installations-types@0.5.4':
+    resolution: {integrity: sha512-U2eFapdHwjb43Vx9o+Pmj4dFfvcHEK1IirEFLqMtWrTHvmdrS3gBpBD1kmJk/9HjsOtoHZxJ2Paoe79e+L1ZPg==}
+    peerDependencies:
+      '@firebase/app-types': 0.x
+
+  '@firebase/installations@0.6.23':
+    resolution: {integrity: sha512-MBkbcQfd+3qHjW+slsH4s7jH5qTdGlYpwqmxEZ7QcIpgDxu1SKyU0f+mCZhCt1BCacLNiOWF5L0R06N0LtlfMg==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/logger@0.5.1':
+    resolution: {integrity: sha512-vZKLsqE1ABOy8OjQiE7cUTFn4gvaqlk88yp8N94Pk/sDpq61YqZGqmVFZTvOyflTwuYFcWirBdYGoJgbDaXKYQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@firebase/messaging-compat@0.2.28':
+    resolution: {integrity: sha512-/AmMqHRnSQhPsdeED3ocs+s30/tpFvZDiiwIYY2uXFRvLujo1fnbPOeCFoe4Y+dRy1LCSjpvJf+dy5ZTsxi1yg==}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@firebase/app-compat': 0.x
+
+  '@firebase/messaging-interop-types@0.2.5':
+    resolution: {integrity: sha512-tUEKnaAP2Y/MNIqgnriPpV6e5l13Vs/+p2yrd6NGlncPJT9O3a8muYZtdnWe+IJ4fgKLHJVC79n/asxk/N5Msw==}
+
+  '@firebase/messaging@0.13.1':
+    resolution: {integrity: sha512-kL8fdjbNBI7hprlXJrUjktDWosrpT4JtfwXtVVevImPF/rBRAsC+LS/jIs+kgQVuotnvMhaBCgAFipBoY9YU9g==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/performance-compat@0.2.26':
+    resolution: {integrity: sha512-jgoocXLN6ao26xWQ8pzosmzQ33uLzGBJQPNK0NTbVy1XvIHr5pfgBf9hWLOxsWe+R7sJq5bjD+8ybXprmt61mA==}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@firebase/app-compat': 0.x
+
+  '@firebase/performance-types@0.2.4':
+    resolution: {integrity: sha512-kJSEk7b0uhpcPRyL4SQ/GPujLqk52XNKcXlnsKDbWGAb9vugcLvOU3u6zfEdwd+d8hWJb5S5ZizV1JFFI0nkKg==}
+
+  '@firebase/performance@0.7.13':
+    resolution: {integrity: sha512-1u6fuXP9cj0s+lkTFAspr/ttfPebPbEdpx+5Wdr4mPZbp8qH2KCMxOddEAR1ZMRa5GI0E7hDYSnolEmbqOFOAg==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/remote-config-compat@0.2.28':
+    resolution: {integrity: sha512-kEO9Gn6fbmVj7eNUtZ6d59mLgUDUD0qo7aCicGOWNfuRWTaUv3CF9DMYychO61zaEQ3cfA+CEny4V1E8A1gRGA==}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@firebase/app-compat': 0.x
+
+  '@firebase/remote-config-types@0.5.1':
+    resolution: {integrity: sha512-cX/1LT6KQwkXzck2eSzeKnuvXZCyr8qaPpDcikoJs7jmI+oBOXixpDLeDtWj1U6GNMkIoXrEDNoyT2Ypcyp5/A==}
+
+  '@firebase/remote-config@0.9.1':
+    resolution: {integrity: sha512-nzQUSJnk1zAZEl2Q5O3I7Z61cYLK5JI4H6wyyOiHkVZ+bmgy1YXNNMptNbVjixMQ/eCzgA6nZRaC+1eBcJGUFA==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/storage-compat@0.4.4':
+    resolution: {integrity: sha512-qSRgCB9f2R/nCp8t/8OC101cIFBFeUazlRInOMdzbnLzvrQBzEfx19SrR4pvdj/0+M+P/y8AK/a2s+3EB+B1Pw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@firebase/app-compat': 0.x
+
+  '@firebase/storage-types@0.8.4':
+    resolution: {integrity: sha512-BT7cwxJOx8SWwlQfrlC+bD/Sk3Cw+1odCi8UZNFNWTVZoPsBnA5W+mqtZzVnvsdJpXCFGSGQ7R7vOR6dtM/BRA==}
+    peerDependencies:
+      '@firebase/app-types': 0.x
+      '@firebase/util': 1.x
+
+  '@firebase/storage@0.14.4':
+    resolution: {integrity: sha512-jfzEWZb3Fpsq3FwAB2ifoc8mcSh935qXdDou3TpyjDWa45hhNcZUv8/w28/10njByhfK7snbakKN30nwnzQ3/w==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/util@1.15.2':
+    resolution: {integrity: sha512-974pWIZVLDMc5GW5YAsj8y0XxULxIy/sPUy7tsxmWbF93KRIyh9xpuHlh0zDL+shUcf5nHDjFOg9YLiQ763eiA==}
+    engines: {node: '>=20.0.0'}
+
+  '@firebase/webchannel-wrapper@1.0.6':
+    resolution: {integrity: sha512-Vr/Mqu79dMwGRAyGbJ4uN4+BtXB3/mRTdzetD1daWNeG8QaWuzhhbG77GltO5c0yYmYls8i250iX73624GJd7Q==}
+
   '@fontsource/ibm-plex-mono@5.3.0':
     resolution: {integrity: sha512-eTgnZjZEGk1QtD3ZstF+Vclo2HLAni8YMy34/DxllwZvyz1lR/1RF/xTiAquOBO7MvqBx8D2Ig2WCPMVfdZu7Q==}
 
@@ -2504,6 +2741,15 @@ packages:
 
   '@formatjs/intl-supportedvaluesof@2.3.9':
     resolution: {integrity: sha512-RquyMkDVrJ5c0fYJSehVfzp7fWELH7vWY4nIvCoEchkDA32Mdm06ms6QvWdW+slECykCmoG4p8SLhwOKj2nCcg==}
+
+  '@grpc/grpc-js@1.9.16':
+    resolution: {integrity: sha512-wE4Ut/olIzfKqp631XrG+wbF0v1vWFN4YL9FyXC2LJiG33DsV7PLzURjrCvY/6je2ntdRkeLpPDluzSRGaVltQ==}
+    engines: {node: ^8.13.0 || >=10.10.0}
+
+  '@grpc/proto-loader@0.7.15':
+    resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   '@hapi/hoek@9.3.0':
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
@@ -3251,6 +3497,33 @@ packages:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
+
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
@@ -3561,6 +3834,25 @@ packages:
       expo:
         optional: true
       react-native-windows:
+        optional: true
+
+  '@react-native-firebase/app@26.4.0':
+    resolution: {integrity: sha512-lqs9vgPcniEw5a+NPRjGNXCQKwuGdVJoSB0iW0HvExR7aGEON/VZYOtSfElBCj3zTwQSiN732zREmqmKrW7Ixw==}
+    peerDependencies:
+      expo: '>=47.0.0'
+      react: '*'
+      react-native: '*'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+
+  '@react-native-firebase/auth@26.4.0':
+    resolution: {integrity: sha512-uNOI7UpR2jzrLQMRwRiIM/mgVkj18j0DQiP/jy8ZiryPJanYS1qmIOk3q2glFvJ8mlYfLCGZgBkIOpV9hwFLWQ==}
+    peerDependencies:
+      '@react-native-firebase/app': 26.4.0
+      expo: '>=47.0.0'
+    peerDependenciesMeta:
+      expo:
         optional: true
 
   '@react-native-google-signin/google-signin@16.1.5':
@@ -4936,11 +5228,6 @@ packages:
 
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
-    engines: {node: '>=10.0.0'}
-    deprecated: this version has critical issues, please update to the latest version
-
-  '@xmldom/xmldom@0.8.13':
-    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
     deprecated: this version has critical issues, please update to the latest version
 
@@ -7132,6 +7419,9 @@ packages:
     resolution: {integrity: sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  firebase@12.17.1:
+    resolution: {integrity: sha512-dhp41ye9jMQvhx5FwjMkf/hjDHJApl7gXmvzOZGvP0M7c/GZGUnQ4qvsvlOBkF0Pa7wAwHMdcpL0ON2pXCQ4Sw==}
+
   flat-cache@6.1.23:
     resolution: {integrity: sha512-f++BY9pTk+983xK1FLzlLpmM0i0z+jHmx3QESGkURMXujQZz1k5wzwX6hjnQ8goaD0B+sYnDK1yZ6MTyZfUaqA==}
 
@@ -7611,6 +7901,9 @@ packages:
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
+
+  idb@7.1.1:
+    resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
 
   idb@8.0.3:
     resolution: {integrity: sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==}
@@ -8307,6 +8600,9 @@ packages:
   locate-path@7.2.0:
     resolution: {integrity: sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
@@ -9856,6 +10152,10 @@ packages:
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
+  protobufjs@7.6.6:
+    resolution: {integrity: sha512-dYDWdjSl5RNb7SgPxGQcRU+GtvP7s2fpkrY0r432PcOIaZ0/rBcxEZnQN67iJhFuQiVw754JDoPruPCNdGsbjg==}
+    engines: {node: '>=12.0.0'}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -9944,6 +10244,10 @@ packages:
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
+
+  re2js@2.8.6:
+    resolution: {integrity: sha512-xLgQil4kIUCrAzVk9fRSkxkFNwmygLFjVxXrLc65aE1F0+Zsb8rxumFBy4XKyvgMCTL6kilDq3EZ0piE2dP/Dg==}
+    engines: {node: '>=18.0.0'}
 
   react-devtools-core@6.1.5:
     resolution: {integrity: sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==}
@@ -11566,6 +11870,9 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  web-vitals@4.2.4:
+    resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -14700,7 +15007,7 @@ snapshots:
 
   '@expo/plist@0.5.4':
     dependencies:
-      '@xmldom/xmldom': 0.8.13
+      '@xmldom/xmldom': 0.8.15
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 
@@ -14831,6 +15138,326 @@ snapshots:
 
   '@faker-js/faker@5.5.3': {}
 
+  '@firebase/ai@2.14.0(@firebase/app-types@0.9.5)(@firebase/app@0.16.0)':
+    dependencies:
+      '@firebase/app': 0.16.0
+      '@firebase/app-check-interop-types': 0.3.4
+      '@firebase/app-types': 0.9.5
+      '@firebase/component': 0.7.4
+      '@firebase/logger': 0.5.1
+      '@firebase/util': 1.15.2
+      tslib: 2.8.1
+
+  '@firebase/analytics-compat@0.2.29(@firebase/app-compat@0.5.16)(@firebase/app@0.16.0)':
+    dependencies:
+      '@firebase/analytics': 0.10.23(@firebase/app@0.16.0)
+      '@firebase/analytics-types': 0.8.4
+      '@firebase/app': 0.16.0
+      '@firebase/app-compat': 0.5.16
+      '@firebase/component': 0.7.4
+      '@firebase/util': 1.15.2
+      tslib: 2.8.1
+
+  '@firebase/analytics-types@0.8.4': {}
+
+  '@firebase/analytics@0.10.23(@firebase/app@0.16.0)':
+    dependencies:
+      '@firebase/app': 0.16.0
+      '@firebase/component': 0.7.4
+      '@firebase/installations': 0.6.23(@firebase/app@0.16.0)
+      '@firebase/logger': 0.5.1
+      '@firebase/util': 1.15.2
+      tslib: 2.8.1
+
+  '@firebase/app-check-compat@0.4.6(@firebase/app-compat@0.5.16)(@firebase/app@0.16.0)':
+    dependencies:
+      '@firebase/app': 0.16.0
+      '@firebase/app-check': 0.13.0(@firebase/app@0.16.0)
+      '@firebase/app-check-types': 0.5.4
+      '@firebase/app-compat': 0.5.16
+      '@firebase/component': 0.7.4
+      '@firebase/logger': 0.5.1
+      '@firebase/util': 1.15.2
+      tslib: 2.8.1
+
+  '@firebase/app-check-interop-types@0.3.4': {}
+
+  '@firebase/app-check-types@0.5.4': {}
+
+  '@firebase/app-check@0.13.0(@firebase/app@0.16.0)':
+    dependencies:
+      '@firebase/app': 0.16.0
+      '@firebase/component': 0.7.4
+      '@firebase/logger': 0.5.1
+      '@firebase/util': 1.15.2
+      tslib: 2.8.1
+
+  '@firebase/app-compat@0.5.16':
+    dependencies:
+      '@firebase/app': 0.16.0
+      '@firebase/component': 0.7.4
+      '@firebase/logger': 0.5.1
+      '@firebase/util': 1.15.2
+      tslib: 2.8.1
+
+  '@firebase/app-types@0.9.5':
+    dependencies:
+      '@firebase/logger': 0.5.1
+
+  '@firebase/app@0.16.0':
+    dependencies:
+      '@firebase/component': 0.7.4
+      '@firebase/logger': 0.5.1
+      '@firebase/util': 1.15.2
+      idb: 7.1.1
+      tslib: 2.8.1
+
+  '@firebase/auth-compat@0.6.9(@firebase/app-compat@0.5.16)(@firebase/app-types@0.9.5)(@firebase/app@0.16.0)(@react-native-async-storage/async-storage@3.1.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))':
+    dependencies:
+      '@firebase/app': 0.16.0
+      '@firebase/app-compat': 0.5.16
+      '@firebase/auth': 1.13.4(@firebase/app@0.16.0)(@react-native-async-storage/async-storage@3.1.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))
+      '@firebase/auth-types': 0.13.1(@firebase/app-types@0.9.5)(@firebase/util@1.15.2)
+      '@firebase/component': 0.7.4
+      '@firebase/util': 1.15.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app-types'
+      - '@react-native-async-storage/async-storage'
+
+  '@firebase/auth-interop-types@0.2.5': {}
+
+  '@firebase/auth-types@0.13.1(@firebase/app-types@0.9.5)(@firebase/util@1.15.2)':
+    dependencies:
+      '@firebase/app-types': 0.9.5
+      '@firebase/util': 1.15.2
+
+  '@firebase/auth@1.13.4(@firebase/app@0.16.0)(@react-native-async-storage/async-storage@3.1.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))':
+    dependencies:
+      '@firebase/app': 0.16.0
+      '@firebase/component': 0.7.4
+      '@firebase/logger': 0.5.1
+      '@firebase/util': 1.15.2
+      tslib: 2.8.1
+    optionalDependencies:
+      '@react-native-async-storage/async-storage': 3.1.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+
+  '@firebase/component@0.7.4':
+    dependencies:
+      '@firebase/util': 1.15.2
+      tslib: 2.8.1
+
+  '@firebase/data-connect@0.7.3(@firebase/app@0.16.0)':
+    dependencies:
+      '@firebase/app': 0.16.0
+      '@firebase/auth-interop-types': 0.2.5
+      '@firebase/component': 0.7.4
+      '@firebase/logger': 0.5.1
+      '@firebase/util': 1.15.2
+      tslib: 2.8.1
+
+  '@firebase/database-compat@2.1.6(@firebase/app-compat@0.5.16)(@firebase/app@0.16.0)':
+    dependencies:
+      '@firebase/component': 0.7.4
+      '@firebase/database': 1.1.4
+      '@firebase/database-types': 1.0.21
+      '@firebase/logger': 0.5.1
+      '@firebase/util': 1.15.2
+      tslib: 2.8.1
+    optionalDependencies:
+      '@firebase/app': 0.16.0
+      '@firebase/app-compat': 0.5.16
+
+  '@firebase/database-types@1.0.21':
+    dependencies:
+      '@firebase/app-types': 0.9.5
+      '@firebase/util': 1.15.2
+
+  '@firebase/database@1.1.4':
+    dependencies:
+      '@firebase/app-check-interop-types': 0.3.4
+      '@firebase/auth-interop-types': 0.2.5
+      '@firebase/component': 0.7.4
+      '@firebase/logger': 0.5.1
+      '@firebase/util': 1.15.2
+      faye-websocket: 0.11.4
+      tslib: 2.8.1
+
+  '@firebase/firestore-compat@0.4.12(@firebase/app-compat@0.5.16)(@firebase/app-types@0.9.5)(@firebase/app@0.16.0)':
+    dependencies:
+      '@firebase/app': 0.16.0
+      '@firebase/app-compat': 0.5.16
+      '@firebase/component': 0.7.4
+      '@firebase/firestore': 4.17.0(@firebase/app@0.16.0)
+      '@firebase/firestore-types': 3.0.4(@firebase/app-types@0.9.5)(@firebase/util@1.15.2)
+      '@firebase/util': 1.15.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app-types'
+
+  '@firebase/firestore-types@3.0.4(@firebase/app-types@0.9.5)(@firebase/util@1.15.2)':
+    dependencies:
+      '@firebase/app-types': 0.9.5
+      '@firebase/util': 1.15.2
+
+  '@firebase/firestore@4.17.0(@firebase/app@0.16.0)':
+    dependencies:
+      '@firebase/app': 0.16.0
+      '@firebase/component': 0.7.4
+      '@firebase/logger': 0.5.1
+      '@firebase/util': 1.15.2
+      '@firebase/webchannel-wrapper': 1.0.6
+      '@grpc/grpc-js': 1.9.16
+      '@grpc/proto-loader': 0.7.15
+      re2js: 2.8.6
+      tslib: 2.8.1
+
+  '@firebase/functions-compat@0.4.6(@firebase/app-compat@0.5.16)(@firebase/app@0.16.0)':
+    dependencies:
+      '@firebase/app': 0.16.0
+      '@firebase/app-compat': 0.5.16
+      '@firebase/component': 0.7.4
+      '@firebase/functions': 0.13.6(@firebase/app@0.16.0)
+      '@firebase/functions-types': 0.6.4
+      '@firebase/util': 1.15.2
+      tslib: 2.8.1
+
+  '@firebase/functions-types@0.6.4': {}
+
+  '@firebase/functions@0.13.6(@firebase/app@0.16.0)':
+    dependencies:
+      '@firebase/app': 0.16.0
+      '@firebase/app-check-interop-types': 0.3.4
+      '@firebase/auth-interop-types': 0.2.5
+      '@firebase/component': 0.7.4
+      '@firebase/messaging-interop-types': 0.2.5
+      '@firebase/util': 1.15.2
+      tslib: 2.8.1
+
+  '@firebase/installations-compat@0.2.23(@firebase/app-compat@0.5.16)(@firebase/app-types@0.9.5)(@firebase/app@0.16.0)':
+    dependencies:
+      '@firebase/app': 0.16.0
+      '@firebase/app-compat': 0.5.16
+      '@firebase/component': 0.7.4
+      '@firebase/installations': 0.6.23(@firebase/app@0.16.0)
+      '@firebase/installations-types': 0.5.4(@firebase/app-types@0.9.5)
+      '@firebase/util': 1.15.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app-types'
+
+  '@firebase/installations-types@0.5.4(@firebase/app-types@0.9.5)':
+    dependencies:
+      '@firebase/app-types': 0.9.5
+
+  '@firebase/installations@0.6.23(@firebase/app@0.16.0)':
+    dependencies:
+      '@firebase/app': 0.16.0
+      '@firebase/component': 0.7.4
+      '@firebase/util': 1.15.2
+      idb: 7.1.1
+      tslib: 2.8.1
+
+  '@firebase/logger@0.5.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@firebase/messaging-compat@0.2.28(@firebase/app-compat@0.5.16)(@firebase/app@0.16.0)':
+    dependencies:
+      '@firebase/app': 0.16.0
+      '@firebase/app-compat': 0.5.16
+      '@firebase/component': 0.7.4
+      '@firebase/messaging': 0.13.1(@firebase/app@0.16.0)
+      '@firebase/util': 1.15.2
+      tslib: 2.8.1
+
+  '@firebase/messaging-interop-types@0.2.5': {}
+
+  '@firebase/messaging@0.13.1(@firebase/app@0.16.0)':
+    dependencies:
+      '@firebase/app': 0.16.0
+      '@firebase/component': 0.7.4
+      '@firebase/installations': 0.6.23(@firebase/app@0.16.0)
+      '@firebase/messaging-interop-types': 0.2.5
+      '@firebase/util': 1.15.2
+      idb: 7.1.1
+      tslib: 2.8.1
+
+  '@firebase/performance-compat@0.2.26(@firebase/app-compat@0.5.16)(@firebase/app@0.16.0)':
+    dependencies:
+      '@firebase/app': 0.16.0
+      '@firebase/app-compat': 0.5.16
+      '@firebase/component': 0.7.4
+      '@firebase/logger': 0.5.1
+      '@firebase/performance': 0.7.13(@firebase/app@0.16.0)
+      '@firebase/performance-types': 0.2.4
+      '@firebase/util': 1.15.2
+      tslib: 2.8.1
+
+  '@firebase/performance-types@0.2.4': {}
+
+  '@firebase/performance@0.7.13(@firebase/app@0.16.0)':
+    dependencies:
+      '@firebase/app': 0.16.0
+      '@firebase/component': 0.7.4
+      '@firebase/installations': 0.6.23(@firebase/app@0.16.0)
+      '@firebase/logger': 0.5.1
+      '@firebase/util': 1.15.2
+      tslib: 2.8.1
+      web-vitals: 4.2.4
+
+  '@firebase/remote-config-compat@0.2.28(@firebase/app-compat@0.5.16)(@firebase/app@0.16.0)':
+    dependencies:
+      '@firebase/app': 0.16.0
+      '@firebase/app-compat': 0.5.16
+      '@firebase/component': 0.7.4
+      '@firebase/logger': 0.5.1
+      '@firebase/remote-config': 0.9.1(@firebase/app@0.16.0)
+      '@firebase/remote-config-types': 0.5.1
+      '@firebase/util': 1.15.2
+      tslib: 2.8.1
+
+  '@firebase/remote-config-types@0.5.1': {}
+
+  '@firebase/remote-config@0.9.1(@firebase/app@0.16.0)':
+    dependencies:
+      '@firebase/app': 0.16.0
+      '@firebase/component': 0.7.4
+      '@firebase/installations': 0.6.23(@firebase/app@0.16.0)
+      '@firebase/logger': 0.5.1
+      '@firebase/util': 1.15.2
+      tslib: 2.8.1
+
+  '@firebase/storage-compat@0.4.4(@firebase/app-compat@0.5.16)(@firebase/app-types@0.9.5)(@firebase/app@0.16.0)':
+    dependencies:
+      '@firebase/app': 0.16.0
+      '@firebase/app-compat': 0.5.16
+      '@firebase/component': 0.7.4
+      '@firebase/storage': 0.14.4(@firebase/app@0.16.0)
+      '@firebase/storage-types': 0.8.4(@firebase/app-types@0.9.5)(@firebase/util@1.15.2)
+      '@firebase/util': 1.15.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app-types'
+
+  '@firebase/storage-types@0.8.4(@firebase/app-types@0.9.5)(@firebase/util@1.15.2)':
+    dependencies:
+      '@firebase/app-types': 0.9.5
+      '@firebase/util': 1.15.2
+
+  '@firebase/storage@0.14.4(@firebase/app@0.16.0)':
+    dependencies:
+      '@firebase/app': 0.16.0
+      '@firebase/component': 0.7.4
+      '@firebase/util': 1.15.2
+      tslib: 2.8.1
+
+  '@firebase/util@1.15.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@firebase/webchannel-wrapper@1.0.6': {}
+
   '@fontsource/ibm-plex-mono@5.3.0': {}
 
   '@fontsource/noto-sans-arabic@5.3.0': {}
@@ -14866,6 +15493,18 @@ snapshots:
   '@formatjs/intl-supportedvaluesof@2.3.9':
     dependencies:
       '@formatjs/fast-memoize': 3.1.7
+
+  '@grpc/grpc-js@1.9.16':
+    dependencies:
+      '@grpc/proto-loader': 0.7.15
+      '@types/node': 26.5.0
+
+  '@grpc/proto-loader@0.7.15':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.6.6
+      yargs: 17.7.3
 
   '@hapi/hoek@9.3.0': {}
 
@@ -15626,6 +16265,26 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react-dom'
 
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.2': {}
+
   '@radix-ui/primitive@1.1.3': {}
 
   '@radix-ui/primitive@1.1.7': {}
@@ -15889,6 +16548,23 @@ snapshots:
       invariant: 2.2.4
       react: 19.2.8
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1)
+    optionalDependencies:
+      expo: 57.0.21(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.15)(expo-router@57.0.20)(react-dom@19.2.8(react@19.2.8))(react-native-web@0.21.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+
+  '@react-native-firebase/app@26.4.0(@react-native-async-storage/async-storage@3.1.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(expo@57.0.21)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)':
+    dependencies:
+      firebase: 12.17.1(@react-native-async-storage/async-storage@3.1.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))
+      react: 19.2.8
+      react-native: 0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1)
+    optionalDependencies:
+      expo: 57.0.21(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.15)(expo-router@57.0.20)(react-dom@19.2.8(react@19.2.8))(react-native-web@0.21.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
+
+  '@react-native-firebase/auth@26.4.0(@react-native-firebase/app@26.4.0(@react-native-async-storage/async-storage@3.1.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(expo@57.0.21)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(expo@57.0.21)':
+    dependencies:
+      '@expo/plist': 0.8.1
+      '@react-native-firebase/app': 26.4.0(@react-native-async-storage/async-storage@3.1.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(expo@57.0.21)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
     optionalDependencies:
       expo: 57.0.21(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.15)(expo-router@57.0.20)(react-dom@19.2.8(react@19.2.8))(react-native-web@0.21.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
 
@@ -17423,8 +18099,6 @@ snapshots:
       '@xtuc/long': 4.2.2
 
   '@xmldom/xmldom@0.7.13': {}
-
-  '@xmldom/xmldom@0.8.13': {}
 
   '@xmldom/xmldom@0.8.15': {}
 
@@ -20170,6 +20844,39 @@ snapshots:
       locate-path: 7.2.0
       path-exists: 5.0.0
 
+  firebase@12.17.1(@react-native-async-storage/async-storage@3.1.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)):
+    dependencies:
+      '@firebase/ai': 2.14.0(@firebase/app-types@0.9.5)(@firebase/app@0.16.0)
+      '@firebase/analytics': 0.10.23(@firebase/app@0.16.0)
+      '@firebase/analytics-compat': 0.2.29(@firebase/app-compat@0.5.16)(@firebase/app@0.16.0)
+      '@firebase/app': 0.16.0
+      '@firebase/app-check': 0.13.0(@firebase/app@0.16.0)
+      '@firebase/app-check-compat': 0.4.6(@firebase/app-compat@0.5.16)(@firebase/app@0.16.0)
+      '@firebase/app-compat': 0.5.16
+      '@firebase/app-types': 0.9.5
+      '@firebase/auth': 1.13.4(@firebase/app@0.16.0)(@react-native-async-storage/async-storage@3.1.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))
+      '@firebase/auth-compat': 0.6.9(@firebase/app-compat@0.5.16)(@firebase/app-types@0.9.5)(@firebase/app@0.16.0)(@react-native-async-storage/async-storage@3.1.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))
+      '@firebase/data-connect': 0.7.3(@firebase/app@0.16.0)
+      '@firebase/database': 1.1.4
+      '@firebase/database-compat': 2.1.6(@firebase/app-compat@0.5.16)(@firebase/app@0.16.0)
+      '@firebase/firestore': 4.17.0(@firebase/app@0.16.0)
+      '@firebase/firestore-compat': 0.4.12(@firebase/app-compat@0.5.16)(@firebase/app-types@0.9.5)(@firebase/app@0.16.0)
+      '@firebase/functions': 0.13.6(@firebase/app@0.16.0)
+      '@firebase/functions-compat': 0.4.6(@firebase/app-compat@0.5.16)(@firebase/app@0.16.0)
+      '@firebase/installations': 0.6.23(@firebase/app@0.16.0)
+      '@firebase/installations-compat': 0.2.23(@firebase/app-compat@0.5.16)(@firebase/app-types@0.9.5)(@firebase/app@0.16.0)
+      '@firebase/messaging': 0.13.1(@firebase/app@0.16.0)
+      '@firebase/messaging-compat': 0.2.28(@firebase/app-compat@0.5.16)(@firebase/app@0.16.0)
+      '@firebase/performance': 0.7.13(@firebase/app@0.16.0)
+      '@firebase/performance-compat': 0.2.26(@firebase/app-compat@0.5.16)(@firebase/app@0.16.0)
+      '@firebase/remote-config': 0.9.1(@firebase/app@0.16.0)
+      '@firebase/remote-config-compat': 0.2.28(@firebase/app-compat@0.5.16)(@firebase/app@0.16.0)
+      '@firebase/storage': 0.14.4(@firebase/app@0.16.0)
+      '@firebase/storage-compat': 0.4.4(@firebase/app-compat@0.5.16)(@firebase/app-types@0.9.5)(@firebase/app@0.16.0)
+      '@firebase/util': 1.15.2
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
+
   flat-cache@6.1.23:
     dependencies:
       cacheable: 2.5.0
@@ -20744,6 +21451,8 @@ snapshots:
   icss-utils@5.1.0(postcss@8.5.25):
     dependencies:
       postcss: 8.5.25
+
+  idb@7.1.1: {}
 
   idb@8.0.3: {}
 
@@ -21341,6 +22050,8 @@ snapshots:
   locate-path@7.2.0:
     dependencies:
       p-locate: 6.0.0
+
+  lodash.camelcase@4.3.0: {}
 
   lodash.debounce@4.0.8: {}
 
@@ -23329,6 +24040,20 @@ snapshots:
 
   proto-list@1.2.4: {}
 
+  protobufjs@7.6.6:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.2
+      '@types/node': 26.5.0
+      long: 5.3.2
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -23422,6 +24147,8 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
+
+  re2js@2.8.6: {}
 
   react-devtools-core@6.1.5:
     dependencies:
@@ -25280,6 +26007,8 @@ snapshots:
       defaults: 1.0.4
 
   web-namespaces@2.0.1: {}
+
+  web-vitals@4.2.4: {}
 
   webidl-conversions@3.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,6 +24,13 @@ allowBuilds:
   '@parcel/watcher': false
   core-js: false
   postman-code-generators: false
+  # Two more that arrived with @react-native-firebase, declined for the same
+  # reason: phone sign-in runs against the *native* Firebase SDKs, so neither
+  # JavaScript postinstall is on any path this app takes. @firebase/util's
+  # generates an ESM/CJS shim for the web SDK; protobufjs's compiles its
+  # reflection types for code generation nothing here does.
+  '@firebase/util': false
+  protobufjs: false
 minimumReleaseAgeExclude:
   - '@expo/cli@57.0.12 || 57.0.13 || 57.0.14'
   - '@expo/router-server@57.0.5'

--- a/supabase/functions/phone-verify/handler.test.ts
+++ b/supabase/functions/phone-verify/handler.test.ts
@@ -302,9 +302,9 @@ describe('when the exchange goes wrong', () => {
       code: 'TOO_MANY',
       message: 'A sign-in code is already being checked for that number. Try again in a moment.',
     });
-    expect(d.fetchImpl.mock.calls.some((call) => call[0] === `${ENV.SUPABASE_URL}/auth/v1/otp`)).toBe(
-      false,
-    );
+    expect(
+      d.fetchImpl.mock.calls.some((call) => call[0] === `${ENV.SUPABASE_URL}/auth/v1/otp`),
+    ).toBe(false);
     expect(rpcNames(d)).toContain('waves_firebase_assertion_release');
     expect(rpcNames(d)).toContain('waves_phone_gate_refund');
   });
@@ -314,9 +314,9 @@ describe('when the exchange goes wrong', () => {
     const response = await handlePhoneVerify(request(), d);
 
     expect(response.status).toBe(500);
-    expect(d.fetchImpl.mock.calls.some((call) => call[0] === `${ENV.SUPABASE_URL}/auth/v1/otp`)).toBe(
-      false,
-    );
+    expect(
+      d.fetchImpl.mock.calls.some((call) => call[0] === `${ENV.SUPABASE_URL}/auth/v1/otp`),
+    ).toBe(false);
     expect(rpcNames(d)).toContain('waves_firebase_assertion_release');
     expect(rpcNames(d)).toContain('waves_phone_gate_refund');
   });

--- a/supabase/functions/phone-verify/handler.test.ts
+++ b/supabase/functions/phone-verify/handler.test.ts
@@ -57,6 +57,7 @@ function deps(
     verifyStatus?: number;
     verifyBody?: unknown;
     parkedCode?: string | null;
+    openError?: string;
     gateAllowed?: boolean;
     gateErrored?: boolean;
     callerId?: string | null;
@@ -92,6 +93,9 @@ function deps(
       });
     }
     if (name === 'waves_otp_relay_open') {
+      if (overrides.openError) {
+        return Promise.resolve({ data: null, error: { message: overrides.openError } });
+      }
       return overrides.relayOpenErrored
         ? Promise.resolve({ data: null, error: { message: 'no relay' } })
         : Promise.resolve({ data: 'exchange-1', error: null });
@@ -287,6 +291,34 @@ describe('when the exchange goes wrong', () => {
 
     expect(response.status).toBe(503);
     expect(rpcNames(d)).not.toContain('waves_otp_relay_open');
+  });
+
+  it('answers a concurrent live exchange as a retry, not a server error', async () => {
+    const d = deps({ openError: 'OTP_RELAY_BUSY: an exchange is already open for this phone' });
+    const response = await handlePhoneVerify(request(), d);
+
+    expect(response.status).toBe(429);
+    expect(await response.json()).toMatchObject({
+      code: 'TOO_MANY',
+      message: 'A sign-in code is already being checked for that number. Try again in a moment.',
+    });
+    expect(d.fetchImpl.mock.calls.some((call) => call[0] === `${ENV.SUPABASE_URL}/auth/v1/otp`)).toBe(
+      false,
+    );
+    expect(rpcNames(d)).toContain('waves_firebase_assertion_release');
+    expect(rpcNames(d)).toContain('waves_phone_gate_refund');
+  });
+
+  it('keeps an unexpected relay-open error internal after giving the attempt back', async () => {
+    const d = deps({ openError: 'permission denied' });
+    const response = await handlePhoneVerify(request(), d);
+
+    expect(response.status).toBe(500);
+    expect(d.fetchImpl.mock.calls.some((call) => call[0] === `${ENV.SUPABASE_URL}/auth/v1/otp`)).toBe(
+      false,
+    );
+    expect(rpcNames(d)).toContain('waves_firebase_assertion_release');
+    expect(rpcNames(d)).toContain('waves_phone_gate_refund');
   });
 
   it('claims and closes with the exchange it opened', async () => {

--- a/supabase/functions/phone-verify/handler.test.ts
+++ b/supabase/functions/phone-verify/handler.test.ts
@@ -59,9 +59,15 @@ function deps(
     parkedCode?: string | null;
     gateAllowed?: boolean;
     gateErrored?: boolean;
+    callerId?: string | null;
+    attachError?: { message: string };
     jwksOk?: boolean;
   } = {},
-): PhoneVerifyDeps & { rpc: ReturnType<typeof vi.fn>; fetchImpl: ReturnType<typeof vi.fn> } {
+): PhoneVerifyDeps & {
+  rpc: ReturnType<typeof vi.fn>;
+  fetchImpl: ReturnType<typeof vi.fn>;
+  updateUserById: ReturnType<typeof vi.fn>;
+} {
   const rpc = vi.fn((name: string) => {
     if (name === 'waves_phone_gate') {
       if (overrides.gateErrored) {
@@ -108,10 +114,16 @@ function deps(
     throw new Error(`unexpected fetch: ${url}`);
   });
 
+  const updateUserById = vi.fn(() =>
+    Promise.resolve({ data: null, error: overrides.attachError ?? null }),
+  );
+
   const env = { ...ENV, ...(overrides.env ?? {}) };
   return {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    service: () => ({ rpc }) as any,
+    service: () => ({ rpc, auth: { admin: { updateUserById } } }) as any,
+    callerId: () => Promise.resolve(overrides.callerId ?? null),
+    updateUserById,
     fetchImpl: fetchImpl as unknown as typeof fetch,
     env: (key: string) => env[key],
     rpc,
@@ -296,5 +308,65 @@ describe('the request itself', () => {
   it('refuses to run unconfigured', async () => {
     const d = deps({ env: { FIREBASE_PROJECT_ID: '' } });
     expect((await handlePhoneVerify(request(), d)).status).toBe(500);
+  });
+});
+
+/**
+ * Attaching a proved number to an account somebody already holds — ADR-006's
+ * other half, and the reason signing in by phone ever finds anything: without
+ * this, no account has a number and every sign-in is a refusal.
+ */
+describe('attaching a number to an account', () => {
+  const attach = () => request({ idToken: 'a.b.c', mode: 'attach' });
+
+  it('puts the number on the caller’s own account, keeping its id', async () => {
+    const d = deps({ callerId: 'user-1' });
+    const response = await handlePhoneVerify(attach(), d);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ attached: true });
+    expect(d.updateUserById).toHaveBeenCalledWith('user-1', {
+      phone: '+919876543210',
+      phone_confirm: true,
+    });
+    // No session is minted and no code is relayed: they are already signed in.
+    expect(rpcNames(d)).not.toContain('waves_otp_relay_open');
+  });
+
+  it('refuses when nobody is signed in', async () => {
+    const d = deps({ callerId: null });
+    const response = await handlePhoneVerify(attach(), d);
+
+    expect(response.status).toBe(401);
+    expect(d.updateUserById).not.toHaveBeenCalled();
+  });
+
+  it('names the one refusal a person cannot fix by retrying', async () => {
+    const d = deps({
+      callerId: 'user-1',
+      attachError: { message: 'Phone number already registered' },
+    });
+    const response = await handlePhoneVerify(attach(), d);
+
+    expect(response.status).toBe(409);
+    expect((await response.json()).code).toBe('PHONE_TAKEN');
+  });
+
+  it('never attaches on a request that did not ask to', async () => {
+    // `functions.invoke` sends the current session with every call, so if the
+    // mode were inferred from the header, somebody signed in as one account and
+    // signing in by phone as another would silently move the number.
+    const d = deps({ callerId: 'user-1' });
+    await handlePhoneVerify(request({ idToken: 'a.b.c' }), d);
+
+    expect(d.updateUserById).not.toHaveBeenCalled();
+  });
+
+  it('still counts against the daily gate', async () => {
+    const d = deps({ callerId: 'user-1', gateAllowed: false });
+    const response = await handlePhoneVerify(attach(), d);
+
+    expect(response.status).toBe(429);
+    expect(d.updateUserById).not.toHaveBeenCalled();
   });
 });

--- a/supabase/functions/phone-verify/handler.test.ts
+++ b/supabase/functions/phone-verify/handler.test.ts
@@ -61,14 +61,27 @@ function deps(
     gateErrored?: boolean;
     callerId?: string | null;
     attachError?: { message: string };
+    /** The number already on the caller's account, as GoTrue stores it: no `+`. */
+    callerPhone?: string | null;
+    /** False makes the proof a replay — the same Firebase sign-in, seen twice. */
+    firstUse?: boolean;
+    assertionErrored?: boolean;
+    relayOpenErrored?: boolean;
     jwksOk?: boolean;
   } = {},
 ): PhoneVerifyDeps & {
   rpc: ReturnType<typeof vi.fn>;
   fetchImpl: ReturnType<typeof vi.fn>;
   updateUserById: ReturnType<typeof vi.fn>;
+  getUserById: ReturnType<typeof vi.fn>;
 } {
   const rpc = vi.fn((name: string) => {
+    if (name === 'waves_firebase_assertion_use') {
+      if (overrides.assertionErrored) {
+        return Promise.resolve({ data: null, error: { message: 'database unreachable' } });
+      }
+      return Promise.resolve({ data: overrides.firstUse ?? true, error: null });
+    }
     if (name === 'waves_phone_gate') {
       if (overrides.gateErrored) {
         return Promise.resolve({ data: null, error: { message: 'database unreachable' } });
@@ -79,7 +92,9 @@ function deps(
       });
     }
     if (name === 'waves_otp_relay_open') {
-      return Promise.resolve({ data: 'exchange-1', error: null });
+      return overrides.relayOpenErrored
+        ? Promise.resolve({ data: null, error: { message: 'no relay' } })
+        : Promise.resolve({ data: 'exchange-1', error: null });
     }
     if (name === 'waves_otp_relay_claim') {
       return Promise.resolve({
@@ -118,12 +133,24 @@ function deps(
     Promise.resolve({ data: null, error: overrides.attachError ?? null }),
   );
 
+  /**
+   * What the account already carries. GoTrue answers with the number stripped of
+   * its `+`, which is the whole reason the handler compares digits.
+   */
+  const getUserById = vi.fn(() =>
+    Promise.resolve({
+      data: { user: { id: overrides.callerId ?? 'user-1', phone: overrides.callerPhone ?? null } },
+      error: null,
+    }),
+  );
+
   const env = { ...ENV, ...(overrides.env ?? {}) };
   return {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    service: () => ({ rpc, auth: { admin: { updateUserById } } }) as any,
+    service: () => ({ rpc, auth: { admin: { updateUserById, getUserById } } }) as any,
     callerId: () => Promise.resolve(overrides.callerId ?? null),
     updateUserById,
+    getUserById,
     fetchImpl: fetchImpl as unknown as typeof fetch,
     env: (key: string) => env[key],
     rpc,
@@ -368,5 +395,220 @@ describe('attaching a number to an account', () => {
 
     expect(response.status).toBe(429);
     expect(d.updateUserById).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The mode is a name, and only two names exist.
+ *
+ * The first version read the mode as "attach, or else sign in", which made every
+ * misspelling of the word a silent request for the *other* thing. That is the
+ * same data-losing surprise the mode exists to prevent, arriving through a
+ * capital letter.
+ */
+describe('the mode', () => {
+  it('refuses a word it does not know rather than reading it as a sign-in', async () => {
+    const d = deps({ callerId: 'user-1' });
+    const response = await handlePhoneVerify(request({ idToken: 'a.b.c', mode: 'Attach' }), d);
+
+    expect(response.status).toBe(400);
+    // Neither thing happened: no number moved, and nobody was signed in as
+    // somebody else while believing they were adding a number to their own.
+    expect(d.updateUserById).not.toHaveBeenCalled();
+    expect(rpcNames(d)).not.toContain('waves_otp_relay_open');
+  });
+
+  it('takes the sign-in spelled out as readily as the one left unsaid', async () => {
+    const d = deps();
+    const response = await handlePhoneVerify(request({ idToken: 'a.b.c', mode: 'signin' }), d);
+    expect(response.status).toBe(200);
+  });
+});
+
+/**
+ * One proof, one use.
+ *
+ * A Firebase ID token stays good for ten minutes after the code was entered, and
+ * it is refreshable, so "the same token twice" is not the only replay — a second
+ * token minted from the same Firebase session is the same proof wearing a
+ * different signature. Both are the same sign-in, and both are refused after the
+ * first, because one proof buying both a session *and* an attachment to a second
+ * account is two irreversible things from one SMS.
+ */
+describe('a proof already spent', () => {
+  it('is refused, and the person is told to ask for a new code', async () => {
+    const d = deps({ firstUse: false });
+    const response = await handlePhoneVerify(request(), d);
+
+    expect(response.status).toBe(401);
+    expect((await response.json()).code).toBe('ALREADY_USED');
+  });
+
+  it('is refused before the gate, so a replay cannot spend the allowance', async () => {
+    // The other order is the attack: somebody holding one captured token replays
+    // it three times and the number's real owner cannot sign in until tomorrow.
+    const d = deps({ firstUse: false });
+    await handlePhoneVerify(request(), d);
+
+    expect(rpcNames(d)).not.toContain('waves_phone_gate');
+    expect(rpcNames(d)).not.toContain('waves_otp_relay_open');
+  });
+
+  it('is claimed against the sign-in, not the token', async () => {
+    // `auth_time` is what makes a refreshed token the same proof. Recording
+    // anything derived from the token itself would pin nothing.
+    const d = deps();
+    await handlePhoneVerify(request(), d);
+
+    const claim = d.rpc.mock.calls.find((call) => call[0] === 'waves_firebase_assertion_use');
+    expect(claim?.[1]).toEqual({ p_uid: 'firebase-1', p_auth_time: 1 });
+  });
+
+  it('goes back when the gate could not be reached, so the code can be retyped', async () => {
+    // Nothing was counted and nothing was sent; sending somebody back to
+    // Firebase for a second SMS because our database blinked is a charge for our
+    // own outage.
+    const d = deps({ gateErrored: true });
+    const response = await handlePhoneVerify(request(), d);
+
+    expect(response.status).toBe(503);
+    expect(rpcNames(d)).toContain('waves_firebase_assertion_release');
+    // No refund: the call that would have counted the ask is the one that just
+    // failed, so a refund here would take away an *earlier* attempt.
+    expect(rpcNames(d)).not.toContain('waves_phone_gate_refund');
+  });
+});
+
+/**
+ * Whose failure it was decides who pays for it.
+ *
+ * Firebase has already sent and billed for the SMS by the time this function
+ * runs, so the value of handing an attempt back is precisely that the same code
+ * can be typed again — no second message, no second charge. What must never be
+ * handed back is an attempt that ended in an answer.
+ */
+describe('an attempt nobody could have avoided', () => {
+  it('is given back when the relay would not open', async () => {
+    const d = deps({ relayOpenErrored: true });
+    const response = await handlePhoneVerify(request(), d);
+
+    expect(response.status).toBe(500);
+    expect(rpcNames(d)).toContain('waves_phone_gate_refund');
+    expect(rpcNames(d)).toContain('waves_firebase_assertion_release');
+  });
+
+  it('is given back when the hook never parked a code', async () => {
+    const d = deps({ parkedCode: null });
+    await handlePhoneVerify(request(), d);
+    expect(rpcNames(d)).toContain('waves_phone_gate_refund');
+  });
+
+  it('is given back when GoTrue would not complete the exchange', async () => {
+    const d = deps({ verifyStatus: 502 });
+    await handlePhoneVerify(request(), d);
+    expect(rpcNames(d)).toContain('waves_phone_gate_refund');
+  });
+
+  it('is kept when the answer was an answer', async () => {
+    // ADR-006 refusing a number with no account is a reply, not a fault. Giving
+    // the attempt back here would make walking the numbers free, and every walk
+    // is a Firebase SMS somebody was billed for.
+    const d = deps({ otpStatus: 422, otpBody: '{"error_code":"otp_disabled"}' });
+    const response = await handlePhoneVerify(request(), d);
+
+    expect(response.status).toBe(404);
+    expect(rpcNames(d)).not.toContain('waves_phone_gate_refund');
+    expect(rpcNames(d)).not.toContain('waves_firebase_assertion_release');
+  });
+
+  it('is kept when the sign-in completed', async () => {
+    const d = deps();
+    await handlePhoneVerify(request(), d);
+    expect(rpcNames(d)).not.toContain('waves_phone_gate_refund');
+  });
+});
+
+/**
+ * The guest half of ADR-006, which is the half that was missing.
+ *
+ * Attaching an email runs through GoTrue's own change-verification and clears
+ * `is_anonymous` on the way past. Attaching a phone runs through the admin API,
+ * which sets the number and nothing else — so the same person, through the other
+ * door, kept the guest ceilings (one group, ten days, read-only after) while
+ * holding a proved contact.
+ */
+describe('a guest who attaches a number', () => {
+  const attach = () => request({ idToken: 'a.b.c', mode: 'attach' });
+
+  it('stops being a guest', async () => {
+    const d = deps({ callerId: 'user-1' });
+    await handlePhoneVerify(attach(), d);
+
+    const promote = d.rpc.mock.calls.find((call) => call[0] === 'waves_promote_guest');
+    expect(promote?.[1]).toEqual({ p_user: 'user-1' });
+  });
+
+  it('is not promoted when the number went somewhere else', async () => {
+    const d = deps({
+      callerId: 'user-1',
+      attachError: { message: 'Phone number already registered' },
+    });
+    await handlePhoneVerify(attach(), d);
+
+    expect(rpcNames(d)).not.toContain('waves_promote_guest');
+  });
+});
+
+/** Attaching a number the account already has is a success, not a collision. */
+describe('attaching the same number twice', () => {
+  const attach = () => request({ idToken: 'a.b.c', mode: 'attach' });
+
+  it('is a quiet success, without asking GoTrue to set it again', async () => {
+    // Somebody whose connection dropped between the attach and the answer will
+    // press the button again. Telling them the number in their hand belongs to
+    // "another account" — theirs — is both wrong and unfixable from there.
+    const d = deps({ callerId: 'user-1', callerPhone: '919876543210' });
+    const response = await handlePhoneVerify(attach(), d);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ attached: true });
+    expect(d.updateUserById).not.toHaveBeenCalled();
+  });
+
+  it('compares digits, because GoTrue stores the number without its plus', async () => {
+    // The naive comparison is `user.phone === '+919876543210'`, which never
+    // matches anything GoTrue returns, so the check above silently never fires.
+    const d = deps({ callerId: 'user-1', callerPhone: '+919876543210' });
+    expect((await handlePhoneVerify(attach(), d)).status).toBe(200);
+    expect(d.updateUserById).not.toHaveBeenCalled();
+  });
+
+  it('reads "already registered" as "by you" when it is', async () => {
+    // GoTrue's duplicate check does not reliably exclude the caller, so the
+    // message alone cannot tell "somebody else has it" from "you do" — and one
+    // of those is a 409 shown to the person who owns the number.
+    const d = deps({ callerId: 'user-1', attachError: { message: 'already registered' } });
+    d.getUserById
+      .mockResolvedValueOnce({ data: { user: { id: 'user-1', phone: null } }, error: null })
+      .mockResolvedValueOnce({
+        data: { user: { id: 'user-1', phone: '919876543210' } },
+        error: null,
+      });
+
+    expect((await handlePhoneVerify(attach(), d)).status).toBe(200);
+  });
+});
+
+/** Attaching must cost nothing until we know who is asking. */
+describe('an attach with nobody signed in', () => {
+  it('spends none of the number’s allowance on its way to a 401', async () => {
+    // The cheapest request there is: no session, a token for somebody else's
+    // number. Three of them used to take that number's whole day.
+    const d = deps({ callerId: null });
+    const response = await handlePhoneVerify(request({ idToken: 'a.b.c', mode: 'attach' }), d);
+
+    expect(response.status).toBe(401);
+    expect(rpcNames(d)).not.toContain('waves_phone_gate');
+    expect(rpcNames(d)).not.toContain('waves_firebase_assertion_use');
   });
 });

--- a/supabase/functions/phone-verify/handler.ts
+++ b/supabase/functions/phone-verify/handler.ts
@@ -407,7 +407,14 @@ export async function handlePhoneVerify(
   const { data: exchange, error: openError } = await service.rpc('waves_otp_relay_open', {
     p_phone: phone,
   });
-  if (openError || typeof exchange !== 'string') {
+  if (openError) {
+    await giveItBack();
+    if ((openError.message ?? '').includes('OTP_RELAY_BUSY')) {
+      return fail(429, 'TOO_MANY', 'A sign-in code is already being checked for that number. Try again in a moment.');
+    }
+    return fail(500, 'INTERNAL', 'Could not sign you in just now');
+  }
+  if (typeof exchange !== 'string') {
     await giveItBack();
     return fail(500, 'INTERNAL', 'Could not sign you in just now');
   }

--- a/supabase/functions/phone-verify/handler.ts
+++ b/supabase/functions/phone-verify/handler.ts
@@ -18,15 +18,25 @@
  * an SMS nobody is waiting for; we claim it and verify it. The code exists for
  * about a second, in a service-role-only table, single use.
  *
- * Two rules this function does not get to bend:
+ * Three rules this function does not get to bend:
  *
  *   * **ADR-006.** A phone number signs somebody back in or attaches to the
  *     account in hand. It never opens a new one, which is why GoTrue is asked
  *     with `create_user: false` and a number nobody owns simply fails. Firebase
- *     having verified the number does not make it an account.
+ *     having verified the number does not make it an account. The other half of
+ *     the same ADR is the in-place upgrade: a guest who attaches a number stops
+ *     being a guest, because a proved contact is exactly what the ceilings on an
+ *     unclaimed account are waiting for.
  *   * **The daily gate.** `waves_phone_gate` counts this the same as any other
  *     ask, so the three-a-day ceiling and the block list apply to a Firebase
- *     sign-in exactly as they apply to an SMS one.
+ *     sign-in exactly as they apply to an SMS one. What it does not count is a
+ *     failure of ours: a relay that never filled or a GoTrue that answered 502
+ *     hands the attempt back, so three of our own bad minutes cannot lock
+ *     somebody out for the day.
+ *   * **One proof, one use.** The assertion is good for ten minutes, and in that
+ *     window the same one could otherwise be presented twice — once to sign in
+ *     as the number's owner, again to move that number onto a second account.
+ *     The Firebase sign-in behind it is recorded and refused thereafter.
  */
 
 import type { SupabaseClient } from 'npm:@supabase/supabase-js@2';
@@ -126,6 +136,60 @@ async function readBoundedText(request: Request, limit: number): Promise<string 
   return new TextDecoder().decode(joined);
 }
 
+/**
+ * Digits and nothing else.
+ *
+ * GoTrue stores a number without its `+`, so the obvious comparison — the E.164
+ * string we were handed against the one on the account — never matches, and the
+ * "you already have this number" check silently never fires.
+ */
+function digitsOf(value: string | null | undefined): string {
+  return (value ?? '').replace(/\D/g, '');
+}
+
+/** Attached just now, already there, spoken for by somebody else, or broken. */
+type AttachOutcome = 'attached' | 'already' | 'taken' | 'failed';
+
+/**
+ * Put the proved number on the account in hand.
+ *
+ * Reads the account first, because the same number attached twice must be a
+ * quiet success and not an error: somebody whose network dropped between the
+ * attach and the answer will press the button again, and telling them the number
+ * they are holding is "already on another account" — theirs — is both wrong and
+ * unfixable from where they are standing.
+ *
+ * The duplicate message is then re-checked against the account rather than
+ * trusted, because GoTrue's duplicate check does not reliably exclude the
+ * caller: "already registered" can mean "by you", and the two cases read
+ * identically from here.
+ */
+async function attachNumber(
+  service: SupabaseClient,
+  caller: string,
+  phone: string,
+): Promise<AttachOutcome> {
+  const holdsIt = async (): Promise<boolean> => {
+    const { data, error } = await service.auth.admin.getUserById(caller);
+    if (error) return false;
+    return digitsOf(data?.user?.phone) === digitsOf(phone);
+  };
+
+  if (await holdsIt()) return 'already';
+
+  const { error } = await service.auth.admin.updateUserById(caller, {
+    phone,
+    phone_confirm: true,
+  });
+  if (!error) return 'attached';
+
+  if (/already|registered|duplicate|exists/i.test(error.message)) {
+    return (await holdsIt()) ? 'already' : 'taken';
+  }
+  console.error('phone-verify could not attach the number:', error.message);
+  return 'failed';
+}
+
 export async function handlePhoneVerify(
   request: Request,
   deps: PhoneVerifyDeps,
@@ -152,7 +216,20 @@ export async function handlePhoneVerify(
     // every call, so inferring it would mean somebody signed in as one account,
     // signing in by phone as another, silently attaching the second number to
     // the first — a data-losing surprise with no error anywhere.
-    if (parsed.mode === 'attach') mode = 'attach';
+    //
+    // And the names are a closed set, which matters more than it looks. The
+    // first version read "anything that is not the word attach" as a sign-in, so
+    // `mode: 'Attach'` — a capital letter, a typo, an older client spelling it
+    // differently — was silently the *other* mode: somebody asking to add a
+    // number to the account in their hand would instead be signed out of it and
+    // into whoever owns that number. That is precisely the data-losing surprise
+    // the paragraph above exists to prevent, arriving through the spelling.
+    if (parsed.mode !== undefined && parsed.mode !== null) {
+      if (parsed.mode !== 'attach' && parsed.mode !== 'signin') {
+        return fail(400, 'BAD_REQUEST', 'Ask for signin or attach');
+      }
+      mode = parsed.mode;
+    }
   } catch {
     return fail(400, 'BAD_REQUEST', 'Body is not JSON');
   }
@@ -169,12 +246,75 @@ export async function handlePhoneVerify(
     console.warn('phone-verify rejected a token:', verdict.reason);
     return fail(401, 'NOT_VERIFIED', 'That sign-in could not be verified');
   }
-  const phone = verdict.identity.phone;
+  const { phone, uid, signedInAt } = verdict.identity;
+
+  const service = deps.service();
+
+  // Attaching needs to know *who* before anything is spent. It used to ask after
+  // the gate, which meant a request with no session at all — the easiest request
+  // in the world to make — took one of that number's three codes for the day on
+  // its way to a 401. Three of those and the number's real owner cannot sign in
+  // until tomorrow, from an attacker who never proved anything.
+  let caller: string | null = null;
+  if (mode === 'attach') {
+    caller = await deps.callerId(request);
+    if (!caller) return fail(401, 'NOT_AUTHENTICATED', 'Sign in first');
+  }
+
+  // One proof, one use. The token stays valid for ten minutes after the code was
+  // entered, and nothing until now stopped the same one being presented twice —
+  // once to sign in as the number's owner, and again, from a second account, to
+  // put that number on it. What is recorded is the Firebase sign-in rather than
+  // the token, because an ID token is refreshable: a fresh one minted from the
+  // same Firebase session carries the same `auth_time`, so pinning the token
+  // would pin nothing at all.
+  //
+  // Ahead of the gate on purpose. The other order lets somebody holding one
+  // captured token spend a number's whole daily allowance by replaying it.
+  const { data: firstUse, error: useError } = await service.rpc('waves_firebase_assertion_use', {
+    p_uid: uid,
+    p_auth_time: signedInAt,
+  });
+  if (useError) {
+    // Closed, for the same reason the gate below is: single use is the only
+    // thing standing between one captured proof and an unlimited supply of them.
+    console.error('phone-verify could not claim the assertion:', useError.message);
+    return fail(503, 'UNAVAILABLE', 'Could not sign you in just now. Try again.');
+  }
+  if (firstUse !== true) {
+    // Said as a thing to do rather than as a diagnosis: to anybody honest this
+    // is a screen that got resubmitted, and the answer is the same either way.
+    return fail(401, 'ALREADY_USED', 'That code has been used. Ask for a new one.');
+  }
+
+  /**
+   * Hand back what a failure on our side took.
+   *
+   * Called only after the gate has actually counted the ask, and only for a
+   * failure nobody asking could have avoided — a database that would not answer,
+   * a relay that never filled, a GoTrue that returned 502. Firebase has already
+   * sent and billed for the SMS by the time this function runs, so the value of
+   * the refund is precisely that the *same* code can be typed again: no second
+   * message, no second charge.
+   *
+   * Never after an answer. A number already on another account, a blocked
+   * number, a number with no account — those are all replies, and the proof was
+   * spent getting them.
+   */
+  const giveItBack = async (): Promise<void> => {
+    const { error } = await service.rpc('waves_firebase_assertion_release', {
+      p_uid: uid,
+      p_auth_time: signedInAt,
+    });
+    if (error) console.error('phone-verify could not release the assertion:', error.message);
+    const { error: refundError } = await service.rpc('waves_phone_gate_refund', { p_phone: phone });
+    if (refundError) console.error('phone-verify could not refund the day:', refundError.message);
+  };
 
   // The same ceiling as every other way of asking, and the same block list.
-  const { data: gate, error: gateError } = await deps
-    .service()
-    .rpc('waves_phone_gate', { p_phone: phone });
+  const { data: gate, error: gateError } = await service.rpc('waves_phone_gate', {
+    p_phone: phone,
+  });
   if (gateError) {
     // Closed, not open — and deliberately the opposite of `otp-send`, which lets a
     // send through when the limiter is unreachable. There, failing open keeps
@@ -184,13 +324,22 @@ export async function handlePhoneVerify(
     // without the database anyway, so failing open buys nothing and waives the
     // block for whoever can make this query fail.
     console.error('phone-verify gate check failed, refusing:', gateError.message);
+    // The proof goes back, but nothing is refunded: the call that would have
+    // counted the ask is the one that just failed, so there is no hit to hand
+    // back and a refund here would take away somebody's *earlier* attempt.
+    const { error: releaseError } = await service.rpc('waves_firebase_assertion_release', {
+      p_uid: uid,
+      p_auth_time: signedInAt,
+    });
+    if (releaseError) {
+      console.error('phone-verify could not release the assertion:', releaseError.message);
+    }
     return fail(503, 'UNAVAILABLE', 'Could not sign you in just now. Try again.');
   }
   if ((gate as { allowed?: boolean } | null)?.allowed === false) {
     return fail(429, 'TOO_MANY', 'That is too many sign-in attempts today. Try again tomorrow.');
   }
 
-  const service = deps.service();
   const auth = `${supabaseUrl}/auth/v1`;
 
   // Attaching, not signing in: somebody already holding an account has proved a
@@ -198,22 +347,37 @@ export async function handlePhoneVerify(
   // keeps its id, so every group, expense and balance stays where it is, and the
   // number becomes a second way back to the same place.
   if (mode === 'attach') {
-    const caller = await deps.callerId(request);
-    if (!caller) return fail(401, 'NOT_AUTHENTICATED', 'Sign in first');
-
-    const { error: attachError } = await service.auth.admin.updateUserById(caller, {
-      phone,
-      phone_confirm: true,
-    });
-    if (attachError) {
+    const attached = await attachNumber(service, caller!, phone);
+    if (attached === 'taken') {
       // A number already on another account is the one refusal worth naming: it
       // is not a fault the person can fix by retrying, and silently doing
-      // nothing would leave them convinced it had worked.
-      if (/already|registered|duplicate/i.test(attachError.message)) {
-        return fail(409, 'PHONE_TAKEN', 'That number is already on another Waves account');
-      }
-      console.error('phone-verify could not attach the number:', attachError.message);
+      // nothing would leave them convinced it had worked. Two devices attaching
+      // the same number to two different accounts at the same moment land here
+      // too: GoTrue's unique index decides, one comes away holding the number
+      // and the other is told plainly that it is spoken for.
+      return fail(409, 'PHONE_TAKEN', 'That number is already on another Waves account');
+    }
+    if (attached === 'failed') {
+      await giveItBack();
       return fail(502, 'UPSTREAM', 'Could not add that number just now');
+    }
+
+    // ADR-006's in-place upgrade, and the reason it needs saying out loud here.
+    // Attaching an email goes through GoTrue's own change-verification, which
+    // clears `is_anonymous` on the way past; the admin call above sets the
+    // number and nothing else. Without this a guest who added a phone kept the
+    // guest ceilings — one group, ten days, read-only after — while holding a
+    // proved contact, which is the exact opposite of what the upgrade path
+    // promises. The function re-checks the confirmed contact itself, so it
+    // cannot be used to lift the ceiling on an account that has not earned it.
+    //
+    // Logged rather than fatal: the number is on the account either way, and
+    // refusing an attachment that worked over a flag would be the larger harm.
+    // The flag is in the access token, so the client refreshes its session
+    // afterwards and the ceiling lifts on the next read.
+    const { error: promoteError } = await service.rpc('waves_promote_guest', { p_user: caller });
+    if (promoteError) {
+      console.error('phone-verify could not lift the guest ceiling:', promoteError.message);
     }
 
     const { error: clearedError } = await service.rpc('waves_phone_verified', { p_phone: phone });
@@ -232,10 +396,19 @@ export async function handlePhoneVerify(
   // the first's, and the first then claims a code minted for somebody else or
   // deletes the second's on its way out, sending that person's code to an SMS
   // nobody asked for.
+  //
+  // The relay's thirty seconds are left where they are, deliberately. Everything
+  // between the open and the claim is bounded by the fifteen-second timeout on
+  // the GoTrue call below, so the window is already twice the longest the
+  // exchange can legitimately take; widening it would only mean a live code
+  // sitting fillable for longer. What a slow GoTrue costs is the attempt, and
+  // that is what `giveItBack` is for — the fix is the refund, not a bigger
+  // window.
   const { data: exchange, error: openError } = await service.rpc('waves_otp_relay_open', {
     p_phone: phone,
   });
   if (openError || typeof exchange !== 'string') {
+    await giveItBack();
     return fail(500, 'INTERNAL', 'Could not sign you in just now');
   }
 
@@ -257,6 +430,7 @@ export async function handlePhoneVerify(
         return fail(404, 'NO_ACCOUNT', 'No Waves account uses that number yet');
       }
       console.error('phone-verify could not ask for a code:', asked.status, detail.slice(0, 200));
+      await giveItBack();
       return fail(502, 'UPSTREAM', 'Could not sign you in just now');
     }
 
@@ -268,6 +442,7 @@ export async function handlePhoneVerify(
       // this was an ordinary send. Either way an SMS may be on its way, and the
       // honest answer is that this route did not work rather than a stuck spinner.
       console.error('phone-verify found no code parked for the exchange');
+      await giveItBack();
       return fail(502, 'UPSTREAM', 'Could not sign you in just now');
     }
 
@@ -279,11 +454,13 @@ export async function handlePhoneVerify(
     });
     if (!verified.ok) {
       console.error('phone-verify could not complete the exchange:', verified.status);
+      await giveItBack();
       return fail(502, 'UPSTREAM', 'Could not sign you in just now');
     }
 
     const session = (await verified.json()) as Session;
     if (!session.access_token || !session.refresh_token) {
+      await giveItBack();
       return fail(502, 'UPSTREAM', 'Could not sign you in just now');
     }
 

--- a/supabase/functions/phone-verify/handler.ts
+++ b/supabase/functions/phone-verify/handler.ts
@@ -410,7 +410,11 @@ export async function handlePhoneVerify(
   if (openError) {
     await giveItBack();
     if ((openError.message ?? '').includes('OTP_RELAY_BUSY')) {
-      return fail(429, 'TOO_MANY', 'A sign-in code is already being checked for that number. Try again in a moment.');
+      return fail(
+        429,
+        'TOO_MANY',
+        'A sign-in code is already being checked for that number. Try again in a moment.',
+      );
     }
     return fail(500, 'INTERNAL', 'Could not sign you in just now');
   }

--- a/supabase/functions/phone-verify/handler.ts
+++ b/supabase/functions/phone-verify/handler.ts
@@ -48,6 +48,8 @@ export interface PhoneVerifyDeps {
   service: () => SupabaseClient;
   fetchImpl: typeof fetch;
   env: (key: string) => string | undefined;
+  /** The caller's own profile id, from their Supabase session, or null. */
+  callerId: (request: Request) => Promise<string | null>;
   now?: () => number;
 }
 
@@ -141,8 +143,16 @@ export async function handlePhoneVerify(
   if (body === null) return fail(413, 'TOO_LARGE', 'That request is too large');
 
   let idToken = '';
+  let mode: 'signin' | 'attach' = 'signin';
   try {
-    idToken = String((JSON.parse(body ?? '{}') as { idToken?: unknown }).idToken ?? '');
+    const parsed = JSON.parse(body ?? '{}') as { idToken?: unknown; mode?: unknown };
+    idToken = String(parsed.idToken ?? '');
+    // Asked for by name, never inferred from whether an Authorization header
+    // happens to be present. `functions.invoke` attaches the current session to
+    // every call, so inferring it would mean somebody signed in as one account,
+    // signing in by phone as another, silently attaching the second number to
+    // the first — a data-losing surprise with no error anywhere.
+    if (parsed.mode === 'attach') mode = 'attach';
   } catch {
     return fail(400, 'BAD_REQUEST', 'Body is not JSON');
   }
@@ -182,6 +192,38 @@ export async function handlePhoneVerify(
 
   const service = deps.service();
   const auth = `${supabaseUrl}/auth/v1`;
+
+  // Attaching, not signing in: somebody already holding an account has proved a
+  // number and wants it on that account. ADR-006's point exactly — the account
+  // keeps its id, so every group, expense and balance stays where it is, and the
+  // number becomes a second way back to the same place.
+  if (mode === 'attach') {
+    const caller = await deps.callerId(request);
+    if (!caller) return fail(401, 'NOT_AUTHENTICATED', 'Sign in first');
+
+    const { error: attachError } = await service.auth.admin.updateUserById(caller, {
+      phone,
+      phone_confirm: true,
+    });
+    if (attachError) {
+      // A number already on another account is the one refusal worth naming: it
+      // is not a fault the person can fix by retrying, and silently doing
+      // nothing would leave them convinced it had worked.
+      if (/already|registered|duplicate/i.test(attachError.message)) {
+        return fail(409, 'PHONE_TAKEN', 'That number is already on another Waves account');
+      }
+      console.error('phone-verify could not attach the number:', attachError.message);
+      return fail(502, 'UPSTREAM', 'Could not add that number just now');
+    }
+
+    const { error: clearedError } = await service.rpc('waves_phone_verified', { p_phone: phone });
+    if (clearedError) console.error('phone-verify could not clear the day:', clearedError.message);
+
+    return new Response(JSON.stringify({ attached: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
 
   // Open the exchange *before* asking for the code, or the hook will have sent
   // it by the time there is anywhere to park it.

--- a/supabase/functions/phone-verify/index.ts
+++ b/supabase/functions/phone-verify/index.ts
@@ -9,7 +9,7 @@
  * checked against Google's published signing keys before anything else happens.
  */
 
-import { asService } from '../_shared/auth.ts';
+import { asCaller, asService } from '../_shared/auth.ts';
 import { handlePhoneVerify } from './handler.ts';
 
 Deno.serve((request) =>
@@ -17,5 +17,16 @@ Deno.serve((request) =>
     service: asService,
     fetchImpl: fetch,
     env: (key) => Deno.env.get(key),
+    // Who is asking, when they are asking to *attach* a number. Read through
+    // the caller's own token rather than taken from the body, so a request can
+    // only ever add a number to the account it is already signed in as.
+    callerId: async (incoming) => {
+      try {
+        const { data } = await asCaller(incoming).auth.getUser();
+        return data.user?.id ?? null;
+      } catch {
+        return null;
+      }
+    },
   }),
 );


### PR DESCRIPTION
Firebase sends the code and checks it — the only way to deliver an SMS worldwide with no registered company, no DLT filing per country and no monthly bill. Firebase cannot mint a Waves session, so `phone-verify` checks Google's signature and mints one through the relay that already exists.

## Two things a proved number can do, asked for by name

* **signin** — the number's owner gets a session. GoTrue is asked with `create_user: false`, so ADR-006 holds: a number nobody owns is "no account uses that number yet", never a new account.
* **attach** — somebody already signed in adds the number to the account in their hand. Same user id, so every group, expense and balance stays put and the number becomes a second door to the same place.

The mode is never inferred from whether an `Authorization` header happens to be present. `functions.invoke` sends the current session on every call, so inferring it would mean somebody signed in as one account, signing in by phone as another, silently moving that number onto the first. An unknown mode is now a 400 rather than a sign-in — `mode: 'Attach'` from an older client was the same surprise wearing a capital letter.

Nobody is signed out. The only `signOut` is against Firebase, the throwaway identity that proves the number and holds nothing.

## What the hardening pass found

**A guest who attached a phone stayed a guest.** The admin update sets the number and nothing else, while the email path goes through GoTrue's own change-verification which clears `is_anonymous` — the single truth behind the guest ceilings. So somebody holding a proved contact kept one group and a ten-day read-only trial. `waves_promote_guest` re-checks the confirmation columns itself, so it cannot lift a ceiling nobody earned.

**A Firebase token could be replayed.** Accepted for ten minutes, and within that window one captured token bought *both* a session as the number's owner *and* an attachment of that number to a second account. Now one proof, one use, keyed on `(uid, auth_time)` because a refreshed token is the same proof — claimed before the gate, so a replay cannot spend the number's allowance either.

**An attach spent the gate before knowing who was asking**, so the cheapest possible request took one of a stranger's three daily codes on its way to a 401.

**Every failure reached the screen as one unreadable line.** `functions.invoke` collapses non-2xx into "Edge Function returned a non-2xx status code", so "That number is already on another Waves account" was invisible to the person it was written for.

**A failure nobody could have avoided spent an attempt.** Refunded now — exactly one hit, on our-fault failures only, never by clearing the day, which would erase genuine abuse evidence.

**GoTrue stores a number without its `+`**, so the "already attached" comparison never fired and its duplicate check could surface as a 409 to the number's own owner.

**`phoneSignInAvailable()` was exported and never called** — an over-the-air JS update onto a binary built before Firebase existed would leave the phone door visible and broken. Wired into the welcome tile, the auth card and the account screen's contact chip.

## Tests

305 edge, 1327 mobile, 984 core — all green. Plus `packages/db/test/phoneRelay.test.ts`: the database-level end-to-end, driving gate → relay open → park → claim → verified with the concurrency cases a mocked test cannot reach — two requests racing for one assertion, two devices racing on one number.

**That DB suite has never run.** Docker is down on the machine it was written on, so CI is its first execution — the same way `phoneOtpGate.test.ts` first ran here, and the same way the Prisma drift check caught a mistake that was invisible locally. Treat the concurrency tests as unverified until this goes green.

**Nothing here has been on a phone.** No code has been sent over SMS.

All three migrations are applied to the live project and recorded in `_prisma_migrations`, through `supabase db query` — the prod database password in `packages/db/.env` is stale and Prisma cannot connect at all, which is worth fixing before the next schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jhzmZz5fkjnZZ14YxHGfS
