### PR TITLE
The private ledger asks one question on one screen, in the rows the bills wear

### DIFF
--- a/apps/mobile/src/app/personal/entry.tsx
+++ b/apps/mobile/src/app/personal/entry.tsx
@@ -1,8 +1,32 @@
 /**
- * Add or edit one personal-finance entry (A48) — an expense or income line in
- * your own private ledger. No group, no split, no members: just an amount, what
- * it was for, and when. Reached from the "Me" tab's add buttons, and (with a
- * `loanId`) as a loan repayment.
+ * The private ledger's one form (A56) — an expense or an income, once or
+ * repeating. No group, no split, no members: an amount, what it was for, when,
+ * and whether it happens again.
+ *
+ * It used to be three forms. "Add expense" and "Add income" were two buttons
+ * into this screen, which then asked the same question again with a segmented
+ * control; and "Recurring" was a room of its own holding a second editor that
+ * forked into expense and income for a third time. Three ways to say the same
+ * sentence, each laid out differently, and the person had to answer "which
+ * screen am I on" before they could answer "what happened". So: one form.
+ * Direction is a control inside it, and repeating is a property of the entry —
+ * a row that reads "Never" until it reads "Monthly".
+ *
+ * The recurring *list* is still its own screen, because a list of rules and the
+ * form that writes one are different things; it now opens this form instead of
+ * carrying an editor of its own.
+ *
+ * The fields below the amount are the rows the expense screens use — the same
+ * `SettingRow` in the same `Card` that add-expense folds its date, category,
+ * rail and currency into. A short answer already filled in, changed from a
+ * sheet, read down one column. The private ledger was the last place still
+ * asking those questions as stacked captions and chip lanes.
+ *
+ * Reached from the Me tab's add buttons, from the ledger's "+", from the
+ * recurring list (`repeats=1` to create, `recurringId` to edit), and — with a
+ * `loanId` — as a loan repayment. A repayment is neither categorised nor
+ * repeatable: the loan decides its direction and the schedule belongs to the
+ * loan, not to one payment on it.
  */
 
 import { useState } from 'react';
@@ -11,22 +35,33 @@ import DateTimePicker from '@react-native-community/datetimepicker';
 import { useLocalSearchParams } from 'expo-router';
 import { ActivityIndicator, Platform, Pressable, ScrollView, View } from 'react-native';
 
-import { encodeTxn, type CategoryMeta, type PersonalTxn, type TxnKind } from '@waves/core';
+import {
+  FREQUENCIES,
+  Frequency,
+  frequencyOf,
+  type PersonalRecurring,
+  type PersonalTxn,
+  type TxnKind,
+} from '@waves/core';
 import {
   AmountField,
   Button,
+  Card,
   directionalIcon,
+  Divider,
   IconButton,
   iconSize,
   Row,
   Screen,
   SegmentedTabs,
   Text,
+  Toggle,
   useTheme,
 } from '@waves/ui';
 
-import { CategoryPicker } from '@/components/Category';
-import { SourcePicker } from '@/components/IncomeSource';
+import { CategoryRow, CategorySheet } from '@/components/Category';
+import { ChoiceRow, SettingRow, SheetOverlay } from '@/components/expense/SheetOverlay';
+import { SourceRow, SourceSheet } from '@/components/IncomeSource';
 import { PersonalNoteField } from '@/components/PersonalNoteField';
 import {
   localIsoDate,
@@ -36,29 +71,42 @@ import {
   useUpsertPersonalRecord,
 } from '@/data/personal';
 import { useDefaultCurrency } from '@/lib/currency';
+import { dateFrom, showDate } from '@/lib/expenseDay';
 import { router } from '@/lib/navigation';
 import { useSync } from '@/sync';
 import { useStrings } from '@/i18n';
 import { PersonalGuard } from '@/components/PersonalGuard';
 import { useBottomClearance } from '@/lib/clearance';
 import { useDialog } from '@/lib/dialog';
+import { frequencyLabel } from '@/lib/frequencyLabel';
+import { entryRecord, NEW_REPEAT, repeatOf, type EntryRepeat } from '@/lib/personalEntry';
 
 function PersonalEntryScreenBody() {
   const theme = useTheme();
   const { t } = useStrings();
   const dc = useDefaultCurrency();
-  const params = useLocalSearchParams<{ kind?: string; id?: string; loanId?: string }>();
+  const params = useLocalSearchParams<{
+    kind?: string;
+    id?: string;
+    loanId?: string;
+    recurringId?: string;
+    repeats?: string;
+  }>();
   const { hydrated } = useSync();
-  const { txns } = usePersonalLedger();
+  const { txns, recurrings } = usePersonalLedger();
 
-  const editing = params.id ? txns.find((txn) => txn.id === params.id) : undefined;
+  const editingTxn = params.id ? txns.find((txn) => txn.id === params.id) : undefined;
+  const editingRule = params.recurringId
+    ? recurrings.find((rule) => rule.id === params.recurringId)
+    : undefined;
 
-  // Editing an id that has not resolved. Two very different cases:
+  // Editing an id that has not resolved — a transaction or a rule, the same two
+  // very different cases either way:
   //  - the mirror is still loading from disk (`!hydrated`): hold a spinner rather
   //    than render a blank form whose Save would overwrite the record with empties;
   //  - hydration is done and the id still isn't there (deleted, or a stale link):
   //    say so and offer a way back, instead of a spinner that never ends.
-  if (params.id && !editing) {
+  if ((params.id || params.recurringId) && !editingTxn && !editingRule) {
     return (
       <Screen>
         <View
@@ -88,64 +136,100 @@ function PersonalEntryScreenBody() {
   // Keyed so a create and each distinct edited record mount their own fresh form.
   return (
     <EntryForm
-      key={editing?.id ?? 'new'}
-      editing={editing}
+      key={editingTxn?.id ?? editingRule?.id ?? 'new'}
+      editingTxn={editingTxn}
+      editingRule={editingRule}
       defaultKind={params.kind === 'income' ? 'income' : 'expense'}
       paramLoanId={typeof params.loanId === 'string' ? params.loanId : null}
-      currency={editing?.currency ?? dc}
+      startRepeating={params.repeats === '1'}
+      currency={editingTxn?.currency ?? editingRule?.currency ?? dc}
       t={t}
     />
   );
 }
 
 function EntryForm({
-  editing,
+  editingTxn,
+  editingRule,
   defaultKind,
   paramLoanId,
+  startRepeating,
   currency,
   t,
 }: {
-  editing?: PersonalTxn;
+  editingTxn?: PersonalTxn;
+  editingRule?: PersonalRecurring;
   defaultKind: TxnKind;
   paramLoanId: string | null;
+  startRepeating: boolean;
   currency: string;
   t: ReturnType<typeof useStrings>['t'];
 }) {
   const theme = useTheme();
+  const { locale } = useStrings();
   const { confirm } = useDialog();
   const clearance = useBottomClearance();
   const upsert = useUpsertPersonalRecord();
   const remove = useDeletePersonalRecord();
 
-  const [kind, setKind] = useState<TxnKind>(editing?.kind ?? defaultKind);
+  const editing = editingTxn ?? editingRule;
+  const [kind, setKind] = useState<TxnKind>(
+    editingTxn?.kind ?? editingRule?.txnKind ?? defaultKind,
+  );
   const [amount, setAmount] = useState<bigint>(editing?.amount ?? 0n);
   const [note, setNote] = useState(editing?.note ?? '');
   const [category, setCategory] = useState<string | null>(editing?.category ?? null);
-  const [date, setDate] = useState(editing?.date ?? todayIso());
-  const [showDate, setShowDate] = useState(false);
+  // For a one-off this is the day it happened; for a repeating one it is the day
+  // the schedule *starts*, which is why an existing rule opens on its anchor and
+  // not on its next due date. A rule can only be told it began last year from
+  // here, and knowing which months are missing is the whole point of its
+  // timeline.
+  const [date, setDate] = useState(editingRule?.anchorDate || editingTxn?.date || todayIso());
+  const [repeat, setRepeat] = useState<EntryRepeat | null>(
+    editingRule
+      ? repeatOf(editingRule, frequencyOf(editingRule))
+      : startRepeating
+        ? NEW_REPEAT
+        : null,
+  );
+  const [showDatePicker, setShowDatePicker] = useState(false);
+  const [picking, setPicking] = useState<'what' | 'repeat' | null>(null);
+
   // A repayment carries the loan it settles through from the loans screen; kept
   // as-is on an edit so the link survives.
-  const loanId = editing?.loanId ?? paramLoanId;
+  const loanId = editingTxn?.loanId ?? paramLoanId;
+  // A repayment answers to its loan, and an existing transaction cannot grow a
+  // schedule: the two are different record kinds under different ids, so making
+  // one into the other would either orphan the entry or mint a second copy of
+  // it. Write a rule from a fresh entry instead, or edit the rule itself.
+  const canRepeat = !loanId && !editingTxn;
+  // An existing rule has no way back to "Never" either, for the same reason.
+  // Stopping one is what pausing and deleting are for, and both are on this
+  // screen.
+  const canStopRepeating = !editingRule;
 
   const canSave = amount > 0n && !upsert.isPending;
 
   const onSave = (): void => {
     if (!canSave) return;
     upsert.mutate(
-      {
-        recordId: editing?.id,
-        recordKind: 'txn',
-        data: encodeTxn({
+      entryRecord(
+        {
           kind,
           amount,
           currency,
-          category,
+          category: loanId ? null : category,
           note: note.trim() || null,
           date,
           loanId,
-          recurringId: editing?.recurringId ?? null,
-        }),
-      },
+          recurringId: editingTxn?.recurringId ?? null,
+        },
+        // Belt and braces: neither a repayment nor an existing transaction can
+        // reach a repeat state at all, and a save is the wrong place to find
+        // out that a form let somebody set something it had nowhere to put.
+        canRepeat || editingRule !== undefined ? repeat : null,
+        { txn: editingTxn, rule: editingRule },
+      ),
       { onSuccess: () => router.back() },
     );
   };
@@ -161,11 +245,13 @@ function EntryForm({
     if (ok) remove.mutate(editing.id, { onSuccess: () => router.back() });
   };
 
-  const title = editing
-    ? t.personal.transactions
-    : kind === 'income'
-      ? t.personal.addIncome
-      : t.personal.addExpense;
+  const title = editingRule
+    ? t.personal.editRecurring
+    : editingTxn
+      ? t.personal.transactions
+      : kind === 'income'
+        ? t.personal.addIncome
+        : t.personal.addExpense;
 
   return (
     <Screen>
@@ -200,12 +286,15 @@ function EntryForm({
           paddingHorizontal: theme.spacing.xl,
           paddingTop: theme.spacing.lg,
           paddingBottom: clearance,
-          gap: theme.spacing.xl,
+          gap: theme.spacing.lg,
         }}
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
-        {/* A repayment's kind is fixed by the loan, so only a plain entry chooses. */}
+        {/* Which way the money went — the one question that has to be answered
+            before any other field means anything, so it stays a control at the
+            top rather than a row among the details. A repayment's direction is
+            fixed by the loan, so only a plain entry chooses. */}
         {loanId ? null : (
           <SegmentedTabs
             value={kind}
@@ -217,74 +306,298 @@ function EntryForm({
           />
         )}
 
-        <View style={{ alignItems: 'center', paddingVertical: theme.spacing.lg }}>
+        <View style={{ alignItems: 'center', paddingVertical: theme.spacing.sm }}>
           <AmountField currency={currency} value={amount} onChange={setAmount} />
         </View>
 
         <PersonalNoteField
           value={note}
           onChange={setNote}
-          label={t.personal.note}
           placeholder={t.personal.notePlaceholder}
           accessibilityLabel={t.personal.note}
         />
 
-        {/* A repayment is not everyday spend, so it carries no category. Income
-            asks where the money came from instead of what it was spent on —
-            the two are different questions and used to share one picker, which
-            is how a salary ended up filed under "Other". */}
-        {loanId ? null : (
-          <View style={{ gap: theme.spacing.sm }}>
-            <Text variant="caption" tone="muted">
-              {kind === 'income' ? t.personal.source : t.personal.category}
-            </Text>
-            {kind === 'income' ? (
-              <SourcePicker value={category} onChange={setCategory} />
-            ) : (
-              <CategoryPicker
-                value={category}
-                onChange={(picked: string, _meta: CategoryMeta | null) => setCategory(picked)}
-              />
-            )}
-          </View>
-        )}
+        {/* The entry's facts, as one card of divided rows — the shape the
+            expense form wears under its receipt. Each of these is the same kind
+            of question: a short answer, already filled in, changed from a sheet.
+            They used to be a caption over a horizontally scrolling lane of chips
+            and a grey date well, which made three settings look like three
+            separate parts of a form.
 
-        <View style={{ gap: theme.spacing.sm }}>
-          <Text variant="caption" tone="muted">
-            {t.personal.date}
-          </Text>
-          <Pressable
-            accessibilityRole="button"
-            onPress={() => setShowDate(true)}
-            style={{
-              flexDirection: 'row',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-              paddingVertical: theme.spacing.md,
-              paddingHorizontal: theme.spacing.lg,
-              backgroundColor: theme.color.surfaceMuted,
-              borderRadius: theme.radius.md,
-            }}
-          >
-            <Text variant="body">{date}</Text>
-            <Ionicons name="calendar-outline" size={iconSize.md} color={theme.color.textMuted} />
-          </Pressable>
-          {showDate ? (
-            <DateTimePicker
-              value={new Date(`${date}T00:00:00`)}
-              mode="date"
-              onChange={(event, picked) => {
-                // Android fires once and dismisses itself; iOS stays open.
-                if (Platform.OS !== 'ios') setShowDate(false);
-                if (event.type === 'set' && picked) setDate(localIsoDate(picked));
-              }}
-            />
+            Income asks where the money came from and an expense asks what it was
+            spent on. The two are different questions and once shared one picker,
+            which is how a salary ended up filed under "Other". */}
+        <Card style={{ paddingVertical: theme.spacing.xs, gap: 0 }}>
+          {loanId ? null : (
+            <>
+              {kind === 'income' ? (
+                <SourceRow value={category} onPress={() => setPicking('what')} />
+              ) : (
+                <CategoryRow value={category} onPress={() => setPicking('what')} />
+              )}
+              <Divider />
+            </>
+          )}
+
+          <SettingRow
+            label={repeat ? t.personal.startsOn : t.personal.date}
+            value={showDate(date, locale)}
+            leading={
+              <Ionicons name="calendar-outline" size={iconSize.md} color={theme.color.textMuted} />
+            }
+            onPress={() => setShowDatePicker(true)}
+          />
+
+          {canRepeat || editingRule ? (
+            <>
+              <Divider />
+              <SettingRow
+                label={t.personal.repeats}
+                value={
+                  repeat
+                    ? frequencyLabel(t, repeat.frequency, repeat.interval)
+                    : t.personal.repeatsNever
+                }
+                leading={
+                  <Ionicons
+                    name={repeat ? 'repeat' : 'repeat-outline'}
+                    size={iconSize.md}
+                    color={repeat ? theme.color.brand : theme.color.textMuted}
+                  />
+                }
+                onPress={() => setPicking('repeat')}
+              />
+            </>
           ) : null}
-        </View>
+        </Card>
+
+        {showDatePicker ? (
+          <DateTimePicker
+            value={dateFrom(date)}
+            mode="date"
+            onChange={(event, picked) => {
+              // Android fires once and dismisses itself; iOS stays open.
+              if (Platform.OS !== 'ios') setShowDatePicker(false);
+              if (event.type === 'set' && picked) setDate(localIsoDate(picked));
+            }}
+          />
+        ) : null}
+
+        {/* Everything that only means something once the entry repeats, kept
+            below the facts rather than inside the pattern sheet: the sheet
+            answers "how often", and these are what the answer then implies. The
+            block simply is not there while the entry happens once, which is the
+            common case and the reason the form is short again. */}
+        {repeat ? (
+          <Card style={{ gap: theme.spacing.md }}>
+            {repeat.frequency === Frequency.TwiceAMonth ? (
+              <DayStepper
+                label={t.personal.secondDay}
+                value={repeat.secondDay}
+                min={1}
+                max={31}
+                onChange={(secondDay) => setRepeat({ ...repeat, secondDay })}
+              />
+            ) : null}
+
+            {repeat.frequency === Frequency.EveryNMonths ? (
+              <DayStepper
+                label={t.personal.everyNMonths}
+                value={repeat.interval}
+                min={2}
+                max={24}
+                onChange={(interval) => setRepeat({ ...repeat, interval })}
+              />
+            ) : null}
+
+            <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+              <View style={{ flex: 1, paddingRight: theme.spacing.md }}>
+                <Text variant="body">{t.personal.autoPost}</Text>
+                <Text variant="micro" tone="muted">
+                  {t.personal.autoPostHint}
+                </Text>
+              </View>
+              <Toggle
+                value={repeat.autoPost}
+                onValueChange={(autoPost) => setRepeat({ ...repeat, autoPost })}
+                accessibilityLabel={t.personal.autoPost}
+              />
+            </Row>
+
+            {/* Pausing belongs to a rule that already exists — a new one is
+                being written precisely because it is meant to run. */}
+            {editingRule ? (
+              <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+                <Text variant="body">{t.personal.active}</Text>
+                <Toggle
+                  value={repeat.active}
+                  onValueChange={(active) => setRepeat({ ...repeat, active })}
+                  accessibilityLabel={t.personal.active}
+                />
+              </Row>
+            ) : null}
+          </Card>
+        ) : null}
 
         <Button label={t.personal.save} size="lg" fullWidth onPress={onSave} disabled={!canSave} />
       </ScrollView>
+
+      {picking === 'what' ? (
+        kind === 'income' ? (
+          <SourceSheet
+            value={category}
+            onChange={(picked) => {
+              setCategory(picked);
+              setPicking(null);
+            }}
+            onClose={() => setPicking(null)}
+          />
+        ) : (
+          <CategorySheet
+            value={category}
+            onChange={(picked) => {
+              setCategory(picked);
+              setPicking(null);
+            }}
+            onClose={() => setPicking(null)}
+          />
+        )
+      ) : null}
+
+      {picking === 'repeat' ? (
+        <RepeatSheet
+          value={repeat}
+          canStop={canStopRepeating}
+          onChange={(next) => {
+            setRepeat(next);
+            setPicking(null);
+          }}
+          onClose={() => setPicking(null)}
+        />
+      ) : null}
     </Screen>
+  );
+}
+
+/**
+ * How often, as a sheet of named patterns — the same list of choices with a
+ * check against the one in force that every other short answer on this form
+ * opens.
+ *
+ * "Never" leads it, because not repeating is what almost every entry is, and
+ * because the row it comes back to has to be able to say so. It is offered only
+ * while the form is writing a transaction: a rule cannot become a one-off
+ * without abandoning the history filed under its id, so an existing one is
+ * stopped by pausing or deleting it instead.
+ */
+function RepeatSheet({
+  value,
+  canStop,
+  onChange,
+  onClose,
+}: {
+  value: EntryRepeat | null;
+  canStop: boolean;
+  onChange: (next: EntryRepeat | null) => void;
+  onClose: () => void;
+}): React.JSX.Element {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const base = value ?? NEW_REPEAT;
+
+  return (
+    <SheetOverlay title={t.personal.repeats} onClose={onClose}>
+      <View style={{ gap: theme.spacing.xs }}>
+        {canStop ? (
+          <ChoiceRow
+            label={t.personal.repeatsNever}
+            selected={value === null}
+            leading={
+              <Ionicons
+                name="close-circle-outline"
+                size={iconSize.md}
+                color={theme.color.textMuted}
+              />
+            }
+            onPress={() => onChange(null)}
+          />
+        ) : null}
+        {FREQUENCIES.map((option) => (
+          <ChoiceRow
+            key={option}
+            label={frequencyLabel(t, option, base.interval)}
+            selected={value?.frequency === option}
+            leading={
+              <Ionicons
+                name="repeat"
+                size={iconSize.md}
+                color={value?.frequency === option ? theme.color.brand : theme.color.textMuted}
+              />
+            }
+            onPress={() => onChange({ ...base, frequency: option })}
+          />
+        ))}
+      </View>
+    </SheetOverlay>
+  );
+}
+
+/** A plain number stepper. Two 44pt targets beat a keyboard for a value that
+ *  only ever moves a step at a time, and it cannot be typed into an invalid
+ *  state. */
+function DayStepper({
+  label,
+  value,
+  min,
+  max,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  onChange: (next: number) => void;
+}) {
+  const theme = useTheme();
+  const step = (delta: number): void => {
+    const next = value + delta;
+    if (next >= min && next <= max) onChange(next);
+  };
+  const button = (delta: number, icon: 'remove' | 'add', disabled: boolean) => (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={`${label} ${icon === 'add' ? '+' : '−'}`}
+      accessibilityState={{ disabled }}
+      disabled={disabled}
+      onPress={() => step(delta)}
+      hitSlop={6}
+      style={({ pressed }) => ({
+        width: 44,
+        height: 44,
+        alignItems: 'center',
+        justifyContent: 'center',
+        borderRadius: theme.radius.md,
+        backgroundColor: theme.color.surfaceMuted,
+        opacity: disabled ? 0.4 : pressed ? 0.6 : 1,
+      })}
+    >
+      <Ionicons name={icon} size={iconSize.md} color={theme.color.text} />
+    </Pressable>
+  );
+
+  return (
+    <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+      <Text variant="body" style={{ flexShrink: 1, minWidth: 0 }}>
+        {label}
+      </Text>
+      <Row style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
+        {button(-1, 'remove', value <= min)}
+        <Text variant="body" style={{ fontWeight: '700', minWidth: 28, textAlign: 'center' }}>
+          {value}
+        </Text>
+        {button(1, 'add', value >= max)}
+      </Row>
+    </Row>
   );
 }
 

--- a/apps/mobile/src/app/personal/recurring.tsx
+++ b/apps/mobile/src/app/personal/recurring.tsx
@@ -1,33 +1,38 @@
 /**
- * Recurring rules (A48): bills and income that repeat — a phone bill, a salary,
+ * Recurring rules (A56): bills and income that repeat — a phone bill, a salary,
  * a subscription. A rule set to "add automatically" posts its entry on its own
  * when due (handled on the Me tab's open); a manual one just shows as due here,
- * to add with one tap. The editor is an inline sheet.
+ * to add with one tap.
+ *
+ * A list, and only a list. The editor that used to live at the bottom of this
+ * file was the third form in the private ledger asking the same question — an
+ * amount, a direction, what for, a date — in a third shape. It has moved into
+ * `personal/entry`, the one form, where repeating is a property of the entry
+ * rather than a room you have to be standing in. The "+" here and the pencil on
+ * each card open that form; nothing about the rules themselves changed.
+ *
+ * The list stays its own screen because a list of rules and the form that writes
+ * one are different things: this is where you come to ask whether the rent has
+ * been arriving, not how it is configured.
  */
 
 import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
-import DateTimePicker from '@react-native-community/datetimepicker';
-import { Platform, Pressable, ScrollView, View } from 'react-native';
+import { Pressable, ScrollView, View } from 'react-native';
 
 import {
   encodeRecurring,
   encodeTxn,
   format,
-  Frequency,
-  FREQUENCIES,
   frequencyOf,
   isRecurringDue,
   money,
   occurrences,
   recurringOccurrenceId,
-  scheduleFor,
   stepOccurrence,
   type PersonalRecurring,
-  type TxnKind,
 } from '@waves/core';
 import {
-  AmountField,
   Button,
   Card,
   directionalIcon,
@@ -37,70 +42,28 @@ import {
   iconSize,
   Row,
   Screen,
-  Sheet,
-  SegmentedTabs,
   Text,
-  Toggle,
   useTheme,
 } from '@waves/ui';
 
-import { CategoryPicker } from '@/components/Category';
-import { SourcePicker, useSourceLabel } from '@/components/IncomeSource';
+import { useSourceLabel } from '@/components/IncomeSource';
 import { OccurrenceStrip } from '@/components/OccurrenceStrip';
-import {
-  localIsoDate,
-  todayIso,
-  usePersonalLedger,
-  useDeletePersonalRecord,
-  useUpsertPersonalRecord,
-} from '@/data/personal';
-import { useDefaultCurrency } from '@/lib/currency';
-import { fill, useStrings } from '@/i18n';
+import { todayIso, usePersonalLedger, useUpsertPersonalRecord } from '@/data/personal';
+import { useStrings } from '@/i18n';
 import { PersonalGuard } from '@/components/PersonalGuard';
-import { PersonalNoteField } from '@/components/PersonalNoteField';
 import { useBottomClearance } from '@/lib/clearance';
 import { router } from '@/lib/navigation';
-import { useDialog } from '@/lib/dialog';
-
-/** A repeat pattern in words. The open-ended one names its own interval, so
- *  "every 5 months" never reads as the vaguer "every few months". */
-export function frequencyLabel(
-  t: ReturnType<typeof useStrings>['t'],
-  frequency: Frequency,
-  interval: number,
-): string {
-  switch (frequency) {
-    case Frequency.Weekly:
-      return t.personal.weekly;
-    case Frequency.Fortnightly:
-      return t.personal.fortnightly;
-    case Frequency.TwiceAMonth:
-      return t.personal.twiceAMonth;
-    case Frequency.Quarterly:
-      return t.personal.quarterly;
-    case Frequency.HalfYearly:
-      return t.personal.halfYearly;
-    case Frequency.Yearly:
-      return t.personal.yearly;
-    case Frequency.EveryNMonths:
-      return fill(t.personal.monthsInterval, { n: String(interval) });
-    default:
-      return t.personal.monthly;
-  }
-}
+import { frequencyLabel } from '@/lib/frequencyLabel';
 
 function RecurringScreenBody() {
   const theme = useTheme();
   const clearance = useBottomClearance();
   const { t, locale } = useStrings();
-  const dc = useDefaultCurrency();
   const { recurrings, txns } = usePersonalLedger();
   const sourceLabel = useSourceLabel();
   const upsert = useUpsertPersonalRecord();
 
   const [today] = useState(() => todayIso());
-  const [editing, setEditing] = useState<PersonalRecurring | null>(null);
-  const [creating, setCreating] = useState(false);
 
   const cadenceLabel = (rule: PersonalRecurring): string =>
     frequencyLabel(t, frequencyOf(rule), rule.interval);
@@ -152,7 +115,13 @@ function RecurringScreenBody() {
         <View style={{ flex: 1, alignItems: 'center' }}>
           <Text variant="heading">{t.personal.recurring}</Text>
         </View>
-        <IconButton label={t.personal.addRecurring} onPress={() => setCreating(true)}>
+        {/* The one form, opened with its repeat already switched on — the same
+            screen the Me tab's add buttons reach, so a rule is written the way
+            everything else in this ledger is written. */}
+        <IconButton
+          label={t.personal.addRecurring}
+          onPress={() => router.push({ pathname: '/personal/entry', params: { repeats: '1' } })}
+        >
           <Ionicons name="add" size={iconSize.xxl} color={theme.color.brand} />
         </IconButton>
       </Row>
@@ -217,6 +186,11 @@ function RecurringScreenBody() {
                           <OccurrenceStrip occurrences={recent} />
                         </View>
                       </View>
+                      {/* Sign and colour together, never one alone: an income
+                          and an expense that differ only by a thin green are
+                          the same row to anybody reading quickly. Expense keeps
+                          the plain ink rather than red — a list where every
+                          spend is red is a wall of red that says nothing. */}
                       <Text
                         variant="body"
                         style={{
@@ -231,7 +205,15 @@ function RecurringScreenBody() {
                       </Text>
                     </Row>
                   </Pressable>
-                  <IconButton label={t.personal.editRecurring} onPress={() => setEditing(rule)}>
+                  <IconButton
+                    label={t.personal.editRecurring}
+                    onPress={() =>
+                      router.push({
+                        pathname: '/personal/entry',
+                        params: { recurringId: rule.id },
+                      })
+                    }
+                  >
                     <Ionicons
                       name="create-outline"
                       size={iconSize.md}
@@ -260,338 +242,7 @@ function RecurringScreenBody() {
           })
         )}
       </ScrollView>
-
-      {creating ? (
-        <RecurringEditor currency={dc} today={today} onClose={() => setCreating(false)} />
-      ) : null}
-      {editing ? (
-        <RecurringEditor
-          rule={editing}
-          currency={dc}
-          today={today}
-          onClose={() => setEditing(null)}
-        />
-      ) : null}
     </Screen>
-  );
-}
-
-/** A plain number stepper. Two 44pt targets beat a keyboard for a value that
- *  only ever moves a step at a time, and it cannot be typed into an invalid
- *  state. */
-function DayStepper({
-  label,
-  value,
-  min,
-  max,
-  onChange,
-}: {
-  label: string;
-  value: number;
-  min: number;
-  max: number;
-  onChange: (next: number) => void;
-}) {
-  const theme = useTheme();
-  const step = (delta: number): void => {
-    const next = value + delta;
-    if (next >= min && next <= max) onChange(next);
-  };
-  const button = (delta: number, icon: 'remove' | 'add', disabled: boolean) => (
-    <Pressable
-      accessibilityRole="button"
-      accessibilityLabel={`${label} ${icon === 'add' ? '+' : '−'}`}
-      accessibilityState={{ disabled }}
-      disabled={disabled}
-      onPress={() => step(delta)}
-      hitSlop={6}
-      style={({ pressed }) => ({
-        width: 44,
-        height: 44,
-        alignItems: 'center',
-        justifyContent: 'center',
-        borderRadius: theme.radius.md,
-        backgroundColor: theme.color.surface,
-        opacity: disabled ? 0.4 : pressed ? 0.6 : 1,
-      })}
-    >
-      <Ionicons name={icon} size={iconSize.md} color={theme.color.text} />
-    </Pressable>
-  );
-
-  return (
-    <Row
-      style={{
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        paddingVertical: theme.spacing.sm,
-        paddingHorizontal: theme.spacing.lg,
-        backgroundColor: theme.color.surfaceMuted,
-        borderRadius: theme.radius.md,
-      }}
-    >
-      <Text variant="body">{label}</Text>
-      <Row style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
-        {button(-1, 'remove', value <= min)}
-        <Text variant="body" style={{ fontWeight: '700', minWidth: 28, textAlign: 'center' }}>
-          {value}
-        </Text>
-        {button(1, 'add', value >= max)}
-      </Row>
-    </Row>
-  );
-}
-
-function RecurringEditor({
-  rule,
-  currency,
-  today,
-  onClose,
-}: {
-  rule?: PersonalRecurring;
-  currency: string;
-  today: string;
-  onClose: () => void;
-}) {
-  const theme = useTheme();
-  const { t } = useStrings();
-  const { confirm } = useDialog();
-  const upsert = useUpsertPersonalRecord();
-  const remove = useDeletePersonalRecord();
-
-  const [txnKind, setTxnKind] = useState<TxnKind>(rule?.txnKind ?? 'expense');
-  const [amount, setAmount] = useState<bigint>(rule?.amount ?? 0n);
-  const [note, setNote] = useState(rule?.note ?? '');
-  const [category, setCategory] = useState<string | null>(rule?.category ?? null);
-  const [frequency, setFrequency] = useState<Frequency>(
-    rule ? frequencyOf(rule) : Frequency.Monthly,
-  );
-  const [months, setMonths] = useState(() => (rule && rule.interval > 1 ? rule.interval : 2));
-  const [secondDay, setSecondDay] = useState(rule?.secondDay ?? 15);
-  // The date the schedule *starts*, not the next one due. It used to be seeded
-  // from `nextDate`, which meant a rule could never be told it began last year —
-  // and knowing which months are missing is the whole point of the timeline.
-  // Moving the start back reveals that history; it does not disturb a rule that
-  // is already ahead of it (see `nextDate` below).
-  const [startDate, setStartDate] = useState(rule?.anchorDate || today);
-  const [showDate, setShowDate] = useState(false);
-  const [autoPost, setAutoPost] = useState(rule?.autoPost ?? false);
-  const [active, setActive] = useState(rule?.active ?? true);
-
-  const canSave = amount > 0n && !upsert.isPending;
-
-  const onSave = (): void => {
-    if (!canSave) return;
-    upsert.mutate(
-      {
-        recordId: rule?.id,
-        recordKind: 'recurring',
-        data: encodeRecurring({
-          txnKind,
-          amount,
-          currency: rule?.currency ?? currency,
-          category,
-          note: note.trim() || null,
-          ...scheduleFor(frequency, { interval: months, secondDay }),
-          anchorDate: startDate,
-          // A rule already ahead of its start keeps its place in the queue; one
-          // whose start has moved forward past it is pulled along with it. Either
-          // way the auto-post path never goes backwards and re-mints months the
-          // timeline can already show.
-          nextDate: rule && rule.nextDate >= startDate ? rule.nextDate : startDate,
-          endDate: rule?.endDate ?? null,
-          autoPost,
-          active,
-        }),
-      },
-      { onSuccess: onClose },
-    );
-  };
-
-  return (
-    <Sheet visible onClose={onClose} padded={false} style={{ maxHeight: '90%' }}>
-      <ScrollView
-        contentContainerStyle={{ padding: theme.spacing.xl, gap: theme.spacing.lg }}
-        keyboardShouldPersistTaps="handled"
-      >
-        <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
-          <Text variant="heading">{rule ? t.personal.editRecurring : t.personal.addRecurring}</Text>
-          <IconButton label={t.common.close} onPress={onClose}>
-            <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
-          </IconButton>
-        </Row>
-
-        <SegmentedTabs
-          value={txnKind}
-          onChange={setTxnKind}
-          tabs={[
-            { value: 'expense', label: t.personal.expense },
-            { value: 'income', label: t.personal.incomeKind },
-          ]}
-        />
-
-        <View style={{ alignItems: 'center', paddingVertical: theme.spacing.md }}>
-          <AmountField currency={rule?.currency ?? currency} value={amount} onChange={setAmount} />
-        </View>
-
-        <PersonalNoteField
-          value={note}
-          onChange={setNote}
-          placeholder={t.personal.notePlaceholder}
-          accessibilityLabel={t.personal.note}
-        />
-
-        {txnKind === 'expense' ? (
-          <CategoryPicker value={category} onChange={(picked) => setCategory(picked)} />
-        ) : (
-          <View style={{ gap: theme.spacing.sm }}>
-            <Text variant="caption" tone="muted">
-              {t.personal.source}
-            </Text>
-            <SourcePicker value={category} onChange={setCategory} />
-          </View>
-        )}
-
-        <View style={{ gap: theme.spacing.sm }}>
-          <Text variant="caption" tone="muted">
-            {t.personal.repeats}
-          </Text>
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            keyboardShouldPersistTaps="handled"
-            contentContainerStyle={{ gap: theme.spacing.sm, paddingRight: theme.spacing.xl }}
-          >
-            {FREQUENCIES.map((option) => {
-              const selected = option === frequency;
-              const label = frequencyLabel(t, option, months);
-              return (
-                <Pressable
-                  key={option}
-                  accessibilityRole="radio"
-                  accessibilityState={{ selected }}
-                  accessibilityLabel={label}
-                  onPress={() => setFrequency(option)}
-                  style={({ pressed }) => ({
-                    minHeight: 44,
-                    justifyContent: 'center',
-                    paddingHorizontal: theme.spacing.md,
-                    borderRadius: theme.radius.md,
-                    borderWidth: 1,
-                    borderColor: selected ? theme.color.brand : theme.color.border,
-                    backgroundColor: selected ? theme.color.brandSoft : theme.color.surface,
-                    opacity: pressed ? 0.7 : 1,
-                  })}
-                >
-                  <Text
-                    variant="body"
-                    style={{ color: selected ? theme.color.brand : theme.color.text }}
-                  >
-                    {label}
-                  </Text>
-                </Pressable>
-              );
-            })}
-          </ScrollView>
-
-          {/* Twice a month is two days of the month, so it asks for the second
-              one. The first is whatever day the start date falls on. */}
-          {frequency === Frequency.TwiceAMonth ? (
-            <DayStepper
-              label={t.personal.secondDay}
-              value={secondDay}
-              min={1}
-              max={31}
-              onChange={setSecondDay}
-            />
-          ) : null}
-
-          {frequency === Frequency.EveryNMonths ? (
-            <DayStepper
-              label={t.personal.everyNMonths}
-              value={months}
-              min={2}
-              max={24}
-              onChange={setMonths}
-            />
-          ) : null}
-        </View>
-
-        <Pressable
-          accessibilityRole="button"
-          onPress={() => setShowDate(true)}
-          style={{
-            flexDirection: 'row',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            paddingVertical: theme.spacing.md,
-            paddingHorizontal: theme.spacing.lg,
-            backgroundColor: theme.color.surfaceMuted,
-            borderRadius: theme.radius.md,
-          }}
-        >
-          <Text variant="body">
-            {t.personal.startsOn}: {startDate}
-          </Text>
-          <Ionicons name="calendar-outline" size={iconSize.md} color={theme.color.textMuted} />
-        </Pressable>
-        {showDate ? (
-          <DateTimePicker
-            value={new Date(`${startDate}T00:00:00`)}
-            mode="date"
-            onChange={(event, picked) => {
-              if (Platform.OS !== 'ios') setShowDate(false);
-              if (event.type === 'set' && picked) setStartDate(localIsoDate(picked));
-            }}
-          />
-        ) : null}
-
-        <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
-          <View style={{ flex: 1, paddingRight: theme.spacing.md }}>
-            <Text variant="body">{t.personal.autoPost}</Text>
-            <Text variant="micro" tone="muted">
-              {t.personal.autoPostHint}
-            </Text>
-          </View>
-          <Toggle
-            value={autoPost}
-            onValueChange={setAutoPost}
-            accessibilityLabel={t.personal.autoPost}
-          />
-        </Row>
-
-        {rule ? (
-          <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
-            <Text variant="body">{t.personal.active}</Text>
-            <Toggle
-              value={active}
-              onValueChange={setActive}
-              accessibilityLabel={t.personal.active}
-            />
-          </Row>
-        ) : null}
-
-        <Button label={t.personal.save} size="lg" fullWidth onPress={onSave} disabled={!canSave} />
-
-        {rule ? (
-          <Button
-            label={t.common.delete}
-            variant="danger"
-            fullWidth
-            onPress={() =>
-              void confirm({
-                title: t.common.delete,
-                body: t.personal.deleteConfirm,
-                confirmLabel: t.common.delete,
-                tone: 'danger',
-              }).then((ok) => {
-                if (ok) remove.mutate(rule.id, { onSuccess: onClose });
-              })
-            }
-          />
-        ) : null}
-      </ScrollView>
-    </Sheet>
   );
 }
 

--- a/apps/mobile/src/app/personal/source/[id].tsx
+++ b/apps/mobile/src/app/personal/source/[id].tsx
@@ -49,7 +49,7 @@ import {
   useTheme,
 } from '@waves/ui';
 
-import { frequencyLabel } from '@/app/personal/recurring';
+import { frequencyLabel } from '@/lib/frequencyLabel';
 import { SourceGlyph, useSourceLabel } from '@/components/IncomeSource';
 import {
   localIsoDate,

--- a/apps/mobile/src/components/IncomeSource.tsx
+++ b/apps/mobile/src/components/IncomeSource.tsx
@@ -1,15 +1,23 @@
 /**
- * Where money came from — the income counterpart of `CategoryPicker`.
+ * Where money came from — the income counterpart of the spend catalog.
  *
- * Deliberately the same chip, the same size, the same selected state as the
- * spend picker next door: choosing a source is the same gesture as choosing a
- * category, and making it look like a different kind of control would suggest
- * it is a different kind of decision. What differs is only the vocabulary —
- * `INCOME_SOURCES` rather than the spend categories — because filing a salary
- * under "Food & drink" was the whole problem.
+ * `SourceRow` + `SourceSheet` mirror `CategoryRow` + `CategorySheet` one file
+ * over, deliberately and to the pixel: a settings row that names the field and
+ * shows what is chosen, and the sheet of options behind it. Choosing a source
+ * is the same gesture as choosing a category, and drawing it as a different
+ * kind of control would suggest it is a different kind of decision. What
+ * differs is only the vocabulary — `INCOME_SOURCES` rather than the spend
+ * categories — because filing a salary under "Food & drink" was the whole
+ * problem.
+ *
+ * There used to be a `SourcePicker` here as well: the same catalog as a lane of
+ * chips, for the private ledger's form before it folded its details into rows.
+ * It went when the last caller did rather than staying as a second way to
+ * answer the same question — the two would have drifted, and a form that asked
+ * "what for" as a row and "where from" as a chip lane looked like two forms.
  */
 
-import { Pressable, ScrollView, View } from 'react-native';
+import { View } from 'react-native';
 import Ionicons from '@expo/vector-icons/Ionicons';
 
 import {
@@ -19,8 +27,9 @@ import {
   type CatalogEntry,
   type IncomeSource,
 } from '@waves/core';
-import { iconSize, Text, useTheme } from '@waves/ui';
+import { iconSize, useTheme } from '@waves/ui';
 
+import { ChoiceRow, SettingRow, SheetOverlay } from '@/components/expense/SheetOverlay';
 import { useCategoryTags } from '@/data/hooks';
 import { useStrings, type UiStrings } from '@/i18n';
 
@@ -42,101 +51,6 @@ export function useSourceLabel(): (id: string | null) => string | null {
     // tag that has not synced to this device yet.
     return tags.find((tag) => tag.id === id)?.label ?? id;
   };
-}
-
-export function SourcePicker({
-  value,
-  onChange,
-}: {
-  value: string | null;
-  onChange: (id: string) => void;
-}) {
-  const theme = useTheme();
-  const { t } = useStrings();
-  // The fifteen we ship, then the person's own — from a pack, or made by hand.
-  // Theirs come second rather than mixed in, so the list somebody learned does
-  // not reorder itself the first time they install something.
-  const mine = incomeTags(useCategoryTags().data).filter((entry) => !entry.hidden);
-
-  return (
-    <ScrollView
-      horizontal
-      showsHorizontalScrollIndicator={false}
-      keyboardShouldPersistTaps="handled"
-      contentContainerStyle={{ gap: theme.spacing.sm, paddingRight: theme.spacing.xl }}
-    >
-      {INCOME_SOURCES.map((source: IncomeSource) => {
-        const selected = source.id === value;
-        const label = t.personal.sources[labelKey(source.id)];
-        return (
-          <Pressable
-            key={source.id}
-            accessibilityRole="radio"
-            accessibilityState={{ selected }}
-            accessibilityLabel={label}
-            onPress={() => onChange(source.id)}
-            style={({ pressed }) => ({
-              flexDirection: 'row',
-              alignItems: 'center',
-              gap: theme.spacing.xs,
-              minHeight: 44,
-              paddingVertical: theme.spacing.sm,
-              paddingHorizontal: theme.spacing.md,
-              borderRadius: theme.radius.md,
-              borderWidth: 1,
-              borderColor: selected ? theme.color.brand : theme.color.border,
-              backgroundColor: selected ? theme.color.brandSoft : theme.color.surface,
-              opacity: pressed ? 0.7 : 1,
-            })}
-          >
-            <Ionicons
-              name={source.icon as keyof typeof Ionicons.glyphMap}
-              size={iconSize.md}
-              color={selected ? theme.color.brand : theme.color.textMuted}
-            />
-            <Text variant="body" style={{ color: selected ? theme.color.brand : theme.color.text }}>
-              {label}
-            </Text>
-          </Pressable>
-        );
-      })}
-
-      {mine.map((entry: CatalogEntry) => {
-        const selected = entry.key === value;
-        return (
-          <Pressable
-            key={entry.key}
-            accessibilityRole="radio"
-            accessibilityState={{ selected }}
-            accessibilityLabel={entry.label}
-            onPress={() => onChange(entry.key)}
-            style={({ pressed }) => ({
-              flexDirection: 'row',
-              alignItems: 'center',
-              gap: theme.spacing.xs,
-              minHeight: 44,
-              paddingVertical: theme.spacing.sm,
-              paddingHorizontal: theme.spacing.md,
-              borderRadius: theme.radius.md,
-              borderWidth: 1,
-              borderColor: selected ? theme.color.brand : theme.color.border,
-              backgroundColor: selected ? theme.color.brandSoft : theme.color.surface,
-              opacity: pressed ? 0.7 : 1,
-            })}
-          >
-            <Ionicons
-              name={entry.icon as keyof typeof Ionicons.glyphMap}
-              size={iconSize.md}
-              color={selected ? theme.color.brand : theme.color.textMuted}
-            />
-            <Text variant="body" style={{ color: selected ? theme.color.brand : theme.color.text }}>
-              {entry.label}
-            </Text>
-          </Pressable>
-        );
-      })}
-    </ScrollView>
-  );
 }
 
 /** The small round glyph a source wears in a list, tinted like its chip. */
@@ -163,5 +77,83 @@ export function SourceGlyph({ id, size = 40 }: { id: string | null; size?: numbe
         color={tint.ink}
       />
     </View>
+  );
+}
+
+/**
+ * The chosen source as one row of a settings list: the field's name, then the
+ * source's own glyph and label, then a chevron into {@link SourceSheet}.
+ *
+ * The sibling of `CategoryRow`, and deliberately identical to it. The private
+ * ledger's form asks "what for" of an expense and "where from" of an income,
+ * and those are different questions with the same shape — a short answer,
+ * already filled in, changed from a sheet. Drawn as a lane of chips for one and
+ * a row for the other, the same form would have looked like two forms depending
+ * on which way the money went.
+ */
+export function SourceRow({
+  value,
+  onPress,
+}: {
+  value: string | null;
+  onPress: () => void;
+}): React.JSX.Element {
+  const { t } = useStrings();
+  const label = useSourceLabel()(value);
+  return (
+    <SettingRow
+      label={t.personal.source}
+      value={label ?? t.personal.sources.other}
+      leading={<SourceGlyph id={value} size={24} />}
+      onPress={onPress}
+    />
+  );
+}
+
+/**
+ * The sources as a sheet of options — the fifteen built in, then the person's
+ * own from a pack or made by hand, one per line with a check against the one in
+ * force.
+ *
+ * Theirs come second rather than mixed in, so the list somebody learned does not
+ * reorder itself the first time they install something.
+ */
+export function SourceSheet({
+  value,
+  onChange,
+  onClose,
+}: {
+  value: string | null;
+  onChange: (id: string) => void;
+  onClose: () => void;
+}): React.JSX.Element {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const mine = incomeTags(useCategoryTags().data).filter((entry) => !entry.hidden);
+
+  return (
+    <SheetOverlay title={t.personal.source} onClose={onClose}>
+      <View style={{ gap: theme.spacing.xs }}>
+        {INCOME_SOURCES.map((source: IncomeSource) => (
+          <ChoiceRow
+            key={source.id}
+            label={t.personal.sources[labelKey(source.id)]}
+            selected={source.id === value}
+            leading={<SourceGlyph id={source.id} size={32} />}
+            onPress={() => onChange(source.id)}
+          />
+        ))}
+
+        {mine.map((entry: CatalogEntry) => (
+          <ChoiceRow
+            key={entry.key}
+            label={entry.label}
+            selected={entry.key === value}
+            leading={<SourceGlyph id={entry.key} size={32} />}
+            onPress={() => onChange(entry.key)}
+          />
+        ))}
+      </View>
+    </SheetOverlay>
   );
 }

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -3009,6 +3009,8 @@ export interface UiStrings {
     addRecurring: string;
     editRecurring: string;
     repeats: string;
+    /** The "Repeats" row's answer when the entry happens once. */
+    repeatsNever: string;
     weekly: string;
     monthly: string;
     yearly: string;
@@ -5590,6 +5592,7 @@ const en: UiStrings = {
     addRecurring: 'Add recurring',
     editRecurring: 'Edit recurring',
     repeats: 'Repeats',
+    repeatsNever: 'Never',
     weekly: 'Weekly',
     monthly: 'Monthly',
     yearly: 'Yearly',
@@ -8299,6 +8302,7 @@ const ta: UiStrings = {
     addRecurring: 'மீண்டும் வருவதைச் சேர்',
     editRecurring: 'மீண்டும் வருவதைத் திருத்து',
     repeats: 'திரும்பும்',
+    repeatsNever: 'திரும்பாது',
     weekly: 'வாராந்திரம்',
     monthly: 'மாதந்தோறும்',
     yearly: 'ஆண்டுதோறும்',
@@ -10897,6 +10901,7 @@ const hi: UiStrings = {
     addRecurring: 'आवर्ती जोड़ें',
     editRecurring: 'आवर्ती संपादित करें',
     repeats: 'दोहराव',
+    repeatsNever: 'कभी नहीं',
     weekly: 'साप्ताहिक',
     monthly: 'मासिक',
     yearly: 'वार्षिक',
@@ -13825,6 +13830,7 @@ const ar: UiStrings = {
     addRecurring: 'إضافة متكرر',
     editRecurring: 'تعديل المتكرر',
     repeats: 'يتكرر',
+    repeatsNever: 'أبدًا',
     weekly: 'أسبوعياً',
     monthly: 'شهرياً',
     yearly: 'سنوياً',

--- a/apps/mobile/src/lib/frequencyLabel.ts
+++ b/apps/mobile/src/lib/frequencyLabel.ts
@@ -1,0 +1,42 @@
+/**
+ * A repeat pattern in words.
+ *
+ * Three places say a cadence out loud — the rules list, the one form that
+ * writes a rule, and a rule's own timeline — and a rule that reads "Quarterly"
+ * in the list and "Every 3 months" in the form is the same rule described
+ * twice. It lived on the recurring screen until the editor moved off it, which
+ * made a route file the thing two other screens imported from.
+ *
+ * Kept apart from `personalEntry.ts` on purpose: that module is the decision
+ * about what a save writes and is unit-tested as plain data, and reaching the
+ * string tables from it would drag `expo-localization` — and through it the
+ * whole of react-native — into a node test suite that has no business loading
+ * either.
+ */
+
+import { Frequency } from '@waves/core';
+
+import { fill, type UiStrings } from '@/i18n';
+
+/** The open-ended pattern names its own interval, so "every 5 months" never
+ *  reads as the vaguer "every few months". */
+export function frequencyLabel(t: UiStrings, frequency: Frequency, interval: number): string {
+  switch (frequency) {
+    case Frequency.Weekly:
+      return t.personal.weekly;
+    case Frequency.Fortnightly:
+      return t.personal.fortnightly;
+    case Frequency.TwiceAMonth:
+      return t.personal.twiceAMonth;
+    case Frequency.Quarterly:
+      return t.personal.quarterly;
+    case Frequency.HalfYearly:
+      return t.personal.halfYearly;
+    case Frequency.Yearly:
+      return t.personal.yearly;
+    case Frequency.EveryNMonths:
+      return fill(t.personal.monthsInterval, { n: String(interval) });
+    default:
+      return t.personal.monthly;
+  }
+}

--- a/apps/mobile/src/lib/personalEntry.ts
+++ b/apps/mobile/src/lib/personalEntry.ts
@@ -1,0 +1,161 @@
+/**
+ * The private ledger's one form (A56), as a decision rather than a screen.
+ *
+ * Putting money into the "Me" tab used to fork before it asked anything: an
+ * "Add expense" door, an "Add income" door, and a "Recurring" room holding a
+ * second editor that forked the same way again. Four ways in to one question —
+ * *what happened?* — and the person had to answer "which screen am I on" first.
+ *
+ * So the form is now one form, and repeating is a property of the thing rather
+ * than a destination of its own. That leaves exactly one decision worth pinning
+ * without a renderer: which record kind a save writes, and with what in it. It
+ * lives here, free of React, of react-native and of the string tables, so the
+ * guarantee that the merged form stores what the two separate ones stored is
+ * held by a unit test and not by somebody's memory of a screenshot. The words a
+ * cadence is said in are one file over, in `frequencyLabel.ts`, for exactly
+ * that reason.
+ *
+ * Nothing here changes the wire. A `txn` blob and a `recurring` blob are byte
+ * for byte what `entry.tsx` and the old inline recurring editor already wrote;
+ * `personal_records` is one opaque json column and the server still cannot tell
+ * a rule from a loan.
+ */
+
+import {
+  encodeRecurring,
+  encodeTxn,
+  Frequency,
+  scheduleFor,
+  type CurrencyCode,
+  type PersonalRecordKind,
+  type PersonalRecurring,
+  type PersonalTxn,
+  type TxnKind,
+} from '@waves/core';
+
+/**
+ * The repeat half of the form — null when the entry happens once.
+ *
+ * `interval` and `secondDay` are always carried, even while the chosen pattern
+ * ignores them: they are what the two steppers hold, and dropping them on every
+ * switch of pattern would lose the "every 5 months" somebody set the moment
+ * they glanced at "Monthly" and back.
+ */
+export interface EntryRepeat {
+  readonly frequency: Frequency;
+  /** Read only by `everyNMonths`. */
+  readonly interval: number;
+  /** Read only by `twiceAMonth`. */
+  readonly secondDay: number;
+  /** Mint the entry when it falls due, rather than only showing it as owed. */
+  readonly autoPost: boolean;
+  /** A paused rule keeps its history and its place, and fires nothing. */
+  readonly active: boolean;
+}
+
+/** What the form holds, whichever of the two things it is about to write. */
+export interface EntryDraft {
+  readonly kind: TxnKind;
+  readonly amount: bigint;
+  readonly currency: CurrencyCode;
+  readonly category: string | null;
+  readonly note: string | null;
+  /** The day it happened — or, for a repeating entry, the day it starts. */
+  readonly date: string;
+  /** Set when this entry is a repayment on a loan; links the two. */
+  readonly loanId: string | null;
+  /** Set when a rule minted the entry being edited; kept so the link survives. */
+  readonly recurringId: string | null;
+}
+
+/** Exactly the upsert the ledger takes — see `useUpsertPersonalRecord`. */
+export interface EntryRecord {
+  /** Absent on a create, where the id is minted at the queue. */
+  readonly recordId?: string;
+  readonly recordKind: PersonalRecordKind;
+  readonly data: Record<string, unknown>;
+}
+
+/**
+ * What one press of Save writes.
+ *
+ * Two shapes out of one form, chosen by whether the entry repeats — and the
+ * important property is that neither shape knows the form exists. A one-off is
+ * the same `txn` blob the add-expense and add-income screens each built; a
+ * repeating one is the same `recurring` blob the inline rule editor built.
+ *
+ * `editing` carries the record being changed, and it is what stops a save from
+ * quietly rewriting history:
+ *
+ * - a rule already ahead of its start keeps its place in the queue, and one
+ *   whose start has moved forward past it is pulled along with it, so the
+ *   auto-post path never goes backwards and re-mints months the timeline can
+ *   already show;
+ * - `endDate` is carried through untouched. Nothing in the app sets it yet, and
+ *   an edit that dropped it would be the first thing that could silently make
+ *   a finished rule run forever.
+ */
+export function entryRecord(
+  draft: EntryDraft,
+  repeat: EntryRepeat | null,
+  editing: { readonly txn?: PersonalTxn; readonly rule?: PersonalRecurring } = {},
+): EntryRecord {
+  if (repeat === null) {
+    return {
+      recordId: editing.txn?.id,
+      recordKind: 'txn',
+      data: encodeTxn({
+        kind: draft.kind,
+        amount: draft.amount,
+        currency: draft.currency,
+        category: draft.category,
+        note: draft.note,
+        date: draft.date,
+        loanId: draft.loanId,
+        recurringId: draft.recurringId,
+      }),
+    };
+  }
+
+  const rule = editing.rule;
+  return {
+    recordId: rule?.id,
+    recordKind: 'recurring',
+    data: encodeRecurring({
+      txnKind: draft.kind,
+      amount: draft.amount,
+      currency: draft.currency,
+      category: draft.category,
+      note: draft.note,
+      ...scheduleFor(repeat.frequency, {
+        interval: repeat.interval,
+        secondDay: repeat.secondDay,
+      }),
+      anchorDate: draft.date,
+      nextDate: rule && rule.nextDate >= draft.date ? rule.nextDate : draft.date,
+      endDate: rule?.endDate ?? null,
+      autoPost: repeat.autoPost,
+      active: repeat.active,
+    }),
+  };
+}
+
+/** The repeat state an existing rule opens the form in. */
+export function repeatOf(rule: PersonalRecurring, frequency: Frequency): EntryRepeat {
+  return {
+    frequency,
+    interval: rule.interval > 1 ? rule.interval : 2,
+    secondDay: rule.secondDay ?? 15,
+    autoPost: rule.autoPost,
+    active: rule.active,
+  };
+}
+
+/** The repeat state a fresh entry switches on into: monthly, manual, live. */
+export const NEW_REPEAT: EntryRepeat = {
+  frequency: Frequency.Monthly,
+  interval: 2,
+  secondDay: 15,
+  autoPost: false,
+  active: true,
+};

--- a/apps/mobile/test/personalEntry.test.ts
+++ b/apps/mobile/test/personalEntry.test.ts
@@ -1,0 +1,245 @@
+/**
+ * The private ledger's one form writes what the three forms wrote.
+ *
+ * Collapsing "add expense", "add income" and the recurring editor into a single
+ * screen is an interface change and nothing else: `personal_records` is one
+ * opaque json column, the server relays it without reading it, and a merged
+ * form that quietly reshaped a blob would be a silent data migration nobody
+ * asked for. So these assert the payloads literally — the exact keys and values
+ * the old `encodeTxn` and `encodeRecurring` call sites produced — rather than
+ * round-tripping them through a decoder that would forgive a dropped field.
+ *
+ * The route checks are the other half of the same worry. Merging forms is how
+ * you break a link: the loans screen, the ledger list, the Me tab and the rules
+ * list all push into `personal/`, and expo-router resolves those paths off the
+ * file tree, so a file that stops existing is a dead button with no compile
+ * error behind it.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { Frequency, type PersonalRecurring, type PersonalTxn } from '@waves/core';
+
+import { entryRecord, NEW_REPEAT, repeatOf, type EntryDraft } from '../src/lib/personalEntry';
+
+const DRAFT: EntryDraft = {
+  kind: 'expense',
+  amount: 125000n,
+  currency: 'INR',
+  category: 'food',
+  note: 'Groceries',
+  date: '2026-09-12',
+  loanId: null,
+  recurringId: null,
+};
+
+const RULE: PersonalRecurring = {
+  id: 'rule-1',
+  txnKind: 'income',
+  amount: 5000000n,
+  currency: 'INR',
+  category: 'inc.salary',
+  note: 'Salary',
+  cadence: 'monthly',
+  interval: 1,
+  secondDay: null,
+  anchorDate: '2026-01-01',
+  nextDate: '2026-10-01',
+  endDate: '2027-12-31',
+  autoPost: true,
+  active: true,
+};
+
+describe('a one-off entry', () => {
+  it('stores an expense exactly as the add-expense screen did', () => {
+    const record = entryRecord(DRAFT, null);
+
+    expect(record.recordKind).toBe('txn');
+    expect(record.recordId).toBeUndefined();
+    expect(record.data).toEqual({
+      kind: 'expense',
+      amount: '125000',
+      currency: 'INR',
+      category: 'food',
+      note: 'Groceries',
+      date: '2026-09-12',
+      loanId: null,
+      recurringId: null,
+    });
+  });
+
+  it('stores an income exactly as the add-income screen did — the same shape, the other way', () => {
+    const record = entryRecord(
+      { ...DRAFT, kind: 'income', category: 'inc.salary', note: 'September' },
+      null,
+    );
+
+    expect(record.recordKind).toBe('txn');
+    expect(record.data).toMatchObject({ kind: 'income', category: 'inc.salary' });
+    // Direction is the only difference. An income filed as an expense is the
+    // wrong sign on every total that reads this row.
+    expect(Object.keys(record.data).sort()).toEqual(
+      Object.keys(entryRecord(DRAFT, null).data).sort(),
+    );
+  });
+
+  it('keeps the loan a repayment settles, and the rule that minted an entry', () => {
+    const editing: PersonalTxn = {
+      id: 'txn-7',
+      kind: 'expense',
+      amount: 1n,
+      currency: 'INR',
+      category: null,
+      note: null,
+      date: '2026-09-01',
+      loanId: 'loan-3',
+      recurringId: 'rule-1',
+    };
+    const record = entryRecord(
+      { ...DRAFT, category: null, loanId: 'loan-3', recurringId: 'rule-1' },
+      null,
+      { txn: editing },
+    );
+
+    expect(record.recordId).toBe('txn-7');
+    expect(record.data).toMatchObject({ loanId: 'loan-3', recurringId: 'rule-1' });
+  });
+});
+
+describe('repeating, as a property of the entry', () => {
+  it('writes a rule rather than a transaction, with the entry’s date as its start', () => {
+    const record = entryRecord(DRAFT, NEW_REPEAT);
+
+    expect(record.recordKind).toBe('recurring');
+    expect(record.data).toEqual({
+      txnKind: 'expense',
+      amount: '125000',
+      currency: 'INR',
+      category: 'food',
+      note: 'Groceries',
+      cadence: 'monthly',
+      interval: 1,
+      secondDay: null,
+      anchorDate: '2026-09-12',
+      nextDate: '2026-09-12',
+      endDate: null,
+      autoPost: false,
+      active: true,
+    });
+  });
+
+  it('carries the named patterns into the schedule the ledger stores', () => {
+    const schedule = (frequency: Frequency, interval = 5, secondDay = 20) =>
+      entryRecord(DRAFT, { ...NEW_REPEAT, frequency, interval, secondDay }).data;
+
+    expect(schedule(Frequency.Fortnightly)).toMatchObject({ cadence: 'weekly', interval: 2 });
+    expect(schedule(Frequency.Quarterly)).toMatchObject({ cadence: 'monthly', interval: 3 });
+    expect(schedule(Frequency.Yearly)).toMatchObject({ cadence: 'yearly', interval: 1 });
+    expect(schedule(Frequency.TwiceAMonth)).toMatchObject({
+      cadence: 'semimonthly',
+      secondDay: 20,
+    });
+    expect(schedule(Frequency.EveryNMonths)).toMatchObject({ cadence: 'monthly', interval: 5 });
+  });
+
+  it('opens an existing rule on the pattern it was written with', () => {
+    const twice = repeatOf(
+      { ...RULE, cadence: 'semimonthly', secondDay: 21 },
+      Frequency.TwiceAMonth,
+    );
+
+    expect(twice).toEqual({
+      frequency: Frequency.TwiceAMonth,
+      interval: 2,
+      secondDay: 21,
+      autoPost: true,
+      active: true,
+    });
+  });
+
+  it('leaves a rule already ahead of its start where it is in the queue', () => {
+    const record = entryRecord(
+      { ...DRAFT, date: RULE.anchorDate },
+      repeatOf(RULE, Frequency.Monthly),
+      {
+        rule: RULE,
+      },
+    );
+
+    expect(record.recordId).toBe('rule-1');
+    // Re-minting October would double up months the timeline can already show.
+    expect(record.data).toMatchObject({ anchorDate: '2026-01-01', nextDate: '2026-10-01' });
+  });
+
+  it('pulls a rule along when its start moves past the next one due', () => {
+    const record = entryRecord(
+      { ...DRAFT, date: '2027-03-01' },
+      repeatOf(RULE, Frequency.Monthly),
+      {
+        rule: RULE,
+      },
+    );
+
+    expect(record.data).toMatchObject({ anchorDate: '2027-03-01', nextDate: '2027-03-01' });
+  });
+
+  it('carries an end date through an edit, because nothing on the form can set one', () => {
+    const record = entryRecord(
+      { ...DRAFT, date: RULE.anchorDate },
+      repeatOf(RULE, Frequency.Monthly),
+      {
+        rule: RULE,
+      },
+    );
+
+    expect(record.data).toMatchObject({ endDate: '2027-12-31' });
+  });
+
+  it('pauses a rule without disturbing anything else about it', () => {
+    const record = entryRecord(
+      { ...DRAFT, date: RULE.anchorDate },
+      { ...repeatOf(RULE, Frequency.Monthly), active: false },
+      { rule: RULE },
+    );
+
+    expect(record.data).toMatchObject({ active: false, autoPost: true, nextDate: '2026-10-01' });
+  });
+});
+
+describe('the rooms of the private ledger', () => {
+  const APP = join(__dirname, '../src/app');
+
+  it('all still exist, so every push into them still resolves', () => {
+    // expo-router resolves a path off the file tree, so a merged form that
+    // deleted a file would leave a button that does nothing and compiles fine.
+    for (const route of [
+      'personal/entry.tsx',
+      'personal/recurring.tsx',
+      'personal/transactions.tsx',
+      'personal/loans.tsx',
+      'personal/budgets.tsx',
+      'personal/source/[id].tsx',
+      '(tabs)/me.tsx',
+    ]) {
+      expect(existsSync(join(APP, route)), route).toBe(true);
+    }
+  });
+
+  it('names the one form from every screen that used to have one of its own', () => {
+    const source = (name: string): string => readFileSync(join(APP, name), 'utf8');
+
+    // The rules list writes nothing itself any more: both its "+" and its pencil
+    // open the shared form, one with a repeat switched on and one on a rule.
+    expect(source('personal/recurring.tsx')).toContain("params: { repeats: '1' }");
+    expect(source('personal/recurring.tsx')).toContain('recurringId: rule.id');
+    expect(source('personal/recurring.tsx')).not.toContain('AmountField');
+
+    // And the Me tab's two add buttons still preselect a direction rather than
+    // leading to two different screens.
+    expect(source('(tabs)/me.tsx')).toContain("params: { kind: 'expense' }");
+    expect(source('(tabs)/me.tsx')).toContain("params: { kind: 'income' }");
+  });
+});

--- a/apps/mobile/test/personalNoteField.test.ts
+++ b/apps/mobile/test/personalNoteField.test.ts
@@ -37,7 +37,10 @@ describe('the private ledger’s note', () => {
   it('is typed on the screens this test knows about', () => {
     // A guard on the guard: if the section is restructured and nothing matches
     // any more, the assertions below would pass by looking at nothing at all.
-    expect(editors.sort()).toEqual(['entry.tsx', 'loans.tsx', 'recurring.tsx']);
+    // Two, not three: the recurring screen's own editor folded into `entry.tsx`
+    // when the private ledger collapsed to one form, so the rules list no longer
+    // types a note of its own.
+    expect(editors.sort()).toEqual(['entry.tsx', 'loans.tsx']);
   });
 
   it('goes through the shared field on every one of them, so it carries a mic', () => {


### PR DESCRIPTION
## What the request was

> "We have add expense and add income. And there's a button called recurring, and recurring itself — when I press it — that's an expense and income. So many screens are coming. It is very, very much hard. So let's keep it simple."

> "And the source, date in the add income or add expense or wherever — I want that to be similar to edit or view expense. Below the add receipt we have this Group / Paid by / Date / Split. I want a similar experience."

Two changes: collapse the fork, and make the fields read like the group expense screen's rows.

## Before / after navigation

**Before**

```
Me tab ──┬─ "Add expense" ──► /personal/entry?kind=expense ─┐
         ├─ "Add income"  ──► /personal/entry?kind=income  ─┴─ form A (segmented tabs inside)
         └─ Recurring tile ─► /personal/recurring ── list
                                      ├─ "+"     ──► inline Sheet ─┐
                                      └─ pencil  ──► inline Sheet ─┴─ form B (segmented tabs again)

Ledger "+"  ──► /personal/entry?kind=expense       (form A)
Loans       ──► /personal/entry?loanId=…           (form A)
Timeline    ──► /personal/entry?id=…               (form A)
```

Two forms, three layouts of the same question, and the direction fork asked twice.

**After**

```
Me tab ──┬─ "Add expense" ──► /personal/entry?kind=expense ─┐
         ├─ "Add income"  ──► /personal/entry?kind=income  ─┤
         └─ Recurring tile ─► /personal/recurring ── list   │
                                      ├─ "+"     ──► /personal/entry?repeats=1      ├─► THE form
                                      └─ pencil  ──► /personal/entry?recurringId=…  │
                                                                                    │
Ledger "+"  ──► /personal/entry?kind=expense                                        │
Loans       ──► /personal/entry?loanId=…                                            │
Timeline    ──► /personal/entry?id=…               ─────────────────────────────────┘
```

- **No route was added, moved or removed.** `personal/entry`, `personal/recurring`, `personal/transactions`, `personal/loans`, `personal/budgets`, `personal/source/[id]` all still exist and still resolve; every existing caller (`me.tsx`, `transactions.tsx`, `loans.tsx`, `source/[id].tsx`, `recurring.tsx`) keeps working unchanged except the two that now open the shared form.
- `/personal/entry` gained two optional params: `repeats=1` (open with the repeat switched on) and `recurringId` (edit a rule). `kind`, `id` and `loanId` are untouched.
- The recurring **list** stays its own screen. A list of rules and the form that writes one are different things; only the editor moved.
- The two Me-tab pills are kept deliberately. They now preselect a segment on one screen rather than leading to two, and dropping "Add income" would have made income a second-class direction — the exact flattening this repo reverted once before.

## The form

Amount, note, then one `Card` of divided `SettingRow`s:

| row | expense | income |
| --- | --- | --- |
| what | **What for?** — `CategoryRow` + `CategorySheet` | **Source** — `SourceRow` + `SourceSheet` |
| when | **Date** (or **Starts on** once it repeats) | same |
| repeat | **Repeats** — `Never` / `Monthly` / … | same |

Turning Repeats on grows a second card with the schedule's implications: the second-day / every-N steppers, "Add automatically", and (editing a rule) the pause toggle. Off — the common case — none of it is there and the form is three rows long.

## Shared row component: reused, not extracted

The idiom the request pointed at already exists as a shared component. `apps/mobile/src/components/expense/SheetOverlay.tsx` exports `SettingRow` (label left, chosen value + glyph right, chevron, a11y label `"{label}: {value}"`), `SheetOverlay` and `ChoiceRow`; `add-expense.tsx` folds its Date / Category / Paid with / Currency into exactly that, and `capture.tsx` uses the stacked sibling `FieldRow`. So the personal form **reuses** it — nothing was copy-pasted and nothing new was invented.

What I did add, in the same file's spirit: `SourceRow` + `SourceSheet` in `IncomeSource.tsx`, mirroring the existing `CategoryRow` + `CategorySheet` one file over, because income had a chip lane where expense had a row.

Deliberately **not** touched: the read-only `DetailLine` inside `group/[id]/expense/[expenseId].tsx`. It is the inverted twin of `SettingRow` — muted caption label with an emphasised value, where the form has an emphasised label with a muted value — so folding them together would have regressed the detail card's hierarchy to unify two things that genuinely differ. Said here rather than done quietly.

## Could not be carried across

Nothing was dropped silently, but two conversions are refused by construction and the UI says so by omission rather than by a disabled control:

1. **An existing transaction cannot grow a schedule**, and **an existing rule cannot become a one-off.** They are different `record_kind`s under different ids; converting would either orphan the entry or mint a second copy of it. So the Repeats row is absent when editing a transaction, and the repeat sheet offers no "Never" when editing a rule. Stopping a rule is pausing or deleting it — both on the form, both unchanged.
2. **`endDate` is still unsettable.** It was unsettable before this PR too (stored, honoured by `isRecurringDue`/`occurrences`, translated in four locales, never written by any editor — see `docs/plan-recurring-money-events.md` §2 bug 9). It is now carried through an edit untouched, with a test pinning that.

A loan repayment keeps its existing exemptions: no direction control, no category, and no repeat — the loan decides the first, and a schedule belongs to the loan rather than to one payment on it.

## Data model

Unchanged. No migration, no edge change, no new field, no Prisma touch. `personal_records` is still one opaque `data` json column on the `:personal` mirror scope with the server as a pure relay. The new test asserts the `txn` and `recurring` blobs **literally** — key for key — against what the old call sites produced, rather than round-tripping through a decoder that would forgive a dropped field.

## Fits the just-merged plan

`docs/plan-recurring-money-events.md` is unimplemented here, and its landing spots survive:

- P1 (glyph + direction word on the recurring card) — the list's card is untouched in shape.
- P2 (recurring button + due strip on transactions) — untouched screen.
- P3's editor half ("Remind me" toggle + time row, under "Add automatically") now lands in the form's repeat card, which is where "Add automatically" moved to. Everything else in P3 is unaffected.
- P4 (`?occurrence=` on the timeline) and P5 (the i18n deep walk) are untouched.

## i18n + RTL

One new key, `personal.repeatsNever`, added to the `UiStrings` interface **and** all four tables — `Never` / `திரும்பாது` / `कभी नहीं` / `أبدًا` — each anchored on that locale's own translated neighbour. No other user-visible string is new: the merged form reuses `repeats`, `startsOn`, `date`, `source`, `autoPost`, `autoPostHint`, `active`, `secondDay`, `everyNMonths`, `editRecurring`, `addRecurring`. Chevrons go through `directionalIcon()` (in `SettingRow` and the back button); `SheetOverlay` and `Row` are already writing-direction aware. No hardcoded user-visible text.

## Accessibility

- The segmented control is the existing `SegmentedTabs`, which states exact selected state.
- Every fact row is a `SettingRow`, whose `accessibilityLabel` is `"{field}: {current value}"` — what it is and what it holds.
- Every sheet option is a `ChoiceRow` with `accessibilityState={{ selected }}`, so the check mark is never the only signal.
- The steppers keep their per-button labels and disabled state.

## Money colour and sign

Untouched, and checked. The recurring card still draws sign **and** colour together (`+`/`−`, income `positive`, expense plain ink rather than red), with a comment now saying why so the next reskin has to argue with it. The form itself never displayed a signed amount before this change and still does not — direction there is the segmented control, which is the thing that sets it.

## Files

| file | what |
| --- | --- |
| `apps/mobile/src/app/personal/entry.tsx` | the one form |
| `apps/mobile/src/app/personal/recurring.tsx` | list only; editor removed, "+"/pencil route to the form |
| `apps/mobile/src/lib/personalEntry.ts` | **new** — pure: what one Save writes (`entryRecord`, `repeatOf`, `NEW_REPEAT`) |
| `apps/mobile/src/lib/frequencyLabel.ts` | **new** — the cadence in words, moved off the route file three screens were importing from (kept apart from the pure module so a node test never loads `expo-localization`) |
| `apps/mobile/src/components/IncomeSource.tsx` | `SourceRow` + `SourceSheet`; the now-unreferenced `SourcePicker` chip lane removed |
| `apps/mobile/src/app/personal/source/[id].tsx` | import moved |
| `apps/mobile/src/i18n/index.ts` | `repeatsNever` ×5 (interface + en/ta/hi/ar) |
| `apps/mobile/test/personalEntry.test.ts` | **new** — 11 cases |
| `apps/mobile/test/personalNoteField.test.ts` | its editor list is two screens now, not three |

## Tests

`apps/mobile/test/personalEntry.test.ts`:

- an expense stores the exact `txn` blob the add-expense path stored;
- an income stores the exact `txn` blob the add-income path stored, same key set, direction the only difference;
- a repayment keeps its `loanId`, and an entry minted by a rule keeps its `recurringId`;
- repeating writes a `recurring` rather than a `txn`, with the entry's date as its anchor;
- every named pattern maps to the schedule the ledger stores (fortnightly → weekly×2, quarterly → monthly×3, twice-a-month → semimonthly + second day, every-N → monthly×N, yearly);
- an existing rule opens on the pattern it was written with;
- a rule ahead of its start keeps its place in the queue; one whose start moved past it is pulled along;
- `endDate` survives an edit; pausing disturbs nothing else;
- every `personal/` route file still exists, and the rules list and Me tab still name the one form.

`personalNoteField.test.ts` updated: the note-typing screens are `entry.tsx` and `loans.tsx` now that the recurring editor folded in — the mic guard still holds on both.

## Gates

| gate | result |
| --- | --- |
| `pnpm format` | clean |
| `pnpm lint` | clean (all 12 projects) |
| `pnpm --filter @waves/mobile typecheck` | clean |
| `pnpm --filter @waves/mobile test` | **102 files, 1360 tests passed** |
| `pnpm --filter @waves/core test` | **63 files, 986 tests passed** |
| `bash scripts/check-filenames.sh` | clean |

`packages/db` tests were not run — they need a local Postgres that is not up, and nothing here touches the schema.

## Not done, and not run

- Not device-tested. There is no simulator or phone in this environment; every claim above is from the source, the type checker and the unit suites.
- No plan item from `docs/plan-recurring-money-events.md` was implemented.
- `recurring.tsx` still renders its rules with `ScrollView` + `.map` rather than FlashList. That is pre-existing, already noted in the plan as its own PR, and folding it in would have buried this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jhzmZz5fkjnZZ14YxHGfS
