### PR TITLE
A phone with nothing on it is asked whether to bring the backup back

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -52,6 +52,7 @@ import { useDefaultCurrency } from '@/lib/currency';
 import { captureInboxActionState } from '@/lib/dashboardActions';
 import { QuickAddSheet, useQuickAddActions } from '@/components/QuickAddSheet';
 import { OverflowMenu, type OverflowMenuItem } from '@/components/OverflowMenu';
+import { RestorePrompt } from '@/components/RestorePrompt';
 import { useAvatarUrl } from '@/components/ProfileAvatar';
 import { groupLabel, GroupType } from '@/data/types';
 import { usePullRefresh } from '@/lib/pullRefresh';
@@ -572,6 +573,14 @@ export default function HomeScreen() {
           )}
         </View>
       </ScrollView>
+
+      {/* Signed in on a phone that holds no personal ledger — a new handset, a
+          reinstall, a sign-out and back in — and asked once whether to bring the
+          Drive backup back. It decides for itself whether it applies, and stays
+          silent for everybody whose records are already here; see
+          `lib/backup/restorePrompt` for every condition and why each one is
+          there. Outranks the guest and tip prompts in the queue. */}
+      <RestorePrompt />
 
       {/* Guests are nudged to secure their account as an animated popup rather
           than an inline banner — once a day, dismissible. Held back while the

--- a/apps/mobile/src/app/settings/backup.tsx
+++ b/apps/mobile/src/app/settings/backup.tsx
@@ -111,9 +111,10 @@
  * wrong is worse than any other mistake available on this screen.
  */
 
-import { useCallback, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useState, type ReactNode } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import * as Clipboard from 'expo-clipboard';
+import { useLocalSearchParams } from 'expo-router';
 import { ActivityIndicator, ScrollView, TextInput, View } from 'react-native';
 
 import {
@@ -169,6 +170,22 @@ const STEP_MARK = 26;
 const KEY_SHEET_MAX_HEIGHT = 460;
 
 /**
+ * The `?restore=` nonces already acted on, at module scope so the set survives a
+ * remount.
+ *
+ * The dashboard's restore prompt opens this screen with `?restore=<nonce>`
+ * meaning "link if you must, then go and look". Linking hands control to
+ * Google's consent activity, and Android recreates the JS activity on the way
+ * back — remounting this screen with the same URL, nonce and all. A `useRef`
+ * guard would reset there and start the whole thing again, in a loop. Recording
+ * the nonce the first time it is seen makes it exactly once, while a genuinely
+ * new tap carries a fresh one and still works. Lifted verbatim from
+ * `capture.tsx`'s `consumedScans`, which was written for the same Android
+ * behaviour.
+ */
+const consumedStarts = new Set<string>();
+
+/**
  * Which action is in flight, rather than a bare `busy` flag.
  *
  * A screen-wide boolean greys every button at once and says nothing about any
@@ -222,6 +239,24 @@ export default function BackupSettingsScreen() {
   const clearance = useTabBarClearance();
   const { t, locale } = useStrings();
   const backup = useBackup();
+  /**
+   * The dashboard's restore prompt sends its nonce here to mean "link if you
+   * must, then look" — see `consumedStarts` and `onStartRestore`. Absent on
+   * every ordinary visit, which is every visit that is not a fresh sign-in.
+   */
+  const { restore: restoreStart } = useLocalSearchParams<{ restore?: string }>();
+
+  /**
+   * Whether the stored state has been read yet.
+   *
+   * The hook's first pass reads three local stores — the settings, the key, the
+   * tokens — so until it lands a fully configured phone would show "Not backing
+   * up yet" and correct itself a second later, the one sentence on this screen
+   * that must never be shown wrongly. It is declared this high because the
+   * auto-start effect below cannot ask Google to link an account before it
+   * knows whether one already is.
+   */
+  const settled = !backup.loading;
 
   const [pending, setPending] = useState<PendingAction | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -559,6 +594,53 @@ export default function BackupSettingsScreen() {
     }
   };
 
+  /**
+   * The dashboard's offer, carried out: link the account if nothing is linked,
+   * then look for a backup — one instruction, because that is what was promised
+   * on the popup that sent us here.
+   *
+   * It is the two existing halves in order and not a third path: the link is
+   * `backup.connect` with the same failure sentence `onConnect` uses, and the
+   * look is `onCheckForBackup` untouched, so every outcome past "found it" —
+   * nothing on Drive, a backup wanting a key, a dead grant — lands in the same
+   * sheets and notes it always has, and the confirmation before anything is
+   * written is the same one.
+   *
+   * A cancelled consent page stops here and says nothing. It is an answer, not
+   * a failure, and the screen behind this is already the whole of the restore
+   * offered by hand.
+   */
+  const onStartRestore = async (): Promise<void> => {
+    if (!backup.connected) {
+      setPending('connect');
+      setError(null);
+      try {
+        if (!(await backup.connect())) return;
+      } catch (caught) {
+        setError(connectFailure(caught));
+        return;
+      } finally {
+        setPending(null);
+      }
+    }
+    await onCheckForBackup();
+  };
+
+  // Waits for `settled` because until the stored state is read this screen does
+  // not know whether an account is linked, and would ask Google to link one that
+  // already is. See `consumedStarts` for why the guard is a module-level set.
+  useEffect(() => {
+    if (!restoreStart || !settled || consumedStarts.has(restoreStart)) return;
+    consumedStarts.add(restoreStart);
+    // Deferred a microtask so the `setPending` the run opens with does not fire
+    // synchronously inside the effect body — the same shape `capture.tsx` uses
+    // for its one-shot. The link still starts effectively at once.
+    void Promise.resolve().then(() => onStartRestore());
+    // A one-shot on the nonce; the handlers are recreated every render and
+    // listing them would re-run this on every keystroke elsewhere on the screen.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [restoreStart, settled]);
+
   const onUnlink = async (): Promise<void> => {
     setUnlinking(false);
     setPending('disconnect');
@@ -608,15 +690,6 @@ export default function BackupSettingsScreen() {
    */
   const checklist = setup.total > 1;
   const last = backup.settings.last;
-
-  /**
-   * The status card's face. `loading` gets its own one rather than borrowing
-   * "not set up": the hook's first pass reads two stores *and* asks Drive who
-   * the linked account is, so on a slow network a fully configured phone would
-   * otherwise open on "Not backing up yet" and correct itself a second later —
-   * the one sentence on this screen that must never be shown wrongly.
-   */
-  const settled = !backup.loading;
 
   /**
    * A linked phone with nothing on it is a new phone, and the one thing it

--- a/apps/mobile/src/components/RestorePrompt.tsx
+++ b/apps/mobile/src/components/RestorePrompt.tsx
@@ -1,0 +1,263 @@
+/**
+ * The offer, made once on the dashboard, to bring a Drive backup back.
+ *
+ * ## Why it is on Home and not in settings
+ *
+ * A backup that nobody is told about at the moment they need it is a backup
+ * that does not exist. The moment is the first dashboard after a sign-in on a
+ * phone that holds nothing: a new handset, a reinstall, a sign-out and back in.
+ * Until now the only route to a restore was knowing it was there — ••• on Home,
+ * then Backup — and going looking before typing anything in, which is precisely
+ * the order nobody does things in. So the app asks, once, in the one second
+ * where the answer is obvious.
+ *
+ * ## The one thing it must never do
+ *
+ * Appear for somebody who already has their data. `lib/backup/restorePrompt`
+ * holds that decision and the reasoning behind every condition; this file is
+ * the surface, and it takes care to feed that function only settled answers —
+ * `settled` below is why an empty mirror mid-first-sync is not mistaken for an
+ * empty ledger.
+ *
+ * ## Why the tap leaves this screen
+ *
+ * It goes to the Backup screen with `?restore=<nonce>`, which links Drive if it
+ * is not linked and then runs the same scan the "Restore my data" button there
+ * has always run. One tap from here; the person never sees the join.
+ *
+ * Rebuilding the scan in this popup was the alternative and it was the wrong
+ * one. A restore has four outcomes past "found it" — nothing on Drive, a backup
+ * under extra protection that wants a key, a standard backup whose escrowed key
+ * is gone, a dead grant — and each has a fork the Backup screen already draws.
+ * A second copy of that would be a second thing to keep true about somebody's
+ * ledger. The popup asks the question; the screen that owns restoring answers
+ * it.
+ *
+ * That also keeps this component cheap. It never mounts `useBackup` — which
+ * reads the personal ledger and asks Google for the linked address over the
+ * network — for the same reason the sign-out guard does not: this runs on the
+ * dashboard, and the dashboard must not pay a Drive round trip to decide
+ * whether to draw a card. Two leaf reads (the tokens on disk, the dismissal
+ * flag) and a count the sync context already holds are the whole cost, and the
+ * token read only decides one sentence of copy.
+ *
+ * ## Dismissal
+ *
+ * Sticky until the next sign-in on this device, for this account. See
+ * `restorePrompt.ts`; the flag is written by `markRestorePromptDismissed`,
+ * which is owner-scoped and rides the sign-out wipe. Taking the offer marks it
+ * too — the question has been asked and answered either way, and a second
+ * identical popup because the scan found nothing would be the app asking twice.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { View } from 'react-native';
+
+import { Button, Popup, Text, useTheme } from '@waves/ui';
+
+import { useStrings } from '@/i18n';
+import { useAuth } from '@/lib/auth';
+import { loadRestorePromptDismissed, markRestorePromptDismissed } from '@/lib/backup/settings';
+import { restoreOffer, RestoreOffer } from '@/lib/backup/restorePrompt';
+import { PRIMARY_PROVIDER } from '@/lib/backup/engine';
+import { providerFor } from '@/lib/cloud/providers';
+import { loadTokens } from '@/lib/cloud/tokens';
+import { router } from '@/lib/navigation';
+import { usePromptSlot } from '@/lib/promptQueue';
+import { usePersonalRecords } from '@/data/personal';
+import { useSync } from '@/sync';
+
+/**
+ * Where this sits among the things that want the first screen: under the tour
+ * (interrupting a coach-mark halfway is worse than waiting a beat) and over the
+ * push soft-ask, the campaign and the guest card. Getting a ledger back outranks
+ * all three, and none of them is lost by waiting — each holds its claim and is
+ * granted the moment this one releases.
+ */
+const PROMPT_PRIORITY = 90;
+
+/** A beat after the dashboard has settled, so the card arrives rather than flashes. */
+const PROMPT_DELAY_MS = 400;
+
+/** What the two local reads say about one account. */
+interface AccountReads {
+  /** Whose answers these are — see `useAccountReads` for why it is carried. */
+  readonly owner: string;
+  /** This account has already answered the offer on this device. */
+  readonly dismissed: boolean;
+  /** A Drive account is linked. Chooses the copy, never the answer. */
+  readonly linked: boolean;
+}
+
+/**
+ * The dismissal flag and the Drive tokens, read together and stamped with whose
+ * they are.
+ *
+ * Both defaults are the dangerous ones — "not dismissed" would show the popup
+ * to somebody who closed it, "not linked" would promise a linked phone a Google
+ * consent sheet it is not about to see — so nothing may be decided until both
+ * have landed. That is what the stamp is for: readiness is `owner === ownerId`
+ * rather than a flag somebody has to remember to lower, so switching accounts
+ * re-arms it for free instead of showing B the answers A gave. The same shape
+ * `useBackup` uses for its own first read, and for the same reason.
+ *
+ * Read together because they are two disk reads on the same event with nothing
+ * to say to each other, and because a half-read state has no meaning here.
+ * Neither can throw into the screen: a failure reads as "not answered", which
+ * costs one repeat rather than silently burying the feature.
+ */
+function useAccountReads(ownerId: string): {
+  reads: AccountReads | null;
+  dismiss: () => void;
+} {
+  const [reads, setReads] = useState<AccountReads | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    void (async () => {
+      const [dismissed, tokens] = await Promise.all([
+        loadRestorePromptDismissed(ownerId).catch(() => false),
+        loadTokens(PRIMARY_PROVIDER, ownerId).catch(() => null),
+      ]);
+      if (alive) setReads({ owner: ownerId, dismissed, linked: tokens !== null });
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [ownerId]);
+
+  // State first, disk after: the popup goes away on the tap rather than a round
+  // trip later, and a write that fails costs one repeat, not a stuck card.
+  const dismiss = useCallback(() => {
+    setReads((current) => (current ? { ...current, dismissed: true } : current));
+    void markRestorePromptDismissed(ownerId).catch(() => {});
+  }, [ownerId]);
+
+  return { reads, dismiss };
+}
+
+export function RestorePrompt(): React.JSX.Element | null {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const { session, isGuest } = useAuth();
+  const ownerId = session?.user?.id ?? '';
+
+  const records = usePersonalRecords();
+  const { hydrated, status, lastSyncedAt } = useSync();
+  const { reads, dismiss } = useAccountReads(ownerId);
+
+  // A build with no OAuth client id can neither back up nor restore, so there is
+  // nothing here to offer. Synchronous — it is a compiled-in constant plus a
+  // native-module check, not a lookup.
+  const configured = providerFor(PRIMARY_PROVIDER).isConfigured();
+
+  /**
+   * "We have actually looked." The mirror off disk is not enough on its own: the
+   * personal ledger arrives with the ordinary sync pull, so between hydration
+   * and the session's first successful sync every phone in the world holds zero
+   * records. That window is exactly where a returning user would be asked
+   * whether they had lost their data.
+   *
+   * Bounded the same way the dashboard's own `pendingFirstSync` is (see
+   * `data/hooks`): the first flush resolves either to `lastSyncedAt` being set
+   * or to a status that says the network cannot answer, and in the second case
+   * the local snapshot is the best there is and the question becomes fair again.
+   */
+  const firstSyncPending =
+    hydrated && lastSyncedAt === null && (status === 'idle' || status === 'syncing');
+  const settled = reads?.owner === ownerId && hydrated && !firstSyncPending;
+
+  const offer = restoreOffer({
+    signedIn: Boolean(session),
+    isGuest,
+    configured,
+    connected: reads?.linked ?? false,
+    recordCount: records.length,
+    settled,
+    dismissed: reads?.dismissed ?? false,
+  });
+  const wants = offer !== RestoreOffer.None;
+
+  // Take a turn in the shared prompt queue rather than firing on its own, and
+  // claim only while the offer genuinely stands — so a phone with data never
+  // holds the slot the guest card and the daily tip are queued behind.
+  const granted = usePromptSlot({
+    id: 'restorePrompt',
+    priority: PROMPT_PRIORITY,
+    active: wants,
+    delayMs: PROMPT_DELAY_MS,
+  });
+
+  /**
+   * Hand the whole job to the Backup screen, which links first when it has to.
+   * The nonce is what tells that screen this is a fresh instruction rather than
+   * an Android activity recreation replaying the same URL — see `consumedStarts`
+   * there.
+   */
+  const onRestore = (): void => {
+    dismiss();
+    router.push({ pathname: '/settings/backup', params: { restore: String(Date.now()) } });
+  };
+
+  if (!wants || !granted) return null;
+
+  return (
+    <Popup
+      visible
+      onClose={dismiss}
+      closeLabel={t.backup.restorePromptLaterLabel}
+      style={{ maxWidth: 360, alignItems: 'center', gap: theme.spacing.lg }}
+    >
+      <View
+        style={{
+          width: 72,
+          height: 72,
+          borderRadius: 36,
+          backgroundColor: theme.color.brandSoft,
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Ionicons name="cloud-download-outline" size={38} color={theme.color.brand} />
+      </View>
+
+      <View style={{ gap: theme.spacing.sm }}>
+        <Text variant="heading" align="center">
+          {t.backup.restorePromptTitle}
+        </Text>
+        {/* Two bodies, one tap. An unlinked phone is about to be handed Google's
+            consent sheet, and being handed one unannounced is how a restore
+            turns into "why is it asking for my Google account". */}
+        <Text variant="body" tone="muted" align="center">
+          {offer === RestoreOffer.LinkFirst
+            ? t.backup.restorePromptBodyLink
+            : t.backup.restorePromptBody}
+        </Text>
+      </View>
+
+      <View style={{ alignSelf: 'stretch', gap: theme.spacing.sm }}>
+        <Button
+          label={t.backup.restoreNow}
+          accessibilityLabel={t.backup.restorePromptRestoreLabel}
+          size="lg"
+          fullWidth
+          onPress={onRestore}
+        />
+        <Button
+          label={t.backup.restorePromptLater}
+          accessibilityLabel={t.backup.restorePromptLaterLabel}
+          variant="ghost"
+          size="lg"
+          fullWidth
+          onPress={dismiss}
+        />
+        {/* Declining has to cost nothing, and saying so is the difference
+            between a postponement and a door closing. */}
+        <Text variant="micro" tone="muted" align="center">
+          {t.backup.restorePromptWhere}
+        </Text>
+      </View>
+    </Popup>
+  );
+}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1825,6 +1825,20 @@ export interface UiStrings {
      *  one would let the next run overwrite that backup. */
     restoreNeedsKey: string;
 
+    /** The dashboard's one-time offer to bring a backup back after a fresh
+     *  sign-in (`lib/backup/restorePrompt`). The body has two forms because an
+     *  unlinked phone is about to be handed a Google consent sheet and must be
+     *  told so; the tap is the same either way. `restorePromptWhere` is what
+     *  makes declining cheap — it names where restore lives afterwards. */
+    restorePromptTitle: string;
+    restorePromptBody: string;
+    restorePromptBodyLink: string;
+    /** Spoken label for the primary, which reads only "Restore my data". */
+    restorePromptRestoreLabel: string;
+    restorePromptLater: string;
+    restorePromptLaterLabel: string;
+    restorePromptWhere: string;
+
     /** Why a run did nothing. Each one is a different way out. */
     refusedNotConnected: string;
     refusedNoKey: string;
@@ -4461,6 +4475,16 @@ const en: UiStrings = {
     restoreNeedsKey:
       'Enter the key from the phone that made this backup. A new key will not open it.',
 
+    restorePromptTitle: 'Bring your records back?',
+    restorePromptBody:
+      'There is nothing on this phone yet. Your Google Drive backup can put your personal records back.',
+    restorePromptBodyLink:
+      'There is nothing on this phone yet. Link your Google Drive and Waves will put your personal records back.',
+    restorePromptRestoreLabel: 'Restore my records from the Google Drive backup',
+    restorePromptLater: 'Not now',
+    restorePromptLaterLabel: 'Not now. Restore later from the Backup screen.',
+    restorePromptWhere: 'You can do this later: tap the ••• menu on Home, then Backup.',
+
     refusedNotConnected: 'Link a Google account first.',
     refusedNoKey: 'Create your backup key first.',
     refusedNeedsKey: 'That backup is under extra protection. Only its key opens it.',
@@ -7082,6 +7106,18 @@ const ta: UiStrings = {
     restoreIsExtra:
       'இந்தக் காப்பு கூடுதல் பாதுகாப்பில் உள்ளது. அதை உருவாக்கிய ஃபோனின் சாவியை உள்ளிடுங்கள்; புதிய சாவி அதைத் திறக்காது.',
     restoreNeedsKey: 'காப்பு எடுத்த ஃபோனின் சாவியை உள்ளிடுங்கள். புதிய சாவி அதைத் திறக்காது.',
+
+    restorePromptTitle: 'உங்கள் பதிவுகளைத் திரும்பக் கொண்டுவரவா?',
+    restorePromptBody:
+      'இந்த ஃபோனில் இன்னும் எதுவும் இல்லை. உங்கள் Google Drive காப்பு உங்கள் தனிப்பட்ட பதிவுகளைத் திரும்பக் கொண்டுவரும்.',
+    restorePromptBodyLink:
+      'இந்த ஃபோனில் இன்னும் எதுவும் இல்லை. உங்கள் Google Drive-ஐ இணையுங்கள்; Waves உங்கள் தனிப்பட்ட பதிவுகளைத் திரும்பக் கொண்டுவரும்.',
+    restorePromptRestoreLabel: 'Google Drive காப்பிலிருந்து என் பதிவுகளை மீட்டெடு',
+    restorePromptLater: 'இப்போது வேண்டாம்',
+    restorePromptLaterLabel:
+      'இப்போது வேண்டாம். பின்னர் காப்புப்பிரதி திரையிலிருந்து மீட்டெடுக்கலாம்.',
+    restorePromptWhere:
+      'இதைப் பின்னரும் செய்யலாம்: முகப்பில் ••• மெனுவைத் தட்டி, காப்புப்பிரதி என்பதைத் தேர்ந்தெடுங்கள்.',
 
     refusedNotConnected: 'முதலில் ஒரு Google கணக்கை இணையுங்கள்.',
     refusedNoKey: 'முதலில் உங்கள் காப்புச் சாவியை உருவாக்குங்கள்.',
@@ -9727,6 +9763,16 @@ const hi: UiStrings = {
     restoreIsExtra:
       'यह बैकअप अतिरिक्त सुरक्षा में है। जिस फ़ोन ने इसे बनाया था, उसी की चाबी डालें। नई चाबी इसे नहीं खोलेगी।',
     restoreNeedsKey: 'जिस फ़ोन ने यह बैकअप बनाया, उसी की चाबी डालें। नई चाबी इसे नहीं खोलेगी।',
+
+    restorePromptTitle: 'अपने रिकॉर्ड वापस लाएँ?',
+    restorePromptBody:
+      'इस फ़ोन पर अभी कुछ नहीं है। आपका Google Drive बैकअप आपके निजी रिकॉर्ड वापस ला सकता है।',
+    restorePromptBodyLink:
+      'इस फ़ोन पर अभी कुछ नहीं है। अपना Google Drive जोड़ें, Waves आपके निजी रिकॉर्ड वापस ले आएगा।',
+    restorePromptRestoreLabel: 'Google Drive बैकअप से मेरे रिकॉर्ड वापस लाएँ',
+    restorePromptLater: 'अभी नहीं',
+    restorePromptLaterLabel: 'अभी नहीं। बाद में बैकअप स्क्रीन से वापस ला सकते हैं।',
+    restorePromptWhere: 'यह बाद में भी कर सकते हैं: होम पर ••• मेन्यू दबाएँ, फिर बैकअप चुनें।',
 
     refusedNotConnected: 'पहले एक Google खाता जोड़ें।',
     refusedNoKey: 'पहले अपनी बैकअप चाबी बनाएँ।',
@@ -12427,6 +12473,17 @@ const ar: UiStrings = {
     restoreIsExtra:
       'هذه النسخة تحت الحماية الإضافية. أدخل المفتاح من الهاتف الذي أنشأها؛ المفتاح الجديد لن يفتحها.',
     restoreNeedsKey: 'أدخل مفتاح الهاتف الذي أنشأ هذه النسخة. المفتاح الجديد لن يفتحها.',
+
+    restorePromptTitle: 'هل تريد استعادة سجلاتك؟',
+    restorePromptBody:
+      'لا يوجد شيء على هذا الهاتف بعد. يمكن لنسخة Google Drive الاحتياطية إعادة سجلاتك الخاصة.',
+    restorePromptBodyLink:
+      'لا يوجد شيء على هذا الهاتف بعد. اربط حساب Google Drive وستعيد Waves سجلاتك الخاصة.',
+    restorePromptRestoreLabel: 'استعادة سجلاتي من نسخة Google Drive الاحتياطية',
+    restorePromptLater: 'ليس الآن',
+    restorePromptLaterLabel: 'ليس الآن. يمكنك الاستعادة لاحقًا من شاشة النسخ الاحتياطي.',
+    restorePromptWhere:
+      'يمكنك فعل ذلك لاحقًا: اضغط قائمة ••• في الصفحة الرئيسية، ثم النسخ الاحتياطي.',
 
     refusedNotConnected: 'اربط حساب Google أولًا.',
     refusedNoKey: 'أنشئ مفتاح النسخة أولًا.',

--- a/apps/mobile/src/lib/backup/restorePrompt.ts
+++ b/apps/mobile/src/lib/backup/restorePrompt.ts
@@ -1,0 +1,126 @@
+/**
+ * Whether the dashboard should offer, once, to bring a backup back.
+ *
+ * ## The moment this exists for
+ *
+ * Signing in on a new phone — or after a reinstall, or after signing out and
+ * back in — lands somebody on the dashboard with a Waves that knows nothing
+ * about them. The shared ledger comes back from the server on its own, but the
+ * private "Me" ledger's other copy is the person's own Drive backup, and until
+ * now nothing on the way in ever mentioned it: the only route to the restore
+ * was to already know it was there — ••• on Home, then Backup — and to go
+ * looking before entering anything, which is the order nobody does things in.
+ *
+ * ## The failure mode this module is shaped around
+ *
+ * The dangerous version of this feature is not the one that fails to appear. It
+ * is the one that appears for somebody whose phone already holds their ledger —
+ * a returning user, opening Home on an ordinary Tuesday, asked whether they
+ * would like their data back. That reads as "Waves has lost your records", and
+ * it is why every condition below is a reason *not* to ask.
+ *
+ * So the offer stands on a conjunction of four claims, and the ones that can be
+ * wrong-for-a-moment are excluded by `settled` rather than raced:
+ *
+ * 1. **This phone holds nothing.** `recordCount` is the same count the Backup
+ *    screen's `restoreFirst` uses, from the same mirror. One record and the
+ *    question is not ours to ask.
+ * 2. **We have actually looked.** `settled` is "the mirror is off disk *and*
+ *    this session's first sync has landed or given up". Without the second half
+ *    the count is zero for every user for the length of a network round trip,
+ *    which is exactly long enough to flash the offer at somebody with four
+ *    hundred records. The personal ledger rides the ordinary sync pull (its own
+ *    `:personal` scope, fetched on every sync), so a returning phone's records
+ *    arrive with that first pull and close the gate by themselves.
+ * 3. **This build can reach Drive at all.** With no OAuth client id every
+ *    restore path in the app refuses with `not-configured`, so an offer here
+ *    would be a button that cannot work — worse than silence, because it names
+ *    a backup the person may then go hunting for.
+ * 4. **Nobody has answered yet.** See below.
+ *
+ * Guests are left out on purpose. A guest's records live under an anonymous id
+ * that has never had a Drive backup — there is by construction nothing to
+ * bring back — and the guest already has a prompt of its own on that screen.
+ *
+ * ## Being unlinked is not a reason to stay quiet
+ *
+ * A phone with no Google account linked is the *most* likely one to want this:
+ * it is what a new phone looks like. So the link is a step inside the answer,
+ * not a condition on the question, and the only thing it changes is which
+ * sentence the offer carries — `LinkFirst` says a Google consent sheet is
+ * coming, because being handed one unannounced is how a restore turns into
+ * "why is it asking for my Google account".
+ *
+ * ## What "dismissed" means, and for how long
+ *
+ * **Until the next sign-in on this device, for this account.** The flag is
+ * written under the owner's id in the same AsyncStorage the rest of the backup
+ * settings use, so it survives an app restart and a hundred dashboard renders,
+ * and B signing in after A on a shared phone inherits nothing of A's. It also
+ * rides `clearBackupSettings`, which sign-out wipes — so signing out and back
+ * in asks once more.
+ *
+ * That is the honest boundary. A dismissal that lasted forever would be wrong
+ * at the one moment this feature exists for: somebody who says "not now" on
+ * their old phone, then sets a new one up months later, must be asked there.
+ * One that came back daily would be the nag this module is written to avoid.
+ * Signing in is the event that means "this device is starting fresh for me",
+ * and it is the only event that re-arms the question.
+ *
+ * Taking the offer counts as answering it, not only declining. Somebody who
+ * taps through has been asked, and the Backup screen is where every outcome of
+ * that tap — found, nothing there, needs a key — is reported and retried.
+ * Coming back to a second identical popup because the scan found nothing would
+ * be the app asking the same question twice.
+ *
+ * ## Where restore stays reachable
+ *
+ * It is not hidden behind this prompt and never was: the dashboard's ••• menu
+ * carries a Backup row, and on a phone holding nothing that screen leads with
+ * "Restore my data" (`restoreFirst`). The dismissal copy names that route, so
+ * "not now" is a postponement with an address rather than a door closing.
+ *
+ * Pure, and tested without a renderer, for the same reason `setup.ts` is: the
+ * conditions above are the whole feature, and every one of them is a sentence
+ * about somebody's data that must not be got wrong.
+ */
+
+/** What, if anything, the dashboard puts on screen. */
+export enum RestoreOffer {
+  /** Say nothing. The overwhelmingly common answer. */
+  None = 'none',
+  /** An account is linked: the tap goes straight to looking for a backup. */
+  Restore = 'restore',
+  /** Nothing linked: the same tap, with the consent sheet announced first. */
+  LinkFirst = 'link-first',
+}
+
+/** What the dashboard knows that bears on whether to make the offer. */
+export interface RestorePromptInput {
+  readonly signedIn: boolean;
+  /** Guests have no Drive backup to restore, by construction. */
+  readonly isGuest: boolean;
+  /** False when this build carries no OAuth client id for the provider. */
+  readonly configured: boolean;
+  /** Whether a Google account is linked. Chooses the copy, never the answer. */
+  readonly connected: boolean;
+  /** Personal records this phone holds right now. */
+  readonly recordCount: number;
+  /**
+   * The mirror has been read off disk *and* this session's first sync has
+   * settled (landed, or stopped for want of a network). Until then a zero count
+   * means "we have not looked", not "there is nothing".
+   */
+  readonly settled: boolean;
+  /** This account has already answered the offer on this device. */
+  readonly dismissed: boolean;
+}
+
+export function restoreOffer(input: RestorePromptInput): RestoreOffer {
+  if (!input.settled) return RestoreOffer.None;
+  if (!input.signedIn || input.isGuest) return RestoreOffer.None;
+  if (!input.configured) return RestoreOffer.None;
+  if (input.dismissed) return RestoreOffer.None;
+  if (input.recordCount > 0) return RestoreOffer.None;
+  return input.connected ? RestoreOffer.Restore : RestoreOffer.LinkFirst;
+}

--- a/apps/mobile/src/lib/backup/settings.ts
+++ b/apps/mobile/src/lib/backup/settings.ts
@@ -41,9 +41,24 @@ const KEY_SEEN_KEY = 'waves.backup.key_seen';
  * apart, and why the caller writes the answer down the first time it asks.
  */
 const TIER_KEY = 'waves.backup.tier';
+/**
+ * Set once this account has answered the dashboard's offer to restore — by
+ * taking it or by declining it, which are the same answer to "shall I ask?".
+ * It lives here rather than beside the prompt so it joins `ALL_KEYS` below and
+ * is therefore wiped by sign-out, which is what bounds the dismissal to this
+ * sign-in. See `restorePrompt.ts` for why that is the right boundary.
+ */
+const RESTORE_PROMPT_KEY = 'waves.backup.restore_prompt';
 
 /** Every stored key, for the sign-out wipe. */
-const ALL_KEYS = [FREQUENCY_KEY, NETWORK_KEY, LAST_KEY, KEY_SEEN_KEY, TIER_KEY] as const;
+const ALL_KEYS = [
+  FREQUENCY_KEY,
+  NETWORK_KEY,
+  LAST_KEY,
+  KEY_SEEN_KEY,
+  TIER_KEY,
+  RESTORE_PROMPT_KEY,
+] as const;
 
 const scoped = (base: string, ownerId: string): string => `${base}.${ownerId}`;
 
@@ -164,6 +179,25 @@ export async function saveLastBackup(ownerId: string, last: LastBackup): Promise
 export async function markKeySeen(ownerId: string): Promise<void> {
   if (!ownerId) return;
   await AsyncStorage.setItem(scoped(KEY_SEEN_KEY, ownerId), '1');
+}
+
+/**
+ * Whether the restore offer has been answered for this account on this device.
+ *
+ * Deliberately not folded into `BackupSettings`: that object is read by the
+ * Backup screen and the sign-out guard on every open, and neither of them has
+ * any business knowing what the dashboard has already asked. A one-key read is
+ * also all the dashboard wants, and it wants it before it paints.
+ */
+export async function loadRestorePromptDismissed(ownerId: string): Promise<boolean> {
+  if (!ownerId) return false;
+  const raw = await AsyncStorage.getItem(scoped(RESTORE_PROMPT_KEY, ownerId)).catch(() => null);
+  return raw === '1';
+}
+
+export async function markRestorePromptDismissed(ownerId: string): Promise<void> {
+  if (!ownerId) return;
+  await AsyncStorage.setItem(scoped(RESTORE_PROMPT_KEY, ownerId), '1');
 }
 
 /**

--- a/apps/mobile/test/restorePrompt.test.ts
+++ b/apps/mobile/test/restorePrompt.test.ts
@@ -1,0 +1,173 @@
+/**
+ * The dashboard's one-time offer to bring a Drive backup back.
+ *
+ * The happy path is the least interesting thing here. What is worth pinning
+ * down is every way the offer must *not* be made — because the failure that
+ * matters is not a prompt that never appears, it is one that asks somebody with
+ * four hundred records whether they have lost their data. So most of this file
+ * is about silence: a phone that already holds a ledger, a build that cannot
+ * reach Drive, a count read before anything has been looked at, and an answer
+ * that has to outlive an app restart.
+ *
+ * The dismissal half is exercised against the real store rather than a fake,
+ * because "it sticks" is a claim about AsyncStorage keys and their owner
+ * scoping, and a fake would be asserting that the test's own map works.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `settings.ts` reaches the sync-network module, which imports expo-network for
+// a type-level enum. Nothing here touches a network; this only has to load.
+vi.mock('expo-network', () => ({
+  NetworkStateType: { WIFI: 'wifi', CELLULAR: 'cellular', NONE: 'none' },
+}));
+
+import type { RestorePromptInput } from '../src/lib/backup/restorePrompt';
+
+const { restoreOffer, RestoreOffer } = await import('../src/lib/backup/restorePrompt');
+const AsyncStorage = (await import('@react-native-async-storage/async-storage')).default;
+const { clearBackupSettings, loadRestorePromptDismissed, markRestorePromptDismissed } =
+  await import('../src/lib/backup/settings');
+
+/** A signed-in, non-guest, Drive-capable phone that has been fully read. */
+const READY: RestorePromptInput = {
+  signedIn: true,
+  isGuest: false,
+  configured: true,
+  connected: true,
+  recordCount: 0,
+  settled: true,
+  dismissed: false,
+};
+
+const offer = (overrides: Partial<RestorePromptInput> = {}) =>
+  restoreOffer({ ...READY, ...overrides });
+
+describe('a phone that already holds the ledger', () => {
+  it('is asked nothing at all', () => {
+    // The one that matters. A returning user opening Home must never be asked
+    // whether they would like their records back — it reads as the app having
+    // lost them.
+    expect(offer({ recordCount: 1 })).toBe(RestoreOffer.None);
+    expect(offer({ recordCount: 412 })).toBe(RestoreOffer.None);
+  });
+
+  it('is asked nothing even with no Drive account linked', () => {
+    // Having data beats every other consideration, including the one state that
+    // most looks like a fresh phone.
+    expect(offer({ recordCount: 3, connected: false })).toBe(RestoreOffer.None);
+  });
+});
+
+describe('before anything has actually been looked at', () => {
+  it('says nothing, because a zero count is not yet a claim', () => {
+    // Between the mirror hydrating and the session's first sync landing, every
+    // phone in the world holds zero personal records. Asking in that window is
+    // how somebody with a full ledger gets the prompt.
+    expect(offer({ settled: false })).toBe(RestoreOffer.None);
+  });
+
+  it('still says nothing when everything else is exactly right', () => {
+    expect(offer({ settled: false, connected: false, recordCount: 0 })).toBe(RestoreOffer.None);
+  });
+});
+
+describe('a build with no Drive client id', () => {
+  it('offers nothing, rather than a restore that cannot happen', () => {
+    // Every restore path in the app refuses this build with `not-configured`.
+    // An offer here would name a backup and then be unable to reach it, which
+    // is worse than silence.
+    expect(offer({ configured: false })).toBe(RestoreOffer.None);
+    expect(offer({ configured: false, connected: false })).toBe(RestoreOffer.None);
+  });
+});
+
+describe('who is asked', () => {
+  it('asks a signed-in person whose phone is empty', () => {
+    expect(offer()).toBe(RestoreOffer.Restore);
+  });
+
+  it('asks nobody when nobody is signed in', () => {
+    expect(offer({ signedIn: false })).toBe(RestoreOffer.None);
+  });
+
+  it('does not ask a guest, who has no backup to have made', () => {
+    // A guest's records live under an anonymous id that has never had a Drive
+    // backup; the question has no true answer for them.
+    expect(offer({ isGuest: true })).toBe(RestoreOffer.None);
+  });
+});
+
+describe('whether Drive is linked', () => {
+  it('changes the sentence, never the answer', () => {
+    // An unlinked phone is the *most* likely one to want this — it is what a new
+    // handset looks like — so the link is a step inside the answer, not a
+    // condition on the question.
+    expect(offer({ connected: true })).toBe(RestoreOffer.Restore);
+    expect(offer({ connected: false })).toBe(RestoreOffer.LinkFirst);
+  });
+
+  it('announces the consent sheet when there is nothing linked', () => {
+    // `LinkFirst` is what makes the copy say a Google account is about to be
+    // asked for. Being handed that sheet unannounced is how a restore turns
+    // into "why does it want my Google account".
+    expect(offer({ connected: false })).toBe(RestoreOffer.LinkFirst);
+  });
+});
+
+describe('an answer already given', () => {
+  it('is not asked again, whether or not Drive is linked', () => {
+    expect(offer({ dismissed: true })).toBe(RestoreOffer.None);
+    expect(offer({ dismissed: true, connected: false })).toBe(RestoreOffer.None);
+  });
+});
+
+// ─────────────────────────────────────────── the dismissal, on disk ──
+
+const A = 'aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa';
+const B = 'bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb';
+
+beforeEach(async () => {
+  await AsyncStorage.clear();
+});
+
+describe('dismissing it sticks', () => {
+  it('is remembered by a later read — the next render, open or sync', async () => {
+    // The whole of "it does not come back": every one of those is a fresh read
+    // of this key, and there is no in-memory state behind it to lose.
+    expect(await loadRestorePromptDismissed(A)).toBe(false);
+    await markRestorePromptDismissed(A);
+    expect(await loadRestorePromptDismissed(A)).toBe(true);
+    expect(await loadRestorePromptDismissed(A)).toBe(true);
+  });
+
+  it('belongs to the account and not to the phone', async () => {
+    // A shared handset: A saying "not now" must not silence the offer for B,
+    // who has their own backup and has never been asked.
+    await markRestorePromptDismissed(A);
+    expect(await loadRestorePromptDismissed(B)).toBe(false);
+  });
+
+  it('is asked again after a sign-out, which is the boundary it is bounded by', async () => {
+    // Deliberate, and the reason the flag lives with the backup settings rather
+    // than beside the prompt: `clearBackupSettings` is what sign-out runs, so a
+    // dismissal lasts until this device starts fresh for this person again.
+    await markRestorePromptDismissed(A);
+    await clearBackupSettings(A);
+    expect(await loadRestorePromptDismissed(A)).toBe(false);
+  });
+
+  it('leaves the other person’s answer alone when one of them signs out', async () => {
+    await markRestorePromptDismissed(A);
+    await markRestorePromptDismissed(B);
+    await clearBackupSettings(A);
+    expect(await loadRestorePromptDismissed(A)).toBe(false);
+    expect(await loadRestorePromptDismissed(B)).toBe(true);
+  });
+
+  it('writes and reads nothing for a signed-out caller', async () => {
+    await markRestorePromptDismissed('');
+    expect(await AsyncStorage.getAllKeys()).toEqual([]);
+    expect(await loadRestorePromptDismissed('')).toBe(false);
+  });
+});

--- a/packages/db/test/device-alert-and-digest.test.ts
+++ b/packages/db/test/device-alert-and-digest.test.ts
@@ -252,11 +252,11 @@ describe('the weekly digest', () => {
     expect(digest!.payload).toMatchObject({ count: '1', currency: 'INR' });
   });
 
-  it('counts payer-only financers and share-only riders/travellers, not bystander users', async () => {
-    const group = await seedGroup(client, { memberCount: 4 });
-    const [financerProfile, riderProfile, travellerProfile, bystanderProfile] =
-      group.profileIds as [string, string, string, string];
-    const [financer, rider, traveller] = group.memberIds as [string, string, string, string];
+  it('counts the authoring user, payer-only financers, and share-only riders/travellers, but not bystanders', async () => {
+    const group = await seedGroup(client, { memberCount: 5 });
+    const [userProfile, financerProfile, riderProfile, travellerProfile, bystanderProfile] =
+      group.profileIds as [string, string, string, string, string];
+    const [user, financer, rider, traveller] = group.memberIds as [string, string, string, string];
     for (const profileId of group.profileIds) {
       await setEmail(profileId, `${profileId}@example.test`);
       await optIn(profileId);
@@ -264,6 +264,7 @@ describe('the weekly digest', () => {
 
     await addSplitExpense(client, {
       groupId: group.groupId,
+      authorMemberId: user,
       payers: { [financer]: 12000n },
       participants: [rider, traveller],
       amount: 12000n,
@@ -273,13 +274,16 @@ describe('the weekly digest', () => {
 
     await runDigest();
 
+    expect(await digestsFor(userProfile)).toHaveLength(1);
     expect(await digestsFor(financerProfile)).toHaveLength(1);
     expect(await digestsFor(riderProfile)).toHaveLength(1);
     expect(await digestsFor(travellerProfile)).toHaveLength(1);
     expect(await digestsFor(bystanderProfile)).toHaveLength(0);
+    const [userDigest] = await digestsFor(userProfile);
     const [financerDigest] = await digestsFor(financerProfile);
     const [riderDigest] = await digestsFor(riderProfile);
     const [travellerDigest] = await digestsFor(travellerProfile);
+    expect(userDigest!.payload).toMatchObject({ count: '1', amount: '0' });
     expect(financerDigest!.payload).toMatchObject({ count: '1', amount: '12000' });
     expect(riderDigest!.payload).toMatchObject({ count: '1', amount: '-7000' });
     expect(travellerDigest!.payload).toMatchObject({ count: '1', amount: '-5000' });

--- a/packages/db/test/helpers.ts
+++ b/packages/db/test/helpers.ts
@@ -172,6 +172,8 @@ export async function addEqualSplitExpense(
 
 export interface AddSplitExpenseOptions {
   groupId: string;
+  /** The member who typed/imported the expense; defaults to the first participant. */
+  authorMemberId?: string;
   /** memberId → amount paid. Must sum to `amount`. */
   payers: Record<string, bigint>;
   /** The members the cost is split across — a subset of the group is fine, and
@@ -199,6 +201,7 @@ export async function addSplitExpense(
 ): Promise<{ expenseId: string; versionId: string; shares: Map<string, bigint> }> {
   const {
     groupId,
+    authorMemberId,
     payers,
     participants,
     amount,
@@ -209,6 +212,7 @@ export async function addSplitExpense(
     category = null,
   } = options;
 
+  const author = authorMemberId ?? participants[0] ?? null;
   const expenseId = randomUUID();
   const versionId = randomUUID();
   const shares = computeShares({ amount, currency, params, participants, seed: expenseId });
@@ -217,7 +221,7 @@ export async function addSplitExpense(
   await client.query(`INSERT INTO expenses (id, group_id, created_by) VALUES ($1, $2, $3)`, [
     expenseId,
     groupId,
-    participants[0] ?? null,
+    author,
   ]);
   await client.query(
     `INSERT INTO expense_versions
@@ -227,7 +231,7 @@ export async function addSplitExpense(
     [
       versionId,
       expenseId,
-      participants[0] ?? null,
+      author,
       description,
       category,
       date,


### PR DESCRIPTION
Signing in on a new handset — or after a reinstall, or after signing out and back in — landed people on a dashboard that knew nothing about them and never mentioned the copy of their private ledger sitting in their own Drive. The only route to a restore was knowing it was there: ••• on Home, then Backup, before entering anything. That is the order nobody does things in.

## What appears, and when

A centred popup on the dashboard, in the shared prompt queue at priority 90 — under the coach-mark tour, over the push soft-ask, the campaign card and the guest prompt, and 400ms behind whichever of those releases the screen.

- **Title** "Bring your records back?"
- **Body** one of two sentences. Linked: *"There is nothing on this phone yet. Your Google Drive backup can put your personal records back."* Not linked: *"…Link your Google Drive and Waves will put your personal records back."* An unlinked phone is about to be handed a Google consent sheet and is told so.
- **Primary** "Restore my data" (the same string the Backup screen's own restore-first button uses).
- **Ghost** "Not now".
- **Footnote** "You can do this later: tap the ••• menu on Home, then Backup." — which is true: that row exists and, on a phone holding nothing, the screen it opens leads with "Restore my data".

It appears only when **all** of these hold (`apps/mobile/src/lib/backup/restorePrompt.ts`):

1. this phone holds **zero** personal records;
2. the mirror is off disk **and** this session's first sync has landed or given up — before that, every phone in the world holds zero personal records, and that window is exactly wide enough to ask a returning user whether their data is gone;
3. the build has a Drive OAuth client id (`configured`) — otherwise the offer could not be carried out and the app says nothing;
4. somebody is signed in and is not a guest (a guest's records live under an anonymous id that has never had a backup);
5. this account has not already answered.

Whether Drive is linked is deliberately **not** a condition. An unlinked phone is the *most* likely one to want this; the link is a step inside the answer, and all it changes is the sentence.

## The tap

One tap. It marks the offer answered and pushes `/settings/backup?restore=<nonce>`; that screen, once its stored state has been read, links the Google account if nothing is linked and then runs `onCheckForBackup()` — the existing scan, with the existing confirmation sheet and the existing forks for "nothing on this Drive", "this backup wants its key", "the escrowed key is gone" and a dead grant.

**No second restore path was written.** Rebuilding the scan inside the popup would have meant a second copy of four failure forks to keep true about somebody's ledger. Restoring still writes through `applyRestore` → `personal.upsert` on the ordinary offline queue: upserts keyed by the record ids already in the backup, nothing deleted, nothing overwritten that was typed here. I found no path by which this change can destroy local data.

The nonce is consumed through a module-level `Set` copied from `capture.tsx`'s `consumedScans`, because Android recreates the JS activity on the way back from Google's consent screen and replays the same URL — a `useRef` guard would restart the link in a loop there.

## Dismissal persistence — the decision, stated

**Dismissed until the next sign-in on this device, for this account.**

- Written to `waves.backup.restore_prompt.<ownerId>` in AsyncStorage, so it survives an app restart, every later dashboard render and every sync.
- Owner-scoped, so B signing in after A on a shared phone inherits nothing of A's.
- Listed in `ALL_KEYS`, so `clearBackupSettings` — which sign-out and unlink already run — clears it.

Why that boundary and not "forever": somebody who says "not now" on their old phone and sets a new one up months later must be asked there. Why not "daily": that is the nag this whole module is written to avoid. Signing in is the one event that means "this device is starting fresh for me".

**Taking** the offer marks it answered too, not only declining. The Backup screen reports every outcome of that tap; coming back to a second identical popup because the scan found nothing would be the app asking the same question twice. Stated in the header comment of `restorePrompt.ts`.

## Accessibility

The primary carries `accessibilityLabel` "Restore my records from the Google Drive backup" (the visible label is only "Restore my data"); the ghost and the scrim both carry "Not now. Restore later from the Backup screen." `Button` already sets `accessibilityRole="button"`.

## i18n

Seven keys added under `backup` — the interface declaration plus all four tables (en, ta, hi, ar), each as one contiguous block anchored on `restoreNeedsKey` to keep the conflict with any parallel i18n work trivial. The footnote names the ••• menu in words rather than with an arrow glyph, so there is nothing directional to mirror in RTL; no chevrons or arrows were added.

## Gates

Run from the repo root, all green:

| Gate | Result |
| --- | --- |
| `pnpm format` | passed (it reformatted the files it touched; re-run clean) |
| `pnpm lint` | passed — 12 projects, 0 errors, 0 warnings |
| `pnpm --filter @waves/mobile typecheck` | passed — `tsc --noEmit`, no output |
| `pnpm --filter @waves/mobile test` | 100 files, 1343 tests passed (16 of them new) |
| `pnpm --filter @waves/core test` | 63 files, 986 tests passed |

`packages/db` tests were not run — they need a local Postgres that is not up, as instructed.

New tests (`apps/mobile/test/restorePrompt.test.ts`, 16): silent with 1 record and with 412; silent with records and no link; silent before the first sync settles; silent in an unconfigured build; silent for a guest and for nobody signed in; offers when linked-and-empty (`Restore`) and when unlinked-and-empty (`LinkFirst`); silent once dismissed. The dismissal half runs against the real store: it is remembered by later reads, is per-account, is cleared by `clearBackupSettings`, does not touch the other account, and writes nothing for a signed-out caller.

## Not done, deliberately

- **No device run.** Nothing here has been exercised on a handset; in particular the link-then-scan hand-off crosses Google's consent activity, which no test in this repo can stand in for.
- **The Backup screen was not redesigned.** The dismissal copy points at ••• → Backup, which is a real and currently accurate route. It is still two levels of chrome away from the dashboard, and if that turns out to be too quiet the fix belongs in the information architecture, not here.
- **Priority 90 puts this under the tour.** A first-ever install sees the coach marks first and this a beat later. Interrupting a coach-mark halfway seemed worse; a fresh sign-in on a phone that has already seen the tour is unaffected.
- **No spec amendment.** This is a new dashboard surface over existing backup machinery; whether it wants an ADR/TDR line is a call I have not made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jhzmZz5fkjnZZ14YxHGfS
