### PR TITLE
The backup screen asks one question, and Backup is in the dashboard menu

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -197,6 +197,15 @@ export default function HomeScreen() {
         route: '/settings/archived',
         section: 'data',
       },
+      // Backup sits with the other data rows rather than three taps down under
+      // the profile screen, because the moment somebody wants it is the moment
+      // they are worried about losing something.
+      {
+        icon: 'cloud-upload-outline',
+        label: t.backup.title,
+        route: '/settings/backup',
+        section: 'data',
+      },
       { icon: 'language-outline', label: t.language, route: '/settings/language', section: 'app' },
       {
         icon: 'contrast-outline',

--- a/apps/mobile/src/app/settings/backup.tsx
+++ b/apps/mobile/src/app/settings/backup.tsx
@@ -617,6 +617,21 @@ export default function BackupSettingsScreen() {
    * the one sentence on this screen that must never be shown wrongly.
    */
   const settled = !backup.loading;
+
+  /**
+   * A linked phone with nothing on it is a new phone, and the one thing it
+   * wants is its ledger back.
+   *
+   * So the card offers that instead of "Back up now" — which on an empty phone
+   * is the one button that must not be pressed, because it would write nothing
+   * over the copy the person came here for. Restore stops being a section
+   * somebody has to find and understand, and becomes the only thing on offer at
+   * the moment it is the only thing that makes sense. Once anything at all has
+   * been entered the card goes back to backing up, and restore steps down to a
+   * single row further down for the rare case of wanting it anyway.
+   */
+  const restoreFirst = settled && setup.complete && backup.recordCount === 0;
+
   const statusTone: 'warning' | 'brand' | 'positive' =
     !settled || (setup.complete && !last) ? 'brand' : setup.complete ? 'positive' : 'warning';
   const statusColor =
@@ -631,7 +646,9 @@ export default function BackupSettingsScreen() {
     : setup.complete
       ? last
         ? t.backup.statusOn
-        : t.backup.statusReady
+        : restoreFirst
+          ? t.backup.statusFresh
+          : t.backup.statusReady
       : t.backup.statusOff;
 
   const statusDetail = !settled
@@ -829,23 +846,33 @@ export default function BackupSettingsScreen() {
             <>
               <Divider />
               <View style={{ gap: theme.spacing.md }}>
+                {/* One button, and which of the two it is was not left to the
+                    person to work out — see `restoreFirst`. */}
                 <Button
-                  label={t.backup.backUpNow}
-                  onPress={() => void onBackUpNow()}
+                  label={restoreFirst ? t.backup.restoreNow : t.backup.backUpNow}
+                  onPress={() => void (restoreFirst ? onCheckForBackup() : onBackUpNow())}
                   disabled={busy || running}
                   fullWidth
                   icon={
-                    running || pending === 'backup' ? (
+                    running || pending === 'backup' || pending === 'scan' ? (
                       <ActivityIndicator size="small" color={theme.color.onBrand} />
                     ) : (
                       <Ionicons
-                        name="cloud-upload-outline"
+                        name={restoreFirst ? 'cloud-download-outline' : 'cloud-upload-outline'}
                         size={iconSize.md}
                         color={theme.color.onBrand}
                       />
                     )
                   }
                 />
+                {/* Where the look ended up, under the button that would look
+                    again — "there is no backup on this Drive account yet" is
+                    often a slow folder rather than an empty one. */}
+                {restoreFirst && restoreNote ? (
+                  <Text variant="micro" tone="muted" align="center">
+                    {restoreNote}
+                  </Text>
+                ) : null}
                 {/* A run in progress says which part it is on; the gap between
                     the tap and the first phase — network checks and a token
                     refresh — says something rather than nothing; and a finished
@@ -1124,66 +1151,87 @@ export default function BackupSettingsScreen() {
           </Card>
         </View>
 
-        {/* Getting it back. Last, and deliberately not beside "Back up now". */}
-        <View style={{ gap: theme.spacing.sm }}>
-          <SectionHeader title={t.backup.restoreSection} />
-          <Card style={{ gap: theme.spacing.md }}>
-            <Text variant="micro" tone="muted">
-              {t.backup.restoreIntro}
-            </Text>
-            {restored !== null ? (
-              <Text variant="body" tone="muted">
-                {plural(locale, restored, t.backup.restoreDone)}
-              </Text>
-            ) : null}
-            <Button
-              label={t.backup.restoreCheck}
-              variant="secondary"
-              onPress={() => void onCheckForBackup()}
-              disabled={restoreReason !== null || busy}
-              icon={pending === 'scan' ? spinner(false) : undefined}
-              fullWidth
-            />
+        {/* Getting it back, for the phone that is not obviously asking for it.
+            A phone with nothing on it has already been offered this as the
+            card's own button, so here it would be the same tap twice.
+            Otherwise it is one row and no paragraph: somebody who wants it
+            knows what the word means, and somebody who does not should not have
+            to read three lines to find out it is not for them. */}
+        {!restoreFirst ? (
+          <View style={{ gap: theme.spacing.sm }}>
+            <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+              <ListRow
+                title={t.backup.restoreSection}
+                // A row with no `onPress` is drawn but not pressable, which is
+                // what a blocked restore wants: the reason sits under it and
+                // the way back stays visible even while it cannot be taken.
+                onPress={restoreReason !== null || busy ? undefined : () => void onCheckForBackup()}
+                leading={
+                  <Ionicons
+                    name="cloud-download-outline"
+                    size={iconSize.xl}
+                    color={theme.color.text}
+                  />
+                }
+                trailing={
+                  pending === 'scan' ? (
+                    <ActivityIndicator size="small" color={theme.color.textFaint} />
+                  ) : (
+                    <Ionicons
+                      name={directionalIcon('chevron-forward')}
+                      size={iconSize.md}
+                      color={theme.color.textFaint}
+                    />
+                  )
+                }
+              />
+            </Card>
             {restoreReason ? (
-              <Text variant="micro" tone="faint" align="center">
+              <Text variant="micro" tone="faint">
                 {restoreReason}
               </Text>
             ) : restoreNote ? (
-              // Where the last look ended up, under the button that would look
-              // again. "There is no backup on this Drive account yet" is often
-              // a slow folder rather than an empty one.
-              <Text variant="micro" tone="muted" align="center">
+              <Text variant="micro" tone="muted">
                 {restoreNote}
               </Text>
+            ) : restored !== null ? (
+              <Text variant="micro" tone="muted">
+                {plural(locale, restored, t.backup.restoreDone)}
+              </Text>
             ) : null}
-            {/* The way out of the one blocked state that has one, right here,
-                so nobody has to go looking for it in the checklist — where the
-                other button is the one that would cost them the backup.
-                On Standard it appears only once a scan has actually found a
-                backup this phone cannot open: offering "I already have a key"
-                to somebody who was never given one is a question with no
-                answer, and it would quietly undercut the tier's promise that
-                nothing has to be kept. */}
-            {settled &&
-            backup.configured &&
-            backup.connected &&
-            !backup.hasKey &&
-            (extra || needsOldKey) ? (
-              <Button
-                label={t.backup.keyEnter}
-                variant="secondary"
-                onPress={onEnterKey}
-                disabled={busy}
-                fullWidth
-              />
-            ) : null}
-          </Card>
-        </View>
+          </View>
+        ) : null}
 
-        {/* Extra protection: the opt-in tier, last on the screen and set apart,
-            where WhatsApp puts its end-to-end row. One line saying Off or On,
-            one footnote, and a door — never a tap that does the thing. */}
-        {settled && !setup.unavailable ? (
+        {/* The way out of the one blocked state that has one. On Standard it
+            appears only once a scan has actually found a backup this phone
+            cannot open: offering "I already have a key" to somebody who was
+            never given one is a question with no answer, and it would quietly
+            undercut the tier's promise that nothing has to be kept. */}
+        {settled &&
+        backup.configured &&
+        backup.connected &&
+        !backup.hasKey &&
+        (extra || needsOldKey) ? (
+          <Button
+            label={t.backup.keyEnter}
+            variant="secondary"
+            onPress={onEnterKey}
+            disabled={busy}
+            fullWidth
+          />
+        ) : null}
+
+        {/* Extra protection: no longer offered, and deliberately not removed.
+            It is the tier whose key lives only on this phone, and it asks
+            somebody to keep 64 characters safe for ever — a fair trade for a
+            person who wants it, and a trap for everybody who does not read the
+            sheet, which on a screen meant to be obvious is most people. So the
+            door is gone for anybody not already through it.
+
+            It is still drawn for anybody who *is*, and that is not politeness:
+            their backup is sealed under a key this screen is the only way back
+            to, so hiding the row would strand the Drive file for good. */}
+        {settled && !setup.unavailable && extra ? (
           <View style={{ gap: theme.spacing.sm }}>
             <SectionHeader title={t.backup.extraSection} />
             <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1719,6 +1719,11 @@ export interface UiStrings {
     statusChecking: string;
     statusOff: string;
     statusReady: string;
+    /** The card on a linked phone that holds nothing yet — a new phone, where
+     *  the only sensible button is the one that brings the ledger back. */
+    statusFresh: string;
+    /** That button. */
+    restoreNow: string;
     statusOn: string;
     statusSealedStandard: string;
     statusSealedExtra: string;
@@ -4351,6 +4356,8 @@ const en: UiStrings = {
     statusChecking: 'Checking…',
     statusOff: 'Not backing up yet',
     statusReady: 'Ready to back up',
+    statusFresh: 'Nothing on this phone yet',
+    restoreNow: 'Restore my data',
     statusOn: 'Backed up',
     statusSealedStandard: 'Locked with a key kept in your Google account',
     statusSealedExtra: 'Locked with a key only you have',
@@ -6967,6 +6974,8 @@ const ta: UiStrings = {
     statusChecking: 'பார்க்கிறது…',
     statusOff: 'இன்னும் காப்பு எடுக்கப்படவில்லை',
     statusReady: 'காப்பு எடுக்கத் தயார்',
+    statusFresh: 'இந்த ஃபோனில் இன்னும் எதுவும் இல்லை',
+    restoreNow: 'என் தரவை மீட்டெடு',
     statusOn: 'காப்பு எடுக்கப்பட்டது',
     statusSealedStandard: 'உங்கள் Google கணக்கில் வைக்கப்பட்ட சாவியால் பூட்டப்பட்டது',
     statusSealedExtra: 'உங்களிடம் மட்டுமே உள்ள சாவியால் பூட்டப்பட்டது',
@@ -9615,6 +9624,8 @@ const hi: UiStrings = {
     statusChecking: 'देखा जा रहा है…',
     statusOff: 'अभी बैकअप नहीं हो रहा',
     statusReady: 'बैकअप के लिए तैयार',
+    statusFresh: 'इस फ़ोन पर अभी कुछ नहीं है',
+    restoreNow: 'मेरा डेटा वापस लाएँ',
     statusOn: 'बैकअप हो गया',
     statusSealedStandard: 'आपके Google खाते में रखी चाबी से बंद',
     statusSealedExtra: 'सिर्फ़ आपके पास मौजूद चाबी से बंद',
@@ -12298,6 +12309,8 @@ const ar: UiStrings = {
     statusChecking: 'يتحقق…',
     statusOff: 'لا نسخ احتياطي بعد',
     statusReady: 'جاهز للنسخ',
+    statusFresh: 'لا يوجد شيء على هذا الهاتف بعد',
+    restoreNow: 'استعادة بياناتي',
     statusOn: 'تم النسخ',
     statusSealedStandard: 'مقفل بمفتاح محفوظ في حساب Google الخاص بك',
     statusSealedExtra: 'مقفل بمفتاح لا يملكه سواك',


### PR DESCRIPTION
The screen was asking for three decisions somebody has no way to make.

## One action, and the screen picks which

"Back up now" and "Restore" sat as peers, and they are opposites. Which is right
is not actually a judgement call — a linked phone holding nothing is a new
phone, and "Back up now" there would write an empty ledger over the copy the
person came for.

So the card decides: **Restore my data** while `recordCount === 0`, **Back up
now** once anything exists. The restore section below drops from a card with a
paragraph, two buttons and two notes to a single row, for the rare case of
wanting it on a phone that already has data.

## Extra protection is no longer offered

It is the tier whose key lives only on this phone, asking somebody to keep 64
characters safe for ever. A fair trade for a person who wants it; a trap for
everybody who does not read the sheet.

The door is gone for anybody not already through it. The row is **still drawn
for anybody who is** — not politeness: their backup is sealed under a key this
screen is the only way back to, so hiding it would strand the Drive file
permanently.

## Backup is in the dashboard's ••• menu

It was three taps down under the profile screen. It now sits with the other data
rows, because the moment somebody wants it is the moment they are worried about
losing something.

## Notes

- `statusFresh` and `restoreNow` added across all four locales.
- "I already have a key" moves out of the restore card but keeps its exact
  conditions — it is the only way back for a phone whose backup is sealed under
  an old key, and minting a fresh one would overwrite it.
- The Extra protection sheet is still compiled and reachable from the row, so
  the upgrade branch inside it is now unreachable in practice. Left in place
  rather than deleted, so the decision is reversible.

## Checks

`pnpm lint` and `pnpm typecheck` clean. `@waves/core` 986 and `@waves/mobile`
1327 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jhzmZz5fkjnZZ14YxHGfS
