### PR TITLE
Follow-up: serialize phone OTP relay exchanges

### DIFF
--- a/packages/db/prisma/migrations/20260912150000_refuse_concurrent_otp_relay/migration.sql
+++ b/packages/db/prisma/migrations/20260912150000_refuse_concurrent_otp_relay/migration.sql
@@ -1,0 +1,32 @@
+-- A second live Firebase→GoTrue phone exchange for the same number must not
+-- replace the first one. Replacement lets one device claim or close another
+-- device's code, and can make the newer request fall through to ordinary SMS
+-- delivery. Stale rows are still replaced so an abandoned exchange does not pin
+-- the number forever.
+
+CREATE OR REPLACE FUNCTION public.waves_otp_relay_open(p_phone text)
+RETURNS uuid
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_exchange uuid := gen_random_uuid();
+BEGIN
+  INSERT INTO public.otp_relay (phone, exchange, code, requested_at)
+  VALUES (p_phone, v_exchange, NULL, now())
+  ON CONFLICT (phone) DO UPDATE
+    SET exchange = EXCLUDED.exchange, code = NULL, requested_at = now()
+    WHERE public.otp_relay.requested_at <= now() - interval '30 seconds'
+  RETURNING exchange INTO v_exchange;
+
+  IF v_exchange IS NULL THEN
+    RAISE EXCEPTION 'OTP_RELAY_BUSY: an exchange is already open for this phone'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  RETURN v_exchange;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.waves_otp_relay_open(text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.waves_otp_relay_open(text) TO service_role;

--- a/packages/db/test/otpRelaySql.test.ts
+++ b/packages/db/test/otpRelaySql.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Static guards for the OTP relay migration.
+ *
+ * The integration suite exercises database behaviour when Postgres is running,
+ * but this branch is often audited on machines without the local service. These
+ * assertions pin the critical concurrency contract in the migration text: one
+ * phone may have only one live Firebase→GoTrue exchange, and a second live open
+ * must refuse instead of replacing the first row.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const originalMigration = readFileSync(
+  join(__dirname, '../prisma/migrations/20260912120000_otp_relay/migration.sql'),
+  'utf8',
+);
+const followupMigration = readFileSync(
+  join(__dirname, '../prisma/migrations/20260912150000_refuse_concurrent_otp_relay/migration.sql'),
+  'utf8',
+);
+
+describe('otp relay migration SQL', () => {
+  it('refuses a second live exchange instead of replacing it', () => {
+    expect(followupMigration).toContain("LANGUAGE plpgsql SECURITY DEFINER");
+    expect(followupMigration).toContain(
+      "WHERE public.otp_relay.requested_at <= now() - interval '30 seconds'",
+    );
+    expect(followupMigration).toContain('OTP_RELAY_BUSY: an exchange is already open for this phone');
+  });
+
+  it('requires claim and close to name the exchange they own', () => {
+    expect(originalMigration).toContain(
+      'CREATE FUNCTION public.waves_otp_relay_claim(p_phone text, p_exchange uuid)',
+    );
+    expect(originalMigration).toContain('AND exchange = p_exchange');
+    expect(originalMigration).toContain(
+      'CREATE FUNCTION public.waves_otp_relay_close(p_phone text, p_exchange uuid)',
+    );
+    expect(originalMigration).toContain(
+      'DELETE FROM public.otp_relay WHERE phone = p_phone AND exchange = p_exchange',
+    );
+  });
+});

--- a/supabase/functions/phone-verify/handler.test.ts
+++ b/supabase/functions/phone-verify/handler.test.ts
@@ -57,6 +57,7 @@ function deps(
     verifyStatus?: number;
     verifyBody?: unknown;
     parkedCode?: string | null;
+    openError?: string;
     gateAllowed?: boolean;
     gateErrored?: boolean;
     jwksOk?: boolean;
@@ -79,6 +80,9 @@ function deps(
       });
     }
     if (name === 'waves_otp_relay_open') {
+      if (overrides.openError) {
+        return Promise.resolve({ data: null, error: { message: overrides.openError } });
+      }
       return Promise.resolve({ data: 'exchange-1', error: null });
     }
     if (name === 'waves_otp_relay_claim') {
@@ -258,6 +262,26 @@ describe('when the exchange goes wrong', () => {
 
     expect(response.status).toBe(503);
     expect(rpcNames(d)).not.toContain('waves_otp_relay_open');
+  });
+
+  it('answers a concurrent live exchange as a retry, not a server error', async () => {
+    const d = deps({ openError: 'OTP_RELAY_BUSY: an exchange is already open for this phone' });
+    const response = await handlePhoneVerify(request(), d);
+
+    expect(response.status).toBe(429);
+    expect(await response.json()).toMatchObject({
+      code: 'TOO_MANY',
+      message: 'A sign-in code is already being checked for that number. Try again in a moment.',
+    });
+    expect(d.events).not.toContain(`fetch:${ENV.SUPABASE_URL}/auth/v1/otp`);
+  });
+
+  it('keeps an unexpected relay-open error internal', async () => {
+    const d = deps({ openError: 'permission denied' });
+    const response = await handlePhoneVerify(request(), d);
+
+    expect(response.status).toBe(500);
+    expect(d.events).not.toContain(`fetch:${ENV.SUPABASE_URL}/auth/v1/otp`);
   });
 
   it('claims and closes with the exchange it opened', async () => {

--- a/supabase/functions/phone-verify/handler.test.ts
+++ b/supabase/functions/phone-verify/handler.test.ts
@@ -61,8 +61,14 @@ function deps(
     gateErrored?: boolean;
     jwksOk?: boolean;
   } = {},
-): PhoneVerifyDeps & { rpc: ReturnType<typeof vi.fn>; fetchImpl: ReturnType<typeof vi.fn> } {
+): PhoneVerifyDeps & {
+  events: string[];
+  rpc: ReturnType<typeof vi.fn>;
+  fetchImpl: ReturnType<typeof vi.fn>;
+} {
+  const events: string[] = [];
   const rpc = vi.fn((name: string) => {
+    events.push(`rpc:${name}`);
     if (name === 'waves_phone_gate') {
       if (overrides.gateErrored) {
         return Promise.resolve({ data: null, error: { message: 'database unreachable' } });
@@ -85,6 +91,7 @@ function deps(
   });
 
   const fetchImpl = vi.fn((url: string) => {
+    events.push(`fetch:${url}`);
     if (url === JWKS_URL) {
       return Promise.resolve(
         new Response(JSON.stringify(JWKS), { status: overrides.jwksOk === false ? 500 : 200 }),
@@ -114,6 +121,7 @@ function deps(
     service: () => ({ rpc }) as any,
     fetchImpl: fetchImpl as unknown as typeof fetch,
     env: (key: string) => env[key],
+    events,
     rpc,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any;
@@ -167,16 +175,14 @@ describe('a verified token', () => {
     const d = deps();
     await handlePhoneVerify(request(), d);
 
-    const names = rpcNames(d);
-    const opened = names.indexOf('waves_otp_relay_open');
-    const claimed = names.indexOf('waves_otp_relay_claim');
+    const opened = d.events.indexOf('rpc:waves_otp_relay_open');
+    const askedAt = d.events.indexOf(`fetch:${ENV.SUPABASE_URL}/auth/v1/otp`);
+    const claimed = d.events.indexOf('rpc:waves_otp_relay_claim');
     expect(opened).toBeGreaterThanOrEqual(0);
-    expect(opened).toBeLessThan(claimed);
-
-    const askedAt = d.fetchImpl.mock.calls.findIndex(
-      (call) => call[0] === `${ENV.SUPABASE_URL}/auth/v1/otp`,
-    );
     expect(askedAt).toBeGreaterThanOrEqual(0);
+    expect(claimed).toBeGreaterThanOrEqual(0);
+    expect(opened).toBeLessThan(askedAt);
+    expect(askedAt).toBeLessThan(claimed);
   });
 
   it('clears the day, because a code was actually used', async () => {
@@ -234,6 +240,10 @@ describe('the daily gate', () => {
     const response = await handlePhoneVerify(request(), d);
 
     expect(response.status).toBe(429);
+    const body = (await response.json()) as { message: string };
+    expect(body.message).toBe('Too many sign-in attempts for that number. Try again later.');
+    expect(body.message).not.toContain('today');
+    expect(body.message).not.toContain('tomorrow');
     expect(rpcNames(d)).not.toContain('waves_otp_relay_open');
   });
 });

--- a/supabase/functions/phone-verify/handler.ts
+++ b/supabase/functions/phone-verify/handler.ts
@@ -177,7 +177,7 @@ export async function handlePhoneVerify(
     return fail(503, 'UNAVAILABLE', 'Could not sign you in just now. Try again.');
   }
   if ((gate as { allowed?: boolean } | null)?.allowed === false) {
-    return fail(429, 'TOO_MANY', 'That is too many sign-in attempts today. Try again tomorrow.');
+    return fail(429, 'TOO_MANY', 'Too many sign-in attempts for that number. Try again later.');
   }
 
   const service = deps.service();

--- a/supabase/functions/phone-verify/handler.ts
+++ b/supabase/functions/phone-verify/handler.ts
@@ -193,7 +193,13 @@ export async function handlePhoneVerify(
   const { data: exchange, error: openError } = await service.rpc('waves_otp_relay_open', {
     p_phone: phone,
   });
-  if (openError || typeof exchange !== 'string') {
+  if (openError) {
+    if ((openError.message ?? '').includes('OTP_RELAY_BUSY')) {
+      return fail(429, 'TOO_MANY', 'A sign-in code is already being checked for that number. Try again in a moment.');
+    }
+    return fail(500, 'INTERNAL', 'Could not sign you in just now');
+  }
+  if (typeof exchange !== 'string') {
     return fail(500, 'INTERNAL', 'Could not sign you in just now');
   }
 


### PR DESCRIPTION
Follow-up to merged PR #769.\n\n- Refuses a second live Firebase→GoTrue phone relay exchange for the same number instead of replacing the first row.\n- Keeps stale relay replacement so abandoned exchanges do not pin a number forever.\n- Makes phone-verify's gate refusal copy neutral for cap changes and blocked-number cases.\n- Strengthens phone-verify tests to assert relay-open precedes the GoTrue OTP request on one shared timeline.\n- Adds static SQL coverage for relay ownership/concurrency because local Postgres is not always available in audit environments.\n\nValidation:\n- pnpm test:edge -- phone-verify otp-send\n- pnpm --dir packages/db exec vitest run test/otpRelaySql.test.ts --pool=forks\n- pnpm --filter @waves/db typecheck\n- pnpm typecheck\n- pnpm lint\n- bash scripts/check-filenames.sh\n- git diff --check\n\nNote: running the package-level DB Vitest command pulled in integration tests and failed because local Postgres on localhost:54330 is unavailable; the targeted static SQL test passed directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved phone verification handling to prevent multiple simultaneous OTP exchanges for the same number.
  * Updated rate-limit messaging to clearly state that too many attempts were made for the number and to try again later.
  * Preserved the existing rate-limit response behavior, including the 429 status and error code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->