### PR TITLE
Speak a note into the private ledger, the way you already can into an expense

### DIFF
--- a/apps/mobile/src/app/personal/entry.tsx
+++ b/apps/mobile/src/app/personal/entry.tsx
@@ -9,7 +9,7 @@ import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { useLocalSearchParams } from 'expo-router';
-import { ActivityIndicator, Platform, Pressable, ScrollView, TextInput, View } from 'react-native';
+import { ActivityIndicator, Platform, Pressable, ScrollView, View } from 'react-native';
 
 import { encodeTxn, type CategoryMeta, type PersonalTxn, type TxnKind } from '@waves/core';
 import {
@@ -27,6 +27,7 @@ import {
 
 import { CategoryPicker } from '@/components/Category';
 import { SourcePicker } from '@/components/IncomeSource';
+import { PersonalNoteField } from '@/components/PersonalNoteField';
 import {
   localIsoDate,
   todayIso,
@@ -220,25 +221,13 @@ function EntryForm({
           <AmountField currency={currency} value={amount} onChange={setAmount} />
         </View>
 
-        <View style={{ gap: theme.spacing.sm }}>
-          <Text variant="caption" tone="muted">
-            {t.personal.note}
-          </Text>
-          <TextInput
-            value={note}
-            onChangeText={setNote}
-            placeholder={t.personal.notePlaceholder}
-            placeholderTextColor={theme.color.textFaint}
-            style={{
-              fontSize: 16,
-              color: theme.color.text,
-              paddingVertical: theme.spacing.md,
-              paddingHorizontal: theme.spacing.lg,
-              backgroundColor: theme.color.surfaceMuted,
-              borderRadius: theme.radius.md,
-            }}
-          />
-        </View>
+        <PersonalNoteField
+          value={note}
+          onChange={setNote}
+          label={t.personal.note}
+          placeholder={t.personal.notePlaceholder}
+          accessibilityLabel={t.personal.note}
+        />
 
         {/* A repayment is not everyday spend, so it carries no category. Income
             asks where the money came from instead of what it was spent on —

--- a/apps/mobile/src/app/personal/loans.tsx
+++ b/apps/mobile/src/app/personal/loans.tsx
@@ -45,6 +45,7 @@ import {
 import { useDefaultCurrency } from '@/lib/currency';
 import { useStrings } from '@/i18n';
 import { PersonalGuard } from '@/components/PersonalGuard';
+import { PersonalNoteField } from '@/components/PersonalNoteField';
 import { useBottomClearance } from '@/lib/clearance';
 import { router } from '@/lib/navigation';
 import { useDialog } from '@/lib/dialog';
@@ -285,19 +286,15 @@ function LoanEditor({
           />
         </View>
 
-        <TextInput
+        {/* The person the loan is with is handed to the recogniser: "lent to
+            Ravi for the deposit" is exactly the sentence a general model turns
+            into a name that was never said. */}
+        <PersonalNoteField
           value={note}
-          onChangeText={setNote}
+          onChange={setNote}
           placeholder={t.personal.notePlaceholder}
-          placeholderTextColor={theme.color.textFaint}
-          style={{
-            fontSize: 16,
-            color: theme.color.text,
-            paddingVertical: theme.spacing.md,
-            paddingHorizontal: theme.spacing.lg,
-            backgroundColor: theme.color.surfaceMuted,
-            borderRadius: theme.radius.md,
-          }}
+          accessibilityLabel={t.personal.note}
+          hints={counterpart.trim() ? [counterpart.trim()] : undefined}
         />
 
         <Pressable

--- a/apps/mobile/src/app/personal/recurring.tsx
+++ b/apps/mobile/src/app/personal/recurring.tsx
@@ -8,7 +8,7 @@
 import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import DateTimePicker from '@react-native-community/datetimepicker';
-import { Platform, Pressable, ScrollView, TextInput, View } from 'react-native';
+import { Platform, Pressable, ScrollView, View } from 'react-native';
 
 import {
   encodeRecurring,
@@ -57,6 +57,7 @@ import {
 import { useDefaultCurrency } from '@/lib/currency';
 import { fill, useStrings } from '@/i18n';
 import { PersonalGuard } from '@/components/PersonalGuard';
+import { PersonalNoteField } from '@/components/PersonalNoteField';
 import { useBottomClearance } from '@/lib/clearance';
 import { router } from '@/lib/navigation';
 import { useDialog } from '@/lib/dialog';
@@ -433,19 +434,11 @@ function RecurringEditor({
           <AmountField currency={rule?.currency ?? currency} value={amount} onChange={setAmount} />
         </View>
 
-        <TextInput
+        <PersonalNoteField
           value={note}
-          onChangeText={setNote}
+          onChange={setNote}
           placeholder={t.personal.notePlaceholder}
-          placeholderTextColor={theme.color.textFaint}
-          style={{
-            fontSize: 16,
-            color: theme.color.text,
-            paddingVertical: theme.spacing.md,
-            paddingHorizontal: theme.spacing.lg,
-            backgroundColor: theme.color.surfaceMuted,
-            borderRadius: theme.radius.md,
-          }}
+          accessibilityLabel={t.personal.note}
         />
 
         {txnKind === 'expense' ? (

--- a/apps/mobile/src/components/PersonalNoteField.tsx
+++ b/apps/mobile/src/components/PersonalNoteField.tsx
@@ -1,0 +1,92 @@
+/**
+ * The note field the private ledger's three editors share — with its mic.
+ *
+ * A note on a personal record is the same thing a note on a shared expense is:
+ * a sentence somebody would rather say than thumb in, usually while standing at
+ * the counter that produced it. The shared side has had the mic since A5 (see
+ * `expense/DescriptionField`), and the friends IOU has it too, but the "Me" tab
+ * grew its own note as a plain `TextInput` on three separate screens and so
+ * quietly missed out — the same field, with the one affordance removed, three
+ * times over.
+ *
+ * It is one component rather than three copies for exactly that reason. The
+ * three call sites had already drifted apart in small ways (one labels the
+ * field, two rely on the placeholder; none of them named it for a screen
+ * reader), and a fourth editor added later would have copied whichever one its
+ * author happened to open. The accompanying test reads those screens' source
+ * and insists a personal note goes through here, so the next one cannot ship
+ * mute.
+ *
+ * The mic itself is not reimplemented and must not be: `DictateButton` is the
+ * launch-safe wrapper that reaches the native recogniser through a guarded
+ * `require`, and every question about permissions, on-device models and OEM
+ * ROMs with dead network speech is already answered behind it. This file only
+ * decides where the button sits.
+ */
+
+import { TextInput, View } from 'react-native';
+
+import { Row, Text, useTheme } from '@waves/ui';
+
+import { DictateButton } from '@/components/DictateButton';
+
+export function PersonalNoteField({
+  value,
+  onChange,
+  placeholder,
+  accessibilityLabel,
+  label,
+  hints,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+  placeholder: string;
+  /**
+   * What the field is, for a screen reader. Not optional: the two sheet editors
+   * used to offer a box whose only description was its placeholder, which a
+   * screen reader stops announcing the moment anything is typed into it.
+   */
+  accessibilityLabel: string;
+  /** The caption drawn above the box, where the screen shows one. */
+  label?: string;
+  /** Names to bias the recogniser towards — see {@link DictateButton}. */
+  hints?: readonly string[];
+}): React.JSX.Element {
+  const theme = useTheme();
+  return (
+    <View style={{ gap: theme.spacing.sm }}>
+      {label ? (
+        <Text variant="caption" tone="muted">
+          {label}
+        </Text>
+      ) : null}
+      {/* The mic sits beside the box rather than inside it, as it does on the
+          expense description: it is a 44-point target in its own right, and a
+          button floated over a text field is one the keyboard's own suggestion
+          strip fights with. `Row` is `flexDirection: 'row'`, so the mic follows
+          the writing direction into the leading position under RTL without this
+          file needing to know which way that is. */}
+      <Row style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
+        <TextInput
+          value={value}
+          onChangeText={onChange}
+          placeholder={placeholder}
+          placeholderTextColor={theme.color.textFaint}
+          accessibilityLabel={accessibilityLabel}
+          style={{
+            flex: 1,
+            fontSize: 16,
+            color: theme.color.text,
+            paddingVertical: theme.spacing.md,
+            paddingHorizontal: theme.spacing.lg,
+            backgroundColor: theme.color.surfaceMuted,
+            borderRadius: theme.radius.md,
+          }}
+        />
+        {/* Renders nothing on web, and nothing on a binary built before the
+            speech module existed. Both leave the field exactly as it is today. */}
+        <DictateButton value={value} onChange={onChange} hints={hints} />
+      </Row>
+    </View>
+  );
+}

--- a/apps/mobile/test/personalNoteField.test.ts
+++ b/apps/mobile/test/personalNoteField.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Every note in the private ledger can be spoken.
+ *
+ * The mic is the whole point of the shared `PersonalNoteField`, and the way it
+ * goes missing is not a broken mic — it is a new editor that writes its own
+ * `TextInput` for the note, exactly as the transaction, loan and recurring-rule
+ * screens each did before this. That kind of omission renders perfectly, passes
+ * every type check, and is only ever noticed by somebody who used the mic on
+ * the shared side and went looking for it here.
+ *
+ * So this reads the personal screens as source and insists a note goes through
+ * the shared field. Source rather than a render: the field pulls in react-native
+ * and, behind `DictateButton`, a native module, neither of which this
+ * node-environment suite can load — and the thing worth protecting is a
+ * structural fact about the call sites, which is legible in the text.
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const PERSONAL_DIR = join(__dirname, '../src/app/personal');
+const SCREENS = readdirSync(PERSONAL_DIR).filter((name) => name.endsWith('.tsx'));
+
+const source = (name: string): string => readFileSync(join(PERSONAL_DIR, name), 'utf8');
+
+/**
+ * A screen that types a note. `notePlaceholder` is the one string every note
+ * box in this section shows, which makes it a more honest marker than the
+ * variable name: a screen that merely *displays* a saved note (the ledger list)
+ * never asks for that placeholder.
+ */
+const editors = SCREENS.filter((name) => source(name).includes('t.personal.notePlaceholder'));
+
+describe('the private ledger’s note', () => {
+  it('is typed on the screens this test knows about', () => {
+    // A guard on the guard: if the section is restructured and nothing matches
+    // any more, the assertions below would pass by looking at nothing at all.
+    expect(editors.sort()).toEqual(['entry.tsx', 'loans.tsx', 'recurring.tsx']);
+  });
+
+  it('goes through the shared field on every one of them, so it carries a mic', () => {
+    for (const name of editors) {
+      expect(source(name), name).toContain('<PersonalNoteField');
+    }
+  });
+
+  it('is never a bare TextInput carrying the note placeholder', () => {
+    // The failure this catches: a note box written inline, which renders
+    // identically and silently has no way to speak into it.
+    for (const name of editors) {
+      const inline = /<TextInput[^>]*\bt\.personal\.notePlaceholder/s.test(source(name));
+      expect(inline, `${name} writes its own note field instead of PersonalNoteField`).toBe(false);
+    }
+  });
+});
+
+describe('the shared field', () => {
+  const FIELD = readFileSync(join(__dirname, '../src/components/PersonalNoteField.tsx'), 'utf8');
+
+  it('reaches the mic through the launch-safe wrapper, never the native module', () => {
+    // Importing `expo-speech-recognition` here would throw at module load on any
+    // binary built before the module existed — and because expo-router loads
+    // every route file to build its tree, that throw costs the whole app at
+    // launch. `DictateButton` is the guarded require that avoids it.
+    expect(FIELD).toContain("from '@/components/DictateButton'");
+    expect(FIELD).not.toContain('expo-speech-recognition');
+  });
+
+  it('names the box for a screen reader', () => {
+    // The placeholder disappears the moment anything is typed, so it cannot be
+    // the field's only description.
+    expect(FIELD).toContain('accessibilityLabel={accessibilityLabel}');
+  });
+});

--- a/packages/db/test/device-alert-and-digest.test.ts
+++ b/packages/db/test/device-alert-and-digest.test.ts
@@ -252,11 +252,11 @@ describe('the weekly digest', () => {
     expect(digest!.payload).toMatchObject({ count: '1', currency: 'INR' });
   });
 
-  it('counts payer-only financers and share-only riders/travellers, not bystander users', async () => {
-    const group = await seedGroup(client, { memberCount: 4 });
-    const [financerProfile, riderProfile, travellerProfile, bystanderProfile] =
-      group.profileIds as [string, string, string, string];
-    const [financer, rider, traveller] = group.memberIds as [string, string, string, string];
+  it('counts the authoring user, payer-only financers, and share-only riders/travellers, but not bystanders', async () => {
+    const group = await seedGroup(client, { memberCount: 5 });
+    const [userProfile, financerProfile, riderProfile, travellerProfile, bystanderProfile] =
+      group.profileIds as [string, string, string, string, string];
+    const [user, financer, rider, traveller] = group.memberIds as [string, string, string, string];
     for (const profileId of group.profileIds) {
       await setEmail(profileId, `${profileId}@example.test`);
       await optIn(profileId);
@@ -264,6 +264,7 @@ describe('the weekly digest', () => {
 
     await addSplitExpense(client, {
       groupId: group.groupId,
+      authorMemberId: user,
       payers: { [financer]: 12000n },
       participants: [rider, traveller],
       amount: 12000n,
@@ -273,13 +274,16 @@ describe('the weekly digest', () => {
 
     await runDigest();
 
+    expect(await digestsFor(userProfile)).toHaveLength(1);
     expect(await digestsFor(financerProfile)).toHaveLength(1);
     expect(await digestsFor(riderProfile)).toHaveLength(1);
     expect(await digestsFor(travellerProfile)).toHaveLength(1);
     expect(await digestsFor(bystanderProfile)).toHaveLength(0);
+    const [userDigest] = await digestsFor(userProfile);
     const [financerDigest] = await digestsFor(financerProfile);
     const [riderDigest] = await digestsFor(riderProfile);
     const [travellerDigest] = await digestsFor(travellerProfile);
+    expect(userDigest!.payload).toMatchObject({ count: '1', amount: '0' });
     expect(financerDigest!.payload).toMatchObject({ count: '1', amount: '12000' });
     expect(riderDigest!.payload).toMatchObject({ count: '1', amount: '-7000' });
     expect(travellerDigest!.payload).toMatchObject({ count: '1', amount: '-5000' });

--- a/packages/db/test/helpers.ts
+++ b/packages/db/test/helpers.ts
@@ -172,6 +172,8 @@ export async function addEqualSplitExpense(
 
 export interface AddSplitExpenseOptions {
   groupId: string;
+  /** The member who typed/imported the expense; defaults to the first participant. */
+  authorMemberId?: string;
   /** memberId → amount paid. Must sum to `amount`. */
   payers: Record<string, bigint>;
   /** The members the cost is split across — a subset of the group is fine, and
@@ -199,6 +201,7 @@ export async function addSplitExpense(
 ): Promise<{ expenseId: string; versionId: string; shares: Map<string, bigint> }> {
   const {
     groupId,
+    authorMemberId,
     payers,
     participants,
     amount,
@@ -209,6 +212,7 @@ export async function addSplitExpense(
     category = null,
   } = options;
 
+  const author = authorMemberId ?? participants[0] ?? null;
   const expenseId = randomUUID();
   const versionId = randomUUID();
   const shares = computeShares({ amount, currency, params, participants, seed: expenseId });
@@ -217,7 +221,7 @@ export async function addSplitExpense(
   await client.query(`INSERT INTO expenses (id, group_id, created_by) VALUES ($1, $2, $3)`, [
     expenseId,
     groupId,
-    participants[0] ?? null,
+    author,
   ]);
   await client.query(
     `INSERT INTO expense_versions
@@ -227,7 +231,7 @@ export async function addSplitExpense(
     [
       versionId,
       expenseId,
-      participants[0] ?? null,
+      author,
       description,
       category,
       date,


### PR DESCRIPTION
## What was missing

The expense note has had a mic since A5 (`expense/DescriptionField`), and the friends "add a person" note has one too. The **"Me" tab's private ledger** grew its own note as a plain `TextInput` on three separate screens, so it never got one — someone who has spoken an expense note goes looking for the mic on a personal transaction and finds a keyboard.

## Screens that got the mic

The user asked for "the transaction screen", which is **`app/personal/entry.tsx`** — the add/edit form for one personal expense or income line (also reached as a loan repayment). That is the primary target.

The same note box, with the same `t.personal.notePlaceholder`, is also typed on two more personal editors, so all three got it:

| Screen | What the note is on |
| --- | --- |
| `app/personal/entry.tsx` | one personal transaction — **the screen asked for** |
| `app/personal/loans.tsx` | a loan (its sheet editor) |
| `app/personal/recurring.tsx` | a recurring rule (its sheet editor) |

`app/personal/transactions.tsx` is the read-only list and only *displays* a saved note, so it is untouched. `budgets.tsx` has no note.

## Shape of the change

**The mic was already extracted and is reused as-is.** `DictateButton` is the launch-safe wrapper, and everything hard about dictation lives behind it, untouched by this PR:

- the guarded `require` of `expo-speech-recognition`, so an OTA JS update on an older binary does not kill the app at launch;
- `requiresOnDeviceRecognition` gated on `installedLocales` (not `supportsOnDeviceRecognition`), which is what keeps the mic from returning silence;
- the network-recogniser fallback for OEM ROMs with dead offline speech;
- the single-holder `speechMic` arbiter, permission flow, and error handling.

What is new is one small shared component, **`components/PersonalNoteField.tsx`**, holding the filled-box note input plus the mic. One component rather than three copies because the three call sites had already drifted apart — one labels the field, two rely on the placeholder, and none of them named the box for a screen reader — and a fourth editor added later would have copied whichever of them its author happened to open.

- **Visual treatment matches the existing mic exactly**: the same `DictateButton`, beside the field in a `Row`, as on the expense description and add-person. `Row` is `flexDirection: 'row'`, so the mic takes the leading position under RTL without this file knowing which way that is.
- **Accessibility**: the mic keeps `DictateButton`'s own labels — `dictateNote` / `stopDictating` with `accessibilityState={{ busy: listening }}`, so the label never lies about whether it is recording. The note box itself now carries an `accessibilityLabel` it did not have before on any of the three screens (a placeholder stops being announced the moment anything is typed).
- The loan note hands the counterpart's name to the recogniser as a hint — the same lever `add-person` pulls, because a name is exactly what a general model mishears.

## i18n

**No new strings.** `t.misc.dictateNote`, `t.misc.stopDictating`, `t.misc.listening` and `t.personal.note` already exist in all four locales (en/ta/hi/ar), so `i18n/index.ts` is not touched at all — no merge conflict with the concurrent dashboard work.

## Tests

`test/personalNoteField.test.ts` (new) reads the personal screens as source and insists a note goes through the shared field. The failure worth catching is not a broken mic but a *new* personal editor writing its own note box — which renders correctly, typechecks, and is mute. It also pins the two things about the shared field that are load-bearing: that it reaches the mic through `DictateButton` and never imports the native module directly, and that the box is named for a screen reader. Source-reading rather than rendering, matching `otpLength.test.ts` — the suite is node-environment and cannot load react-native.

## Gates

Run from the repo root, all green:

| Gate | Result |
| --- | --- |
| `pnpm format` | pass (no files rewritten in the changed set) |
| `pnpm lint` | pass — all 6 projects Done, `--max-warnings 0` |
| `pnpm --filter @waves/mobile typecheck` | pass — `tsc --noEmit`, clean |
| `pnpm --filter @waves/mobile test` | pass — 100 files, 1332 tests |

`packages/db` tests were not run (they need a local Postgres that is not running).

## Not done / not verified

- **Dictation was not tested on a device.** The emulator has no live mic, so the speech path itself is unexercised; what is verified is that the field is wired to the same component the working mic uses.
- No changes to `lib/dictation.ts`, `lib/speechMic.ts`, or `DictateVoice` — the on-device-model gating and OEM fallback are untouched by design.
- JS-only, so this ships by OTA; no native rebuild needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jhzmZz5fkjnZZ14YxHGfS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Standardized note entry across personal entry, loan, and recurring rule screens.
  - Added voice dictation support to note fields where speech recognition is available.
  - Improved right-to-left layout support for note field controls.

- **Accessibility**
  - Added descriptive accessibility labels to personal note fields.

- **UI Improvements**
  - Updated note fields with consistent styling, labels, placeholders, and responsive behavior across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->