### PR TITLE
The web gets an Apple button, and signing in stops replacing a guest

### DIFF
--- a/apps/web/e2e/signin.spec.ts
+++ b/apps/web/e2e/signin.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 /**
  * The front door. With no session, `/` routes to the sign-in card (AppFrame),
- * which offers the three ways in ADR-006 names — Google, an email-and-password
+ * which offers the ways in ADR-006 names — Google, Apple, an email-and-password
  * account, and a passwordless email link — plus the note that an invite link is
  * the guest way in.
  *
@@ -12,10 +12,14 @@ import { test, expect } from '@playwright/test';
  * it.
  */
 test.describe('sign-in (the unauthenticated front door)', () => {
-  test('offers Google, password, and the email magic link', async ({ page }) => {
+  test('offers Google, Apple, password, and the email magic link', async ({ page }) => {
     await page.goto('/');
 
     await expect(page.getByRole('button', { name: /continue with google/i })).toBeVisible();
+    // Apple is a button with words, not a bare glyph: the mark is decorative
+    // and the accessible name is the sentence, so this query is also the
+    // assertion that a screen reader has something to announce.
+    await expect(page.getByRole('button', { name: /continue with apple/i })).toBeVisible();
     await expect(page.getByPlaceholder('you@email.com')).toBeVisible();
     await expect(page.getByPlaceholder('Password')).toBeVisible();
     await expect(page.getByRole('button', { name: /^sign in$/i })).toBeVisible();

--- a/apps/web/src/app/auth/callback/page.tsx
+++ b/apps/web/src/app/auth/callback/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * Where Google sends the browser back.
+ * Where a provider sends the browser back — Google, Apple, or a mailed link.
  *
  * The client is configured not to read the URL on its own
  * (`detectSessionInUrl: false` in lib/waves.ts) so this is the one place a
@@ -9,10 +9,30 @@
  * carrying its own token is never mistaken for a login. Once the session is
  * written, `onAuthChange` in the AuthProvider re-renders the app and we send
  * the person to the dashboard.
+ *
+ * Reading the URL is `readOAuthCallback`'s job, not a `get('code')` here, and
+ * the reason is that a redirect can mean three things rather than two. It used
+ * to mean two: a code, or "Missing authorization code". That third case is a
+ * redirect carrying neither a code nor an error, and it is what an identity
+ * *link* looks like — a guest attaching Google or Apple to the account they
+ * already have. Nothing is supposed to come back, because the session the
+ * identity was just added to is the one already in this browser. Treating that
+ * as a failure showed an error over a sign-in that had worked.
+ *
+ * The other two it settles properly as well. A provider that refuses answers
+ * with `error` and often `error_description`, sometimes in the fragment rather
+ * than the query, and a server misconfiguration comes back the same way — a
+ * stale OAuth client secret surfaces here as `server_error` /
+ * "Unable to exchange external code". None of that is shown to the reader:
+ * `friendlyError` keeps backend sentences off the page and sends them to
+ * Sentry, which is exactly where a message naming the real fault is wanted.
+ * "Missing authorization code" was not that message.
  */
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
+
+import { readOAuthCallback } from '@waves/core';
 
 import { supabase } from '@/lib/waves';
 import { useStrings } from '@/i18n-context';
@@ -26,10 +46,21 @@ export default function AuthCallback() {
   useEffect(() => {
     void (async () => {
       try {
-        const code = new URLSearchParams(window.location.search).get('code');
-        if (!code) throw new Error('Missing authorization code');
-        const { error: exchangeError } = await supabase.auth.exchangeCodeForSession(code);
-        if (exchangeError) throw exchangeError;
+        const callback = readOAuthCallback(window.location.href);
+        if (callback.kind === 'error') throw new Error(callback.message);
+        if (callback.kind === 'none') {
+          // A link that added an identity to the session already held, or —
+          // if there is no session — a round trip that came back with nothing
+          // at all. The first is a success with nothing left to do; the second
+          // is the failure the old "Missing authorization code" meant.
+          const { data } = await supabase.auth.getSession();
+          if (!data.session) throw new Error('Sign-in came back without a code');
+        } else {
+          const { error: exchangeError } = await supabase.auth.exchangeCodeForSession(
+            callback.code,
+          );
+          if (exchangeError) throw exchangeError;
+        }
         router.replace('/');
       } catch (caught) {
         setError(

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -640,6 +640,18 @@
     @apply border border-line-strong bg-white text-[#1f1f1f];
     box-shadow: 0 1px 2px rgb(0 0 0 / 0.05);
   }
+  /* Sign in with Apple, at Apple's colours rather than ours: black field, white
+     mark and white words. Fixed hex, not a theme token, for the same reason the
+     glyph beside it is fixed — this button is Apple's, and one that followed our
+     palette would stop being the button their guidelines describe. It keeps the
+     shared .btn geometry, so it and the Google button above it are the same
+     size and corner, which is the other half of what those guidelines ask. */
+  .btn.apple {
+    @apply border border-black bg-black text-white;
+  }
+  .btn.apple:hover {
+    @apply bg-[#1a1a1a];
+  }
 
   .split-input {
     @apply flex items-center gap-[10px] border-t border-line py-2;

--- a/apps/web/src/components/SignIn.tsx
+++ b/apps/web/src/components/SignIn.tsx
@@ -1,10 +1,16 @@
 'use client';
 
 /**
- * The door for a real user: Google, an email-and-password account, or a
+ * The door for a real user: Google, Apple, an email-and-password account, or a
  * passwordless email link (ADR-006 names them). A guest with an invite link
  * does not come through here at all — they open the link and the anonymous
  * session is minted for them.
+ *
+ * Apple was here on the phone long before it was here. The app has a native
+ * sheet to present and this does not, which is the whole of the difference:
+ * both end up at the same Supabase provider, and the Services id that flow uses
+ * has been configured and working on the project for months. What was missing
+ * was a button.
  *
  * Which Supabase call the password form makes — sign up, sign in, or upgrade a
  * guest in place — is decided by @waves/core inside the client, never guessed
@@ -45,10 +51,59 @@ function validationWords(caught: unknown, t: WebStrings): string | null {
   }
 }
 
+/**
+ * The two provider marks, drawn rather than lettered.
+ *
+ * The Google button used to carry a bare capital "G". That was fine while it
+ * stood alone and merely looked homemade; beside an Apple button it stops being
+ * a matter of taste. Both brands publish rules for their sign-in buttons, and
+ * both rules are about the mark: Apple's require their own glyph, white on a
+ * black button, and Google's require the four-colour G on white behind a
+ * hairline. A letter typed in the page font is neither.
+ *
+ * Same paths as the app's `SocialTile`, at fixed hex for the same reason given
+ * there — a brand glyph that followed our palette would no longer be the brand
+ * glyph. `aria-hidden`, because the button's own words are its name; a reader
+ * that announced "G, Continue with Google" would say it twice.
+ */
+function GoogleMark() {
+  return (
+    <svg width={18} height={18} viewBox="0 0 48 48" aria-hidden focusable="false">
+      <path
+        fill="#4285F4"
+        d="M45.12 24.5c0-1.56-.14-3.06-.4-4.5H24v8.51h11.84c-.51 2.75-2.06 5.08-4.39 6.64v5.52h7.11c4.16-3.83 6.56-9.47 6.56-16.17z"
+      />
+      <path
+        fill="#34A853"
+        d="M24 46c5.94 0 10.92-1.97 14.56-5.33l-7.11-5.52c-1.97 1.32-4.49 2.1-7.45 2.1-5.73 0-10.58-3.87-12.31-9.07H4.34v5.7C7.96 41.07 15.4 46 24 46z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M11.69 28.18C11.25 26.86 11 25.45 11 24s.25-2.86.69-4.18v-5.7H4.34C2.85 17.09 2 20.45 2 24s.85 6.91 2.34 9.88l7.35-5.7z"
+      />
+      <path
+        fill="#EA4335"
+        d="M24 10.75c3.23 0 6.13 1.11 8.41 3.29l6.31-6.31C34.91 4.18 29.93 2 24 2 15.4 2 7.96 6.93 4.34 14.12l7.35 5.7c1.73-5.2 6.58-9.07 12.31-9.07z"
+      />
+    </svg>
+  );
+}
+
+function AppleMark() {
+  return (
+    <svg width={18} height={18} viewBox="0 0 24 24" aria-hidden focusable="false">
+      <path
+        fill="#FFFFFF"
+        d="M17.05 12.54c-.02-2.2 1.8-3.26 1.88-3.31-1.03-1.5-2.63-1.71-3.19-1.73-1.36-.14-2.65.8-3.34.8-.69 0-1.75-.78-2.88-.76-1.48.02-2.85.86-3.61 2.19-1.54 2.67-.39 6.62 1.1 8.79.73 1.06 1.6 2.25 2.74 2.21 1.1-.04 1.51-.71 2.84-.71 1.32 0 1.7.71 2.86.69 1.18-.02 1.93-1.08 2.65-2.15.84-1.23 1.18-2.42 1.2-2.48-.03-.01-2.29-.88-2.31-3.49zM14.86 5.62c.61-.74 1.02-1.77.91-2.8-.88.04-1.94.59-2.57 1.32-.56.65-1.06 1.7-.93 2.7.98.08 1.98-.5 2.59-1.22z"
+      />
+    </svg>
+  );
+}
+
 export function SignIn() {
   const { t } = useStrings();
-  const { signInWithGoogle, signInWithEmail, withPassword } = useAuth();
-  const [busy, setBusy] = useState<null | 'google' | 'password' | 'link'>(null);
+  const { signInWithGoogle, signInWithApple, signInWithEmail, withPassword } = useAuth();
+  const [busy, setBusy] = useState<null | 'google' | 'apple' | 'password' | 'link'>(null);
   const [mode, setMode] = useState<'sign_in' | 'sign_up'>('sign_in');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -64,6 +119,23 @@ export function SignIn() {
       setBusy(null);
       setError(
         friendlyError(caught, 'web.signIn.google', {
+          fallback: t.errors.couldNotSignIn,
+          offline: t.errors.offline,
+          tooMany: t.errors.tooMany,
+        }),
+      );
+    }
+  }
+
+  async function onApple() {
+    setBusy('apple');
+    setError(null);
+    try {
+      await signInWithApple(); // navigates away; no return
+    } catch (caught) {
+      setBusy(null);
+      setError(
+        friendlyError(caught, 'web.signIn.apple', {
           fallback: t.errors.couldNotSignIn,
           offline: t.errors.offline,
           tooMany: t.errors.tooMany,
@@ -147,14 +219,31 @@ export function SignIn() {
           <>
             <p>{t.dash.signInBody}</p>
 
+            {/*
+              Google first, Apple second, on every platform.
+
+              The app reorders these — Apple leads on iOS, where its guidelines
+              want it at least as prominent as its neighbours — but the app
+              knows what it is running on before it draws anything. This is
+              server-rendered: a platform sniff here would produce one order on
+              the server and possibly another in the browser, and React would
+              throw the markup away and redraw. The guideline is satisfied
+              without reordering, because both are the same full-width pill at
+              the same size and corner; only the order is fixed.
+            */}
             <button
               type="button"
               className="btn google"
               onClick={onGoogle}
               disabled={busy !== null}
             >
-              <span aria-hidden>G</span>
+              <GoogleMark />
               {busy === 'google' ? t.dash.signingIn : t.dash.continueWithGoogle}
+            </button>
+
+            <button type="button" className="btn apple" onClick={onApple} disabled={busy !== null}>
+              <AppleMark />
+              {busy === 'apple' ? t.dash.signingIn : t.dash.continueWithApple}
             </button>
 
             <div className="signin-or">{t.dash.orDivider}</div>

--- a/apps/web/src/i18n.ts
+++ b/apps/web/src/i18n.ts
@@ -214,6 +214,7 @@ export interface WebStrings {
     signInTitle: string;
     signInBody: string;
     continueWithGoogle: string;
+    continueWithApple: string;
     orDivider: string;
     emailPlaceholder: string;
     passwordPlaceholder: string;
@@ -667,6 +668,7 @@ const en: WebStrings = {
     signInTitle: 'Waves',
     signInBody: 'Split expenses without the argument at the end.',
     continueWithGoogle: 'Continue with Google',
+    continueWithApple: 'Continue with Apple',
     orDivider: 'or',
     emailPlaceholder: 'you@email.com',
     passwordPlaceholder: 'Password',
@@ -1136,6 +1138,7 @@ const ta: WebStrings = {
     signInTitle: 'Waves',
     signInBody: 'கடைசியில் வாக்குவாதம் இல்லாமல் செலவுகளைப் பிரியுங்கள்.',
     continueWithGoogle: 'Google மூலம் தொடரவும்',
+    continueWithApple: 'Apple மூலம் தொடரவும்',
     orDivider: 'அல்லது',
     emailPlaceholder: 'you@email.com',
     passwordPlaceholder: 'கடவுச்சொல்',
@@ -1613,6 +1616,7 @@ const hi: WebStrings = {
     signInTitle: 'Waves',
     signInBody: 'आख़िर में बहस किए बिना खर्च बाँटें।',
     continueWithGoogle: 'Google से जारी रखें',
+    continueWithApple: 'Apple से जारी रखें',
     orDivider: 'या',
     emailPlaceholder: 'you@email.com',
     passwordPlaceholder: 'पासवर्ड',
@@ -2092,6 +2096,7 @@ const ar: WebStrings = {
     signInTitle: 'Waves',
     signInBody: 'قسّموا المصاريف دون خلاف في النهاية.',
     continueWithGoogle: 'المتابعة عبر Google',
+    continueWithApple: 'المتابعة عبر Apple',
     orDivider: 'أو',
     emailPlaceholder: 'you@email.com',
     passwordPlaceholder: 'كلمة المرور',

--- a/apps/web/src/lib/auth.tsx
+++ b/apps/web/src/lib/auth.tsx
@@ -32,6 +32,7 @@ interface AuthValue {
   isGuest: boolean;
   loading: boolean;
   signInWithGoogle: () => Promise<void>;
+  signInWithApple: () => Promise<void>;
   signInWithEmail: (email: string) => Promise<void>;
   withPassword: (email: string, password: string, intent: 'sign_in' | 'sign_up') => Promise<void>;
   signOut: () => Promise<void>;
@@ -69,6 +70,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     await waves.signInWithGoogle(`${window.location.origin}/auth/callback`);
   }, []);
 
+  const signInWithApple = useCallback(async () => {
+    // Apple's own round trip is `form_post` to Supabase, not to us, so by the
+    // time the browser is handed back it looks exactly like Google's: the same
+    // callback route, the same one-time code. Nothing here is Apple-shaped.
+    await waves.signInWithApple(`${window.location.origin}/auth/callback`);
+  }, []);
+
   const signInWithEmail = useCallback(async (email: string) => {
     // The mailed link lands on the same callback route as Google does.
     await waves.signInWithEmail(email, `${window.location.origin}/auth/callback`);
@@ -94,11 +102,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       isGuest: session?.user.is_anonymous === true,
       loading,
       signInWithGoogle,
+      signInWithApple,
       signInWithEmail,
       withPassword,
       signOut,
     }),
-    [session, loading, signInWithGoogle, signInWithEmail, withPassword, signOut],
+    [session, loading, signInWithGoogle, signInWithApple, signInWithEmail, withPassword, signOut],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -22,6 +22,7 @@ import {
   AuthMethod,
   buildExpenseWriteBody,
   checkPassword,
+  OAuthMethod,
   planAuth,
   readIdentifier,
   type CategoryMeta,
@@ -137,6 +138,61 @@ export function createWavesClient({ supabase }: WavesClientOptions) {
     return data as T;
   }
 
+  /**
+   * Who is signed in right now, in the shape @waves/core's `planAuth` reads.
+   *
+   * Asked fresh each time rather than remembered. Between one button and the
+   * next an invite link opened in another tab may have minted a guest, and a
+   * stale `nobody` here is the whole difference between upgrading that account
+   * and quietly replacing it.
+   */
+  async function currentViewer(): Promise<Viewer> {
+    const { data } = await supabase.auth.getSession();
+    const user = data.session?.user;
+    if (!user) return { kind: 'nobody' };
+    return user.is_anonymous === true
+      ? { kind: 'guest', userId: user.id }
+      : { kind: 'user', userId: user.id };
+  }
+
+  /**
+   * Start a provider sign-in — and make it the *right* one.
+   *
+   * This was a single `signInWithOAuth` for a long time, whatever the session.
+   * On the sign-in card that is correct, because there is nobody to lose. On
+   * the two places the web client actually offers it — the guest banner and
+   * the guest panel in settings, both of which say in so many words that
+   * signing in is how you keep what you have — it was exactly backwards.
+   * `signInWithOAuth` under an anonymous session does not attach the provider
+   * to that account; it signs into a different one. The guest's groups are not
+   * deleted, they are simply somebody else's now, and the anonymous session
+   * that was the only route back has just been overwritten. Nothing errors,
+   * and nothing on screen suggests anything happened at all.
+   *
+   * So the choice is not made here. `planAuth` makes it — @waves/core sets out
+   * why at length — and this performs it: `linkIdentity` for anybody already
+   * signed in, guest or not, and `signInWithOAuth` only for nobody.
+   *
+   * Both navigate the browser away, so there is no success to return. Note
+   * what that costs the caller, because it is not obvious: `linkIdentity`
+   * comes back to `redirectTo` with **no code**, since the session it just
+   * attached an identity to is the one already in this browser. A callback
+   * route that reads an empty redirect as a failure will therefore report an
+   * error on the one path that worked.
+   */
+  async function startOAuth(method: OAuthMethod, redirectTo: string): Promise<void> {
+    const isGoogle = method === OAuthMethod.Google;
+    const action = planAuth(await currentViewer(), isGoogle ? AuthMethod.Google : AuthMethod.Apple);
+    // A string enum is nominal to TypeScript and supabase-js wants its own
+    // `Provider` union, so the one crossing between the two lives here.
+    const provider = isGoogle ? 'google' : 'apple';
+    const { error } =
+      action.call === 'linkIdentity'
+        ? await supabase.auth.linkIdentity({ provider, options: { redirectTo } })
+        : await supabase.auth.signInWithOAuth({ provider, options: { redirectTo } });
+    if (error) throw new WavesApiError(error.message);
+  }
+
   return {
     /**
      * A guest is a real account with no credentials on it yet (ADR-006). It is
@@ -154,19 +210,36 @@ export function createWavesClient({ supabase }: WavesClientOptions) {
     /**
      * The real login (ADR-006 names Google among the upgrade providers). An
      * anonymous guest who does this keeps the same user id, so the groups and
-     * expenses made as a guest come with them — Supabase links the identity in
-     * place rather than minting a second account.
+     * expenses made as a guest come with them — which is `startOAuth`'s doing,
+     * not something Supabase arranges on its own.
      *
-     * Returns nothing useful: `signInWithOAuth` navigates the browser to
-     * Google and control does not come back here — it comes back to
-     * `redirectTo` with the session in the URL.
+     * Returns nothing useful: the call navigates the browser to Google, and
+     * control does not come back here — it comes back to `redirectTo`.
      */
     async signInWithGoogle(redirectTo: string): Promise<void> {
-      const { error } = await supabase.auth.signInWithOAuth({
-        provider: 'google',
-        options: { redirectTo },
-      });
-      if (error) throw new WavesApiError(error.message);
+      await startOAuth(OAuthMethod.Google, redirectTo);
+    },
+
+    /**
+     * The same door, through Apple.
+     *
+     * On a phone this is Apple's own sheet and an identity token
+     * (`appleNativeSignIn` in the app); a browser has no sheet, so it is the
+     * ordinary redirect Google already uses. Apple answers that one with
+     * `response_mode=form_post` to Supabase's own `/auth/v1/callback`, which
+     * then sends the browser on to `redirectTo` carrying the same one-time
+     * code — so nothing downstream of here has to know which provider it was.
+     *
+     * One thing genuinely differs, and it stays invisible until somebody's
+     * name is blank: Apple hands over a display name on the **first**
+     * authorization only, and on the web that name is posted to Supabase
+     * rather than to this client. There is no web equivalent of the app's
+     * `persistAppleName`, and no second authorization to recover it from, so
+     * somebody whose very first Waves sign-in was Apple-in-a-browser arrives
+     * with a name still to fill in.
+     */
+    async signInWithApple(redirectTo: string): Promise<void> {
+      await startOAuth(OAuthMethod.Apple, redirectTo);
     },
 
     /**
@@ -206,13 +279,7 @@ export function createWavesClient({ supabase }: WavesClientOptions) {
       const method = who.kind === 'email' ? AuthMethod.EmailPassword : AuthMethod.PhonePassword;
       const credential = who.kind === 'email' ? { email: who.value } : { phone: who.value };
 
-      const { data } = await supabase.auth.getSession();
-      const viewer: Viewer = !data.session?.user
-        ? { kind: 'nobody' }
-        : data.session.user.is_anonymous === true
-          ? { kind: 'guest', userId: data.session.user.id }
-          : { kind: 'user', userId: data.session.user.id };
-      const action = planAuth(viewer, method, intent);
+      const action = planAuth(await currentViewer(), method, intent);
 
       if (action.call === 'updateUser') {
         // The upgrade: same user id, so the groups stay put (ADR-006).


### PR DESCRIPTION
Two separate faults were reported together — Google sign-in failing on the web, and no Apple sign-in on the web at all. They have nothing in common. One is a server configuration I cannot fix from here; the other was a missing button.

## Google: configuration, not code — and it still needs you

**Diagnosis: the OAuth client secret stored on the Supabase project is stale.** The web client uses Supabase's hosted flow, which exchanges an authorization code at Google's token endpoint using a client id *and its secret*. Native uses `signInWithIdToken`, which needs only the audience — which is why the phone keeps working while the browser does not.

Evidence, gathered without changing anything:

| Check | Result |
|---|---|
| `external_google_client_id` on prod | `484909326858-1va1lbsiba9chuouu8e3m7u9bbivoj02…` (primary), then `654054834944-jjuc5oh…` |
| Is the stored secret the new client's? | **No.** The Management API returns the secret as a SHA-256 hash; it does not match the hash of the secret in the JSON you uploaded. |
| Old client, redirect URI registered? | **Yes** — an authorize probe returns Google's real sign-in page, so authorization starts fine and the failure is at the *exchange*. |
| New client's secret valid at Google? | **Yes** — probing `oauth2.googleapis.com/token` with a bogus code returns `invalid_grant`, not `invalid_client`. |
| New client, redirect URI registered? | **No** — the same probe returns `redirect_uri_mismatch`. |

Together with the previously recorded GoTrue log (`500: Unable to exchange external code` / `oauth2: "invalid_client" "The provided client secret is invalid."`), that pins it: the primary client's secret is stale.

**I deliberately did not change the provider config.** The tempting fix — promote the new client and paste in the secret we have — would have moved the failure *earlier*, from "invalid_client after you pick your account" to "redirect_uri_mismatch before Google will show you anything". That is more broken, not less, so prod is exactly as I found it.

### What you need to do (one of these)

**Option A — smallest, recommended.** In Google Cloud console for project **484909326858**, open **APIs & Services → Credentials → OAuth 2.0 Client IDs → `484909326858-1va1lbsiba9chuouu8e3m7u9bbivoj02`**, click **Add secret**, copy the new secret, then set it on Supabase (Authentication → Providers → Google → Client Secret), and update the gitignored `supabase/.env` to match. Nothing else changes: the redirect URI on that client is already correct. Delete the old secret once sign-in works.

**Option B — use the secret already uploaded.** In Google Cloud console for project **654054834944** (Firebase `waves-3e7b8`), open client `654054834944-jjuc5oh59gavuvkld7ov2kk35v1v9s6m` and add

```
https://ywojpnfyxxltvihqmcni.supabase.co/auth/v1/callback
```

as an **Authorized redirect URI**. Then tell me and I will flip the Supabase config — the new client id first, the old one kept behind it as an accepted audience so native id-token sign-in is unaffected — and set its matching secret. Sending the full provider block and re-reading it is important here: patching only `external_google_additional_client_ids` has previously overwritten the primary id.

Either way, **verify the secret before trusting it**: POST to `https://oauth2.googleapis.com/token` with the client id, the secret and a junk `code`. `invalid_grant` means the secret is right; `invalid_client` means it is not.

## Apple: the server was ready, the web had no button

**Diagnosis: app code.** Apple is fully configured and live on prod, and I verified it rather than assuming:

- `external_apple_enabled = true`, and `external_apple_client_id` is `app.wavs.web,app.wavs.mobile` — the Services id **first**. That order is load-bearing and is preserved untouched: GoTrue accepts every id as an audience for an identity token but sends only the *first* to Apple when it starts a browser round trip, and a bundle id is not a valid web client. Nothing in this PR goes near it.
- `GET /auth/v1/authorize?provider=apple` returns a 302 to `appleid.apple.com` carrying `client_id=app.wavs.web`, `response_mode=form_post`, and the Supabase callback — and following it returns Apple's **full** sign-in page (131 KB, not the ~11 KB rejection shell). So the Services id and Return URL are registered on Apple's side and working.
- `https://app.wavs.co.in/auth/callback` is already in `uri_allow_list`.

**So there is no console action owed for Apple.** The web client simply never rendered the button. It does now.

## What changed

- **`packages/api-client`** — `signInWithApple`, and both providers now route through `planAuth` in `@waves/core` instead of calling `signInWithOAuth` unconditionally. This fixes a real data-loss bug, not just an omission: the two places the web actually offers Google are the guest banner and the guest panel in settings, both of which say signing in is how you keep what you have. `signInWithOAuth` under an anonymous session does not attach the identity — it signs into a *different* account, silently, leaving the guest's groups unreachable. `planAuth` returns `linkIdentity` for anyone already signed in. (`security_manual_linking_enabled = true` on prod, so that call is supported — checked.)
- **`apps/web/src/app/auth/callback/page.tsx`** — reads the URL via `readOAuthCallback`. A completed *link* comes back with no code, and the old `if (!code) throw` reported an error over a sign-in that had worked. It also means a provider refusal, or the Google exchange failure above, now reaches Sentry as its own message instead of "Missing authorization code".
- **`apps/web/src/components/SignIn.tsx`** — the Apple button, plus real brand marks (the same SVG paths the app's `SocialTile` uses) replacing the plain capital "G". Both buttons carry visible text, so the accessible name is a sentence and the glyphs are `aria-hidden`; order is fixed rather than platform-sniffed, because this page is server-rendered and a sniff would cause a hydration mismatch.
- **i18n** — `continueWithApple` in all four locales (en/ta/hi/ar), phrased to match each table's existing Google line.
- **`globals.css`** — `.btn.apple`, black with a white mark, same geometry as the Google button beside it.
- **e2e** — the sign-in spec asserts the Apple button.

## Gates

| Gate | Result |
|---|---|
| `pnpm format` | clean |
| `pnpm lint` | pass (all 12 projects) |
| `pnpm --filter @waves/web typecheck` | pass |
| `pnpm --filter @waves/web test` | 53 passed |
| `packages/core` + `packages/api-client` tests | 986 + 12 passed |
| `apps/web` Playwright e2e | **9 passed** — including the new Apple assertion, RTL Arabic, and no horizontal overflow at 360 px |

The e2e run needed a workaround worth naming: Playwright 1.63 wants chromium build 1243 and this machine cannot download it (the browser fetch is blocked), so I ran the repo's own config against the installed system Chrome via a throwaway override, which was deleted before committing. CI will run it on the real chromium. `packages/db` tests were not run — they need a local Postgres that is not up.

## Not verified

Nobody has attempted an OAuth sign-in against this project in 14 days, so there is no recent log line to point at — the Google diagnosis rests on the config and probe evidence above, not on a live reproduction. The Apple button itself has not been through a real end-to-end sign-in, because that needs an Apple ID and a browser session; every server-side precondition for it is verified, the client half is the same code path Google uses, but the round trip is unproven until someone signs in.

## Deliberately left alone

The guest banner and the settings guest panel still offer Google only. Their Google button is no longer destructive, which was the urgent half, but bringing Apple to those two surfaces is a separate bit of layout work rather than a string and a button. Worth a follow-up.

## Deploy

**Not deployed — I have no credentials to deploy with, and I would rather say so than imply otherwise.**

This is not the merge-and-it-ships setup I first assumed. Every project sets `"git": { "deploymentEnabled": false }` in its `vercel.json`, so no push, PR or merge ever creates a deployment. The only route is the manual `Vercel deploy (manual)` workflow, and it needs `VERCEL_TOKEN`, `VERCEL_ORG_ID` and `VERCEL_PROJECT_ID_WEB` as repository secrets. There are **zero** Actions secrets on this repository — repository and environment scope both — no Vercel CLI on this machine, and no `.vercel/project.json` linking `apps/web`. The workflow would stop at its own guard step rather than deploy anything.

To ship it yourself, once this is merged: **Actions → Vercel deploy (manual) → Run workflow**, project `web`, target `production`. If it fails on the missing-project-id guard, the secrets above have to be added first (`vercel link` in `apps/web`, then the id from `.vercel/project.json`). Deploy `web` only — admin and the marketing site are separate projects and nothing here touches them.

And the thing worth being blunt about: **deploying will not fix Google.** The Apple button ships with the deploy, but the Google failure is a secret stored on Supabase, which no amount of shipping web code can change. The console step above is the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jhzmZz5fkjnZZ14YxHGfS
