### PR TITLE
Adding someone to a group says where the person is coming from

### DIFF
--- a/apps/mobile/src/app/group/[id]/settings.tsx
+++ b/apps/mobile/src/app/group/[id]/settings.tsx
@@ -1,8 +1,8 @@
-import { useState, type ReactNode } from 'react';
+import { Fragment, useState, type ReactNode } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useQuery } from '@tanstack/react-query';
 import { useLocalSearchParams } from 'expo-router';
-import { ActivityIndicator, ScrollView, TextInput, View } from 'react-native';
+import { ActivityIndicator, Platform, ScrollView, TextInput, View } from 'react-native';
 
 import {
   Avatar,
@@ -30,6 +30,7 @@ import { type CurrencyCode } from '@waves/core';
 
 import { GroupPhoto } from '@/components/GroupPhoto';
 import { type PickedContact } from '@/components/ContactPicker';
+import { addSomeoneRoutes, type AddSomeoneRoute } from '@/lib/addSomeoneRoutes';
 import { friendlyError } from '@/lib/errors';
 import { groupDeleteWarning, orderDebtsForWarning } from '@/lib/groupDeleteWarning';
 import { GROUP_DESCRIPTION_MAX, normaliseGroupDescription } from '@/lib/groupDescription';
@@ -219,16 +220,41 @@ export default function GroupSettingsScreen() {
     ),
   );
 
-  // Opens the address book on its own screen rather than unfolding it inline —
-  // a thousand-name list needs the whole height (ADR-006: no book is uploaded).
-  // The ticked people come back through the bridge into `addPicked`.
-  const openContactPicker = (): void => {
-    requestContacts({
-      initial: [],
-      existing: alreadyAdded,
-      onPicked: (people) => void addPicked(people),
-    });
-    router.push('/contact-picker');
+  /**
+   * The ways in, named: what each row of the "add someone" section offers and
+   * where it leads. The list itself is decided in `lib/addSomeoneRoutes` so it
+   * can be read — and tested — without a renderer.
+   *
+   * `addressBook` is the device question, not the permission one. Web has no
+   * `expo-contacts` at all, so that row would be a door into an apology and is
+   * dropped; a phone that *can* be asked keeps the row whatever the answer
+   * turns out to be, because the answer is the picker's to get.
+   */
+  const routes = addSomeoneRoutes({ groupId, t, addressBook: Platform.OS !== 'web' });
+
+  /**
+   * Follow one of them.
+   *
+   * The contacts row leaves its intent with the bridge before navigating,
+   * because the picker is a pushed route and cannot hand a value back the way
+   * an inline callback could; the ticked people come back through `addPicked`.
+   * It also means the OS permission sheet is never raised cold — it is asked on
+   * the way into the screen this row has just opened, and a refusal is answered
+   * there, leaving every other way in this section exactly as it was.
+   *
+   * The address book is read on the device and stays on it: only the people
+   * ticked are sent anywhere, and only as the name and address needed to invite
+   * them (ADR-006).
+   */
+  const openRoute = (route: AddSomeoneRoute): void => {
+    if (route.key === 'contacts') {
+      requestContacts({
+        initial: [],
+        existing: alreadyAdded,
+        onPicked: (people) => void addPicked(people),
+      });
+    }
+    router.push(route.href as never);
   };
 
   const [name, setName] = useState(group.data?.name ?? '');
@@ -771,12 +797,91 @@ export default function GroupSettingsScreen() {
             ))}
           </Card>
 
-          {/* Add a member before the share row — the common case (someone with a
-              name, not a link) shouldn't require the invite flow. */}
-          <Card style={{ gap: theme.spacing.sm }}>
+          {/* The ways in, each one named.
+
+              This section used to ask you to guess. A text field with nothing
+              over it but the words "Add someone", a ghost button under it
+              reading "Browse my contacts", and — four rows further down the
+              page, in a card of its own — the invite link. Three different ways
+              of getting a person into the group, and none of the three said
+              where that person was coming from before you pressed it; the one
+              most people actually want (send a link, they join themselves) did
+              not look like part of adding anybody at all.
+
+              So the doors come first, as rows with a mark, a name and a line
+              saying what the tap does, ordered by how often each is the right
+              answer rather than alphabetically. Typing a name follows under a
+              rule, as the fallback it is — the same shape the members screen
+              settled on, drawn in this screen's own row idiom.
+
+              `ListRow` rather than a `DetailRow`: these are entries you *open*,
+              each with a name and a subtitle, not facts about the group with a
+              value on the right. That is the row this screen already wears for
+              duplicate, favourite and the three ways out, so the section reads
+              as part of the page instead of introducing a fourth kind of row.
+
+              Missing, and worth saying out loud: the people already in your
+              other groups — the same friends, a new trip — which is very likely
+              the commonest reason this section is opened. No flow exists for it
+              yet, and a row leading nowhere is worse than no row, so none is
+              drawn (see `lib/addSomeoneRoutes`). */}
+          <Card style={{ gap: theme.spacing.md }}>
             <Text variant="caption" tone="muted">
               {t.people.addSomeone}
             </Text>
+
+            {/* The hairline belongs to the gap, not to the row: drawn by the
+                row itself it would leave a stray line under the last one. Keyed
+                off the position in the list that was actually returned, so a
+                row that is absent (no address book) takes its divider with it
+                rather than leaving a line with nothing on one side of it. */}
+            <View>
+              {routes.map((route, index) => (
+                <Fragment key={route.key}>
+                  {index > 0 ? (
+                    <View style={{ height: 1, backgroundColor: theme.color.border }} />
+                  ) : null}
+                  <ListRow
+                    title={route.title}
+                    subtitle={route.hint}
+                    // The name alone says a place, not an act. A reader hears
+                    // both halves — "From your contacts, pick names out of this
+                    // phone's address book" — which is the whole point of the
+                    // rewrite and would be lost to a label of just the title.
+                    accessibilityLabel={route.spoken}
+                    leading={
+                      <Ionicons
+                        name={route.icon}
+                        size={iconSize.xl}
+                        color={theme.color.textMuted}
+                      />
+                    }
+                    onPress={() => openRoute(route)}
+                    trailing={
+                      <Ionicons
+                        // Content, not layout: RN mirrors the row in RTL but
+                        // leaves the glyph pointing whichever way it was drawn.
+                        name={directionalIcon('chevron-forward')}
+                        size={iconSize.md}
+                        color={theme.color.textFaint}
+                      />
+                    }
+                  />
+                </Fragment>
+              ))}
+            </View>
+
+            {/* A rule with the alternative written into it, so the field below
+                reads as the other way rather than as the only way — the same
+                divider, and the same string, the members screen uses. */}
+            <Row style={{ alignItems: 'center', gap: theme.spacing.md }}>
+              <View style={{ flex: 1, height: 1, backgroundColor: theme.color.border }} />
+              <Text variant="micro" tone="faint">
+                {t.people.orByName}
+              </Text>
+              <View style={{ flex: 1, height: 1, backgroundColor: theme.color.border }} />
+            </Row>
+
             <Row style={{ gap: theme.spacing.sm }}>
               <TextInput
                 value={newName}
@@ -807,36 +912,11 @@ export default function GroupSettingsScreen() {
               />
             </Row>
 
-            {/* The fuller add — the same address-book picker the members screen
-                and new-group flow open, so adding somebody already in your phone
-                no longer means retyping their name here. */}
-            <Button
-              label={t.people.browseContacts}
-              variant="ghost"
-              disabled={addingContacts || addGhost.isPending}
-              onPress={openContactPicker}
-            />
+            {/* Both add paths drive the one mutation, so the one spinner and
+                the one error line sit at the foot of the whole card rather than
+                beside whichever of them started it. */}
             {addingContacts ? <ActivityIndicator color={theme.color.brand} /> : null}
             {addError ? <Callout tone="negative">{addError}</Callout> : null}
-          </Card>
-
-          {/* Share a link for anyone who should join themselves. */}
-          <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
-            <ListRow
-              title={t.group.invitePeople}
-              subtitle={t.group.invitePeopleHint}
-              leading={
-                <Ionicons name="share-outline" size={iconSize.xl} color={theme.color.textMuted} />
-              }
-              onPress={() => router.push(`/group/${groupId}/invite`)}
-              trailing={
-                <Ionicons
-                  name={directionalIcon('chevron-forward')}
-                  size={iconSize.md}
-                  color={theme.color.textFaint}
-                />
-              }
-            />
           </Card>
 
           {/* Make another group from this one, and star it so it sits at the top

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1950,8 +1950,6 @@ export interface UiStrings {
     simplifyDebtsBody: string;
     simplifyDebtsHint: string;
     membersHint: string;
-    invitePeople: string;
-    invitePeopleHint: string;
     bringThingsIn: string;
     importMessages: string;
     importMessagesHint: string;
@@ -2074,6 +2072,11 @@ export interface UiStrings {
     emailSubject: string;
     hideContacts: string;
     browseContacts: string;
+    /** The line under "From your contacts", saying which book is read. */
+    fromContactsHint: string;
+    /** The way in for somebody who joins themselves: link or QR. */
+    shareJoinLink: string;
+    shareJoinLinkHint: string;
     /** The rule between the invite tiles and the by-name fields. */
     orByName: string;
     /** Short label for the phone-contacts entry point. */
@@ -4604,8 +4607,6 @@ const en: UiStrings = {
       'Suggest the fewest payments that settle the group. The real who-owes-whom ledger is never rewritten.',
     simplifyDebtsHint: 'Fewest payments to settle up',
     membersHint: 'Add people, rename, set UPI IDs',
-    invitePeople: 'Invite people',
-    invitePeopleHint: 'Share a link — no install needed to join',
     bringThingsIn: 'Bring things in',
     importMessages: 'Import from messages',
     importMessagesHint: 'Paste bank messages — read on this phone, confirmed by you',
@@ -4703,6 +4704,9 @@ const en: UiStrings = {
     emailSubject: 'Join {group} on Waves',
     hideContacts: 'Hide contacts',
     browseContacts: 'Browse my contacts',
+    fromContactsHint: 'Pick names out of this phone’s address book',
+    shareJoinLink: 'Share a join link',
+    shareJoinLinkHint: 'Send the link or show the QR — they join themselves',
     orByName: 'or add by name',
     contacts: 'Contacts',
     remind: 'Remind',
@@ -7257,8 +7261,6 @@ const ta: UiStrings = {
       'குழுவைத் தீர்க்கும் மிகக் குறைந்த பணப்பரிமாற்றங்களைப் பரிந்துரைக்கும். யார் யாருக்குத் தர வேண்டும் என்ற உண்மையான கணக்கு மாற்றப்படுவதே இல்லை.',
     simplifyDebtsHint: 'தீர்க குறைந்தபட்ச பணம் செலுத்தல்கள்',
     membersHint: 'ஆட்களைச் சேர், பெயர் மாற்று, UPI ID அமை',
-    invitePeople: 'ஆட்களை அழை',
-    invitePeopleHint: 'ஒரு இணைப்பைப் பகிருங்கள் — சேர ஆப் நிறுவத் தேவையில்லை',
     bringThingsIn: 'கொண்டுவருதல்',
     importMessages: 'செய்திகளிலிருந்து இறக்குமதி',
     importMessagesHint:
@@ -7365,6 +7367,9 @@ const ta: UiStrings = {
     emailSubject: 'Waves-ல் {group} குழுவில் சேரவும்',
     hideContacts: 'தொடர்புகளை மறை',
     browseContacts: 'என் தொடர்புகளைப் பார்',
+    fromContactsHint: 'இந்த போனின் தொடர்புப் பட்டியலிலிருந்து பெயர்களைத் தேர்ந்தெடு',
+    shareJoinLink: 'சேரும் இணைப்பைப் பகிர்',
+    shareJoinLinkHint: 'இணைப்பை அனுப்பு அல்லது QR-ஐக் காட்டு — அவர்களே சேர்ந்துகொள்வார்கள்',
     orByName: 'அல்லது பெயரால் சேர்',
     contacts: 'தொடர்புகள்',
     remind: 'நினைவூட்டு',
@@ -9922,8 +9927,6 @@ const hi: UiStrings = {
       'समूह को निपटाने के सबसे कम भुगतान सुझाता है। किस पर किसका बाकी है, वह असली हिसाब कभी नहीं बदला जाता।',
     simplifyDebtsHint: 'सेटल करने के लिए कम से कम भुगतान',
     membersHint: 'लोग जोड़ें, नाम बदलें, UPI ID सेट करें',
-    invitePeople: 'लोगों को बुलाएँ',
-    invitePeopleHint: 'एक लिंक साझा करें — जुड़ने के लिए कुछ इंस्टॉल करने की ज़रूरत नहीं',
     bringThingsIn: 'बाहर से लाएँ',
     importMessages: 'मैसेज से आयात',
     importMessagesHint: 'बैंक मैसेज पेस्ट करें — इसी फ़ोन पर पढ़े जाते हैं, पुष्टि आप करते हैं',
@@ -10024,6 +10027,9 @@ const hi: UiStrings = {
     emailSubject: 'Waves पर {group} में शामिल हों',
     hideContacts: 'संपर्क छिपाएँ',
     browseContacts: 'मेरे संपर्क देखें',
+    fromContactsHint: 'इस फ़ोन की संपर्क सूची से नाम चुनें',
+    shareJoinLink: 'जुड़ने का लिंक साझा करें',
+    shareJoinLinkHint: 'लिंक भेजें या QR दिखाएँ — वे खुद जुड़ जाएँगे',
     orByName: 'या नाम से जोड़ें',
     contacts: 'संपर्क',
     remind: 'याद दिलाएँ',
@@ -12670,8 +12676,6 @@ const ar: UiStrings = {
       'يقترح أقل عدد من الدفعات لتسوية المجموعة. أما دفتر من يدين لمن فلا يُعاد كتابته أبدًا.',
     simplifyDebtsHint: 'أقل عدد من المدفوعات للتسوية',
     membersHint: 'أضف أشخاصًا، غيّر الأسماء، اضبط معرّفات الدفع',
-    invitePeople: 'ادعُ أشخاصًا',
-    invitePeopleHint: 'شارك رابطًا — لا حاجة لتثبيت شيء للانضمام',
     bringThingsIn: 'استيراد',
     importMessages: 'استيراد من الرسائل',
     importMessagesHint: 'ألصق رسائل المصرف — تُقرأ على هذا الهاتف وتؤكدها أنت',
@@ -12786,6 +12790,9 @@ const ar: UiStrings = {
     emailSubject: 'انضم إلى {group} على Waves',
     hideContacts: 'إخفاء جهات الاتصال',
     browseContacts: 'تصفّح جهات اتصالي',
+    fromContactsHint: 'اختر أسماءً من دفتر عناوين هذا الهاتف',
+    shareJoinLink: 'شارك رابط الانضمام',
+    shareJoinLinkHint: 'أرسل الرابط أو اعرض رمز QR — وسينضمّون بأنفسهم',
     orByName: 'أو أضف بالاسم',
     contacts: 'جهات الاتصال',
     remind: 'ذكّر',

--- a/apps/mobile/src/lib/addSomeoneRoutes.ts
+++ b/apps/mobile/src/lib/addSomeoneRoutes.ts
@@ -1,0 +1,106 @@
+/**
+ * The named ways of getting another person into a group, and the order they are
+ * offered in.
+ *
+ * The group settings screen used to answer "how do I add someone?" with an
+ * unlabelled text field, a ghost button reading "Browse my contacts", and —
+ * four rows further down the page, in a card of its own — the invite link.
+ * Three ways in, none of which said where the person was coming from before you
+ * pressed it, and the one most people actually reach for (send a link, they
+ * join themselves) did not look like part of adding anybody at all.
+ *
+ * So the doors are described here rather than drawn inline: a key, a mark, a
+ * name, and one line saying what pressing it does. Keeping them in a pure
+ * module has a point beyond tidiness — the screen renders whatever this returns,
+ * so "which ways does this group offer, in what order, leading where" becomes a
+ * question a test can ask without a renderer, which is the only kind of test
+ * this app runs (see `vitest.config.ts`).
+ *
+ * Two things are deliberately *not* here:
+ *
+ *  - Typing a name. It is not a door — there is nowhere to go — it is the
+ *    fallback field under the rule, which is what ADR-006 actually says: a name
+ *    alone is enough to start splitting with somebody, not that a name alone is
+ *    the first thing to reach for. The members screen settled on the same shape.
+ *  - "From another group" — the people already in your other groups, which is
+ *    what a second trip with the same friends wants and probably the commonest
+ *    reason this section is opened at all. Nothing in the app does it today.
+ *    The contacts picker comes closest: it floats people you have written down
+ *    before to the head of its list and names the group they are already in —
+ *    but only for the ones it can match against the phone's address book, and
+ *    only on the screens that hand it that index. A row leading nowhere is
+ *    worse than no row, so none is returned until the flow exists.
+ */
+
+import Ionicons from '@expo/vector-icons/Ionicons';
+
+import type { UiStrings } from '@/i18n';
+
+export type AddSomeoneRouteKey = 'contacts' | 'inviteLink';
+
+export interface AddSomeoneRoute {
+  /** Stable id — what the screen switches on, never what it draws. */
+  readonly key: AddSomeoneRouteKey;
+  readonly icon: keyof typeof Ionicons.glyphMap;
+  /** The row's name. On its own it has to predict what pressing it does. */
+  readonly title: string;
+  /** The line under it, saying where the person is coming from. */
+  readonly hint: string;
+  /**
+   * What a screen reader hears. The name and the hint together, because a
+   * reader that stops at "From your contacts" has been told a place and not an
+   * act — the hint is the half that says what the tap will do.
+   */
+  readonly spoken: string;
+  /** The route pressing it pushes. */
+  readonly href: string;
+}
+
+export interface AddSomeoneContext {
+  readonly groupId: string;
+  readonly t: UiStrings;
+  /**
+   * Whether this device has an address book to read at all. False on web, where
+   * `expo-contacts` has no implementation and the picker can do nothing but
+   * apologise — so the row is dropped rather than drawn as a door into a dead
+   * end. It is only the *device* question, never the permission one: a refusal
+   * is answered inside the picker, on its own screen, and coming back leaves
+   * every other way in this section untouched.
+   */
+  readonly addressBook: boolean;
+}
+
+export function addSomeoneRoutes({
+  groupId,
+  t,
+  addressBook,
+}: AddSomeoneContext): readonly AddSomeoneRoute[] {
+  const routes: AddSomeoneRoute[] = [];
+
+  // Ordered by how often each is the right answer rather than alphabetically:
+  // most people added to a group are already in the phone, and the link is for
+  // the ones who are not.
+  if (addressBook) {
+    routes.push({
+      key: 'contacts',
+      icon: 'people-outline',
+      // The picker's own screen title, on purpose: the row and the screen it
+      // opens say the same words, so arriving confirms rather than surprises.
+      title: t.misc.fromYourContacts,
+      hint: t.people.fromContactsHint,
+      spoken: `${t.misc.fromYourContacts}, ${t.people.fromContactsHint}`,
+      href: '/contact-picker',
+    });
+  }
+
+  routes.push({
+    key: 'inviteLink',
+    icon: 'qr-code-outline',
+    title: t.people.shareJoinLink,
+    hint: t.people.shareJoinLinkHint,
+    spoken: `${t.people.shareJoinLink}, ${t.people.shareJoinLinkHint}`,
+    href: `/group/${groupId}/invite`,
+  });
+
+  return routes;
+}

--- a/apps/mobile/test/addSomeoneRoutes.test.ts
+++ b/apps/mobile/test/addSomeoneRoutes.test.ts
@@ -1,0 +1,112 @@
+/**
+ * The "add someone" section of a group's settings says where each way in leads.
+ *
+ * The old section offered a bare field and a button called "Browse my
+ * contacts"; nothing on screen said what pressing anything would do. These
+ * routes are the fix, so what is worth holding still is not how they look but
+ * what they claim: every row carries a name, a line under it and a destination,
+ * in a fixed order, and a row that cannot work on this device is not drawn at
+ * all rather than drawn as a door into an apology.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('expo-localization', () => ({ getLocales: () => [{ languageCode: 'en' }] }));
+
+const { STRINGS_BY_LANGUAGE } = await import('../src/i18n');
+const { addSomeoneRoutes } = await import('../src/lib/addSomeoneRoutes');
+
+const LANGUAGES = ['en', 'ta', 'hi', 'ar'] as const;
+
+const en = STRINGS_BY_LANGUAGE.en;
+
+/** Where the row with this key leads, or undefined when it was not drawn. */
+function href(
+  routes: readonly { readonly key: string; readonly href: string }[],
+  key: string,
+): string | undefined {
+  return routes.find((route) => route.key === key)?.href;
+}
+
+describe('the ways into a group', () => {
+  it('offers contacts first and the join link second on a phone', () => {
+    const routes = addSomeoneRoutes({ groupId: 'trip-group', t: en, addressBook: true });
+    // Order is the claim, not a coincidence: most people added to a group are
+    // already in the phone, and the link is for the ones who are not.
+    expect(routes.map((route) => route.key)).toEqual(['contacts', 'inviteLink']);
+  });
+
+  it('sends each row at the flow it names', () => {
+    const routes = addSomeoneRoutes({ groupId: 'trip-group', t: en, addressBook: true });
+    expect(href(routes, 'contacts')).toBe('/contact-picker');
+    expect(href(routes, 'inviteLink')).toBe('/group/trip-group/invite');
+  });
+
+  it('keeps the group id out of the address-book route', () => {
+    // The picker is a shared screen driven by the bridge, not a per-group one.
+    // A groupId baked into its path would be a second, silently ignored source
+    // of truth about who the ticked people are being added to.
+    const routes = addSomeoneRoutes({ groupId: 'trip-group', t: en, addressBook: true });
+    expect(href(routes, 'contacts')).not.toContain('trip-group');
+  });
+
+  it('drops the contacts row where there is no address book to read', () => {
+    // Web has no expo-contacts at all, so that row could only ever apologise.
+    const routes = addSomeoneRoutes({ groupId: 'trip-group', t: en, addressBook: false });
+    expect(routes.map((route) => route.key)).toEqual(['inviteLink']);
+  });
+
+  it('leaves the other ways in alone when contacts are unavailable', () => {
+    // A device that cannot read an address book can still hand somebody a link
+    // — the point of dropping one row rather than the section.
+    const routes = addSomeoneRoutes({ groupId: 'trip-group', t: en, addressBook: false });
+    expect(href(routes, 'inviteLink')).toBe('/group/trip-group/invite');
+  });
+
+  it('gives every row a name, a hint and a spoken label that carries both', () => {
+    const routes = addSomeoneRoutes({ groupId: 'trip-group', t: en, addressBook: true });
+    for (const route of routes) {
+      expect(route.title.trim(), route.key).not.toBe('');
+      expect(route.hint.trim(), route.key).not.toBe('');
+      // The name alone says a place, not an act. A screen reader that stops at
+      // "From your contacts" has been told half of it.
+      expect(route.spoken, route.key).toContain(route.title);
+      expect(route.spoken, route.key).toContain(route.hint);
+      expect(route.icon.trim(), route.key).not.toBe('');
+    }
+  });
+
+  it('names the contacts row exactly as the screen it opens is titled', () => {
+    // The row and the picker's own heading say the same words, so arriving
+    // confirms the tap rather than surprising it.
+    const routes = addSomeoneRoutes({ groupId: 'trip-group', t: en, addressBook: true });
+    expect(routes[0]?.title).toBe(en.misc.fromYourContacts);
+  });
+
+  it('is written in every language', () => {
+    // The parity test only checks top-level keys, so a row left in English
+    // inside `people` is caught by nothing else.
+    for (const language of LANGUAGES) {
+      const t = STRINGS_BY_LANGUAGE[language];
+      for (const route of addSomeoneRoutes({ groupId: 'trip-group', t, addressBook: true })) {
+        expect(route.title.trim(), `${language}.${route.key}.title`).not.toBe('');
+        expect(route.hint.trim(), `${language}.${route.key}.hint`).not.toBe('');
+      }
+      expect(t.people.fromContactsHint.trim(), language).not.toBe('');
+      expect(t.people.shareJoinLink.trim(), language).not.toBe('');
+      expect(t.people.shareJoinLinkHint.trim(), language).not.toBe('');
+      // The rule under the rows, which the by-name field is labelled by.
+      expect(t.people.orByName.trim(), language).not.toBe('');
+    }
+  });
+
+  it('says something different in each language', () => {
+    // A key copied from the English table into the other three passes every
+    // "not blank" check ever written and ships an English screen anyway.
+    const said = LANGUAGES.map(
+      (language) =>
+        `${STRINGS_BY_LANGUAGE[language].people.shareJoinLink}|${STRINGS_BY_LANGUAGE[language].people.fromContactsHint}`,
+    );
+    expect(new Set(said).size).toBe(LANGUAGES.length);
+  });
+});


### PR DESCRIPTION
## The section

Group settings → **Add someone**, under the member roster.

### Before

```
┌ Add someone ──────────────────────────────┐
│  [                    ] [ Add ]           │   ← unlabelled field
│         Browse my contacts                │   ← ghost button, no hint
└───────────────────────────────────────────┘

           … four rows further down …

┌───────────────────────────────────────────┐
│ ⤴  Invite people                        › │   ← a card of its own
│    Share a link — no install needed       │
└───────────────────────────────────────────┘
```

Three different ways of getting a person into the group. None of them said where
that person was coming from before you pressed it, and the one most people
actually reach for — send a link, they join themselves — did not look like part
of adding anybody at all.

### After

```
┌ Add someone ──────────────────────────────┐
│ 👥  From your contacts                  › │
│     Pick names out of this phone’s        │
│     address book                          │
│ ─────────────────────────────────────────  │
│ ▣   Share a join link                   › │
│     Send the link or show the QR —        │
│     they join themselves                  │
│                                           │
│ ───────── or add by name ─────────        │
│  [                    ] [ Add ]           │
└───────────────────────────────────────────┘
```

Doors first, each with a mark, a name and one line saying what the tap does,
ordered by how often each is the right answer. Typing a name follows under a
rule, as the fallback it is — the shape the members screen already settled on.

## The routes, and where each leads

| Row | Leads to | Status |
| --- | --- | --- |
| **From your contacts** | `/contact-picker` — the same bridge + full-screen `ContactPicker` the ghost button opened | existing, relabelled |
| **Share a join link** | `/group/[id]/invite` — the durable join link + QR screen | existing, moved into the section |
| _or add by name_ | the same `useAddGhostMember` field and Add button | unchanged |

**Nothing any route does has changed.** The contacts row stashes the same
request with `contactPickerBridge` and pushes the same screen; the link row
pushes the screen the deleted card pushed. This is labelling and layout plus one
flow (the invite link) that was hard to find because it sat in a card of its own
four rows away.

## What I found missing rather than built

**“From another group” — the people already in your other groups.** This was the
route named first, and it has no implementation anywhere in the app. What exists
is adjacent but not it:

- `ContactPicker` floats people you have written down before to the head of its
  list and names the group they are already in (`pickers.splitWithBefore`,
  `knownInGroup`) — but only for entries it can match against the phone’s
  **address book**, and only on the screens that hand it that index
  (`/friends/contacts` does; the group-settings picker does not).
- `/clone-group` and “Duplicate this group” copy people into a **new** group —
  the opposite direction.

A row leading nowhere is worse than no row, so none is drawn. Building it means a
new picker screen over `useKnownContacts().membersByGroup` feeding the existing
`addGhostMember` call — the same add path, a different source list. That is a new
flow, not a relabelling, so it is written up here instead of built. `DetailRow`
was considered and not used: these are entries you *open* (name + subtitle +
chevron), not facts with a value on the right, so they use `ListRow` — the row
this screen already wears for duplicate, favourite and the three ways out.

## Also in this PR

- The route list lives in `apps/mobile/src/lib/addSomeoneRoutes.ts`, a pure
  module, so “which ways, in what order, leading where” is testable without a
  renderer (this app runs no renderer tests — see `vitest.config.ts`).
- **A route that cannot work is not rendered:** the contacts row is dropped where
  there is no address book at all (`Platform.OS === 'web'`; `expo-contacts` has
  no web implementation and the picker could only apologise). The link and
  by-name ways are untouched by it. That is the *device* question only — a
  **denied permission** still keeps the row, because the refusal is the picker’s
  to report on its own screen, and coming back leaves this section working.
- Contacts permission is never asked cold: the row stashes its request and
  pushes, and `ContactPicker` asks the OS on the way in.
- New strings `people.fromContactsHint`, `people.shareJoinLink`,
  `people.shareJoinLinkHint` in the interface and all four locale tables
  (en/ta/hi/ar), one contiguous block each. `group.invitePeople` /
  `invitePeopleHint` are removed — this PR orphaned them.
- `directionalIcon('chevron-forward')` on every row, so the chevron mirrors in
  Arabic.
- `accessibilityLabel` on each row is the name **and** the hint
  (“From your contacts, pick names out of this phone’s address book”): the name
  alone announces a place, not an act.

## Tests

`apps/mobile/test/addSomeoneRoutes.test.ts` — 9 cases: order; every row points at
the flow it names; the picker route carries no group id; the contacts row is
dropped with no address book and the others still work; every row has a name, a
hint and a spoken label carrying both; the contacts row is titled exactly as the
screen it opens; all three new strings are filled in all four locales and differ
between them (a key copy-pasted from `en` passes every “not blank” check ever
written and ships an English screen anyway).

## Gates

| Gate | Result |
| --- | --- |
| `pnpm format` | clean |
| `pnpm lint` | pass (12 projects) |
| `pnpm --filter @waves/mobile typecheck` | pass |
| `pnpm --filter @waves/mobile test` | 105 files, 1402 tests pass |
| `pnpm --filter @waves/core test` | 63 files, 986 tests pass |
| `bash scripts/check-filenames.sh` | pass |

`packages/db` tests were **not run** — they need a local Postgres that is not
running here.

Not run on a device or emulator: this is JS-only and ships by OTA, but nobody has
looked at it on a phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jhzmZz5fkjnZZ14YxHGfS
