### PR TITLE
A group can say what it is for, and its settings stop hiding behind a drawer

### DIFF
--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -30,6 +30,7 @@ import {
 import { balanceDirection, copyFor, format, money, moneyAccessibilityLabel } from '@waves/core';
 
 import { CategoryBadge } from '@/components/Category';
+import { DetailRow, DetailRows } from '@/components/DetailRows';
 import { useAvatarUrl } from '@/components/ProfileAvatar';
 import { MapPreview } from '@/components/MapPreview';
 import { ExpenseReceipts } from '@/components/ExpenseReceipts';
@@ -85,45 +86,6 @@ function MemberAvatar({
 }): React.JSX.Element {
   const url = useAvatarUrl(photo);
   return <Avatar name={name} photoUrl={url} ghost={ghost} size={size} />;
-}
-
-/** One labelled row of the bill's detail card — a glyph and muted label on the
- *  left, its value on the right. The stacked "paid by · date · split" caption
- *  the hero used to carry, given room to breathe as a proper key/value list.
- *
- *  The glyph is what makes the card scannable: four rows of grey words read as
- *  a paragraph, and the split row's icon is the same one the form's chips wear,
- *  so "how was this split" is answered by a mark rather than only by a word. */
-function DetailLine({
-  label,
-  value,
-  icon,
-}: {
-  label: string;
-  value: string;
-  icon: keyof typeof Ionicons.glyphMap;
-}): React.JSX.Element {
-  const theme = useTheme();
-  return (
-    <Row
-      style={{
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        gap: theme.spacing.md,
-        paddingVertical: theme.spacing.md,
-      }}
-    >
-      <Row style={{ alignItems: 'center', gap: theme.spacing.sm, flexShrink: 0 }}>
-        <Ionicons name={icon} size={iconSize.md} color={theme.color.textMuted} />
-        <Text variant="caption" tone="muted">
-          {label}
-        </Text>
-      </Row>
-      <Text variant="body" numberOfLines={1} style={{ flexShrink: 1, textAlign: 'right' }}>
-        {value}
-      </Text>
-    </Row>
-  );
 }
 
 export default function ExpenseDetailScreen() {
@@ -587,38 +549,37 @@ export default function ExpenseDetailScreen() {
                 used to wear. The group it belongs to leads the list so the bill
                 is placed without crowding the hero. */}
             <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
-              <DetailLine
-                icon="people-circle-outline"
-                label={t.expense.detailGroup}
-                value={groupLabel(group.data, members.data ?? [], profile?.id)}
-              />
-              <View style={{ height: 1, backgroundColor: theme.color.border }} />
-              <DetailLine
-                icon="wallet-outline"
-                label={t.paidBy}
-                value={
-                  version.payers.length > 1
-                    ? plural(locale, version.payers.length, t.misc.peopleCount)
-                    : nameOf(version.payers[0]?.member_id ?? null)
-                }
-              />
-              <View style={{ height: 1, backgroundColor: theme.color.border }} />
-              <DetailLine
-                icon="calendar-outline"
-                label={t.expense.detailDate}
-                value={new Intl.DateTimeFormat(locale, {
-                  day: 'numeric',
-                  month: 'long',
-                  year: 'numeric',
-                  timeZone: 'UTC',
-                }).format(new Date(version.expense_date))}
-              />
-              <View style={{ height: 1, backgroundColor: theme.color.border }} />
-              <DetailLine
-                icon={splitIcon(version.split_type)}
-                label={t.expense.detailSplit}
-                value={splitLabels(t)[version.split_type] ?? version.split_type}
-              />
+              <DetailRows>
+                <DetailRow
+                  icon="people-circle-outline"
+                  label={t.expense.detailGroup}
+                  value={groupLabel(group.data, members.data ?? [], profile?.id)}
+                />
+                <DetailRow
+                  icon="wallet-outline"
+                  label={t.paidBy}
+                  value={
+                    version.payers.length > 1
+                      ? plural(locale, version.payers.length, t.misc.peopleCount)
+                      : nameOf(version.payers[0]?.member_id ?? null)
+                  }
+                />
+                <DetailRow
+                  icon="calendar-outline"
+                  label={t.expense.detailDate}
+                  value={new Intl.DateTimeFormat(locale, {
+                    day: 'numeric',
+                    month: 'long',
+                    year: 'numeric',
+                    timeZone: 'UTC',
+                  }).format(new Date(version.expense_date))}
+                />
+                <DetailRow
+                  icon={splitIcon(version.split_type)}
+                  label={t.expense.detailSplit}
+                  value={splitLabels(t)[version.split_type] ?? version.split_type}
+                />
+              </DetailRows>
             </Card>
 
             {/* The full note, when the clamped hero heading could not have shown

--- a/apps/mobile/src/app/group/[id]/settings.tsx
+++ b/apps/mobile/src/app/group/[id]/settings.tsx
@@ -32,6 +32,7 @@ import { GroupPhoto } from '@/components/GroupPhoto';
 import { type PickedContact } from '@/components/ContactPicker';
 import { friendlyError } from '@/lib/errors';
 import { groupDeleteWarning, orderDebtsForWarning } from '@/lib/groupDeleteWarning';
+import { GROUP_DESCRIPTION_MAX, normaliseGroupDescription } from '@/lib/groupDescription';
 import { pickGroupPhoto } from '@/lib/image';
 import { requestContacts } from '@/lib/contactPickerBridge';
 import { router } from '@/lib/navigation';
@@ -239,16 +240,30 @@ export default function GroupSettingsScreen() {
   // group query is still catching up (see `commitName`). Cleared alongside the
   // field whenever a different group is loaded into this screen.
   const [sentName, setSentName] = useState<string | null>(null);
+  // The description follows the name exactly: same seeding, same
+  // commit-on-blur, same guard against the double trigger. It is the other half
+  // of what the group says about itself, so it is edited the same way rather
+  // than acquiring a Save button of its own.
+  const [description, setDescription] = useState(group.data?.description ?? '');
+  // `undefined` is "nothing sent yet", and it has to be distinguishable from
+  // the `null` a cleared description normalises to — otherwise the very first
+  // clear would compare equal to "nothing sent" and be swallowed, and the
+  // description would be unclearable. The name field gets away with a plain
+  // null here only because its empty value is '' rather than null.
+  const [sentDescription, setSentDescription] = useState<string | null | undefined>(undefined);
   if (group.data && seededId !== group.data.id) {
     setSeededId(group.data.id);
     setName(group.data.name ?? '');
     setSentName(null);
+    setDescription(group.data.description ?? '');
+    setSentDescription(undefined);
   }
   const [status, setStatus] = useState<string | null>(null);
   const [uploading, setUploading] = useState(false);
   // Whether the name is being edited (the rule under it lights up) and whether
   // the cover sheet is open. Both are about the identity row at the top.
   const [naming, setNaming] = useState(false);
+  const [describing, setDescribing] = useState(false);
   const [coverOpen, setCoverOpen] = useState(false);
 
   /**
@@ -272,6 +287,22 @@ export default function GroupSettingsScreen() {
     if (next === (group.data?.name ?? '') || next === sentName) return;
     setSentName(next);
     updateGroup.mutate({ name: next || null }, { onSuccess: () => setStatus(t.account.saved) });
+  };
+
+  /**
+   * Save the description, on the same two triggers and with the same two
+   * guards as the name above.
+   *
+   * The comparison is against the normalised form on both sides, not against
+   * the raw field: a description that differs from the stored one only by the
+   * whitespace somebody left at the end is not a change, and queueing it would
+   * put a mutation on the wire and a "Saved" on the screen for nothing.
+   */
+  const commitDescription = (): void => {
+    const next = normaliseGroupDescription(description);
+    if (next === (group.data?.description ?? null) || next === sentDescription) return;
+    setSentDescription(next);
+    updateGroup.mutate({ description: next }, { onSuccess: () => setStatus(t.account.saved) });
   };
 
   // A group photo is a paid feature; the cover emoji is free. The group may
@@ -559,6 +590,43 @@ export default function GroupSettingsScreen() {
               />
             </View>
           </Row>
+
+          {/* What the group is for, under what it is called — the same pair, in
+              the same card, that the create screen opens with. It sits across
+              the full width rather than beside the mark: a sentence needs the
+              room, and the mark belongs to the name. */}
+          <View style={{ gap: theme.spacing.xs, marginTop: theme.spacing.lg }}>
+            <Text variant="caption" tone="muted">
+              {t.group.descriptionOptional}
+            </Text>
+            <TextInput
+              value={description}
+              onChangeText={setDescription}
+              onFocus={() => setDescribing(true)}
+              onBlur={() => {
+                setDescribing(false);
+                commitDescription();
+              }}
+              accessibilityLabel={t.group.groupDescription}
+              placeholder={t.group.descriptionPlaceholder}
+              placeholderTextColor={theme.color.textFaint}
+              maxLength={GROUP_DESCRIPTION_MAX}
+              // Multiline, so there is no "done" key to submit on — blur is the
+              // only commit here, which is why `returnKeyType` is not set the
+              // way the name's is. A return inside a description is a line
+              // break, not a save.
+              multiline
+              style={{
+                fontSize: 15,
+                color: theme.color.text,
+                paddingVertical: theme.spacing.sm,
+                minHeight: 48,
+                textAlignVertical: 'top',
+                borderBottomWidth: 1.5,
+                borderBottomColor: describing ? theme.color.brand : theme.color.border,
+              }}
+            />
+          </View>
         </Card>
 
         {/* Opened by the mark above and nothing else, so there is one door to

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -18,19 +18,19 @@ import {
   Callout,
   Card,
   ChipRow,
-  Divider,
   IconButton,
   iconSize,
   Row,
   Screen,
   Text,
-  type TintName,
   Toggle,
   useTheme,
 } from '@waves/ui';
 
+import { DetailRow, DetailRows } from '@/components/DetailRows';
 import { GroupPhoto } from '@/components/GroupPhoto';
 import { friendlyError } from '@/lib/errors';
+import { GROUP_DESCRIPTION_MAX, normaliseGroupDescription } from '@/lib/groupDescription';
 import { router } from '@/lib/navigation';
 import { isPhoneCountryError, normaliseContactPhone } from '@/lib/phone';
 import { type PickedContact } from '@/components/ContactPicker';
@@ -75,131 +75,6 @@ const iconFor =
   // eslint-disable-next-line react/display-name
   (color: string): ReactNode => <Ionicons name={name} size={iconSize.base} color={color} />;
 
-/** The leading colour tile of a grouped row — a pastel square with an inked
- *  glyph, the way each Apple Wallet row is led by its own coloured icon. */
-const TILE = 38;
-function IconTile({ tint, icon }: { tint: TintName; icon: keyof typeof Ionicons.glyphMap }) {
-  const theme = useTheme();
-  const pair = theme.tint[tint];
-  return (
-    <View
-      style={{
-        width: TILE,
-        height: TILE,
-        borderRadius: theme.radius.md,
-        alignItems: 'center',
-        justifyContent: 'center',
-        backgroundColor: pair.bg,
-      }}
-    >
-      <Ionicons name={icon} size={iconSize.md} color={pair.ink} />
-    </View>
-  );
-}
-
-/**
- * One row of the grouped attributes card, Apple-Wallet style: a leading colour
- * tile, a bold label (with an optional one-line hint under it), and its control
- * — a value pill or a toggle — at the far right.
- */
-function AttrRow({
-  tint,
-  icon,
-  label,
-  subtitle,
-  children,
-}: {
-  tint: TintName;
-  icon: keyof typeof Ionicons.glyphMap;
-  label: string;
-  subtitle?: string;
-  children: ReactNode;
-}) {
-  const theme = useTheme();
-  return (
-    <Row
-      style={{
-        alignItems: 'center',
-        gap: theme.spacing.md,
-        paddingHorizontal: theme.spacing.lg,
-        paddingVertical: theme.spacing.md,
-      }}
-    >
-      <IconTile tint={tint} icon={icon} />
-      <View style={{ flex: 1, gap: 2 }}>
-        <Text variant="subheading" style={{ fontWeight: '600' }}>
-          {label}
-        </Text>
-        {subtitle ? (
-          <Text variant="caption" tone="muted">
-            {subtitle}
-          </Text>
-        ) : null}
-      </View>
-      {children}
-    </Row>
-  );
-}
-
-/** The hairline between grouped rows, inset past the colour tile so it starts
- *  under the label the way a native grouped list draws it. */
-function InsetDivider() {
-  const theme = useTheme();
-  return (
-    <View style={{ paddingLeft: theme.spacing.lg + TILE + theme.spacing.md }}>
-      <Divider />
-    </View>
-  );
-}
-
-/**
- * The tappable value at the right of an AttrRow: the current value and a chevron
- * that flips while its editor is unfolded below. It sits on a solid chip so it
- * reads against the tinted group fill, and lights up in the brand tint open.
- */
-function Pill({
-  label,
-  placeholder = false,
-  expanded,
-  onPress,
-  accessibilityLabel,
-}: {
-  label: string;
-  placeholder?: boolean;
-  expanded: boolean;
-  onPress: () => void;
-  accessibilityLabel: string;
-}) {
-  const theme = useTheme();
-  const ink = expanded ? theme.color.brand : placeholder ? theme.color.textMuted : theme.color.text;
-  return (
-    <Pressable
-      accessibilityRole="button"
-      accessibilityState={{ expanded }}
-      accessibilityLabel={accessibilityLabel}
-      onPress={onPress}
-      style={({ pressed }) => ({
-        flexDirection: 'row',
-        alignItems: 'center',
-        gap: theme.spacing.xs,
-        paddingLeft: theme.spacing.md,
-        paddingRight: theme.spacing.sm,
-        height: 36,
-        borderRadius: theme.radius.pill,
-        backgroundColor: expanded ? theme.color.brandSoft : theme.color.surface,
-        borderWidth: 1,
-        borderColor: expanded ? theme.color.brand : theme.color.border,
-        opacity: pressed ? 0.7 : 1,
-      })}
-    >
-      <Text variant="subheading" style={{ fontWeight: '600', color: ink }}>
-        {label}
-      </Text>
-      <Ionicons name={expanded ? 'chevron-up' : 'chevron-down'} size={iconSize.sm} color={ink} />
-    </Pressable>
-  );
-}
-
 /**
  * Making a group, wearing the same clothes as the settings that edit one.
  *
@@ -239,6 +114,10 @@ export default function NewGroupScreen() {
   const captures = useCaptures();
 
   const [name, setName] = useState('');
+  // A sentence about the group, under its name and in the same card, because it
+  // is part of naming the thing rather than a setting about it. Optional, and
+  // capped — see `groupDescription.ts` for why at that number.
+  const [description, setDescription] = useState('');
   // The group cover is an emoji icon, chosen by tapping the avatar. Photos are
   // a paid feature edited from group settings, not part of creating one.
   const [iconOpen, setIconOpen] = useState(false);
@@ -247,12 +126,17 @@ export default function NewGroupScreen() {
   // group called "Goa" still becomes one, "Dinner" does not, and an untyped
   // name falls back to Other rather than dragging trip fields in behind it.
   const [pickedType, setPickedType] = useState<GroupType | null>(null);
-  // Kind, dates, budget and simplify all live behind one collapsed row: the
-  // shortest path is name, people, create, and everything here is optional.
-  const [showMore, setShowMore] = useState(false);
-  // Which attribute row of the combined card is unfolded, if any — one at a
+  // Which attribute row of the settings card is unfolded, if any — one at a
   // time, so the card stays a short list until you open the one you want.
-  const [openAttr, setOpenAttr] = useState<'dates' | 'budget' | null>(null);
+  //
+  // These used to sit behind a "More options" disclosure, which hid four
+  // already-answered facts behind a row that said nothing about any of them. A
+  // group has a kind whether or not you open anything, so the screen now states
+  // it — the same way the expense screen states who paid and how a bill was
+  // split, as a stack of named facts with their values, each one a tap from
+  // being changed. Nothing here is required; the point is that the screen reads
+  // as already filled in rather than as a form still to be completed.
+  const [openAttr, setOpenAttr] = useState<'kind' | 'dates' | 'budget' | null>(null);
   const [ghostName, setGhostName] = useState('');
   // People to add on Create — a typed name carries no address, a contact carries
   // whatever the phone had. Same shape either way, so the create loop treats
@@ -314,6 +198,10 @@ export default function NewGroupScreen() {
     // same shape GroupPhoto's signed-URL fetch uses).
     void Promise.resolve().then(() => {
       setName(group.name ? fill(t.clone.copyOf, { name: group.name }) : '');
+      // The description comes across as-is. It describes what the group is for,
+      // and a clone is for the same thing — it is the name that needs "copy of"
+      // on it to tell the two apart, not the sentence explaining them both.
+      setDescription(group.description ?? '');
       setPickedType(group.type);
       setPickedEmoji(group.cover_emoji ?? null);
       setSimplify(group.simplify_debts);
@@ -431,6 +319,27 @@ export default function NewGroupScreen() {
         });
       }
 
+      // The description rides behind the create as an ordinary group.update,
+      // the same way the trip dates below do, rather than being added to
+      // `waves_create_group`.
+      //
+      // That is deliberate and is the safer of the two shapes. `group.create`
+      // is the one mutation in the app whose refusal takes something away: the
+      // queue overlay is the only place a group exists until it syncs, so a
+      // create the server will not accept ends with the person dropping it and
+      // the group going with it. Giving the create a new argument gives it a new
+      // way to be refused — by a server that has not yet learned the column, by
+      // a length the client let through — for the sake of a field nobody needs
+      // the group to have. Behind the create, the worst case is a description
+      // that did not save on a group that did.
+      //
+      // Only sent when something was actually typed, so the ordinary path
+      // (create a group, do not describe it) queues exactly what it did before.
+      const trimmedDescription = normaliseGroupDescription(description);
+      if (trimmedDescription) {
+        await mutate(MutationKind.GroupUpdate, groupId, { description: trimmedDescription });
+      }
+
       // Trip dates are not part of the create call, so they ride behind it as
       // an update on the same ordered queue — only when a trip was actually
       // given a start and end, since that is what turns the reminders on.
@@ -545,7 +454,11 @@ export default function NewGroupScreen() {
         showsVerticalScrollIndicator={false}
       >
         {/* One compact row: the cover — tapped to choose an icon — with the
-            name inline beside it and a clear (×) once there is a name. */}
+            name inline beside it and a clear (×) once there is a name; and
+            under it, in the same card, the sentence that says what the group is
+            for. The two belong together: they are both the group's own account
+            of itself, where everything below is a setting about how it behaves.
+            Splitting them into two cards would have said otherwise. */}
         <Card style={{ paddingVertical: theme.spacing.md }}>
           <Row style={{ alignItems: 'center', gap: theme.spacing.md }}>
             <Pressable
@@ -583,6 +496,45 @@ export default function NewGroupScreen() {
               </Pressable>
             ) : null}
           </Row>
+
+          {/* Inset past the cover so it lines up with the name rather than with
+              the mark, which is what makes the two read as one block of writing
+              about the group instead of two unrelated fields.
+
+              Multiline and auto-growing: a description is a sentence, and a
+              sentence that scrolls inside two lines of a text box is a sentence
+              nobody re-reads before saving. `maxLength` is the same cap the
+              column carries, so the field simply stops accepting keystrokes
+              rather than letting somebody type a paragraph the database will
+              refuse — a refusal they would only meet after tapping Create. */}
+          <View
+            style={{
+              marginTop: theme.spacing.md,
+              paddingTop: theme.spacing.md,
+              marginStart: 44 + theme.spacing.md,
+              borderTopWidth: 1,
+              borderTopColor: theme.color.border,
+            }}
+          >
+            <TextInput
+              value={description}
+              onChangeText={setDescription}
+              placeholder={t.group.descriptionPlaceholder}
+              placeholderTextColor={theme.color.textFaint}
+              accessibilityLabel={t.group.groupDescription}
+              maxLength={GROUP_DESCRIPTION_MAX}
+              multiline
+              style={{
+                fontSize: 15,
+                color: theme.color.text,
+                paddingVertical: 0,
+                // Two lines of room before it grows, so the field looks like
+                // somewhere to write rather than a one-line input.
+                minHeight: 40,
+                textAlignVertical: 'top',
+              }}
+            />
+          </View>
         </Card>
 
         {/* Controlled by the avatar tap above — no trigger of its own. */}
@@ -676,150 +628,110 @@ export default function NewGroupScreen() {
           ) : null}
         </Card>
 
-        {/* Everything that is not name-people-create folds behind one row, so
-            the screen opens as a short path and the settings are there for who
-            wants them. The collapsed row still shows the current kind, so a
-            wrong guess from the name is visible without opening it.
+        {/* The group's settings, stated rather than hidden.
 
-            Dates and budget are trip-only; the budget, left at zero, sets
+            This was a "More options" disclosure: one row that named none of the
+            four things behind it, with the kind of group — already decided,
+            already guessed from the name — sitting unread on its right. The
+            shape it wears now is the expense screen's: a stack of named facts
+            with their current values, hairlines between, each one a tap from
+            being changed. The screen reads as a group that already exists and
+            can be adjusted, which is what it is, instead of a form with a
+            drawer of unanswered questions in it.
+
+            Kind and simplify are always here; dates and budget are trip-only,
+            so a dinner or a flat never sees them. The budget, left at zero, sets
             nothing; entered, it seeds the planner's overall cap on create.
             ADR-009: simplification is presentation only — the pairwise ledger
             underneath is untouched. */}
-        <Card
-          flat
-          padded={false}
-          style={{ backgroundColor: theme.color.surfaceMuted, overflow: 'hidden' }}
-        >
-          <Pressable
-            accessibilityRole="button"
-            accessibilityState={{ expanded: showMore }}
-            // The explicit label overrides the descendant text, so the current
-            // kind shown on the right of the collapsed row is announced here too
-            // — a screen reader would otherwise never hear it.
-            accessibilityLabel={`${t.extras.moreOptions}, ${currentType.label}`}
-            onPress={() => setShowMore((current) => !current)}
-            style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}
-          >
-            <Row
-              style={{
-                alignItems: 'center',
-                gap: theme.spacing.md,
-                paddingHorizontal: theme.spacing.lg,
-                paddingVertical: theme.spacing.md,
-              }}
-            >
-              <IconTile tint="lilac" icon="options-outline" />
-              <View style={{ flex: 1, gap: 2 }}>
-                <Text variant="subheading" style={{ fontWeight: '600' }}>
-                  {t.extras.moreOptions}
-                </Text>
-                <Text variant="caption" tone="muted">
-                  {t.extras.moreOptionsHint}
-                </Text>
-              </View>
-              {!showMore ? (
-                <Text variant="caption" tone="muted">
-                  {currentType.label}
-                </Text>
-              ) : null}
-              <Ionicons
-                name={showMore ? 'chevron-up' : 'chevron-down'}
-                size={iconSize.base}
-                color={theme.color.textFaint}
+        <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+          <DetailRows>
+            {/* Row plus the editor it unfolds, as one child, so the divider
+                between rows lands above the row and not between a row and its
+                own open editor. Same shape for the three that unfold. */}
+            <View>
+              <DetailRow
+                icon={currentType.icon}
+                label={t.extras.groupKind}
+                value={currentType.label}
+                expanded={openAttr === 'kind'}
+                accessibilityLabel={`${t.extras.groupKind}, ${currentType.label}`}
+                onPress={() => setOpenAttr((current) => (current === 'kind' ? null : 'kind'))}
               />
-            </Row>
-          </Pressable>
-
-          {showMore ? (
-            <>
-              <InsetDivider />
-              <AttrRow tint="lilac" icon={currentType.icon} label={t.extras.groupKind}>
-                <View />
-              </AttrRow>
-              <View
-                style={{ paddingHorizontal: theme.spacing.lg, paddingBottom: theme.spacing.md }}
-              >
-                <ChipRow<GroupType>
-                  value={type}
-                  onChange={setPickedType}
-                  options={typeOptions.map((option) => ({
-                    value: option.value,
-                    label: option.label,
-                    icon: iconFor(option.icon),
-                  }))}
-                />
-              </View>
-
-              {type === GroupType.Trip ? (
-                <>
-                  <InsetDivider />
-                  <AttrRow tint="sky" icon="calendar-outline" label={t.misc.tripDatesTitle}>
-                    <Pill
-                      label={dateSummary}
-                      placeholder={!tripDates.start_date || !tripDates.end_date}
-                      expanded={openAttr === 'dates'}
-                      accessibilityLabel={t.misc.tripDatesTitle}
-                      onPress={() =>
-                        setOpenAttr((current) => (current === 'dates' ? null : 'dates'))
-                      }
-                    />
-                  </AttrRow>
-                  {openAttr === 'dates' ? (
-                    <View
-                      style={{
-                        paddingHorizontal: theme.spacing.lg,
-                        paddingBottom: theme.spacing.md,
-                      }}
-                    >
-                      <TripDates
-                        group={tripDates}
-                        locale={locale}
-                        embedded
-                        onChange={(patch) => setTripDates((current) => ({ ...current, ...patch }))}
-                      />
-                    </View>
-                  ) : null}
-
-                  <InsetDivider />
-                  <AttrRow tint="mint" icon="wallet-outline" label={t.extras.tripBudget}>
-                    <Pill
-                      label={budgetSummary}
-                      placeholder={budget <= 0n}
-                      expanded={openAttr === 'budget'}
-                      accessibilityLabel={t.extras.tripBudgetOptional}
-                      onPress={() =>
-                        setOpenAttr((current) => (current === 'budget' ? null : 'budget'))
-                      }
-                    />
-                  </AttrRow>
-                  {openAttr === 'budget' ? (
-                    <View
-                      style={{
-                        paddingHorizontal: theme.spacing.lg,
-                        paddingBottom: theme.spacing.md,
-                      }}
-                    >
-                      <AmountField currency={currency} value={budget} onChange={setBudget} />
-                    </View>
-                  ) : null}
-                </>
+              {openAttr === 'kind' ? (
+                <View style={{ paddingBottom: theme.spacing.md }}>
+                  <ChipRow<GroupType>
+                    value={type}
+                    onChange={setPickedType}
+                    options={typeOptions.map((option) => ({
+                      value: option.value,
+                      label: option.label,
+                      icon: iconFor(option.icon),
+                    }))}
+                  />
+                </View>
               ) : null}
+            </View>
 
-              <InsetDivider />
-              <AttrRow
-                tint="peach"
-                icon="flash-outline"
-                label={t.group.simplifyDebts}
-                subtitle={t.group.simplifyDebtsHint}
-              >
+            {type === GroupType.Trip ? (
+              <View>
+                <DetailRow
+                  icon="calendar-outline"
+                  label={t.misc.tripDatesTitle}
+                  value={dateSummary}
+                  placeholder={!tripDates.start_date || !tripDates.end_date}
+                  expanded={openAttr === 'dates'}
+                  accessibilityLabel={`${t.misc.tripDatesTitle}, ${dateSummary}`}
+                  onPress={() => setOpenAttr((current) => (current === 'dates' ? null : 'dates'))}
+                />
+                {openAttr === 'dates' ? (
+                  <View style={{ paddingBottom: theme.spacing.md }}>
+                    <TripDates
+                      group={tripDates}
+                      locale={locale}
+                      embedded
+                      onChange={(patch) => setTripDates((current) => ({ ...current, ...patch }))}
+                    />
+                  </View>
+                ) : null}
+              </View>
+            ) : null}
+
+            {type === GroupType.Trip ? (
+              <View>
+                <DetailRow
+                  icon="wallet-outline"
+                  label={t.extras.tripBudget}
+                  value={budgetSummary}
+                  placeholder={budget <= 0n}
+                  expanded={openAttr === 'budget'}
+                  accessibilityLabel={`${t.extras.tripBudgetOptional}, ${budgetSummary}`}
+                  onPress={() => setOpenAttr((current) => (current === 'budget' ? null : 'budget'))}
+                />
+                {openAttr === 'budget' ? (
+                  <View style={{ paddingBottom: theme.spacing.md }}>
+                    <AmountField currency={currency} value={budget} onChange={setBudget} />
+                  </View>
+                ) : null}
+              </View>
+            ) : null}
+
+            {/* The one row that is not tappable, because its control says the
+                value and changes it in the same gesture. A chevron here would
+                promise a second place to go that does not exist. */}
+            <DetailRow
+              icon="flash-outline"
+              label={t.group.simplifyDebts}
+              subtitle={t.group.simplifyDebtsHint}
+              trailing={
                 <Toggle
                   value={effectiveSimplify}
                   onValueChange={setSimplify}
                   accessibilityLabel={t.group.simplifyDebts}
                 />
-              </AttrRow>
-            </>
-          ) : null}
+              }
+            />
+          </DetailRows>
         </Card>
 
         {/* Seed the whole form from a group you already have — a power move, so

--- a/apps/mobile/src/components/DetailRows.tsx
+++ b/apps/mobile/src/components/DetailRows.tsx
@@ -1,0 +1,179 @@
+import { type ReactNode, Children, Fragment, isValidElement } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { Pressable, View } from 'react-native';
+
+import { directionalIcon, iconSize, Row, Text, useTheme } from '@waves/ui';
+
+/**
+ * The app's one way of stating a fact about a thing, and letting it be changed.
+ *
+ * This is the shape the expense screen settled on — a glyph and a muted label
+ * on the left, the current value on the right, hairlines between — and it is
+ * the shape the new-group screen now wears too. It used to live inline in
+ * `expense/[expenseId].tsx` as `DetailLine`, where it could only ever describe a
+ * bill; a second screen wanting the same idiom would have had to copy fourteen
+ * lines of markup, and the two would have drifted the first time either was
+ * touched. So it moved here instead of being duplicated.
+ *
+ * The glyph is what makes a stack of these scannable: four rows of grey words
+ * read as a paragraph, where four marked rows read as a list you can find your
+ * place in. It is not decoration — the split row's icon is the same one the
+ * expense form's chips wear, so "how was this split" is answered by a mark as
+ * well as by a word.
+ *
+ * Two things distinguish this from `ListRow` in @waves/ui, which is the other
+ * row in the app and is deliberately not this one. `ListRow` is a list *entry*
+ * — a thing, with a name and a subtitle, that you open. This is an *attribute* —
+ * a named fact with a value, that you change in place. And this one takes an
+ * Ionicons glyph name, which is why it is here in the app rather than in
+ * @waves/ui: that package takes no icon dependency, by design, and every
+ * component there that draws a glyph takes it as a render prop instead.
+ */
+export function DetailRow({
+  icon,
+  label,
+  subtitle,
+  value,
+  placeholder = false,
+  trailing,
+  onPress,
+  expanded,
+  accessibilityLabel,
+}: {
+  icon: keyof typeof Ionicons.glyphMap;
+  label: string;
+  /** One line under the label, for a fact whose name does not explain it —
+   *  "simplify debts" being the case this exists for. Most rows need none, and
+   *  a row with one gives up the right-aligned value's share of the width. */
+  subtitle?: string;
+  /** The fact's current value, as one line. Omitted when `trailing` says it. */
+  value?: string;
+  /** True when `value` is a prompt ("Add") rather than an answer, so it is
+   *  drawn as faint the way an unfilled input's placeholder is. */
+  placeholder?: boolean;
+  /** A control that states the value itself — a toggle, say — instead of a word.
+   *  Mutually exclusive with `value` in practice; the row draws both if given
+   *  both, which is a caller's mistake rather than a supported layout. */
+  trailing?: ReactNode;
+  /** Makes the row tappable and gives it a chevron. Left off, the row is a
+   *  read-only statement — which is exactly what the expense screen wants. */
+  onPress?: () => void;
+  /** When the row's editor unfolds in place rather than pushing a screen, this
+   *  says whether it is open: the chevron then points down/up like a
+   *  disclosure, instead of forward like a door. Left undefined, it is a door. */
+  expanded?: boolean;
+  /** What a screen reader hears. Required on a tappable row, because "Kind" on
+   *  its own does not say what the row currently holds — the value is drawn to
+   *  the right of the label, and a reader that stops at the label learns half
+   *  of it. */
+  accessibilityLabel?: string;
+}) {
+  const theme = useTheme();
+  const chevron = onPress
+    ? expanded === undefined
+      ? directionalIcon('chevron-forward')
+      : expanded
+        ? 'chevron-up'
+        : 'chevron-down'
+    : null;
+
+  const content = (
+    <Row
+      style={{
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        gap: theme.spacing.md,
+        paddingVertical: theme.spacing.md,
+        // A tappable row is a target before it is a statement, so it is floored
+        // at the 44pt minimum even when its one line of text is shorter.
+        minHeight: onPress ? 44 : undefined,
+      }}
+    >
+      <Row
+        style={{
+          alignItems: 'center',
+          gap: theme.spacing.sm,
+          // A bare label is as wide as its word and the value takes the rest;
+          // a label with a hint under it is the wordy half, so it takes the
+          // room instead and the value shrinks around it.
+          flexShrink: subtitle ? 1 : 0,
+          flex: subtitle ? 1 : undefined,
+        }}
+      >
+        <Ionicons name={icon} size={iconSize.md} color={theme.color.textMuted} />
+        <View style={{ gap: 2, flexShrink: 1 }}>
+          <Text variant="caption" tone="muted">
+            {label}
+          </Text>
+          {subtitle ? (
+            <Text variant="micro" tone="muted">
+              {subtitle}
+            </Text>
+          ) : null}
+        </View>
+      </Row>
+      <Row style={{ alignItems: 'center', gap: theme.spacing.xs, flexShrink: 1 }}>
+        {value === undefined ? null : (
+          <Text
+            variant="body"
+            tone={placeholder ? 'muted' : undefined}
+            numberOfLines={1}
+            style={{ flexShrink: 1, textAlign: 'right' }}
+          >
+            {value}
+          </Text>
+        )}
+        {trailing}
+        {chevron ? (
+          <Ionicons name={chevron} size={iconSize.base} color={theme.color.textFaint} />
+        ) : null}
+      </Row>
+    </Row>
+  );
+
+  if (!onPress) return content;
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      // Only claimed when the row actually folds something out. A row that
+      // pushes a screen is not expandable, and announcing it as collapsed says
+      // there is something here to unfold that never will.
+      accessibilityState={expanded === undefined ? undefined : { expanded }}
+      accessibilityLabel={accessibilityLabel ?? `${label}${value ? `, ${value}` : ''}`}
+      onPress={onPress}
+      style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}
+    >
+      {content}
+    </Pressable>
+  );
+}
+
+/**
+ * A stack of {@link DetailRow}s with a hairline between each pair.
+ *
+ * The divider belongs to the gap, not to the row — a row that drew its own
+ * would leave a stray line under the last one, and every caller stitching them
+ * in by hand is how the expense screen ended up with four copies of the same
+ * one-pixel `View`. Non-element children (a `null` from a conditional row) are
+ * dropped before the count, so a trip-only row that is absent takes its divider
+ * with it rather than leaving two lines with nothing between them.
+ *
+ * This draws no background of its own: the caller wraps it in whatever surface
+ * the screen uses, so the same stack sits on a Card here and a tinted panel
+ * there without the rows knowing.
+ */
+export function DetailRows({ children }: { children: ReactNode }) {
+  const theme = useTheme();
+  const rows = Children.toArray(children).filter(isValidElement);
+  return (
+    <View>
+      {rows.map((row, index) => (
+        <Fragment key={row.key ?? index}>
+          {index > 0 ? <View style={{ height: 1, backgroundColor: theme.color.border }} /> : null}
+          {row}
+        </Fragment>
+      ))}
+    </View>
+  );
+}

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -48,9 +48,9 @@ import type {
 } from './types';
 
 const GROUP_SELECT = `
-  id, name, type, country_code, default_currency, simplify_debts, cover_emoji, photo_path,
-  start_date, end_date, time_zone, remind_daily, remind_morning_at, remind_evening_at,
-  archived_at, deleted_at, created_at
+  id, name, description, type, country_code, default_currency, simplify_debts, cover_emoji,
+  photo_path, start_date, end_date, time_zone, remind_daily, remind_morning_at,
+  remind_evening_at, archived_at, deleted_at, created_at
 `;
 
 // profiles is embedded by its FK column (profile_id): ghost_merges references
@@ -885,6 +885,9 @@ export async function updateGroup(
   groupId: string,
   patch: Partial<{
     name: string | null;
+    /** Normalise through `normaliseGroupDescription` before sending: NULL, not
+     *  '', and never longer than the column's CHECK allows. */
+    description: string | null;
     type: GroupType;
     cover_emoji: string | null;
     photo_path: string | null;

--- a/apps/mobile/src/data/types.ts
+++ b/apps/mobile/src/data/types.ts
@@ -27,6 +27,11 @@ export interface GroupRow {
   id: string;
   /** Optional — an unnamed group is labelled by who is in it (see groupLabel). */
   name: string | null;
+  /** What the group is for, in the maker's own words. Optional, capped at
+   *  GROUP_DESCRIPTION_MAX by both the input and a CHECK on the column. NULL,
+   *  never '' — an empty string would render as a blank line everywhere this is
+   *  shown, where an absent one renders as nothing. */
+  description: string | null;
   type: GroupType;
   /**
    * ISO-3166 alpha-2 — where this group settles, which decides which payment

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1914,6 +1914,11 @@ export interface UiStrings {
     photoUpdated: string;
     nameOptional: string;
     groupName: string;
+    /** The group's own sentence about itself, under its name on both the create
+     *  and the settings screen. Optional, capped at GROUP_DESCRIPTION_MAX. */
+    descriptionOptional: string;
+    groupDescription: string;
+    descriptionPlaceholder: string;
     /** The cover sheet, reached by tapping the group's mark: pick one of the
      *  drawn marks, put a photo from the phone in its place (a Plus feature),
      *  or drop a photo already set. */
@@ -2916,8 +2921,6 @@ export interface UiStrings {
   extras: {
     blankNameHint: string;
     tripBudgetOptional: string;
-    moreOptions: string;
-    moreOptionsHint: string;
     tripWelcomeTitle: string;
     tripWelcomeBody: string;
     tripWelcomeAddDates: string;
@@ -4555,6 +4558,9 @@ const en: UiStrings = {
     photoUpdated: 'Photo updated',
     nameOptional: 'Name (optional)',
     groupName: 'Group name',
+    descriptionOptional: 'Description (optional)',
+    groupDescription: 'Group description',
+    descriptionPlaceholder: 'What is this group for?',
     changeCover: 'Group cover',
     chooseIcon: 'Choose an icon',
     chooseIconHint: 'One of the drawn marks',
@@ -5492,8 +5498,6 @@ const en: UiStrings = {
   extras: {
     blankNameHint: 'Leave it blank and the group is named after whoever is in it.',
     tripBudgetOptional: 'Trip budget (optional)',
-    moreOptions: 'More options',
-    moreOptionsHint: 'Type, dates, budget',
     tripWelcomeTitle: 'Want to plan this trip?',
     tripWelcomeBody: 'Add dates to turn on daily reminders, or set a budget to track spending.',
     tripWelcomeAddDates: 'Add dates',
@@ -7194,6 +7198,9 @@ const ta: UiStrings = {
     photoUpdated: 'புகைப்படம் புதுப்பிக்கப்பட்டது',
     nameOptional: 'பெயர் (விருப்பம்)',
     groupName: 'குழுவின் பெயர்',
+    descriptionOptional: 'விவரம் (விருப்பம்)',
+    groupDescription: 'குழுவின் விவரம்',
+    descriptionPlaceholder: 'இந்தக் குழு எதற்காக?',
     changeCover: 'குழுவின் அட்டை',
     chooseIcon: 'ஐகானைத் தேர்ந்தெடு',
     chooseIconHint: 'வரையப்பட்ட அடையாளங்களில் ஒன்று',
@@ -8198,8 +8205,6 @@ const ta: UiStrings = {
   extras: {
     blankNameHint: 'காலியாக விட்டால், குழுவில் உள்ளவர்களின் பெயரில் குழு அமையும்.',
     tripBudgetOptional: 'பயண பட்ஜெட் (விருப்பம்)',
-    moreOptions: 'மேலும் விருப்பங்கள்',
-    moreOptionsHint: 'வகை, தேதிகள், பட்ஜெட்',
     tripWelcomeTitle: 'இந்தப் பயணத்தைத் திட்டமிடலாமா?',
     tripWelcomeBody:
       'தினசரி நினைவூட்டல்களை இயக்க தேதிகளைச் சேர்க்கவும், அல்லது செலவைக் கண்காணிக்க பட்ஜெட் அமைக்கவும்.',
@@ -9845,6 +9850,9 @@ const hi: UiStrings = {
     photoUpdated: 'फ़ोटो बदल गई',
     nameOptional: 'नाम (वैकल्पिक)',
     groupName: 'समूह का नाम',
+    descriptionOptional: 'विवरण (वैकल्पिक)',
+    groupDescription: 'समूह का विवरण',
+    descriptionPlaceholder: 'यह समूह किसलिए है?',
     changeCover: 'समूह का कवर',
     chooseIcon: 'आइकन चुनें',
     chooseIconHint: 'बने-बनाए चिह्नों में से एक',
@@ -10799,8 +10807,6 @@ const hi: UiStrings = {
   extras: {
     blankNameHint: 'खाली छोड़ दें तो समूह का नाम उसमें शामिल लोगों पर रख दिया जाएगा।',
     tripBudgetOptional: 'ट्रिप बजट (वैकल्पिक)',
-    moreOptions: 'और विकल्प',
-    moreOptionsHint: 'प्रकार, तारीखें, बजट',
     tripWelcomeTitle: 'इस ट्रिप की योजना बनाएँ?',
     tripWelcomeBody:
       'रोज़ाना रिमाइंडर चालू करने के लिए तारीखें जोड़ें, या खर्च देखने के लिए बजट सेट करें।',
@@ -12572,6 +12578,9 @@ const ar: UiStrings = {
     photoUpdated: 'تم تحديث الصورة',
     nameOptional: 'الاسم (اختياري)',
     groupName: 'اسم المجموعة',
+    descriptionOptional: 'الوصف (اختياري)',
+    groupDescription: 'وصف المجموعة',
+    descriptionPlaceholder: 'ما الغرض من هذه المجموعة؟',
     changeCover: 'غلاف المجموعة',
     chooseIcon: 'اختر أيقونة',
     chooseIconHint: 'أحد الرموز المرسومة',
@@ -13727,8 +13736,6 @@ const ar: UiStrings = {
   extras: {
     blankNameHint: 'اتركه فارغًا فتُسمّى المجموعة بأسماء من فيها.',
     tripBudgetOptional: 'ميزانية الرحلة (اختياري)',
-    moreOptions: 'خيارات إضافية',
-    moreOptionsHint: 'النوع، التواريخ، الميزانية',
     tripWelcomeTitle: 'هل تريد التخطيط لهذه الرحلة؟',
     tripWelcomeBody: 'أضِف التواريخ لتشغيل التذكيرات اليومية، أو حدّد ميزانية لتتبّع الإنفاق.',
     tripWelcomeAddDates: 'أضف التواريخ',

--- a/apps/mobile/src/lib/groupDescription.ts
+++ b/apps/mobile/src/lib/groupDescription.ts
@@ -1,0 +1,36 @@
+/**
+ * What a group's description is allowed to be, in one place.
+ *
+ * The column is plain `text` with a CHECK on its length, the `/sync` boundary
+ * normalises what reaches it, and two screens type into it. Three places that
+ * have to agree on the same number is how a cap drifts, so the number lives
+ * here and the screens read it — the database constraint is the one copy that
+ * cannot import this, and it names this file so the pair stays findable.
+ *
+ * 280 is chosen, not inherited. A description answers "what is this group" —
+ * "Goa, Jan 2026, the four of us, flights already settled" — and that is a
+ * sentence or two. Long enough that nobody has to abbreviate; short enough that
+ * it stays a caption under the name rather than becoming a notes field the
+ * group screen would then have to find room to show in full.
+ */
+export const GROUP_DESCRIPTION_MAX = 280;
+
+/**
+ * A typed description as the column should hold it: trimmed, capped, and NULL
+ * rather than empty.
+ *
+ * The NULL matters and is the same bargain `name` strikes: '' renders as a blank
+ * line everywhere a description is shown, where NULL renders as nothing at all.
+ * Clearing the field has to reach the column as an absence, not as an empty
+ * string that every reader then has to remember to treat as one.
+ *
+ * The cap is applied here as well as by `maxLength` on the input, because the
+ * input is not the only writer — a clone seeds this field from another group's
+ * row, and a row written before the cap existed would otherwise walk straight
+ * into the CHECK constraint and be refused as an unexplained save failure.
+ */
+export function normaliseGroupDescription(raw: string | null | undefined): string | null {
+  const trimmed = (raw ?? '').trim();
+  if (!trimmed) return null;
+  return trimmed.slice(0, GROUP_DESCRIPTION_MAX);
+}

--- a/apps/mobile/test/groupDescription.test.ts
+++ b/apps/mobile/test/groupDescription.test.ts
@@ -1,0 +1,175 @@
+/**
+ * A group's description: what reaches the column, and what comes back.
+ *
+ * The field is written on the create screen but not by the create call — it
+ * rides behind `group.create` as an ordinary `group.update`, the same way the
+ * trip dates and the starting budget do, so that a new field can never give
+ * `group.create` a new way to be refused (the one mutation whose refusal takes
+ * the group with it). That shape is the thing worth pinning down without a
+ * device: a group made with no description must queue exactly what it queued
+ * before, and one made with a description must show it the instant it is typed
+ * — before any sync — because the queue overlay is the only place either lives
+ * until the phone finds a network.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  emptyMirror,
+  enqueue,
+  materialiseGroup,
+  MutationKind,
+  reconcile,
+  SyncTable,
+  type MutationEnvelope,
+  type QueuedMutation,
+} from '@waves/core';
+
+import { GROUP_DESCRIPTION_MAX, normaliseGroupDescription } from '../src/lib/groupDescription';
+
+const GROUP = 'g-1';
+const AT = '2026-03-01T09:00:00Z';
+
+/** The envelope's payload is `unknown` by design — the queue carries every kind
+ *  of mutation — so these tests pin it to a plain record and read fields off it
+ *  directly, rather than casting at each assertion. */
+type Envelope = MutationEnvelope<MutationKind, Record<string, unknown>>;
+
+function envelope(id: string, kind: MutationKind, payload: Record<string, unknown>): Envelope {
+  return { clientMutationId: id, kind, groupId: GROUP, clientCreatedAt: AT, payload };
+}
+
+function queued(...envelopes: Envelope[]): QueuedMutation[] {
+  let queue: QueuedMutation[] = [];
+  for (const item of envelopes) queue = enqueue(queue, item);
+  return queue;
+}
+
+/** What the create screen would queue for a given typed description — the two
+ *  lines of `submit` that decide it, with nothing else in the way. */
+function mutationsFor(typed: string): Envelope[] {
+  const create = envelope('m-1', MutationKind.GroupCreate, { name: 'Goa', currency: 'INR' });
+  const description = normaliseGroupDescription(typed);
+  return description
+    ? [create, envelope('m-2', MutationKind.GroupUpdate, { description })]
+    : [create];
+}
+
+describe('normaliseGroupDescription', () => {
+  it('reads an empty or blank field as no description at all', () => {
+    // NULL, not '': an empty string renders as a blank line everywhere the
+    // description is shown, where an absent one renders as nothing.
+    expect(normaliseGroupDescription('')).toBeNull();
+    expect(normaliseGroupDescription('   \n  ')).toBeNull();
+    expect(normaliseGroupDescription(null)).toBeNull();
+    expect(normaliseGroupDescription(undefined)).toBeNull();
+  });
+
+  it('trims the whitespace around a real description', () => {
+    expect(normaliseGroupDescription('  Goa, January, four of us  ')).toBe(
+      'Goa, January, four of us',
+    );
+  });
+
+  it('caps a long description at the length the column will accept', () => {
+    const tooLong = 'a'.repeat(GROUP_DESCRIPTION_MAX + 50);
+    const capped = normaliseGroupDescription(tooLong);
+    expect(capped).toHaveLength(GROUP_DESCRIPTION_MAX);
+  });
+
+  it('leaves a description exactly at the cap alone', () => {
+    // The boundary is inclusive on both sides — the input's maxLength lets this
+    // one be typed, and the column's CHECK is `<= 280`.
+    const exact = 'b'.repeat(GROUP_DESCRIPTION_MAX);
+    expect(normaliseGroupDescription(exact)).toBe(exact);
+  });
+
+  it('counts characters, not bytes, so every script gets the same room', () => {
+    // A Tamil description must not run out of space at a third of an English
+    // one. `slice` works in UTF-16 code units and the column's CHECK uses
+    // char_length, which is the same count for everything in these scripts.
+    const tamil = 'கோ'.repeat(GROUP_DESCRIPTION_MAX);
+    expect(normaliseGroupDescription(tamil)).toHaveLength(GROUP_DESCRIPTION_MAX);
+  });
+});
+
+describe('creating a group', () => {
+  it('queues nothing extra when no description was typed', () => {
+    // The unchanged path, and the one that matters most: a group with no
+    // description must put exactly one mutation on the queue, so the shortest
+    // way through the screen is the same shape it has always been.
+    const mutations = mutationsFor('');
+    expect(mutations.map((m) => m.kind)).toEqual([MutationKind.GroupCreate]);
+  });
+
+  it('queues the description behind the create, never inside it', () => {
+    const mutations = mutationsFor('Goa, January, flights already settled');
+    expect(mutations.map((m) => m.kind)).toEqual([
+      MutationKind.GroupCreate,
+      MutationKind.GroupUpdate,
+    ]);
+    // Nothing about the description reaches the create payload: that is the
+    // whole point of the ordering, so assert it rather than trusting it.
+    expect(mutations[0]?.payload).not.toHaveProperty('description');
+    expect(mutations[1]?.payload.description).toBe('Goa, January, flights already settled');
+  });
+
+  it('shows the description on the group before anything has synced', () => {
+    // Offline, the queue overlay is the only place this group exists. A
+    // description that could be typed but not read back until a network
+    // appeared would be indistinguishable from one the app had thrown away.
+    const queue = queued(...mutationsFor('Goa, January, flights already settled'));
+    const group = materialiseGroup(emptyMirror(), queue, GROUP);
+    expect(group?.description).toBe('Goa, January, flights already settled');
+    expect(group?.pending).toBe(true);
+  });
+
+  it('leaves the group without a description when none was typed', () => {
+    const queue = queued(...mutationsFor('   '));
+    const group = materialiseGroup(emptyMirror(), queue, GROUP);
+    expect(group?.id).toBe(GROUP);
+    expect(group?.description ?? null).toBeNull();
+  });
+});
+
+describe('editing a group', () => {
+  /** A group as the server has already sent it down. */
+  const mirrorWith = (description: string | null) =>
+    reconcile(emptyMirror(), [
+      {
+        table: SyncTable.Groups,
+        groupId: GROUP,
+        seq: 1,
+        row: {
+          id: GROUP,
+          name: 'Goa',
+          description,
+          default_currency: 'INR',
+          created_at: AT,
+          archived_at: null,
+          deleted_at: null,
+        },
+      },
+    ]).state;
+
+  it('round-trips a description the server has confirmed', () => {
+    const group = materialiseGroup(mirrorWith('Goa, January'), [], GROUP);
+    expect(group?.description).toBe('Goa, January');
+    expect(group?.pending).toBeUndefined();
+  });
+
+  it('shows an edit over the confirmed row while it is still queued', () => {
+    const queue = queued(envelope('m-9', MutationKind.GroupUpdate, { description: 'Goa, August' }));
+    const group = materialiseGroup(mirrorWith('Goa, January'), queue, GROUP);
+    expect(group?.description).toBe('Goa, August');
+  });
+
+  it('clears a description with NULL, and the clear survives the overlay', () => {
+    // Clearing has to reach the column as an absence rather than an empty
+    // string, and the overlay has to show the absence — otherwise the field
+    // looks cleared, then fills itself back in from the mirror row underneath.
+    const queue = queued(envelope('m-9', MutationKind.GroupUpdate, { description: null }));
+    const group = materialiseGroup(mirrorWith('Goa, January'), queue, GROUP);
+    expect(group?.description).toBeNull();
+  });
+});

--- a/packages/core/src/sync/mirror.ts
+++ b/packages/core/src/sync/mirror.ts
@@ -542,6 +542,11 @@ export function materialiseMembers(
 export interface MirrorGroup extends MirrorRow {
   readonly id: string;
   readonly name: string | null;
+  /** What the group is for, in the maker's own words — or NULL. Optional here
+   *  because the row the `group.create` overlay builds has never carried one:
+   *  a description is written by the `group.update` that rides behind the
+   *  create, which the overlay below spreads onto the row the moment it queues. */
+  readonly description?: string | null;
   readonly default_currency: string;
   readonly created_at: string;
   readonly archived_at: string | null;

--- a/packages/db/prisma/migrations/20260912170000_group_description/migration.sql
+++ b/packages/db/prisma/migrations/20260912170000_group_description/migration.sql
@@ -1,0 +1,156 @@
+-- A group could say which one it was. It could not say what it was for.
+--
+-- `groups.name` is the only thing a group has ever been able to write about
+-- itself, and a name is an identifier: "Goa", "Flat", "Dinner". It answers
+-- *which* group, and it answers it to the people who were there when it was
+-- made. Six months and four groups later, "Goa" does not say whether it is the
+-- January trip with flights already settled or the one in August where they
+-- were not, and the only way to find out is to open the ledger and read it.
+--
+-- So: one optional sentence, written by whoever makes the group, alongside the
+-- name and on the same card, because it is part of the group's account of
+-- itself rather than a setting about how it behaves.
+
+-- ──────────────────────────────────────────────────────────── the column ──
+--
+-- Nullable with no default, like `name`: a group that says nothing about itself
+-- is the normal case, not a degenerate one, and NULL is what "said nothing"
+-- looks like. '' is deliberately not a supported state — it renders as a blank
+-- line wherever the description is shown, where NULL renders as nothing at all
+-- — so the client and the `/sync` boundary both normalise an emptied field back
+-- to NULL before it reaches here. This does not enforce that: a CHECK banning
+-- '' would turn a client bug into a refused save, and the cost of one empty
+-- string arriving is a blank line, not a wrong number.
+ALTER TABLE public.groups
+  ADD COLUMN IF NOT EXISTS description text;
+
+-- 280 characters, and the number is a decision rather than an inheritance.
+--
+-- A description is a caption under a name — a sentence or two saying what this
+-- group is for. Long enough that nobody has to abbreviate; short enough that it
+-- stays a caption, rather than becoming a notes field every screen showing a
+-- group then has to find room to render in full. `text` with a CHECK, not
+-- `varchar(280)`, because the cap is a product rule that may change and an
+-- ALTER on a constraint is cheaper to reason about than one on a column type.
+--
+-- `char_length`, not `length` or `octet_length`: the cap is in characters, and
+-- a Tamil or Arabic description must get the same 280 as an English one. Eleven
+-- bytes per character in one script and one in another would be a cap that
+-- quietly means something different in every language the app speaks.
+--
+-- The client's `maxLength` on the input is the same number, expressed in
+-- `apps/mobile/src/lib/groupDescription.ts` — so the field stops accepting
+-- keystrokes rather than letting somebody type a paragraph and meet this
+-- constraint as an unexplained save failure after tapping Create. That copy is
+-- a courtesy; this one is the boundary.
+DO $do$
+BEGIN
+  ALTER TABLE public.groups
+    ADD CONSTRAINT groups_description_length
+    CHECK (description IS NULL OR char_length(description) <= 280);
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$do$;
+
+-- ───────────────────────────────────────────── and the allowlist it needs ──
+--
+-- `waves_guard_group_columns` (20260910090000_group_column_guard) refuses any
+-- column an ordinary member writes that is not on one hand-maintained list. It
+-- was deliberately rewritten from "what is forbidden" to "what is allowed"
+-- precisely so that a column added later is refused by default instead of
+-- exposed by default — which means a new column the app *does* mean members to
+-- write is invisible until it is named here. Adding it is the whole ceremony:
+-- without this, the description typed on the create screen would be refused as
+-- FORBIDDEN_COLUMN, and the refusal would arrive as a red mark on the sync
+-- banner over a group that was otherwise made correctly.
+--
+-- The list is kept in step with `GROUP_UPDATABLE_FIELDS` in
+-- `supabase/functions/sync/index.ts`, which is the same list; that one is a
+-- convenience filter returning a tidy 400, and this one is the boundary that
+-- holds when somebody skips `/sync` and PATCHes PostgREST directly.
+--
+-- Everything else in this function is 20260910090000 verbatim — same signature,
+-- same trigger, same `current_user` gate, same photo check after the allowlist,
+-- so `CREATE OR REPLACE` is enough and there is no return-type change to drop
+-- around. Only the one array entry is new.
+CREATE OR REPLACE FUNCTION public.waves_guard_group_columns() RETURNS trigger
+    LANGUAGE plpgsql
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+DECLARE
+  -- Kept in step with `GROUP_UPDATABLE_FIELDS` in supabase/functions/sync/index.ts.
+  v_allowed constant text[] := ARRAY[
+    'name',
+    'description',
+    'type',
+    'cover_emoji',
+    'photo_path',
+    'simplify_debts',
+    'default_currency',
+    'country_code',
+    'archived_at',
+    'start_date',
+    'end_date',
+    'time_zone',
+    'remind_daily',
+    'remind_morning_at',
+    'remind_evening_at'
+  ];
+  v_refused text;
+BEGIN
+  IF current_user NOT IN ('anon', 'authenticated') THEN
+    RETURN NEW;
+  END IF;
+
+  -- Compare the whole row rather than named columns, so the list above is the
+  -- only thing anybody has to maintain. `to_jsonb` on a record gives one key per
+  -- column with a jsonb `null` (not SQL NULL) for an empty one, so `IS DISTINCT
+  -- FROM` compares cleanly in both directions — including the null-to-value and
+  -- value-to-null writes, which is how a group gets resurrected.
+  SELECT string_agg(changed.key, ', ' ORDER BY changed.key)
+    INTO v_refused
+    FROM jsonb_each(to_jsonb(NEW)) AS changed(key, value)
+   WHERE changed.value IS DISTINCT FROM (to_jsonb(OLD) -> changed.key)
+     AND NOT (changed.key = ANY (v_allowed));
+
+  IF v_refused IS NOT NULL THEN
+    -- Named in the message because the caller is usually our own client and the
+    -- useful bug report is "which column", not "something was refused". The
+    -- names are column names, not user data, so there is nothing to leak.
+    RAISE EXCEPTION
+      'FORBIDDEN_COLUMN: % is set by the server or through its own RPC, not by a direct write', v_refused
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Not a forbidden column — a forbidden *writer*. A member may set the photo
+  -- path; only a group entitled to a photo may have one set.
+  IF NEW.photo_path IS DISTINCT FROM OLD.photo_path
+     AND NEW.photo_path IS NOT NULL
+     AND NOT public.waves_can_upload_group_photo(NEW.id) THEN
+    RAISE EXCEPTION 'PHOTO_GATE: a group photo is a paid feature'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  RETURN NEW;
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.waves_guard_group_columns() TO anon, authenticated, service_role;
+
+-- `waves_create_group` is deliberately left alone.
+--
+-- The obvious place for a new field on a new group is the RPC that makes one,
+-- and it is the wrong place here. `group.create` is the single mutation in this
+-- app whose refusal takes something away: until it syncs, the queue overlay is
+-- the only place that group exists, so a create the server will not accept ends
+-- with somebody discarding it and the group going with it (see the
+-- refusal-is-not-a-deletion note on `waves_create_group`'s history). Giving the
+-- create a new argument gives it new ways to be refused — by a server that has
+-- not yet run this migration, by a length the client let through — in exchange
+-- for a field no group needs in order to exist.
+--
+-- So the client writes the description as an ordinary `group.update` queued
+-- behind the create, the same way the trip dates and the starting budget
+-- already ride behind it. Worst case there is a description that did not save
+-- on a group that did, which is a retry rather than a loss.

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -214,6 +214,14 @@ model Group {
   /// Optional: starting a group should cost one tap, and the people in it
   /// identify it better than a name does. NULL means "unnamed", not "".
   name            String?
+  /// Optional: what the group is *for*, in the maker's own words — "Goa, Jan
+  /// 2026, flights already settled". A name says which group this is; a
+  /// description says why it exists, and the two are different questions.
+  /// Capped at 280 characters by `groups_description_length` — long enough for
+  /// a sentence or two, short enough to stay a caption under the name. NULL
+  /// means "none given"; '' never reaches the column (both the `/sync`
+  /// boundary and the client normalise an emptied field back to NULL).
+  description     String?
   /// Object path in the private `group-photos` bucket, read via a signed URL.
   photoPath       String?   @map("photo_path")
   /// The raw token of the group's durable join link (WhatsApp-style), re-showable

--- a/packages/db/test/group-column-guard.test.ts
+++ b/packages/db/test/group-column-guard.test.ts
@@ -152,6 +152,7 @@ describe('the columns the app actually writes still go through', () => {
     const member = profileIds[1]!;
 
     await patch(member, groupId, 'name', 'Goa 2026');
+    await patch(member, groupId, 'description', 'January, the four of us');
     await patch(member, groupId, 'cover_emoji', '🏖️');
     await patch(member, groupId, 'start_date', '2026-01-01');
     await patch(member, groupId, 'end_date', '2026-01-08');
@@ -162,11 +163,50 @@ describe('the columns the app actually writes still go through', () => {
     await patch(member, groupId, 'country_code', 'IN');
 
     const { rows } = await client.query(
-      `SELECT name, cover_emoji, remind_daily FROM groups WHERE id = $1`,
+      `SELECT name, description, cover_emoji, remind_daily FROM groups WHERE id = $1`,
       [groupId],
     );
     expect(rows[0]?.name).toBe('Goa 2026');
+    expect(rows[0]?.description).toBe('January, the four of us');
     expect(rows[0]?.remind_daily).toBe(false);
+  });
+
+  it('caps a description at 280 characters, and lets exactly 280 through', async () => {
+    // The cap is the column's, not the input's. The client's `maxLength` stops
+    // a paragraph being typed, but the client is not the only writer — a
+    // PostgREST PATCH is the same door the tests above use, and a description
+    // longer than the column allows has to be refused there rather than stored.
+    //
+    // `char_length`, so the cap means the same number of characters in every
+    // script the app speaks. A Tamil description of 280 characters is 280, not
+    // the 93 an octet cap would have allowed.
+    const { groupId, profileIds } = await seedGroup(client, { memberCount: 2 });
+    const member = profileIds[1]!;
+
+    await patch(member, groupId, 'description', 'a'.repeat(280));
+    await patch(member, groupId, 'description', 'கோ'.repeat(140));
+
+    const message = await expectDenied(patch(member, groupId, 'description', 'a'.repeat(281)));
+    expect(message).toMatch(/groups_description_length/);
+
+    // Refused, so the last accepted write is what the column still holds.
+    const { rows } = await client.query(`SELECT description FROM groups WHERE id = $1`, [groupId]);
+    expect(rows[0]?.description).toBe('கோ'.repeat(140));
+  });
+
+  it('lets a member clear a description back to NULL', async () => {
+    // Clearing is an ordinary edit, not a special case — the group goes back to
+    // saying nothing about itself. It has to reach the column as NULL rather
+    // than '', which is what the `/sync` boundary normalises, but the guard
+    // must not stand in the way of either.
+    const { groupId, profileIds } = await seedGroup(client, { memberCount: 2 });
+    const member = profileIds[1]!;
+
+    await patch(member, groupId, 'description', 'January, the four of us');
+    await patch(member, groupId, 'description', null);
+
+    const { rows } = await client.query(`SELECT description FROM groups WHERE id = $1`, [groupId]);
+    expect(rows[0]?.description).toBeNull();
   });
 
   it('lets a member archive and unarchive, which is deliberate', async () => {

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -134,6 +134,7 @@ interface MutationEnvelope {
 /** Columns a member is allowed to set via `group.update` (mirrors client `updateGroup`). */
 const GROUP_UPDATABLE_FIELDS = [
   'name',
+  'description',
   'type',
   'cover_emoji',
   'photo_path',
@@ -525,6 +526,14 @@ export class SyncSession {
         // how the two ends drift apart. Only when the key is actually there, so
         // a patch that never mentioned the name is untouched.
         if ('name' in patch) patch.name = optionalString(patch.name, 'name');
+        // The description reads the same way, and for the same reason: clearing
+        // it has to reach the column as NULL, because '' is a blank line in
+        // every reader rather than an absent one. The length is not checked
+        // here — the column's CHECK is the boundary for that, and a second
+        // number in a second place is the drift this file has been bitten by
+        // before (see GROUP_UPDATABLE_FIELDS vs the guard trigger).
+        if ('description' in patch)
+          patch.description = optionalString(patch.description, 'description');
         const { error } = await this.caller.from('groups').update(patch).eq('id', mutation.groupId);
         if (error) throw new HttpError(400, 'VALIDATION_FAILED', error.message);
         return { groupId: mutation.groupId };


### PR DESCRIPTION
## ⚠️ Deploy-gated — this PR includes a migration

`packages/db/prisma/migrations/20260912170000_group_description/` adds
`groups.description` and re-creates `waves_guard_group_columns` with
`description` on its allowlist.

**Do not merge-and-forget.** The client writes the description through `/sync`,
and `/sync` writes it straight to the column — so on a server that has not run
this migration, the `group.update` carrying a description is refused
(`FORBIDDEN_COLUMN`, or an unknown-column 400). The group itself is unaffected:
the description rides *behind* `group.create`, never inside it.

Order to deploy, when someone decides to: migration → edge (`sync`) → client.
Nothing here has been deployed anywhere by me.

---

## 1. A description for a group

A group has only ever been able to write its own name, and a name is an
identifier. "Goa" says *which* group; it does not say whether it is the January
trip with flights already settled or the one in August where they were not.

So there is now one optional sentence, under the name and **in the same card** —
both are the group's own account of itself, where everything below is a setting
about how it behaves.

- **Max length: 280 characters.** A sentence or two: long enough that nobody
  abbreviates, short enough that it stays a caption under the name rather than
  becoming a notes field every screen showing a group has to find room for.
  Enforced in the UI (`maxLength` on the input, plus `normaliseGroupDescription`
  for the paths the input does not cover, e.g. cloning) and in the DB
  (`groups_description_length`, a `char_length` CHECK — characters not bytes, so
  a Tamil description gets the same 280 as an English one).
- **NULL, never an empty string.** `''` renders as a blank line everywhere the
  description is shown. Both the client and the `/sync` boundary normalise an
  emptied field back to NULL.
- **Read back**: group settings shows and edits it, on the same commit-on-blur
  the name already uses. Cloning a group carries it across.

### Why `waves_create_group` is untouched

`group.create` is the one mutation in this app whose refusal *takes something
away* — until it syncs, the queue overlay is the only place the group exists, so
a create the server will not accept ends with somebody discarding it and the
group going with it. Giving the create a new argument gives it new ways to be
refused, in exchange for a field no group needs in order to exist.

So the description is queued as an ordinary `group.update` **behind** the
create, exactly the way the trip dates and the starting budget already ride
behind it on this screen. Worst case: a description that did not save on a group
that did. Tests pin this shape down.

### The allowlist ceremony

`waves_guard_group_columns` (`20260910090000_group_column_guard`) was
deliberately rewritten from "what is forbidden" to "what is allowed" so a new
column is refused by default. That means a new column the app *does* mean
members to write is invisible until it is named there — so the migration
re-creates the function with `description` added, and `GROUP_UPDATABLE_FIELDS`
in `supabase/functions/sync/index.ts` (the same list) gets the same entry.

## 2. "More options" → the edit-expense row idiom

**Before:** kind, trip dates, trip budget and simplify-debts sat behind a "More
options" disclosure — one row that named none of the four things behind it, with
the group's kind (already decided, already guessed from the name) sitting unread
on its right.

**After:** the same four are a stack of named facts with their current values and
hairlines between, each a tap from being changed — the shape the expense screen
uses for Group / Paid by / Date / Split. Kind and simplify always; dates and
budget only on a trip. Defaults are already filled in, so the screen reads as a
group that exists and can be adjusted rather than a form still to be completed.

### Shared component, not copy-paste

That idiom was inline in `expense/[expenseId].tsx` as a local `DetailLine`. It is
now `DetailRow` / `DetailRows` in `apps/mobile/src/components/DetailRows.tsx` and
both screens use it. Two additions over the original:

- an optional `onPress` + `expanded`, for a row whose editor unfolds in place
  (chevron down/up) versus one that pushes a screen (`directionalIcon`
  `chevron-forward`) versus a plain read-only statement (no chevron — which is
  what the expense screen still is, rendering exactly as before);
- an optional `subtitle`, for the one fact ("simplify debts") whose name does not
  explain it.

It lives in the app rather than `@waves/ui` because it takes an Ionicons glyph
name, and `@waves/ui` deliberately takes no icon dependency.

> **Note for whoever merges second:** another branch is doing the same
> extraction for the personal-ledger screens under
> `apps/mobile/src/app/personal/`. Both will want one shared row component; this
> one is `apps/mobile/src/components/DetailRows.tsx`.

## i18n

Three new keys (`group.descriptionOptional`, `group.groupDescription`,
`group.descriptionPlaceholder`) in the interface and all four locale tables
(en/ta/hi/ar), each in one contiguous block. `extras.moreOptions` and
`extras.moreOptionsHint` are removed — nothing else used them.

## Tests

- `apps/mobile/test/groupDescription.test.ts` (new, 12 cases): a group created
  with no description queues exactly one mutation as before; a description is
  queued behind the create and never inside its payload; it shows on the group
  through the queue overlay before anything syncs; a confirmed description
  round-trips; a queued edit overlays a confirmed row; a clear reaches NULL and
  survives the overlay; the cap trims, the exact length is kept, blank becomes
  NULL, and the count is characters not bytes.
- `packages/db/test/group-column-guard.test.ts` (extended): `description` is on
  the writable list; 280 is accepted (in Latin and Tamil), 281 is refused with
  `groups_description_length`; clearing to NULL is allowed.
  **Unrun** — the db suite needs a local Postgres that is not running here.
  Correct by inspection only.

## Gates

| Gate | Result |
| --- | --- |
| `pnpm format` | pass |
| `pnpm lint` | pass |
| `pnpm --filter @waves/mobile typecheck` | pass |
| `pnpm --filter @waves/mobile test` | pass — 102 files, 1360 tests |
| `pnpm --filter @waves/core test` | pass — 63 files, 986 tests |
| `pnpm --filter @waves/db typecheck` | pass (`prisma generate` + `tsc`; needed a dummy `DIRECT_URL`, which `prisma generate` never connects with) |
| `pnpm typecheck` (whole repo) | pass |
| `pnpm test:edge` | pass — 10 files, 307 tests |
| `pnpm --filter @waves/db test` | **not run** — needs a local Postgres |
| On a device | **not run** — no device available |

## Deliberately not done

- `apps/api` (the developer API's `PATCH /v1/groups/:id`) and
  `packages/api-client` do not carry the description. Both select an explicit
  column list and are separate surfaces with their own tests; adding the field
  there is its own change.
- `apps/web` untouched (another branch is in there).
- The description is not surfaced on the group hero/header — only on the create
  screen and in group settings, which is where it is written and read back.
- Group creation does nothing new beyond the one field; currency and country are
  still not asked on this screen.
- The new-group screen's bottom padding is still a plain spacing token, not the
  clearance hook, with its existing comment explaining why: `Screen` already
  applies the bottom safe-area inset here, so a clearance hook would count the
  gesture bar twice. Unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jhzmZz5fkjnZZ14YxHGfS
