### PR TITLE
The phone itself mentions the expenses still saved for later

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -44,6 +44,7 @@ import { UpdateBanner, UpdateGate } from '@/components/UpdateGate';
 import { AuthProvider, useAuth } from '@/lib/auth';
 import { AutoBackup } from '@/lib/backup/AutoBackup';
 import { backendConfigured } from '@/lib/backend';
+import { CaptureNudge } from '@/lib/captureNudge/CaptureNudge';
 import { DeviceSessionProvider } from '@/lib/deviceSession';
 import { useFlagEnabled } from '@/lib/flags';
 import { isRtl, isRtlLanguage, useStrings } from '@/i18n';
@@ -263,6 +264,14 @@ function RootLayout() {
                                 have stopped trusting, and must not decrypt a
                                 ledger while the app is still locked. */}
                                           <AutoBackup />
+                                          {/* Renders nothing: it decides whether this phone
+                                should remind anybody about the expenses they
+                                saved for later, and sets or cancels the local
+                                alarm that does it. Beside the backup and inside
+                                the same gates — the count it speaks about is
+                                read from the mirror, which must not be touched
+                                while the app is still locked. */}
+                                          <CaptureNudge />
                                           {/* Inside the lock so the two-device gate never
                                 paints over the lock screen, and past auth so it
                                 only ever asks a signed-in account. */}

--- a/apps/mobile/src/app/settings/notifications.tsx
+++ b/apps/mobile/src/app/settings/notifications.tsx
@@ -29,8 +29,16 @@ import {
 import { useStrings, type UiStrings } from '@/i18n';
 import { friendlyError } from '@/lib/errors';
 import { useAuth } from '@/lib/auth';
+import { loadCaptureNudgeEnabled, saveCaptureNudgeEnabled } from '@/lib/captureNudge/settings';
+import { useCaptureNudgePass, useNudgePassInputs } from '@/lib/captureNudge/useNudgePass';
 import { router } from '@/lib/navigation';
-import { enablePush, PushFailure, PushPermission, pushPermission } from '@/lib/push';
+import {
+  enablePush,
+  ensureLocalNotificationPermission,
+  PushFailure,
+  PushPermission,
+  pushPermission,
+} from '@/lib/push';
 
 type IconName = ComponentProps<typeof Ionicons>['name'];
 type PrefRow = { key: keyof NotificationPrefs; title: string; body: string; icon: IconName };
@@ -119,6 +127,27 @@ export default function NotificationSettingsScreen() {
   const [permission, setPermission] = useState<PushPermission>(PushPermission.Undetermined);
   const [asking, setAsking] = useState(false);
 
+  // The one switch on this screen that is not a server preference: the reminder
+  // this phone raises itself about expenses saved for later. It is stored on
+  // the device, because the device is the only thing that can obey it — see
+  // `lib/captureNudge/settings.ts`. `null` means "still reading", which keeps
+  // the switch from flicking on and then off again on a phone where it is off.
+  const [nudge, setNudge] = useState<boolean | null>(null);
+  const nudgeInputs = useNudgePassInputs();
+  const runNudgePass = useCaptureNudgePass(nudgeInputs);
+
+  useEffect(() => {
+    const ownerId = profile?.id;
+    if (!ownerId) return;
+    let active = true;
+    void loadCaptureNudgeEnabled(ownerId).then((value) => {
+      if (active) setNudge(value);
+    });
+    return () => {
+      active = false;
+    };
+  }, [profile?.id]);
+
   useEffect(() => {
     let active = true;
     void pushPermission().then((value) => {
@@ -161,6 +190,46 @@ export default function NotificationSettingsScreen() {
       active = false;
     };
   }, [profile?.id]);
+
+  /**
+   * The device-side switch.
+   *
+   * Turning it **on** asks the operating system first, and only when it has to
+   * — a control the person has just touched, having read what it is for, which
+   * is the same door `enablePush` and the soft ask use and the only one this
+   * app ever opens. A refusal puts the switch back rather than leaving it on
+   * over a permission that will silently swallow every reminder.
+   *
+   * Either way a pass runs immediately afterwards, so turning it off clears
+   * tonight's reminder now and turning it on sets one now. A switch whose
+   * effect waits for the next foreground is a switch people press twice.
+   */
+  const toggleNudge = async (value: boolean): Promise<void> => {
+    const ownerId = profile?.id;
+    if (!ownerId) {
+      setStatus(t.notifications.failNotSignedIn);
+      return;
+    }
+    setStatus(null);
+    if (value) {
+      const allowed = await ensureLocalNotificationPermission();
+      setPermission(await pushPermission());
+      if (!allowed) {
+        setNudge(false);
+        setStatus(t.notifications.failDenied);
+        return;
+      }
+    }
+    setNudge(value);
+    try {
+      await saveCaptureNudgeEnabled(ownerId, value);
+    } catch (caught: unknown) {
+      setNudge(!value);
+      setStatus(friendlyError(caught, t.notifications.failSaveFailed, 'notifications.saveNudge'));
+      return;
+    }
+    runNudgePass();
+  };
 
   const toggle = (key: keyof NotificationPrefs, value: boolean): void => {
     const previous = prefs;
@@ -264,6 +333,40 @@ export default function NotificationSettingsScreen() {
               <SectionHeader title={t.notifications.pushSection} />
               <PrefSection rows={pushRows(t)} prefs={prefs} onToggle={toggle} />
             </View>
+            {/* Its own section because it is a different promise. Everything
+                above is something our servers send; this is the phone setting
+                an alarm on itself, out of what it already holds — nothing about
+                these drafts is read by anything but this device. Grouping it
+                with the four above would quietly claim otherwise. */}
+            <View style={{ gap: theme.spacing.sm }}>
+              <SectionHeader title={t.notifications.localSection} />
+              <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+                <Row gap={theme.spacing.md} style={{ paddingVertical: theme.spacing.md }}>
+                  <Ionicons
+                    name="file-tray-outline"
+                    size={iconSize.xl}
+                    color={theme.color.textMuted}
+                  />
+                  <View style={{ flex: 1 }}>
+                    <Text variant="subheading">{t.notifications.savedForLater}</Text>
+                    <Text variant="caption" tone="muted">
+                      {t.notifications.savedForLaterBody}
+                    </Text>
+                  </View>
+                  <Toggle
+                    // `null` is "still reading the stored value", which reads as
+                    // off rather than flashing on; the switch is disabled until
+                    // it is known so a tap cannot race the read and save the
+                    // default back over a person's own choice.
+                    value={nudge === true}
+                    disabled={nudge === null}
+                    onValueChange={(value) => void toggleNudge(value)}
+                    accessibilityLabel={t.notifications.savedForLater}
+                  />
+                </Row>
+              </Card>
+            </View>
+
             <View style={{ gap: theme.spacing.sm }}>
               <SectionHeader title={t.notifications.emailSection} />
               <PrefSection rows={emailRows(t)} prefs={prefs} onToggle={toggle} />

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1201,6 +1201,15 @@ export interface UiStrings {
     failNotConfigured: string;
     failSaveFailed: string;
     footnote: string;
+    /**
+     * The one group on this screen our servers never see: reminders this phone
+     * raises itself, out of what it already holds. Its own section because "we
+     * send you this" and "your phone reminds you" are different promises, and
+     * because this one keeps working with no signal and no push credentials.
+     */
+    localSection: string;
+    savedForLater: string;
+    savedForLaterBody: string;
   };
   /** Attaching an email or phone to the account you already have (ADR-006). */
   contact: {
@@ -1627,6 +1636,14 @@ export interface UiStrings {
     savedOnDevice: string;
     couldNotSave: string;
     save: string;
+    /**
+     * The reminder this phone sets for itself when drafts have been waiting a
+     * day. It says how many are waiting and nothing else: a lock screen is
+     * readable without unlocking the phone, so no amount, no note and no
+     * category may ever be interpolated into either of these.
+     */
+    nudgeTitle: PluralForms;
+    nudgeBody: PluralForms;
   };
   /** Attaching where a spend happened (A43): the opt-in control on the expense
    *  forms and the tappable place on the expense detail. */
@@ -3937,6 +3954,10 @@ const en: UiStrings = {
     failSaveFailed: 'Could not save this phone. Check your connection and try again.',
     footnote:
       'Email delivery is still to come. Everything here is also in your inbox, which is the record of what Waves has told you whether or not a notification arrived.',
+    localSection: 'From this phone',
+    savedForLater: 'Expenses saved for later',
+    savedForLaterBody:
+      'If one is still waiting for a group a day later, this phone reminds you in the evening. Once a day at most, and never when nothing is waiting.',
   },
   contact: {
     title: 'Your account',
@@ -4306,6 +4327,14 @@ const en: UiStrings = {
     savedOnDevice: 'Saved on this device',
     couldNotSave: "Couldn't save this — please try again in a moment.",
     save: 'Save',
+    nudgeTitle: {
+      one: 'You saved {n} expense for later',
+      other: 'You saved {n} expenses for later',
+    },
+    nudgeBody: {
+      one: 'It still needs a group. Tap to add it.',
+      other: 'They still need a group. Tap to add them.',
+    },
   },
   location: {
     label: 'Location',
@@ -6542,6 +6571,10 @@ const ta: UiStrings = {
     failSaveFailed: 'இந்த ஃபோனைச் சேமிக்க முடியவில்லை. இணைப்பைச் சரிபார்த்து மீண்டும் முயலவும்.',
     footnote:
       'மின்னஞ்சல் இன்னும் வரவில்லை. இங்குள்ள அனைத்தும் உங்கள் அஞ்சல் பெட்டியிலும் இருக்கும் — அறிவிப்பு வந்ததா இல்லையா என்பதைப் பொருட்படுத்தாமல் Waves உங்களிடம் சொன்னதற்கான பதிவு அதுவே.',
+    localSection: 'இந்த ஃபோனிலிருந்து',
+    savedForLater: 'பிறகு சேமித்த செலவுகள்',
+    savedForLaterBody:
+      'ஒரு நாள் கழித்தும் ஒரு செலவு குழுவுக்காகக் காத்திருந்தால், இந்த ஃபோன் மாலையில் நினைவூட்டும். நாளொன்றுக்கு ஒரு முறை மட்டுமே; காத்திருப்பது எதுவும் இல்லாதபோது ஒருபோதும் இல்லை.',
   },
   contact: {
     title: 'உங்கள் கணக்கு',
@@ -6925,6 +6958,14 @@ const ta: UiStrings = {
     savedOnDevice: 'இந்தச் சாதனத்தில் சேமிக்கப்பட்டது',
     couldNotSave: 'இதைச் சேமிக்க முடியவில்லை — சிறிது நேரத்தில் மீண்டும் முயற்சிக்கவும்.',
     save: 'சேமி',
+    nudgeTitle: {
+      one: '{n} செலவைப் பிறகு சேமித்தீர்கள்',
+      other: '{n} செலவுகளைப் பிறகு சேமித்தீர்கள்',
+    },
+    nudgeBody: {
+      one: 'அதற்கு இன்னும் ஒரு குழு வேண்டும். சேர்க்கத் தட்டுங்கள்.',
+      other: 'அவற்றுக்கு இன்னும் ஒரு குழு வேண்டும். சேர்க்கத் தட்டுங்கள்.',
+    },
   },
   location: {
     label: 'இடம்',
@@ -9223,6 +9264,10 @@ const hi: UiStrings = {
     failSaveFailed: 'यह फ़ोन सेव नहीं हो सका। कनेक्शन जाँचकर दोबारा कोशिश करें।',
     footnote:
       'ईमेल अभी आना बाकी है। यहाँ का सब कुछ आपके इनबॉक्स में भी है, और सूचना पहुँची या नहीं, Waves ने आपसे क्या कहा उसका रिकॉर्ड वही है।',
+    localSection: 'इस फ़ोन से',
+    savedForLater: 'बाद के लिए सहेजे गए खर्च',
+    savedForLaterBody:
+      'अगर कोई खर्च एक दिन बाद भी किसी समूह का इंतज़ार कर रहा हो, तो यह फ़ोन शाम को याद दिलाता है। दिन में ज़्यादा से ज़्यादा एक बार, और जब कुछ बाकी न हो तो कभी नहीं।',
   },
   contact: {
     title: 'आपका खाता',
@@ -9592,6 +9637,14 @@ const hi: UiStrings = {
     savedOnDevice: 'इस डिवाइस पर सहेजा गया',
     couldNotSave: 'इसे सहेजा नहीं जा सका — कृपया थोड़ी देर में फिर से कोशिश करें।',
     save: 'सहेजें',
+    nudgeTitle: {
+      one: 'आपने {n} खर्च बाद के लिए सहेजा है',
+      other: 'आपने {n} खर्च बाद के लिए सहेजे हैं',
+    },
+    nudgeBody: {
+      one: 'इसे अब भी एक समूह चाहिए। जोड़ने के लिए टैप करें।',
+      other: 'इन्हें अब भी एक समूह चाहिए। जोड़ने के लिए टैप करें।',
+    },
   },
   location: {
     label: 'स्थान',
@@ -11889,6 +11942,10 @@ const ar: UiStrings = {
     failSaveFailed: 'تعذّر حفظ هذا الهاتف. تحقق من اتصالك وحاول مرة أخرى.',
     footnote:
       'البريد لم يصل بعد. كل ما هنا موجود أيضًا في صندوقك، وهو سجل ما أخبرك به Waves سواء وصل إشعار أم لا.',
+    localSection: 'من هذا الهاتف',
+    savedForLater: 'مصاريف محفوظة لوقت لاحق',
+    savedForLaterBody:
+      'إذا بقي مصروف ينتظر مجموعة بعد يوم كامل، يذكّرك هذا الهاتف مساءً. مرة واحدة في اليوم على الأكثر، ولا شيء إطلاقًا حين لا ينتظر شيء.',
   },
   contact: {
     title: 'حسابك',
@@ -12287,6 +12344,21 @@ const ar: UiStrings = {
     savedOnDevice: 'محفوظ على هذا الجهاز',
     couldNotSave: 'تعذّر حفظ هذا — يُرجى المحاولة مرة أخرى بعد قليل.',
     save: 'حفظ',
+    // Arabic counts in six categories, and this is one of the few strings in the
+    // app that can genuinely land in all of them, so all of them are written
+    // out rather than falling through to `other` with the wrong agreement.
+    nudgeTitle: {
+      one: 'حفظت مصروفًا واحدًا لوقت لاحق',
+      two: 'حفظت مصروفين لوقت لاحق',
+      few: 'حفظت {n} مصاريف لوقت لاحق',
+      many: 'حفظت {n} مصروفًا لوقت لاحق',
+      other: 'حفظت {n} مصروف لوقت لاحق',
+    },
+    nudgeBody: {
+      one: 'ما زال بحاجة إلى مجموعة. اضغط لإضافته.',
+      two: 'ما زالا بحاجة إلى مجموعة. اضغط لإضافتهما.',
+      other: 'ما زالت بحاجة إلى مجموعة. اضغط لإضافتها.',
+    },
   },
   location: {
     label: 'الموقع',

--- a/apps/mobile/src/lib/auth.tsx
+++ b/apps/mobile/src/lib/auth.tsx
@@ -15,6 +15,8 @@ import {
   type Viewer,
 } from '@waves/core';
 
+import { cancelNudges } from './captureNudge/schedule';
+import { clearCaptureNudge } from './captureNudge/settings';
 import { appleNativeSignIn, googleNativeSignIn } from './nativeIdentity';
 import { identifyForReporting, reportHandled } from './observability';
 import { claimCode } from './oauthClaim';
@@ -660,6 +662,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         // the revocation to, and the token would keep receiving notifications
         // for an account nobody is signed in on.
         await revokePushToken();
+        // And the reminders this phone set for itself. A local alarm survives
+        // the session that created it, so leaving one scheduled means a phone
+        // nobody is signed in on announcing "you saved 3 expenses for later" —
+        // about drafts that are no longer on it. The stored switch and the
+        // marker go with it, scoped to the account that is leaving.
+        const leaving = session?.user?.id ?? '';
+        await cancelNudges().catch(() => {});
+        await clearCaptureNudge(leaving).catch(() => {});
         // The private ledger's unlock belongs to whoever proved they were
         // holding the phone, not to the phone. It does not survive the account
         // it was granted under.

--- a/apps/mobile/src/lib/captureNudge/CaptureNudge.tsx
+++ b/apps/mobile/src/lib/captureNudge/CaptureNudge.tsx
@@ -1,0 +1,68 @@
+/**
+ * When the reminder is decided on.
+ *
+ * A headless component, mounted once inside the lock and auth gates beside
+ * `<AutoBackup />`. It renders nothing; it exists because the only honest
+ * source for the waiting drafts is a hook, and a hook needs somewhere to live.
+ *
+ * Like `AutoBackup`, it is deliberately **not** a background task — no
+ * `expo-background-task`, no WorkManager, no BGTaskScheduler. The difference is
+ * that here that costs almost nothing: the reminder itself is an OS alarm and
+ * fires with the app closed. What needs the app open is only the *deciding*.
+ *
+ * The honest limit, stated rather than papered over: a reminder already set for
+ * this evening fires whether or not the app is opened again, but the *next* one
+ * is only ever set on a pass. So somebody who never opens Waves again hears
+ * from it once and then not at all — which is the right way round for a feature
+ * whose whole risk is becoming a nag.
+ *
+ * ## Two effects, on purpose
+ *
+ * The AppState subscription is keyed on the owner alone, so it is not torn down
+ * and rebuilt every time somebody saves an expense — the same reason
+ * `AutoBackup` keeps its ledger in a ref. The pass itself is keyed on what
+ * would change the answer: the count, the age of the oldest draft, and the
+ * language the text would be written in. That second effect is what makes
+ * placing the last draft cancel this evening's reminder immediately, rather
+ * than whenever the app next happens to be foregrounded — the single most
+ * important thing this feature has to get right.
+ *
+ * ## Why nothing is throttled
+ *
+ * `AutoBackup` throttles because a backup is the whole ledger over the network.
+ * A pass here is two AsyncStorage reads, a permission read and a list of
+ * pending alarms — and the one event that must never wait is the cancel.
+ */
+
+import { useEffect, useRef } from 'react';
+import { AppState } from 'react-native';
+
+import { useCaptureNudgePass, useNudgePassInputs } from './useNudgePass';
+
+export function CaptureNudge() {
+  const inputs = useNudgePassInputs();
+  const pass = useCaptureNudgePass(inputs);
+
+  // The freshest callback, so a pass raised by the subscription below never
+  // runs on a stale count.
+  const passRef = useRef(pass);
+  useEffect(() => {
+    passRef.current = pass;
+  }, [pass]);
+
+  // One subscription for the life of the session.
+  useEffect(() => {
+    if (!inputs.ownerId) return;
+    const subscription = AppState.addEventListener('change', (state) => {
+      if (state === 'active') passRef.current();
+    });
+    return () => subscription.remove();
+  }, [inputs.ownerId]);
+
+  // And a pass whenever what we would say — or whether we would say it — moves.
+  useEffect(() => {
+    pass();
+  }, [pass]);
+
+  return null;
+}

--- a/apps/mobile/src/lib/captureNudge/plan.ts
+++ b/apps/mobile/src/lib/captureNudge/plan.ts
@@ -1,0 +1,209 @@
+/**
+ * Whether this phone should tap somebody on the shoulder about the expenses
+ * they saved for later, and when.
+ *
+ * ## What this is a reminder about
+ *
+ * The capture inbox (A34) — "Saved for later" on screen — holds expenses caught
+ * before they had a group: an amount, maybe a note and a photo of the bill,
+ * waiting for somebody to say where they belong. The dashboard already carries
+ * a badge for them, which works perfectly for anybody who opens the app. This
+ * is for the drafts of somebody who does not: a receipt snapped on Friday night
+ * and never placed is a spend nobody in the group ever sees.
+ *
+ * ## Why the whole decision is one pure function
+ *
+ * Everything that could turn this into a nag is a rule, and every rule is a
+ * sentence about somebody's attention that must not be got wrong. So they are
+ * written here, with no clock of their own, no storage and no notification API
+ * — `now` and the stored history come in as arguments, and what comes back is a
+ * verb. `restorePrompt.ts` is shaped the same way and for the same reason: the
+ * conditions *are* the feature, and a condition buried in a component is a
+ * condition nobody can test.
+ *
+ * ## The four rules, and what each one is protecting against
+ *
+ * **1. Never for nothing.** Zero waiting drafts is not a reminder; it is an app
+ * that lies. This is also the one that must *cancel*: somebody who clears their
+ * inbox on Tuesday afternoon must not be told on Tuesday evening about work
+ * they have already done. That is the single most important correctness
+ * property in this file, and it is why `Cancel` exists as an answer at all
+ * rather than the schedule simply being left to expire.
+ *
+ * **2. Never the moment it is saved.** Saving a draft is not a reason to be
+ * told about it — the person is holding the phone, looking at the screen that
+ * says so. The honest trigger is that something has been *sitting*, so a draft
+ * only counts once it is a day old (`SETTLE_MS`). A person who saves an expense
+ * and places it an hour later never hears from this feature at all, which is
+ * the correct outcome for the majority of drafts.
+ *
+ * **3. At a civilised hour.** The reminder lands at `NUDGE_HOUR` local — the
+ * evening, when somebody is plausibly sorting out their day and the tap has
+ * somewhere to go. The alternative, "fire as soon as a draft turns 24 hours
+ * old", puts a notification at whatever hour the photo was taken, which for a
+ * restaurant bill is close to midnight.
+ *
+ * **4. A hard ceiling.** At most one in any `CEILING_MS` window, whatever else
+ * changes. The slot is daily, so in ordinary running the ceiling is never the
+ * binding constraint — it exists for the days that are not ordinary. A phone
+ * carried across time zones, a clock corrected, a person who assigns two of
+ * five drafts and leaves three: each of those moves the slot, and without a
+ * floor under the gap between fires, moving the slot is how one reminder
+ * becomes three.
+ *
+ * ## What is deliberately not here
+ *
+ * **No amounts, ever.** A lock screen is readable without unlocking it. The
+ * count of waiting drafts is in the text; what they cost is not, and the caller
+ * has no parameter with which to put it there.
+ *
+ * **No second nudge.** If the first is ignored, nothing escalates. The drafts
+ * stay in the inbox, the dashboard badge keeps its count, and the next evening
+ * is the next chance — the app does not raise its voice.
+ */
+
+/** What the next pass should do with the reminder this phone holds. */
+export enum NudgeAction {
+  /** Leave things exactly as they are. The overwhelmingly common answer. */
+  Keep = 'keep',
+  /** There is one scheduled and it must not fire. */
+  Cancel = 'cancel',
+  /** Cancel whatever we hold, then schedule this. */
+  Schedule = 'schedule',
+}
+
+/**
+ * How long a draft has to have been sitting before it is worth mentioning.
+ *
+ * A day. Short enough that a Friday receipt is raised on Saturday evening while
+ * the outing is still recent; long enough that nothing anybody saved today can
+ * possibly generate a notification.
+ */
+export const SETTLE_MS = 24 * 60 * 60 * 1000;
+
+/** Local wall-clock hour the reminder lands at. Early evening, not bedtime. */
+export const NUDGE_HOUR = 19;
+
+/**
+ * The floor under the gap between two reminders. Twenty hours rather than
+ * twenty-four so that a slot which drifts by an hour — a daylight-saving
+ * change, a clock correction — does not skip a whole day; and well above the
+ * "several times an evening" the rules above are written to prevent.
+ */
+export const CEILING_MS = 20 * 60 * 60 * 1000;
+
+/** A reminder this phone has already handed to the operating system. */
+export interface PendingNudge {
+  /** Epoch ms it is set to fire at. */
+  readonly fireAt: number;
+  /** How many waiting drafts its text names. */
+  readonly count: number;
+  /** The language its text was written in. */
+  readonly locale: string;
+}
+
+/** Everything that bears on whether to speak, and what to say. */
+export interface NudgeInput {
+  /** The switch on the notification settings screen. */
+  readonly enabled: boolean;
+  /** The operating system has actually granted permission. */
+  readonly permitted: boolean;
+  /**
+   * Waiting drafts, counted the way a person counts them — a voice batch is
+   * one, not one per spend (`foldedCaptureCount`).
+   */
+  readonly waitingCount: number;
+  /** When the oldest waiting draft was saved. Null when none is waiting. */
+  readonly oldestWaitingAt: number | null;
+  /** Now, epoch ms. */
+  readonly now: number;
+  /**
+   * The fire time of the last reminder that has actually gone off, or null if
+   * none has. Never a reminder still in the future — one that has not fired
+   * cannot have spent the ceiling.
+   */
+  readonly lastFiredAt: number | null;
+  /** What the OS is currently holding for us, if anything. */
+  readonly pending: PendingNudge | null;
+  /** The app's current language, which the text is baked in. */
+  readonly locale: string;
+}
+
+export type NudgePlan =
+  | { readonly action: NudgeAction.Keep }
+  | { readonly action: NudgeAction.Cancel }
+  | { readonly action: NudgeAction.Schedule; readonly fireAt: number; readonly count: number };
+
+/**
+ * The next `NUDGE_HOUR` on the local clock, strictly after `now`.
+ *
+ * Local wall clock on purpose, and built by moving the *date* rather than by
+ * adding 24 hours in milliseconds: across a daylight-saving boundary the two
+ * disagree, and the one that keeps the reminder at seven in the evening is
+ * this one. The same reason `localIsoDate` exists in the personal ledger —
+ * `toISOString` shifts the day for everybody who is not on UTC.
+ */
+export function nextNudgeSlot(now: number): number {
+  const at = new Date(now);
+  at.setHours(NUDGE_HOUR, 0, 0, 0);
+  if (at.getTime() <= now) at.setDate(at.getDate() + 1);
+  return at.getTime();
+}
+
+/**
+ * What to do with the phone's reminder, given what is waiting and what has
+ * already been said.
+ *
+ * Every early return is a reason *not* to speak, and each one cancels rather
+ * than merely declining to schedule: a condition that stops being true has to
+ * take any reminder it already caused with it. A `Cancel` is only ever returned
+ * when there is something to cancel, so the caller can act on the verb without
+ * checking whether it is a no-op.
+ */
+export function planCaptureNudge(input: NudgeInput): NudgePlan {
+  // "Say nothing" and "say nothing, and take back what was already said" are
+  // the same decision with different consequences; which one applies depends
+  // only on whether a reminder is outstanding.
+  const silence = (): NudgePlan =>
+    input.pending ? { action: NudgeAction.Cancel } : { action: NudgeAction.Keep };
+
+  // The switch, and the permission behind it. A revoked permission is not just
+  // a reason to stop scheduling — anything already scheduled has to go, since
+  // on Android a granted-then-revoked permission leaves live alarms behind.
+  if (!input.enabled || !input.permitted) return silence();
+
+  // Nothing for zero. Also the cancel that matters: this is the branch somebody
+  // lands in the moment they finish placing their last draft.
+  if (input.waitingCount <= 0 || input.oldestWaitingAt === null) return silence();
+
+  // Nothing has been *sitting* yet — everything waiting was saved today, and
+  // the person who saved it has seen the screen that says so.
+  if (input.now - input.oldestWaitingAt < SETTLE_MS) return silence();
+
+  let fireAt = nextNudgeSlot(input.now);
+  if (input.lastFiredAt !== null) {
+    // The ceiling, enforced on fire times rather than on scheduling passes:
+    // this function runs whenever the app comes forward, and a rule counted in
+    // passes would be a rule about how often somebody opens Waves.
+    const earliest = input.lastFiredAt + CEILING_MS;
+    while (fireAt < earliest) fireAt = nextNudgeSlot(fireAt);
+  }
+
+  // Already holding exactly this. Rescheduling an identical reminder would tear
+  // down and rebuild an OS alarm on every foreground for no visible change.
+  if (
+    input.pending &&
+    input.pending.fireAt === fireAt &&
+    input.pending.count === input.waitingCount &&
+    input.pending.locale === input.locale
+  ) {
+    return { action: NudgeAction.Keep };
+  }
+
+  // The count and the language are both baked into the text at schedule time,
+  // so either one moving makes the held reminder wrong rather than merely
+  // stale. A notification that says three when two are waiting is worse than
+  // no notification, and one in a language the person has just switched away
+  // from is the app forgetting a setting it was told about.
+  return { action: NudgeAction.Schedule, fireAt, count: input.waitingCount };
+}

--- a/apps/mobile/src/lib/captureNudge/run.ts
+++ b/apps/mobile/src/lib/captureNudge/run.ts
@@ -1,0 +1,74 @@
+/**
+ * One pass: read what is true, ask `planCaptureNudge` what to do, do it.
+ *
+ * The shape is deliberate — the reads are all above the decision and the writes
+ * are all below it, so the rules stay in a function with no clock and no
+ * storage of its own. Everything this module adds is plumbing.
+ *
+ * The one piece of reasoning that lives here rather than in the planner is how
+ * "the last reminder that actually fired" is recovered, because it is a fact
+ * about storage rather than about people. `expo-notifications` reports no
+ * deliveries and a fired notification simply leaves the scheduled list, so the
+ * only evidence is the fire time we wrote down when we set it: once that moment
+ * is in the past, the reminder went off. Which is also why a cancel only clears
+ * the marker when it is still in the future — wiping the record of a reminder
+ * that already happened would hand back the ceiling it spent.
+ */
+
+import { localNotificationsAllowed } from '@/lib/push';
+
+import { NudgeAction, planCaptureNudge, type NudgePlan } from './plan';
+import { cancelNudges, pendingNudge, scheduleNudge, type NudgeText } from './schedule';
+import { loadCaptureNudgeEnabled, loadPlannedNudge, savePlannedNudge } from './settings';
+
+export interface NudgeRunInput {
+  readonly ownerId: string;
+  /** Waiting drafts, folded the way the dashboard badge folds them. */
+  readonly waitingCount: number;
+  /** When the oldest of them was saved, epoch ms. Null when none is waiting. */
+  readonly oldestWaitingAt: number | null;
+  readonly locale: string;
+  readonly now: number;
+  /** The reminder's words, in the app's current language. */
+  readonly text: (count: number) => NudgeText;
+}
+
+/** Runs one pass and reports what it decided, which is what the tests read. */
+export async function syncCaptureNudge(input: NudgeRunInput): Promise<NudgePlan> {
+  if (!input.ownerId) return { action: NudgeAction.Keep };
+
+  const [enabled, planned, permitted, pending] = await Promise.all([
+    loadCaptureNudgeEnabled(input.ownerId),
+    loadPlannedNudge(input.ownerId),
+    localNotificationsAllowed(),
+    pendingNudge(),
+  ]);
+
+  const plan = planCaptureNudge({
+    enabled,
+    permitted,
+    waitingCount: input.waitingCount,
+    oldestWaitingAt: input.oldestWaitingAt,
+    now: input.now,
+    lastFiredAt: planned !== null && planned <= input.now ? planned : null,
+    pending,
+    locale: input.locale,
+  });
+
+  if (plan.action === NudgeAction.Cancel) {
+    await cancelNudges();
+    if (planned !== null && planned > input.now) await savePlannedNudge(input.ownerId, null);
+  } else if (plan.action === NudgeAction.Schedule) {
+    const set = await scheduleNudge({
+      fireAt: plan.fireAt,
+      count: plan.count,
+      locale: input.locale,
+      text: input.text(plan.count),
+    });
+    // Only once something really is scheduled. A marker written for a reminder
+    // the OS refused would spend the ceiling on silence.
+    if (set) await savePlannedNudge(input.ownerId, plan.fireAt);
+  }
+
+  return plan;
+}

--- a/apps/mobile/src/lib/captureNudge/schedule.ts
+++ b/apps/mobile/src/lib/captureNudge/schedule.ts
@@ -1,0 +1,173 @@
+/**
+ * The half that talks to the operating system: read what alarm we hold, drop
+ * it, set a new one.
+ *
+ * ## Local, not a push
+ *
+ * `scheduleNotificationAsync` with a DATE trigger — the phone setting an alarm
+ * on itself. Nothing here goes near `waves_notify`, `notify-fanout` or pg_cron,
+ * and the reasons are argued in full in `docs/plan-recurring-money-events.md`
+ * §5.1. The short version, for the capture inbox specifically:
+ *
+ * - The server would have to be told what somebody is holding unfiled and how
+ *   long they have held it, in order to decide whether to say anything. Nothing
+ *   needs to know that but the phone, which already does.
+ * - `notifications.title` and `.body` are plaintext columns read by the fanout,
+ *   by the email claim and by the operator console. A reminder about a person's
+ *   own unfiled receipts does not belong in a shared table.
+ * - There is no per-user time zone anywhere in this schema — only
+ *   `groups.time_zone` — so a server job has no hour to fire at. The device has
+ *   the only clock that knows what "this evening" means here.
+ * - It needs nothing: no FCM/APNs credentials, no EAS project id, no
+ *   `push_tokens` row, no Vault secret, no cron. Five things that must all hold
+ *   for a server push to land, against one (permission) for this.
+ *
+ * ## Nothing here throws, and nothing here is required
+ *
+ * `expo-notifications` is a native module. It is imported the same way
+ * `lib/push.ts` imports it — statically, because it is already in every binary
+ * this code can reach, and guarded by `pushSupported` before any call, because
+ * reaching into it on web throws rather than no-opping and would take the whole
+ * app down on the platform this repo uses for visual checks. Every exported
+ * function below swallows its own failures and reports a value: a reminder that
+ * could not be set is a reminder that does not happen, never a crash in a
+ * headless component nobody is looking at.
+ *
+ * ## Why the OS list is the source of truth
+ *
+ * What we hold is read back from `getAllScheduledNotificationsAsync` rather
+ * than from our own storage, and matched on a `key` inside the payload. A
+ * reinstall, a "clear all", another build's leftovers — the list is the only
+ * thing that actually knows. Our stored copy records when the last one was
+ * *due*, which the list cannot tell us because a fired notification simply
+ * disappears from it.
+ */
+
+import * as Notifications from 'expo-notifications';
+
+import { ensureAndroidChannel, pushSupported } from '@/lib/push';
+
+import type { PendingNudge } from './plan';
+
+/**
+ * Stamped into every reminder this feature schedules, so the sweep below can
+ * tell ours from anything else the app might one day schedule — and so a
+ * cancel-all never reaches somebody else's notification.
+ */
+const NUDGE_KEY = 'waves.captures.nudge';
+
+/**
+ * Where the tap goes. `routeForNotification` strips `waves://` and hands the
+ * rest to the router, so this needs no change to the tap handler in
+ * `_layout.tsx` — it routes on `data.url`, not on a notification kind. The
+ * `waves://` form matches the majority of the server's own deep links.
+ */
+const NUDGE_URL = 'waves://captures';
+
+/** Every reminder of ours the OS is currently holding, newest schedule last. */
+async function ourRequests(): Promise<Notifications.NotificationRequest[]> {
+  if (!pushSupported) return [];
+  try {
+    const all = await Notifications.getAllScheduledNotificationsAsync();
+    return all.filter((request) => {
+      const data = request.content.data as { key?: unknown } | undefined;
+      return data?.key === NUDGE_KEY;
+    });
+  } catch {
+    // An unreadable list is treated as an empty one. The worst case is that we
+    // schedule a duplicate, which the cancel in `scheduleNudge` then clears.
+    return [];
+  }
+}
+
+/**
+ * The reminder this phone is holding, or null.
+ *
+ * If more than one is somehow outstanding — a build that crashed between the
+ * cancel and the schedule — the first is reported and `scheduleNudge` clears
+ * the rest, because it always cancels everything of ours before adding one.
+ */
+export async function pendingNudge(): Promise<PendingNudge | null> {
+  const [first] = await ourRequests();
+  if (!first) return null;
+  const data = first.content.data as
+    { fireAt?: unknown; count?: unknown; locale?: unknown } | undefined;
+  const fireAt = Number(data?.fireAt);
+  const count = Number(data?.count);
+  const locale = typeof data?.locale === 'string' ? data.locale : '';
+  // A payload we cannot read is one we cannot compare against a plan, so it is
+  // reported as "something is scheduled, and it is not what you want" — the
+  // fire time of 0 can never equal a real slot, so the caller replaces it.
+  if (!Number.isFinite(fireAt) || !Number.isFinite(count)) return { fireAt: 0, count: -1, locale };
+  return { fireAt, count, locale };
+}
+
+/** Drop every reminder of ours. Used by the planner, and by sign-out. */
+export async function cancelNudges(): Promise<void> {
+  for (const request of await ourRequests()) {
+    try {
+      await Notifications.cancelScheduledNotificationAsync(request.identifier);
+    } catch {
+      // One that will not cancel is one that may still fire. Nothing useful to
+      // do about it, and stopping here would leave the others standing too.
+    }
+  }
+}
+
+/** What the reminder says. Rendered by the caller, which is where the strings live. */
+export interface NudgeText {
+  readonly title: string;
+  readonly body: string;
+}
+
+/**
+ * Replace whatever we hold with one reminder at `fireAt`.
+ *
+ * Returns whether it was actually set, so the caller only writes the "we
+ * scheduled this" marker when something really is scheduled — a marker for a
+ * reminder that failed would spend the ceiling on silence.
+ */
+export async function scheduleNudge(input: {
+  readonly fireAt: number;
+  readonly count: number;
+  readonly locale: string;
+  readonly text: NudgeText;
+}): Promise<boolean> {
+  if (!pushSupported) return false;
+  await cancelNudges();
+  try {
+    // Android delivers silently without a channel, which looks exactly like a
+    // bug. The shared `default` channel is deliberate rather than a dedicated
+    // one at HIGH importance: this is a gentle "you left something", and a
+    // heads-up banner that covers whatever somebody is doing is the wrong
+    // register for it entirely.
+    await ensureAndroidChannel();
+    await Notifications.scheduleNotificationAsync({
+      content: {
+        title: input.text.title,
+        body: input.text.body,
+        // No amount, and no description of any single draft: a lock screen is
+        // readable without unlocking the phone, and the count is the whole of
+        // what needs saying.
+        data: {
+          key: NUDGE_KEY,
+          url: NUDGE_URL,
+          fireAt: input.fireAt,
+          count: input.count,
+          locale: input.locale,
+        },
+      },
+      trigger: {
+        type: Notifications.SchedulableTriggerInputTypes.DATE,
+        date: new Date(input.fireAt),
+        channelId: 'default',
+      },
+    });
+    return true;
+  } catch {
+    // A build with no notification permission, an OS that refused the alarm, a
+    // module that is not there. None of them are worth a crash, and the person
+    // loses a reminder rather than the app.
+    return false;
+  }
+}

--- a/apps/mobile/src/lib/captureNudge/settings.ts
+++ b/apps/mobile/src/lib/captureNudge/settings.ts
@@ -1,0 +1,108 @@
+/**
+ * What the phone remembers about its own reminder: whether it is allowed to
+ * raise one, and when the last one it set was due to go off.
+ *
+ * ## Why this is not on the server
+ *
+ * Every other switch on the notifications screen lives in
+ * `profiles.notification_prefs`, because every other switch governs something
+ * the *server* decides to send — `waves_claim_push_notifications` reads those
+ * keys, and a preference the database cannot see is a preference nobody has.
+ *
+ * This one is the opposite shape. Nothing is sent: the phone sets an alarm on
+ * itself, from data it already holds, and the phone is therefore the only thing
+ * that can obey the switch. Putting it on the server would mean a reminder that
+ * silently stops working offline (the pass would have no preference to read),
+ * and it would put "how often does this person leave receipts unfiled" on our
+ * servers to govern something our servers never touch — the same argument that
+ * keeps the backup schedule local.
+ *
+ * The honest reading of the switch is therefore "remind me **on this phone**",
+ * and the settings screen says so in its own section rather than mixing it in
+ * with the four that travel with the account.
+ *
+ * ## Owner-scoped, and wiped on the way out
+ *
+ * Every key carries the owner id, exactly as the backup settings do. A device
+ * is not always one person's, and "you have four expenses you never filed" is
+ * not something the next person to sign in on a shared phone should inherit.
+ * `clearCaptureNudge` is called from sign-out alongside the cancel, so nothing
+ * about the previous account survives it.
+ *
+ * ## The default is on
+ *
+ * Opt-out, matching every push switch in `DEFAULT_NOTIFICATION_PREFS` — all of
+ * which start on, with the weekly email as the single deliberate exception. The
+ * exception is instructive: the weekly email arrives whether or not there is
+ * anything to say, so silence has to be the default. This one can only ever
+ * speak about work the person themselves left unfinished, and only on a phone
+ * where they have already granted notification permission through the soft ask.
+ * A switch defaulted off would make it the one reminder in the app that exists
+ * but never happens.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+/** The switch. Absent means on — see the header. */
+const ENABLED_KEY = 'waves.capture_nudge.enabled';
+/**
+ * The fire time of the reminder this phone most recently scheduled.
+ *
+ * One value doing two jobs, which is why it is worth naming carefully. While it
+ * is in the future it is "what we asked for"; once it is in the past it is the
+ * evidence that a reminder went off, which is the only thing the ceiling can be
+ * measured from — nothing in `expo-notifications` reports a delivery, and a
+ * fired notification simply vanishes from the scheduled list.
+ */
+const PLANNED_KEY = 'waves.capture_nudge.planned_at';
+
+/** Every stored key, for the sign-out wipe. */
+const ALL_KEYS = [ENABLED_KEY, PLANNED_KEY] as const;
+
+const scoped = (base: string, ownerId: string): string => `${base}.${ownerId}`;
+
+/** Whether this phone may remind this account about its waiting drafts. */
+export async function loadCaptureNudgeEnabled(ownerId: string): Promise<boolean> {
+  if (!ownerId) return false;
+  // A read that fails must not read as "they turned it off" — an unavailable
+  // store is not an answer, and the default is the honest fallback.
+  const stored = await AsyncStorage.getItem(scoped(ENABLED_KEY, ownerId)).catch(() => null);
+  return stored === null ? true : stored === 'yes';
+}
+
+export async function saveCaptureNudgeEnabled(ownerId: string, enabled: boolean): Promise<void> {
+  if (!ownerId) return;
+  await AsyncStorage.setItem(scoped(ENABLED_KEY, ownerId), enabled ? 'yes' : 'no');
+}
+
+/**
+ * The fire time of the last reminder we set, or null if we have set none.
+ *
+ * Garbage — a key written by some future build, a half-written value — reads as
+ * null, which costs at most one extra reminder rather than suppressing them
+ * forever.
+ */
+export async function loadPlannedNudge(ownerId: string): Promise<number | null> {
+  if (!ownerId) return null;
+  const stored = await AsyncStorage.getItem(scoped(PLANNED_KEY, ownerId)).catch(() => null);
+  if (stored === null) return null;
+  const at = Number(stored);
+  return Number.isFinite(at) && at > 0 ? at : null;
+}
+
+/** Records what we just scheduled, or clears it when we cancel. */
+export async function savePlannedNudge(ownerId: string, fireAt: number | null): Promise<void> {
+  if (!ownerId) return;
+  const key = scoped(PLANNED_KEY, ownerId);
+  await (fireAt === null
+    ? AsyncStorage.removeItem(key)
+    : AsyncStorage.setItem(key, String(fireAt)));
+}
+
+/** On the way out. Best effort: signing out must succeed whether or not this does. */
+export async function clearCaptureNudge(ownerId: string): Promise<void> {
+  if (!ownerId) return;
+  await Promise.all(
+    ALL_KEYS.map((base) => AsyncStorage.removeItem(scoped(base, ownerId)).catch(() => {})),
+  );
+}

--- a/apps/mobile/src/lib/captureNudge/useNudgePass.ts
+++ b/apps/mobile/src/lib/captureNudge/useNudgePass.ts
@@ -1,0 +1,93 @@
+/**
+ * One pass over the reminder, from wherever the app happens to be.
+ *
+ * Two callers need exactly the same thing and must not each assemble it: the
+ * headless `CaptureNudge`, which runs a pass when the inbox or the app's state
+ * moves, and the switch on the notifications screen, which has to make its own
+ * answer true the moment it is touched rather than at the next foreground. A
+ * switch that takes effect later is a switch people press twice.
+ *
+ * The returned callback is fire-and-forget and never rejects: a reminder that
+ * could not be set or cleared is reported to observability and otherwise
+ * silent, because there is no screen this belongs on.
+ */
+
+import { useCallback } from 'react';
+
+import { useCaptures } from '@/data/hooks';
+import { plural, useStrings } from '@/i18n';
+import { useAuth } from '@/lib/auth';
+import { foldedCaptureCount } from '@/lib/captureBatch';
+import { reportHandled } from '@/lib/observability';
+
+import { syncCaptureNudge } from './run';
+
+/** What the pass is about to be told, so a caller can key an effect on it. */
+export interface NudgePassInputs {
+  readonly ownerId: string;
+  /** Waiting drafts, folded the way the dashboard badge folds them. */
+  readonly waitingCount: number;
+  /** When the oldest of them was saved, epoch ms. Null when none is waiting. */
+  readonly oldestWaitingAt: number | null;
+  readonly locale: string;
+  /**
+   * The mirror is off disk. Until it is, the count is "we have not looked", not
+   * "nothing is waiting" — and acting on it would cancel this evening's
+   * reminder on every single launch. The same trap `restorePrompt` is built
+   * around.
+   */
+  readonly ready: boolean;
+}
+
+export function useNudgePassInputs(): NudgePassInputs {
+  const { session } = useAuth();
+  const ownerId = session?.user?.id ?? '';
+  const captures = useCaptures();
+  const { locale } = useStrings();
+
+  const rows = captures.data;
+  // A voice batch counts as one draft, exactly as the dashboard badge counts it
+  // — one utterance must not read as four things waiting.
+  const waitingCount = foldedCaptureCount(rows);
+  // The oldest of them decides whether anything has been *sitting*. An
+  // unparseable stamp is skipped rather than treated as the beginning of time,
+  // which would turn one malformed row into a permanent reminder.
+  let oldestWaitingAt: number | null = null;
+  for (const row of rows) {
+    const at = Date.parse(row.created_at);
+    if (!Number.isFinite(at)) continue;
+    if (oldestWaitingAt === null || at < oldestWaitingAt) oldestWaitingAt = at;
+  }
+
+  return {
+    ownerId,
+    waitingCount,
+    oldestWaitingAt,
+    locale,
+    ready: ownerId !== '' && !captures.isLoading,
+  };
+}
+
+/** Runs a pass with whatever is true right now. Safe to call from an event handler. */
+export function useCaptureNudgePass(inputs: NudgePassInputs): () => void {
+  const { t } = useStrings();
+  const { ownerId, waitingCount, oldestWaitingAt, locale, ready } = inputs;
+
+  return useCallback(() => {
+    if (!ready) return;
+    void syncCaptureNudge({
+      ownerId,
+      waitingCount,
+      oldestWaitingAt,
+      locale,
+      now: Date.now(),
+      // Rendered here, in the app's current language, because the words are
+      // baked into the OS alarm at schedule time. `planCaptureNudge` reschedules
+      // on a language change for exactly that reason.
+      text: (count) => ({
+        title: plural(locale, count, t.captures.nudgeTitle),
+        body: plural(locale, count, t.captures.nudgeBody),
+      }),
+    }).catch((error: unknown) => reportHandled(error, 'captureNudge.sync'));
+  }, [ready, ownerId, waitingCount, oldestWaitingAt, locale, t]);
+}

--- a/apps/mobile/src/lib/push.ts
+++ b/apps/mobile/src/lib/push.ts
@@ -77,6 +77,58 @@ export async function pushPermission(): Promise<PushPermission> {
 }
 
 /**
+ * Whether the phone may raise a notification *this app* schedules.
+ *
+ * Deliberately not `pushPermission()`, which answers a different question. That
+ * one reports `denied` on a simulator, because a simulator has no push token to
+ * give — true of the server's notifications and irrelevant to a local alarm,
+ * which a simulator delivers perfectly well. Asking the token question about a
+ * notification that needs no token would make every reminder in this app
+ * untestable on a simulator for no reason.
+ *
+ * Never asks. This is the read the scheduler does on every pass.
+ */
+export async function localNotificationsAllowed(): Promise<boolean> {
+  if (!pushSupported) return false;
+  try {
+    const { status } = await Notifications.getPermissionsAsync();
+    return status === 'granted';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Permission for a notification this device raises itself: no token, no EAS
+ * project id, no FCM — a local alarm needs none of that, and `enablePush` would
+ * report `not_configured` on a build that lacks them while the alarm would have
+ * worked fine.
+ *
+ * Raises the OS dialog, so it is only ever called from a control somebody has
+ * just touched having read what it is for — the same doctrine as `enablePush`
+ * and `NotificationPrompt`. Never on launch, never from the scheduler: on iOS a
+ * denial is close to permanent, and the one shot is not this feature's to
+ * spend on somebody who has not asked for anything.
+ */
+export async function ensureLocalNotificationPermission(): Promise<boolean> {
+  if (!pushSupported) return false;
+  try {
+    const existing = await Notifications.getPermissionsAsync();
+    const status =
+      existing.status === 'granted'
+        ? existing.status
+        : (await Notifications.requestPermissionsAsync()).status;
+    if (status !== 'granted') return false;
+    // Android delivers silently without a channel, which looks exactly like a
+    // bug — and the channel has to exist before anything is scheduled on it.
+    await ensureAndroidChannel();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Why registering did not happen. Only `denied` is the person's doing; the
  * others are this app's, and telling somebody to check their phone settings
  * when the real problem is a missing Firebase key sends them somewhere that

--- a/apps/mobile/test/captureNudge.test.ts
+++ b/apps/mobile/test/captureNudge.test.ts
@@ -1,0 +1,251 @@
+/**
+ * The rules that keep the phone's own reminder from becoming a nag.
+ *
+ * Every case here is one of the things this feature could do wrong to somebody:
+ * speak about nothing, speak about work they have already done, speak the
+ * moment they saved something, speak twice in an evening, or speak in a
+ * language they have just switched away from. The planner is pure precisely so
+ * that each of those is a two-line assertion rather than a device you have to
+ * be holding at seven in the evening.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  CEILING_MS,
+  NUDGE_HOUR,
+  NudgeAction,
+  nextNudgeSlot,
+  planCaptureNudge,
+  SETTLE_MS,
+  type NudgeInput,
+} from '@/lib/captureNudge/plan';
+import {
+  clearCaptureNudge,
+  loadCaptureNudgeEnabled,
+  loadPlannedNudge,
+  saveCaptureNudgeEnabled,
+  savePlannedNudge,
+} from '@/lib/captureNudge/settings';
+
+/** Local wall clock, which is the only clock this feature reasons in. */
+function at(year: number, month: number, day: number, hour: number, minute = 0): number {
+  return new Date(year, month - 1, day, hour, minute, 0, 0).getTime();
+}
+
+const NOW = at(2026, 3, 10, 11);
+
+function input(overrides: Partial<NudgeInput> = {}): NudgeInput {
+  return {
+    enabled: true,
+    permitted: true,
+    waitingCount: 3,
+    // Saved two days ago, so the settling rule is satisfied by default and each
+    // test below only has to state the one thing it is about.
+    oldestWaitingAt: NOW - 2 * SETTLE_MS,
+    now: NOW,
+    lastFiredAt: null,
+    pending: null,
+    locale: 'en',
+    ...overrides,
+  };
+}
+
+describe('nextNudgeSlot', () => {
+  it('lands on the evening hour in local time, never UTC', () => {
+    const slot = new Date(nextNudgeSlot(at(2026, 3, 10, 11)));
+    expect(slot.getHours()).toBe(NUDGE_HOUR);
+    expect(slot.getMinutes()).toBe(0);
+    expect(slot.getDate()).toBe(10);
+  });
+
+  it('moves to tomorrow once the hour has passed', () => {
+    const slot = new Date(nextNudgeSlot(at(2026, 3, 10, 19, 1)));
+    expect(slot.getDate()).toBe(11);
+    expect(slot.getHours()).toBe(NUDGE_HOUR);
+  });
+
+  it('treats the hour itself as gone, so a slot is never scheduled for now', () => {
+    const slot = new Date(nextNudgeSlot(at(2026, 3, 10, 19, 0)));
+    expect(slot.getDate()).toBe(11);
+  });
+});
+
+describe('planCaptureNudge', () => {
+  it('schedules for this evening when drafts have been sitting', () => {
+    const plan = planCaptureNudge(input());
+    expect(plan.action).toBe(NudgeAction.Schedule);
+    if (plan.action !== NudgeAction.Schedule) throw new Error('unreachable');
+    expect(plan.count).toBe(3);
+    expect(new Date(plan.fireAt).getHours()).toBe(NUDGE_HOUR);
+  });
+
+  it('says nothing when nothing is waiting', () => {
+    expect(planCaptureNudge(input({ waitingCount: 0, oldestWaitingAt: null }))).toEqual({
+      action: NudgeAction.Keep,
+    });
+  });
+
+  /**
+   * The single most important property in the feature: placing the last draft
+   * has to take back a reminder that was already set, not merely stop the next
+   * one. Being told in the evening about work you finished at lunchtime is how
+   * an app's notifications get turned off for good.
+   */
+  it('cancels a pending reminder once everything has been placed', () => {
+    const plan = planCaptureNudge(
+      input({
+        waitingCount: 0,
+        oldestWaitingAt: null,
+        pending: { fireAt: at(2026, 3, 10, 19), count: 3, locale: 'en' },
+      }),
+    );
+    expect(plan).toEqual({ action: NudgeAction.Cancel });
+  });
+
+  it('says nothing when the switch is off, and cancels what the switch already caused', () => {
+    expect(planCaptureNudge(input({ enabled: false }))).toEqual({ action: NudgeAction.Keep });
+    expect(
+      planCaptureNudge(
+        input({
+          enabled: false,
+          pending: { fireAt: at(2026, 3, 10, 19), count: 3, locale: 'en' },
+        }),
+      ),
+    ).toEqual({ action: NudgeAction.Cancel });
+  });
+
+  it('says nothing without permission, however the switch is set', () => {
+    expect(planCaptureNudge(input({ permitted: false }))).toEqual({ action: NudgeAction.Keep });
+    expect(
+      planCaptureNudge(
+        input({
+          permitted: false,
+          pending: { fireAt: at(2026, 3, 10, 19), count: 3, locale: 'en' },
+        }),
+      ),
+    ).toEqual({ action: NudgeAction.Cancel });
+  });
+
+  /** Saving a draft is not a reason to be told about it — you are right there. */
+  it('waits a day before mentioning anything', () => {
+    expect(planCaptureNudge(input({ oldestWaitingAt: NOW - 60 * 1000 }))).toEqual({
+      action: NudgeAction.Keep,
+    });
+    expect(planCaptureNudge(input({ oldestWaitingAt: NOW - SETTLE_MS + 1000 }))).toEqual({
+      action: NudgeAction.Keep,
+    });
+    expect(planCaptureNudge(input({ oldestWaitingAt: NOW - SETTLE_MS })).action).toBe(
+      NudgeAction.Schedule,
+    );
+  });
+
+  it('measures the wait from the oldest draft, not the newest', () => {
+    // Two drafts: one from last week, one from a minute ago. The old one is
+    // what the reminder is for, and the fresh one must not suppress it.
+    const plan = planCaptureNudge(input({ waitingCount: 2, oldestWaitingAt: NOW - 7 * SETTLE_MS }));
+    expect(plan.action).toBe(NudgeAction.Schedule);
+  });
+
+  describe('the ceiling', () => {
+    it('never puts two reminders closer together than the floor allows', () => {
+      // One fired an hour ago. This evening's slot is inside the window, so the
+      // next one is pushed a day rather than landing the same night.
+      const now = at(2026, 3, 10, 10);
+      const plan = planCaptureNudge(
+        input({ now, oldestWaitingAt: now - 2 * SETTLE_MS, lastFiredAt: now - 60 * 60 * 1000 }),
+      );
+      expect(plan.action).toBe(NudgeAction.Schedule);
+      if (plan.action !== NudgeAction.Schedule) throw new Error('unreachable');
+      expect(new Date(plan.fireAt).getDate()).toBe(11);
+      expect(plan.fireAt - (now - 60 * 60 * 1000)).toBeGreaterThanOrEqual(CEILING_MS);
+    });
+
+    it('still allows one a day in ordinary running', () => {
+      // Fired at seven last night; the app is opened five minutes later.
+      const fired = at(2026, 3, 9, 19);
+      const now = at(2026, 3, 9, 19, 5);
+      const plan = planCaptureNudge(
+        input({ now, oldestWaitingAt: now - 2 * SETTLE_MS, lastFiredAt: fired }),
+      );
+      expect(plan.action).toBe(NudgeAction.Schedule);
+      if (plan.action !== NudgeAction.Schedule) throw new Error('unreachable');
+      expect(plan.fireAt).toBe(at(2026, 3, 10, 19));
+    });
+  });
+
+  describe('churn', () => {
+    it('leaves an identical reminder alone', () => {
+      const plan = planCaptureNudge(
+        input({ pending: { fireAt: at(2026, 3, 10, 19), count: 3, locale: 'en' } }),
+      );
+      expect(plan).toEqual({ action: NudgeAction.Keep });
+    });
+
+    it('rewrites one whose count has gone stale', () => {
+      // Two of five placed. A reminder that still says five is worse than none.
+      const plan = planCaptureNudge(
+        input({
+          waitingCount: 3,
+          pending: { fireAt: at(2026, 3, 10, 19), count: 5, locale: 'en' },
+        }),
+      );
+      expect(plan.action).toBe(NudgeAction.Schedule);
+      if (plan.action !== NudgeAction.Schedule) throw new Error('unreachable');
+      expect(plan.count).toBe(3);
+    });
+
+    it('rewrites one after a language change', () => {
+      // The words are baked into the OS alarm at schedule time, so a switch to
+      // Tamil cannot reach a notification that is already set.
+      const plan = planCaptureNudge(
+        input({
+          locale: 'ta',
+          pending: { fireAt: at(2026, 3, 10, 19), count: 3, locale: 'en' },
+        }),
+      );
+      expect(plan.action).toBe(NudgeAction.Schedule);
+    });
+
+    it('replaces a reminder whose payload could not be read', () => {
+      // `pendingNudge` reports an unreadable one as fireAt 0 / count -1, which
+      // can never match a real plan, so it is always swept away.
+      const plan = planCaptureNudge(input({ pending: { fireAt: 0, count: -1, locale: '' } }));
+      expect(plan.action).toBe(NudgeAction.Schedule);
+    });
+  });
+});
+
+describe('the stored switch', () => {
+  it('is on for an account that has never touched it', async () => {
+    expect(await loadCaptureNudgeEnabled('owner-never-asked')).toBe(true);
+  });
+
+  it('remembers a no, and does not read it back as an absent key', async () => {
+    await saveCaptureNudgeEnabled('owner-a', false);
+    expect(await loadCaptureNudgeEnabled('owner-a')).toBe(false);
+    await saveCaptureNudgeEnabled('owner-a', true);
+    expect(await loadCaptureNudgeEnabled('owner-a')).toBe(true);
+  });
+
+  /** A device is not always one person's. B must not inherit A's answer. */
+  it('keeps one account out of another account', async () => {
+    await saveCaptureNudgeEnabled('owner-shared', false);
+    expect(await loadCaptureNudgeEnabled('owner-next-in')).toBe(true);
+  });
+
+  it('forgets everything on the way out', async () => {
+    await saveCaptureNudgeEnabled('owner-leaving', false);
+    await savePlannedNudge('owner-leaving', 1_700_000_000_000);
+    await clearCaptureNudge('owner-leaving');
+    expect(await loadCaptureNudgeEnabled('owner-leaving')).toBe(true);
+    expect(await loadPlannedNudge('owner-leaving')).toBeNull();
+  });
+
+  it('round-trips the fire marker, and clears it on request', async () => {
+    await savePlannedNudge('owner-marked', 1_700_000_000_000);
+    expect(await loadPlannedNudge('owner-marked')).toBe(1_700_000_000_000);
+    await savePlannedNudge('owner-marked', null);
+    expect(await loadPlannedNudge('owner-marked')).toBeNull();
+  });
+});


### PR DESCRIPTION
## What this is

A **local** notification — an alarm this device sets on itself — telling somebody that expenses they saved for later are still waiting for a group. Tapping it opens the app on `/captures`.

## Which screen I decided the user meant, and why

The **captures inbox** (A34), which the app itself calls **"Saved for later"** (`t.captures.title`) — `apps/mobile/src/app/captures.tsx`, badged on the dashboard hero by `foldedCaptureCount(useCaptures())`.

The request was "uncategorised expenses that we have saved for later". There is a separate notion of an expense with no `category` set, but nothing in the app ever treats that as a queue of unfinished work, there is no screen for it, and "saved for later" is the literal on-screen name of the capture inbox. A capture with no group is genuinely unfinished — it is not in anybody's ledger until it is placed — whereas an expense with no category is already counted and merely untagged. So: captures. Only one was built.

## Exactly when it fires

- The oldest waiting draft is **at least 24 hours old**. Never at the moment something is saved — the person is holding the phone, looking at the screen that says so.
- At **19:00 on the local wall clock**, built by moving the *date* rather than adding 24 hours in milliseconds, so it stays at seven in the evening across a daylight-saving change. (Never `toISOString`: the trap the personal ledger's `localIsoDate` exists for.)
- Only if the switch is on **and** the OS has actually granted permission.

## The ceiling

**One in any 20-hour window**, enforced on *fire times* rather than on scheduling passes — a rule counted in passes would be a rule about how often somebody opens Waves. The slot is daily, so in ordinary running the ceiling never binds; it exists for the days that are not ordinary (a phone carried across time zones, a clock corrected, a partly-cleared inbox moving the slot).

## When it is cancelled

A scheduled reminder is **cancelled**, not merely left to expire, the moment any of these becomes true:

- the waiting count reaches zero — **placing the last draft clears this evening's reminder immediately**, not on the next foreground;
- the switch is turned off;
- notification permission is withdrawn;
- somebody signs out (the alarm is cancelled and the stored keys wiped, so a phone nobody is signed in on cannot announce a previous account's drafts).

Being told in the evening about work you finished at lunchtime is how an app's notifications get turned off for good, so that is the property the tests lead with. A changed count or a changed language also rewrites the held reminder, since both are baked into the OS alarm at schedule time.

**Nothing for zero**, ever — there is no path that schedules a notification saying 0 are waiting.

## Opt-in or opt-out

**Opt-out — on by default**, behind the OS permission, which is itself opt-in and still never asked cold.

Every push switch in `DEFAULT_NOTIFICATION_PREFS` starts on; `weeklyEmail` is the single deliberate exception, and the reason is instructive — a weekly summary arrives whether or not there is anything to say. This one can only ever speak about work the person themselves left unfinished, on a phone where they have already granted permission through the existing soft ask (`NotificationPrompt`). A switch defaulted off would make it the one reminder in the app that exists and never happens.

The switch lives on **`/settings/notifications`** with the others, in its own section ("From this phone"), because the four above it are things our servers send and this one is the phone talking to itself. It is stored per-owner in AsyncStorage rather than in `profiles.notification_prefs`, because the device is the only thing that can obey it — a server-side flag would make the reminder stop working offline and would put "how often does this person leave receipts unfiled" on our servers to govern something our servers never touch. Same argument as the backup schedule.

## Local, not a server push

Nothing here touches `notifications`, `waves_notify`, `notify-fanout` or pg_cron. The reasoning is already written out in `docs/plan-recurring-money-events.md` §5.1 and holds for the capture inbox for the same reasons: the server would have to be told what somebody is holding unfiled and for how long; `notifications.title`/`.body` are plaintext columns read by the fanout, the mail claim and the operator console; there is no per-user time zone anywhere in the schema for a server job to fire at; and a local alarm needs one thing (permission) where a server push needs five.

`routeForNotification` already switches on `data.url`, so the payload carries `waves://captures` and **the tap handler in `_layout.tsx` is unchanged**.

**No amounts.** A lock screen is readable without unlocking the phone, so the text says how many are waiting and nothing else — no figure, no note, no category. The i18n comment says so, so a future edit has to argue with it.

## Shape

The whole decision is a pure function with no clock and no storage of its own — `apps/mobile/src/lib/captureNudge/plan.ts`, in the shape `lib/backup/restorePrompt.ts` set. Around it:

| file | what it is |
| --- | --- |
| `captureNudge/plan.ts` | the rules. Pure, tested. |
| `captureNudge/settings.ts` | the per-owner switch and the fire marker, AsyncStorage. |
| `captureNudge/schedule.ts` | the only `expo-notifications` caller: read, cancel, schedule. |
| `captureNudge/run.ts` | one pass: reads above the decision, writes below it. |
| `captureNudge/useNudgePass.ts` | the inputs and a fire-and-forget pass, shared by the two callers. |
| `captureNudge/CaptureNudge.tsx` | headless, mounted beside `<AutoBackup />` inside the lock and auth gates. |

`expo-notifications` is imported exactly the way `lib/push.ts` imports it — statically, because it is already in every binary this JS can reach, and guarded by `pushSupported` before any call, since reaching into it on web throws rather than no-opping. Every function in `schedule.ts` swallows its own failures and returns a value: a reminder that could not be set is a reminder that does not happen, never a crash in a headless component nobody is looking at.

Permission reuses the existing flow: the soft ask (`NotificationPrompt`) is untouched, and the new `ensureLocalNotificationPermission()` in `lib/push.ts` is the same getPermissions-then-requestPermissions door `enablePush` uses, minus the EAS project id and push token a local alarm does not need. It is only ever called from the switch the person has just touched.

i18n in all four locales (en/ta/hi/ar), one contiguous block per table; title and body are pluralised through the existing `plural` helper, with Arabic written out across its categories rather than falling through to `other` with the wrong agreement.

JS only: no migration, no edge function, no new native module, nothing deploy-gated.

## Gates

| gate | result |
| --- | --- |
| `pnpm format` | pass (3 files reformatted, committed) |
| `pnpm lint` | pass |
| `pnpm --filter @waves/mobile typecheck` | pass |
| `pnpm --filter @waves/mobile test` | pass — 102 files, 1369 tests (21 new) |
| `pnpm --filter @waves/core test` | pass — 63 files, 986 tests |

`packages/db` tests were not run: they need a local Postgres that is not running.

`bash scripts/check-filenames.sh` clean; `git status --short` reviewed line by line before staging.

## What I did not do, and what is unverified

- **No notification has been seen appear.** A local notification cannot be raised on this machine — no device, no emulator in this session. Everything above is reasoning over the API and the tests; the firing, the 19:00 landing, the Android channel and the tap route all want a device pass.
- The tests cover the planner and the stored settings. `schedule.ts` (the `expo-notifications` calls) has no test, matching the house rule that anything needing a native module or a renderer belongs in Maestro rather than vitest; there is no captures flow in `e2e/` to add it to.
- No second nudge, no snooze, no notification action buttons ("Place them" / "Not now" from the shade) — the last would need the mirror hydrated and the biometric gate considered from a notification response, which is its own decision.
- Nothing was changed on the captures screen or the dashboard badge.
- Android OEMs that kill scheduled alarms for apps not opened recently will eat this, as they eat everything of the kind. Said out loud rather than promised around.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jhzmZz5fkjnZZ14YxHGfS
