### PR TITLE
A token that dies is not somebody asking to be forgotten

### DIFF
--- a/apps/mobile/src/lib/auth.tsx
+++ b/apps/mobile/src/lib/auth.tsx
@@ -24,6 +24,10 @@ import { confirmPhoneCode, sendPhoneCode } from './phoneAuth';
 import { lockPersonal, syncPersonalAccount } from './personalLock';
 import { refreshPushToken, revokePushToken } from './push';
 import { backend } from './backend';
+// A leaf module with no imports of its own, reached directly rather than
+// through `@/sync` — the sync barrel pulls in `SyncProvider`, which imports
+// this file, and that circle is not worth one function.
+import { markDeliberateSignOut } from '@/sync/retention';
 
 /**
  * What @waves/core needs to know to pick the right call. The distinction that
@@ -674,6 +678,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         // holding the phone, not to the phone. It does not survive the account
         // it was granted under.
         lockPersonal();
+        // The one bit `SyncProvider` cannot work out for itself. Every way a
+        // session ends arrives at `onAuthStateChange` as the same `SIGNED_OUT`
+        // with the same null session — a revoked token looks exactly like this
+        // — and only one of them earns the wipe that destroys the unsent queue.
+        // Marked here, immediately before the call, so the window in which it
+        // could be mistaken for a later involuntary loss is as narrow as the
+        // call itself. See `sync/retention.ts`.
+        markDeliberateSignOut();
         await backend.auth.signOut();
       },
     }),

--- a/apps/mobile/src/sync/driver.ts
+++ b/apps/mobile/src/sync/driver.ts
@@ -18,6 +18,7 @@ import { reportHandled } from '@/lib/observability';
 import { mapYielding } from './hydrateChunk';
 import { DATABASE_NAME, migrateLegacyDatabaseFile } from './legacyDatabase';
 import { decryptWith, destroyKey, encryptWith, isSealed, loadKey } from './rowCipher';
+import type { RetainedWork } from './retention';
 import { Serial } from './serial';
 import type { LocalStore, StoredRow } from './store';
 
@@ -111,6 +112,22 @@ CREATE TABLE IF NOT EXISTS drafts (
   key      TEXT PRIMARY KEY,
   json     TEXT NOT NULL,
   saved_at TEXT NOT NULL
+);
+
+-- Whose unsent work this file is holding after a session ended without anybody
+-- asking (see retention.ts). At most one row, ever: this is a property of the
+-- database, not a list.
+--
+-- Deliberately not sealed, unlike every json column above. It is an account id
+-- and a timestamp — no ledger content — and it has to stay readable in exactly
+-- the case where the key is the question being asked. It lives in this file
+-- rather than the keystore so the stamp and the rows it describes share one
+-- fate: a marker that outlived its data, or data that outlived its marker,
+-- would be the one state with no safe answer.
+CREATE TABLE IF NOT EXISTS retained_work (
+  id          INTEGER PRIMARY KEY CHECK (id = 1),
+  owner_id    TEXT NOT NULL,
+  retained_at TEXT NOT NULL
 );
 `;
 
@@ -515,6 +532,10 @@ class SqliteStore implements LocalStore {
         await database.runAsync(`DELETE FROM pending_mutations WHERE 1 = 1`);
         await database.runAsync(`DELETE FROM sync_cursors WHERE 1 = 1`);
         await database.runAsync(`DELETE FROM drafts WHERE 1 = 1`);
+        // Any claim on this file goes with the thing it was claiming. A stamp
+        // left behind would point at a queue that no longer exists, and the
+        // next account's sign-in would spend a check on nothing.
+        await database.runAsync(`DELETE FROM retained_work WHERE 1 = 1`);
       });
       this.quarantinedQueueIds = [];
       // Crypto-erase: with the rows gone, drop the key too. Any ciphertext still
@@ -522,6 +543,54 @@ class SqliteStore implements LocalStore {
       // next account on this device mints a fresh key rather than inheriting this
       // one. `secure_delete` handled the bytes; this handles the key.
       await destroyKey();
+    });
+  }
+
+  /**
+   * The other ending: a session that stopped without anybody asking.
+   *
+   * Note what is *not* here. No `DELETE FROM pending_mutations`, no
+   * `DELETE FROM drafts`, and no `destroyKey` — those three lines are the
+   * difference between this and `reset`, and each of them would destroy
+   * something no other copy of exists. What does go is the mirror and the
+   * cursors: the server holds that ledger and will hand it back on the next
+   * sign-in, so keeping it on a phone nobody is signed into is cost without
+   * benefit.
+   *
+   * One transaction, for the same reason `reset` is one: the stamp is what
+   * makes the surviving queue attributable, and a queue on disk with no stamp
+   * beside it is data nobody may adopt. Written together or not at all.
+   */
+  retainUnsent(ownerId: string, retainedAt: string): Promise<void> {
+    return this.serial.run(async () => {
+      const database = await this.db();
+      await database.withTransactionAsync(async () => {
+        await database.runAsync(`DELETE FROM mirror_rows WHERE 1 = 1`);
+        await database.runAsync(`DELETE FROM sync_cursors WHERE 1 = 1`);
+        await database.runAsync(
+          `INSERT INTO retained_work (id, owner_id, retained_at) VALUES (1, ?, ?)
+           ON CONFLICT (id) DO UPDATE SET
+             owner_id = excluded.owner_id, retained_at = excluded.retained_at`,
+          [ownerId, retainedAt],
+        );
+      });
+    });
+  }
+
+  readRetained(): Promise<RetainedWork | null> {
+    return this.serial.run(async () => {
+      const database = await this.db();
+      const row = await database.getFirstAsync<{ owner_id: string; retained_at: string }>(
+        `SELECT owner_id, retained_at FROM retained_work WHERE id = 1`,
+      );
+      return row ? { ownerId: row.owner_id, retainedAt: row.retained_at } : null;
+    });
+  }
+
+  clearRetained(): Promise<void> {
+    return this.serial.run(async () => {
+      const database = await this.db();
+      await database.runAsync(`DELETE FROM retained_work WHERE 1 = 1`);
     });
   }
 }

--- a/apps/mobile/src/sync/driver.web.ts
+++ b/apps/mobile/src/sync/driver.web.ts
@@ -26,6 +26,7 @@ import type { QueuedMutation } from '@waves/core';
 
 import { legacyKeysMigrated } from '@/lib/legacyKeys';
 
+import type { RetainedWork } from './retention';
 import { Serial } from './serial';
 import type { LocalStore, StoredRow } from './store';
 
@@ -34,6 +35,8 @@ const WEB_KEYS = {
   cursors: 'waves:cursors',
   queue: 'waves:queue',
   drafts: 'waves:drafts',
+  /** Whose unsent work survived a session ending nobody asked for. */
+  retained: 'waves:retained',
 } as const;
 
 class AsyncStorageStore implements LocalStore {
@@ -145,6 +148,39 @@ class AsyncStorageStore implements LocalStore {
 
   reset(): Promise<void> {
     return this.serial.run(() => AsyncStorage.removeMany(Object.values(WEB_KEYS)));
+  }
+
+  /**
+   * The same line native draws (see `driver.ts`): drop what the server will
+   * hand back, keep what only this browser has, and stamp whose it is.
+   *
+   * There is no key to keep here — the web store is plaintext on purpose, for
+   * the reason at the top of this file — so the trade this makes on native does
+   * not arise. What does carry over is the owner stamp, because the rule it
+   * enforces is not about encryption: a queue must never drain into an account
+   * that did not write it, and a shared browser is exactly where that would
+   * otherwise happen.
+   */
+  retainUnsent(ownerId: string, retainedAt: string): Promise<void> {
+    return this.serial.run(async () => {
+      await AsyncStorage.removeMany([WEB_KEYS.rows, WEB_KEYS.cursors]);
+      await AsyncStorage.setItem(WEB_KEYS.retained, JSON.stringify({ ownerId, retainedAt }));
+    });
+  }
+
+  readRetained(): Promise<RetainedWork | null> {
+    return this.serial.run(async () => {
+      const held = await this.read<RetainedWork | null>(WEB_KEYS.retained, null);
+      // A blob that parsed but is not a stamp claims nothing (see
+      // `retentionVerdict`: an unattributable hold is discarded, not adopted).
+      return held && typeof held.ownerId === 'string' && typeof held.retainedAt === 'string'
+        ? held
+        : null;
+    });
+  }
+
+  clearRetained(): Promise<void> {
+    return this.serial.run(() => AsyncStorage.removeItem(WEB_KEYS.retained));
   }
 }
 

--- a/apps/mobile/src/sync/engine.ts
+++ b/apps/mobile/src/sync/engine.ts
@@ -39,6 +39,7 @@ import { reportHandled } from '@/lib/observability';
 import { backend } from '@/lib/backend';
 import { loadSyncNetworkPreference, networkAllows, SyncNetworkPreference } from '@/lib/syncNetwork';
 
+import type { RetainedWork } from './retention';
 import { createLocalStore, type LocalStore, type StoredRow } from './store';
 
 export enum SyncStatus {
@@ -222,7 +223,55 @@ export class SyncEngine {
 
   /** Sign-out: nothing of the previous account may survive on the device. */
   async clear(): Promise<void> {
+    await this.settleFlush();
     await this.store.reset();
+    this.forgetInMemory();
+  }
+
+  /**
+   * A session lost rather than left (`retention.ts`): keep the unsent work.
+   *
+   * In memory this looks exactly like `clear` — the tree is about to render a
+   * signed-out app, and a queue count or a ledger belonging to an account that
+   * is no longer signed in must not be on screen. On disk it is the opposite:
+   * the queue, the drafts and the key stay, stamped with `ownerId`, and the
+   * next `hydrate` by that same account reads them straight back.
+   */
+  async retainUnsent(ownerId: string): Promise<void> {
+    await this.settleFlush();
+    await this.store.retainUnsent(ownerId, new Date().toISOString());
+    this.forgetInMemory();
+  }
+
+  /**
+   * Let an in-flight flush land before the disk is rewritten underneath it.
+   *
+   * The same wait `forgetGroup` takes, for the same reason and one more. A
+   * flush's `reconcile` and `putRows` run *after* its network await, so a pull
+   * that was already on the wire can write ledger rows back moments after a
+   * wipe decided they should be gone — signed-out data, readable on disk,
+   * arriving by a door the wipe had already locked. It also hydrates when the
+   * engine is cold, which would restore the very queue that was just cleared.
+   *
+   * `flushing` never rejects (see `flush`), and is capped by the flush's own
+   * timeout, so this cannot hang a sign-out indefinitely.
+   */
+  private async settleFlush(): Promise<void> {
+    await this.flushing;
+  }
+
+  /** Whose unsent work, if any, this device is holding for a lost session. */
+  retainedWork(): Promise<RetainedWork | null> {
+    return this.store.readRetained();
+  }
+
+  /** The owner came back: the queue is an ordinary queue again. */
+  adoptRetained(): Promise<void> {
+    return this.store.clearRetained();
+  }
+
+  /** Drop everything this engine holds in memory. Says nothing about disk. */
+  private forgetInMemory(): void {
     this.set({
       mirror: emptyMirror(),
       queue: [],

--- a/apps/mobile/src/sync/provider.tsx
+++ b/apps/mobile/src/sync/provider.tsx
@@ -30,6 +30,15 @@ import { clearReceiptQueue, flushReceiptQueue } from '@/lib/receiptQueue';
 import { clearImageCache } from '@/lib/storage/imageCache';
 
 import { syncEngine, type SyncState } from './engine';
+import {
+  destroyedBy,
+  forgetSignOutMark,
+  Retention,
+  retentionExpired,
+  retentionVerdict,
+  takeSessionEnd,
+  type SessionEnd,
+} from './retention';
 
 interface SyncContextValue extends SyncState {
   /** Queue a mutation. Resolves once it is durably on disk, not once it syncs. */
@@ -79,6 +88,89 @@ async function clearLocalPrivateData(ownerId: string): Promise<void> {
 }
 
 /**
+ * Close out a session, destroying exactly what its ending earns.
+ *
+ * The two endings are not the same event, and running one wipe for both is the
+ * bug `retention.ts` documents at length: a revoked token used to arrive here
+ * as an indistinguishable null session and take the unsent queue with it.
+ * `destroyedBy` answers the question once, in a pure function that is tested;
+ * this only carries the answer out.
+ *
+ * A deliberate departure is unchanged, deliberately — same wipe, same order,
+ * same crypto-erase. What is new is the other branch, which keeps the three
+ * things nothing else in the world holds a copy of: the mutation queue, the
+ * drafts, and the receipt bytes taken from a bill that is already in the bin.
+ */
+async function endSession(ownerId: string, reason: SessionEnd): Promise<void> {
+  const scope = destroyedBy(reason);
+  if (scope.unsent) {
+    // `clearLocalPrivateData` is the whole wipe — queue, drafts, receipts,
+    // credentials, cache and key — and the only path that reaches it.
+    await clearLocalPrivateData(ownerId);
+    return;
+  }
+
+  const failures: unknown[] = [];
+  // Stamped with the owner in the same transaction that drops the mirror: work
+  // that cannot say whose it is may never be adopted by anybody.
+  await syncEngine.retainUnsent(ownerId).catch((error: unknown) => failures.push(error));
+  if (scope.cache) {
+    try {
+      clearImageCache();
+    } catch (error) {
+      failures.push(error);
+    }
+  }
+  if (failures.length > 0) throw failures[0];
+}
+
+/**
+ * Decide what the account now signing in inherits from the last one.
+ *
+ * Three answers, and two of them are cheap. Nothing held: the common case, and
+ * the only one on a phone that has never lost a session. The same account back
+ * inside the window: drop the stamp and let `hydrate` read its own queue.
+ * Anybody else, or too long ago: destroy it *before* this session hydrates,
+ * because a queue drained under the wrong session would write one person's
+ * expenses into another person's groups — a worse outcome than the loss this
+ * whole change exists to prevent.
+ *
+ * The verdict is pure and tested; the failure path is not silent, because a
+ * device that cannot read its own stamp is holding data nobody can attribute.
+ */
+async function settleRetainedWork(signingInAs: string): Promise<void> {
+  const retained = await syncEngine.retainedWork().catch((error: unknown) => {
+    reportHandled(error, 'sync.readRetained');
+    return null;
+  });
+  const verdict = retentionVerdict(retained, signingInAs, Date.now());
+  if (verdict === Retention.Nothing || !retained) return;
+  if (verdict === Retention.Adopt) {
+    await syncEngine.adoptRetained().catch((error: unknown) => {
+      reportHandled(error, 'sync.adoptRetained');
+    });
+    return;
+  }
+  await clearLocalPrivateData(retained.ownerId).catch((error: unknown) => {
+    reportHandled(error, 'sync.discardRetained');
+  });
+}
+
+/**
+ * A launch with nobody signed in, where the last session ended on its own.
+ *
+ * This is the only moment the window in `retention.ts` can be enforced for
+ * somebody who never comes back: every other check hangs off a sign-in, and a
+ * phone left in a drawer has none. Anything still held past the window goes,
+ * under the id it was stamped with.
+ */
+async function sweepExpiredRetention(): Promise<void> {
+  const retained = await syncEngine.retainedWork().catch(() => null);
+  if (!retained || !retentionExpired(retained, Date.now())) return;
+  await clearLocalPrivateData(retained.ownerId);
+}
+
+/**
  * Send whatever receipt captures are still parked on this device.
  *
  * A receipt is the one thing the app takes from somebody that it cannot re-ask
@@ -111,31 +203,42 @@ export function SyncProvider({ children }: { children: ReactNode }) {
   const [state, setState] = useState<SyncState>(() => syncEngine.getState());
   const signedIn = Boolean(session);
   const ownerId = session?.user?.id ?? null;
-  // Who is signed in, held across the render in which they stop being — the
-  // sign-out wipe needs the id, and by the time it runs the session is gone.
-  // Null when signed out, which is also the "was anybody here?" test the old
-  // boolean served.
+  // Who is signed in, held across the render in which they stop being — both
+  // endings need the id (one to wipe under, one to stamp the hold with), and by
+  // the time either runs the session is gone. Null when signed out, which is
+  // also the "was anybody here?" test the old boolean served.
   const lastOwnerId = useRef<string | null>(ownerId);
-  // The in-flight sign-out cleanup, if any. Sign-out does not block on it, but
-  // the next sign-in must: the receipt queue and image cache are device-global,
-  // so a cleanup still deleting when a new account signs in would wipe the new
-  // session's freshly-hydrated data. Awaiting it first serialises the two.
+  // The in-flight cleanup, if any — the wipe, the retain, or the expiry sweep a
+  // signed-out launch runs. Leaving does not block on it, but the next sign-in
+  // must: the receipt queue and image cache are device-global, so a cleanup
+  // still deleting when a new account signs in would wipe the new session's
+  // freshly-hydrated data. Awaiting it first serialises the two.
   const pendingCleanup = useRef<Promise<void> | null>(null);
 
   useEffect(() => syncEngine.subscribe(setState), []);
 
   useEffect(() => {
     if (!signedIn) {
-      // Signing out wipes the mirror: the next person to use this phone must
-      // not find the previous account's ledger in it. Worth reporting rather
-      // than swallowing — a wipe that failed is a privacy problem, not a
-      // cosmetic one — but not worth throwing at a screen mid-sign-out. The
-      // promise is kept (never rejects — the catch resolves it) so the next
-      // sign-in can await its completion before hydrating.
+      // The session is gone — but *why* it is gone decides what may be deleted,
+      // and this is the last place that knows. `takeSessionEnd` spends the mark
+      // `lib/auth`'s `signOut` leaves; anything unmarked is a session nobody
+      // asked to end, and keeps the work that has reached nobody (retention.ts).
+      //
+      // Worth reporting rather than swallowing — a wipe that failed is a privacy
+      // problem, not a cosmetic one — but not worth throwing at a screen
+      // mid-sign-out. The promise is kept (never rejects — the catch resolves
+      // it) so the next sign-in can await its completion before hydrating.
       const departing = lastOwnerId.current;
       if (departing !== null) {
-        pendingCleanup.current = clearLocalPrivateData(departing).catch((error: unknown) =>
-          reportHandled(error, 'sync.clearPrivateData'),
+        pendingCleanup.current = endSession(departing, takeSessionEnd()).catch((error: unknown) =>
+          reportHandled(error, 'sync.endSession'),
+        );
+      } else {
+        // A launch onto the sign-in door. The one moment a hold left by a
+        // session that ended months ago, on a phone nobody came back to, can be
+        // noticed at all.
+        pendingCleanup.current = sweepExpiredRetention().catch((error: unknown) =>
+          reportHandled(error, 'sync.sweepRetention'),
         );
       }
       lastOwnerId.current = null;
@@ -144,6 +247,9 @@ export function SyncProvider({ children }: { children: ReactNode }) {
     }
 
     lastOwnerId.current = ownerId;
+    // A mark that was never spent — a `signOut` that threw before the session
+    // actually ended — must not sit armed waiting for the next revoked token.
+    forgetSignOutMark();
     let cancelled = false;
     void (async () => {
       // A prior sign-out's cleanup may still be deleting the device-global
@@ -155,6 +261,13 @@ export function SyncProvider({ children }: { children: ReactNode }) {
         pendingCleanup.current = null;
         if (cancelled) return;
       }
+      // Before anything is read off disk: is what is on disk this account's?
+      // A queue held for somebody else is destroyed here, while there is still
+      // nothing of this session's to confuse it with — and crucially before
+      // `flush`, which would otherwise send the previous owner's mutations
+      // under this session's token.
+      if (ownerId !== null) await settleRetainedWork(ownerId);
+      if (cancelled) return;
       // Nothing awaits this, so anything thrown here would surface as an
       // uncaught promise rejection over whatever screen happens to be up.
       // `flush` hydrates too, and records the failure where the banner can

--- a/apps/mobile/src/sync/retention.ts
+++ b/apps/mobile/src/sync/retention.ts
@@ -1,0 +1,241 @@
+/**
+ * What the end of a session is allowed to destroy.
+ *
+ * ## The bug this module exists for
+ *
+ * The wipe used to run on one condition: the session became null. That is not
+ * the same event as somebody signing out, and the gap between the two is a
+ * data-loss bug.
+ *
+ * `supabase-js` removes the stored session — and emits the same `SIGNED_OUT`,
+ * with the same null session, that a deliberate sign-out emits — in five
+ * places, only one of which is a person asking to leave (`GoTrueClient`):
+ * `_signOut` (the deliberate one), `_callRefreshToken` when the refresh token
+ * is rejected and the access token has already expired, `__loadSession` and
+ * `_recoverAndRefresh` when the stored session does not validate, and
+ * `getUser` when the JWT names a session the server no longer has. A revoked
+ * token, a refresh expired past recovery, an account signed out from another
+ * device, a server that has moved — every one of them arrived at the wipe, and
+ * the wipe deletes `pending_mutations`. So an expense entered in a dead zone,
+ * which by definition has reached nobody, was destroyed without anybody being
+ * asked, along with every draft, and then the key that could have opened them.
+ *
+ * That defeats the rest of the queue's design, which is careful about exactly
+ * this: client-generated ids so a replay is idempotent, dead-lettering rather
+ * than dropping, quarantine rather than deletion for a row that will not open,
+ * and the rule written into the engine after a refused `group.create` took the
+ * group with it — *a refusal is not a deletion*. A session ending is not one
+ * either.
+ *
+ * ## The line this draws
+ *
+ * The device keeps what only it has, and destroys what the server can give
+ * back. Concretely, an involuntary loss drops the mirror and the cursors — a
+ * readable copy of a ledger that is safe on the server, so keeping it buys
+ * nothing and costs privacy — and keeps the mutation queue, the drafts and the
+ * receipt bytes, which exist nowhere else in the world.
+ *
+ * A deliberate sign-out is untouched: it still destroys everything, key
+ * included. That is a security promise (the next person to hold this phone
+ * must find nothing), a person who taps sign-out is warned about exactly this
+ * loss by `SignOutSheet` and offered two ways to keep it, and account deletion
+ * comes through the same door.
+ *
+ * ## The key, and what keeping it costs
+ *
+ * Keeping the queue is worthless if the key that opens it is destroyed, so an
+ * involuntary loss keeps the key too. That is the real trade, and it is worth
+ * stating plainly rather than burying: after an involuntary loss this device
+ * holds, readable, the expenses and drafts that were never sent — for one
+ * account, for a bounded window — where before it held nothing. What it does
+ * *not* hold is the ledger: that goes with the mirror, immediately, on every
+ * path. The crypto-erase is not weakened where it was doing its job; it is
+ * simply no longer triggered by an event that is not a departure.
+ *
+ * Three things bound the exposure, and all three are decided here:
+ *
+ * 1. **It is stamped with an owner.** Retained work belongs to the account that
+ *    made it. Somebody else signing in on this phone destroys it before their
+ *    session starts — a queue replayed into another account would write one
+ *    person's spending into another person's groups, which is worse than
+ *    losing it.
+ * 2. **It is stamped with a time.** Past {@link RETENTION_WINDOW_MS} it is a
+ *    liability rather than a rescue, and the next launch destroys it whether
+ *    anybody signs in or not.
+ * 3. **An unreadable stamp is not a claim.** No marker, or one that will not
+ *    parse, means nothing here is attributable, and unattributable data is
+ *    discarded rather than adopted.
+ *
+ * Pure, and tested without a device, for the reason `lib/backup/restorePrompt`
+ * is: every branch below is a sentence about whether somebody's records still
+ * exist, and there is no version of getting one wrong that is cosmetic.
+ */
+
+/** How a session stopped being a session. */
+export enum SessionEnd {
+  /**
+   * Somebody chose to leave: the sign-out sheet, or the last step of deleting
+   * the account (which signs out through the same call).
+   */
+  SignedOut = 'signed-out',
+  /**
+   * Nobody asked. A refresh token revoked or expired past recovery, a stored
+   * session that no longer validates, a server that has moved. The person is
+   * still whoever they were a second ago, and is about to be shown a door they
+   * did not choose to walk through.
+   */
+  Lost = 'lost',
+}
+
+/**
+ * The account's data on this device, in the five groups that have different
+ * rights. True means "this session ending destroys it".
+ */
+export interface LocalDataScope {
+  /** `mirror_rows` and `sync_cursors` — the server's ledger, copied here. */
+  readonly mirror: boolean;
+  /**
+   * `pending_mutations`, `drafts` and the parked receipt bytes: work that has
+   * reached nobody, and that nothing else in the world holds a copy of.
+   */
+  readonly unsent: boolean;
+  /** This account's cloud-backup grant and its recovery key. */
+  readonly credentials: boolean;
+  /** Downloaded images. Derived, re-fetchable, never the only copy. */
+  readonly cache: boolean;
+  /**
+   * The mirror's data-encryption key — the crypto-erase. Destroying it is what
+   * makes ciphertext still sitting in the WAL or the free list unrecoverable.
+   */
+  readonly key: boolean;
+}
+
+/**
+ * What this ending may destroy.
+ *
+ * The key follows `unsent` exactly, and must: destroying the key while keeping
+ * the queue leaves a queue nobody can read, and keeping the key while
+ * destroying the queue leaves a crypto-erase that erased nothing.
+ */
+export function destroyedBy(reason: SessionEnd): LocalDataScope {
+  switch (reason) {
+    case SessionEnd.SignedOut:
+      return { mirror: true, unsent: true, credentials: true, cache: true, key: true };
+    case SessionEnd.Lost:
+      // The ledger and the cache go on this path too — they are the server's
+      // to hand back, and holding a readable ledger on a phone nobody is signed
+      // into is the thing the wipe was always for.
+      return { mirror: true, unsent: false, credentials: false, cache: true, key: false };
+  }
+}
+
+/** Unsent work held for an account that is no longer signed in. */
+export interface RetainedWork {
+  /** Whose it is. The queue may only ever be drained back into this account. */
+  readonly ownerId: string;
+  /** When the session was lost, ISO-8601. */
+  readonly retainedAt: string;
+}
+
+/**
+ * How long unsent work may wait for its owner to come back.
+ *
+ * Thirty days covers a trip, a replaced SIM, a forgotten password and a support
+ * round trip — every ordinary reason somebody does not sign in again today. It
+ * is also short enough that a phone which has genuinely moved on is not still
+ * holding a stranger's expenses a year later. There is no right number; there
+ * is only the requirement that one exist, because "until the disk fills" is not
+ * a retention policy.
+ */
+export const RETENTION_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** What to do with retained work when somebody signs in. */
+export enum Retention {
+  /** Nothing is being held. The overwhelmingly common answer. */
+  Nothing = 'nothing',
+  /** The same account, inside the window: hydrate it and let the queue drain. */
+  Adopt = 'adopt',
+  /** Somebody else, or too long ago: destroy it before this session starts. */
+  Discard = 'discard',
+}
+
+/**
+ * Has retained work outlived the window?
+ *
+ * A stamp that will not parse counts as expired: an unreadable date is not a
+ * claim on the disk. A stamp in the *future* does not — a phone whose clock has
+ * been wrong, or moved across a timezone by a careless OS, is not a reason to
+ * destroy somebody's unsent expenses, and the window will catch it soon enough
+ * once the clock is right.
+ */
+export function retentionExpired(retained: RetainedWork, now: number): boolean {
+  const at = Date.parse(retained.retainedAt);
+  if (Number.isNaN(at)) return true;
+  return now - at >= RETENTION_WINDOW_MS;
+}
+
+/**
+ * Whether the account now signing in may have what the last session left here.
+ *
+ * The owner check is the one that must never be got wrong. A queue carries
+ * expenses addressed to groups, written as the account that made them; draining
+ * it under a different session would post one person's spending into whatever
+ * that session can reach. So the answer is identity, not similarity, and
+ * anything that is not a plain match of the stored owner id is a discard.
+ */
+export function retentionVerdict(
+  retained: RetainedWork | null,
+  signingInAs: string,
+  now: number,
+): Retention {
+  if (!retained) return Retention.Nothing;
+  if (!retained.ownerId || retained.ownerId !== signingInAs) return Retention.Discard;
+  if (retentionExpired(retained, now)) return Retention.Discard;
+  return Retention.Adopt;
+}
+
+// ── which ending this was ───────────────────────────────────────────────────
+
+/**
+ * The one bit the auth layer knows and the sync layer cannot infer.
+ *
+ * Everything downstream of `onAuthStateChange` sees the same thing for all five
+ * ways a session can end — `SIGNED_OUT`, session null — so the intent has to be
+ * recorded at the only place it exists: the call that asks for it.
+ * `lib/auth`'s `signOut` marks it immediately before `backend.auth.signOut()`,
+ * and `SyncProvider` consumes it when the session goes.
+ *
+ * Two guards, because the failure mode of a stale mark is the bug this whole
+ * module is about, in reverse — an involuntary loss misread as a departure, and
+ * the wipe running anyway:
+ *
+ * * It is consumed. One mark answers one ending.
+ * * It goes stale. A sign-out that threw before the session actually ended
+ *   would otherwise leave the mark armed indefinitely, and the next revoked
+ *   token minutes later would spend it. A real sign-out is a local storage
+ *   write that happens in the same breath as the mark.
+ *
+ * `SyncProvider` also clears it whenever a session is established, so a mark
+ * that outlived its call cannot survive a sign-in either.
+ */
+const DELIBERATE_WINDOW_MS = 60_000;
+
+let deliberateAt: number | null = null;
+
+/** Record that the sign-out about to happen is one somebody asked for. */
+export function markDeliberateSignOut(now: number = Date.now()): void {
+  deliberateAt = now;
+}
+
+/** Forget any unspent mark. Called when a session starts. */
+export function forgetSignOutMark(): void {
+  deliberateAt = null;
+}
+
+/** Why the session that just ended ended, consuming the mark. */
+export function takeSessionEnd(now: number = Date.now()): SessionEnd {
+  const marked = deliberateAt;
+  deliberateAt = null;
+  if (marked === null) return SessionEnd.Lost;
+  return now - marked <= DELIBERATE_WINDOW_MS ? SessionEnd.SignedOut : SessionEnd.Lost;
+}

--- a/apps/mobile/src/sync/store.ts
+++ b/apps/mobile/src/sync/store.ts
@@ -16,6 +16,8 @@
 
 import type { MirrorRow, QueuedMutation, SyncTable } from '@waves/core';
 
+import type { RetainedWork } from './retention';
+
 export interface StoredRow {
   table: SyncTable;
   id: string;
@@ -47,6 +49,21 @@ export interface LocalStore {
   forgetGroup(groupId: string, queue: readonly QueuedMutation[]): Promise<void>;
   /** Signing out must leave nothing of the previous account behind. */
   reset(): Promise<void>;
+  /**
+   * A session that ended without anybody asking for it (see `retention.ts`).
+   *
+   * Drops the mirror and the cursors — the server's copy of the ledger, which
+   * it will hand back on the next sign-in — and keeps the queue, the drafts and
+   * the encryption key that opens them, because nothing else holds those. The
+   * owner is stamped in the same transaction: work that cannot say whose it is
+   * can never be adopted, so writing the stamp and clearing the mirror have to
+   * commit together or not at all.
+   */
+  retainUnsent(ownerId: string, retainedAt: string): Promise<void>;
+  /** Whose the retained work is, or null when nothing is being held. */
+  readRetained(): Promise<RetainedWork | null>;
+  /** Adopted: the same account came back, and the queue is theirs again. */
+  clearRetained(): Promise<void>;
 }
 
 /**

--- a/apps/mobile/test/localStore.test.ts
+++ b/apps/mobile/test/localStore.test.ts
@@ -38,6 +38,8 @@ class FakeDatabase {
   >();
   readonly cursors = new Map<string, number>();
   readonly drafts = new Map<string, { key: string; json: string; saved_at: string }>();
+  /** The single-row hold stamp. Null when nothing is being kept. */
+  retained: { owner_id: string; retained_at: string } | null = null;
   // Defaults to the current schema version so the one-time encryption migration
   // (driver.migrate) is a no-op for these tests; the migration is exercised on
   // its own below by seeding a fresh DB at version 0.
@@ -160,6 +162,15 @@ class FakeDatabase {
         }
         return;
       }
+      if (statement === 'INSERT INTO retained_work') {
+        const [ownerId, retainedAt] = params as [string, string];
+        this.retained = { owner_id: ownerId, retained_at: retainedAt };
+        return;
+      }
+      if (statement === 'DELETE FROM retained_work') {
+        this.retained = null;
+        return;
+      }
       // Used only by the one-time encryption migration.
       if (statement === 'UPDATE mirror_rows SET') {
         const [json, tableName, id] = params as [string, string, string];
@@ -204,6 +215,7 @@ class FakeDatabase {
     return this.enter(async () => {
       await tick();
       if (source.includes('user_version')) return { user_version: this.userVersion } as T;
+      if (source.includes('FROM retained_work')) return (this.retained as T | null) ?? null;
       const [key] = params as [string];
       return (this.drafts.get(key) as T | undefined) ?? null;
     });
@@ -450,6 +462,73 @@ describe('native local store lifecycle', () => {
     expect(await store.readCursors()).toEqual({});
     expect(await store.readQueue()).toEqual([]);
     expect(await store.listDrafts()).toEqual([]);
+  });
+
+  it('keeps the queue, the drafts and the key when a session is lost, not left', async () => {
+    // The data-loss bug in one assertion. `retainUnsent` is what a revoked
+    // token now reaches instead of `reset`: the ledger goes, because the server
+    // has it, and the two things nothing else in the world holds stay exactly
+    // where they are.
+    const DEK = 'waves.mirror.dek.v1';
+    const store = createLocalStore();
+    await store.putRows([
+      { table: 'expenses', id: 'e1', groupId: 'g1', seq: 1, row: { id: 'e1' } },
+    ] as never);
+    await store.writeCursors({ g1: 1 });
+    await store.writeQueue([mutation('a'), mutation('b')]);
+    await store.writeDraft('expense:new', { amount: 100 });
+
+    const deletesBefore = secure.deletes.filter((key) => key === DEK).length;
+    await store.retainUnsent('ana', '2026-09-12T10:00:00.000Z');
+
+    expect((await store.readQueue()).map((entry) => entry.clientMutationId)).toEqual(['a', 'b']);
+    expect(await store.readDraft('expense:new')).toEqual({ amount: 100 });
+    // No crypto-erase: a queue kept under a destroyed key is a queue nobody can
+    // read, which would be the same loss by a slower route.
+    expect(secure.deletes.filter((key) => key === DEK).length).toBe(deletesBefore);
+    // And the ledger is gone, exactly as on a sign-out.
+    expect(await store.readRows()).toEqual([]);
+    expect(await store.readCursors()).toEqual({});
+  });
+
+  it('stamps the hold with its owner in the same transaction that drops the mirror', async () => {
+    // Both or neither. Unsent work on disk with no stamp beside it is work
+    // nobody may adopt, so a kill between the two must not be able to produce
+    // one — the store's only defence is the transaction.
+    const store = createLocalStore();
+    await store.putRows([
+      { table: 'expenses', id: 'e1', groupId: 'g1', seq: 1, row: { id: 'e1' } },
+    ] as never);
+    await store.writeQueue([mutation('a')]);
+
+    await store.retainUnsent('ana', '2026-09-12T10:00:00.000Z');
+
+    const begins = database.statements.filter((statement) => statement === 'BEGIN').length;
+    expect(begins).toBeGreaterThan(0);
+    expect(await store.readRetained()).toEqual({
+      ownerId: 'ana',
+      retainedAt: '2026-09-12T10:00:00.000Z',
+    });
+  });
+
+  it('drops the stamp when the owner comes back, and when anyone wipes', async () => {
+    const store = createLocalStore();
+    await store.retainUnsent('ana', '2026-09-12T10:00:00.000Z');
+
+    await store.clearRetained();
+    expect(await store.readRetained()).toBeNull();
+
+    // A wipe takes the stamp with it too: one left behind would point at a
+    // queue that no longer exists.
+    await store.retainUnsent('ana', '2026-09-12T10:00:00.000Z');
+    await store.reset();
+    expect(await store.readRetained()).toBeNull();
+  });
+
+  it('reports nothing held on a phone that has never lost a session', async () => {
+    const store = createLocalStore();
+    await store.ready();
+    expect(await store.readRetained()).toBeNull();
   });
 
   it('hydrates a large mirror without dropping rows on the chunked parse path', async () => {

--- a/apps/mobile/test/sessionRetention.test.ts
+++ b/apps/mobile/test/sessionRetention.test.ts
@@ -1,0 +1,194 @@
+/**
+ * What the end of a session is allowed to destroy.
+ *
+ * The bug being pinned here destroyed people's records without anybody asking:
+ * the wipe ran on "the session became null", and a refresh token revoked, or
+ * expired past recovery, or rejected by a server that had moved, arrives at
+ * that condition looking exactly like somebody tapping sign out. It took
+ * `pending_mutations` with it — an expense entered in a dead zone, which by
+ * definition nobody else has a copy of — and then the key that could have
+ * opened them.
+ *
+ * So most of this file is about the difference between the two endings, and the
+ * assertions that matter are the ones nobody would notice failing until a real
+ * phone lost a real day's expenses. Every branch is a sentence about whether
+ * somebody's records still exist.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  destroyedBy,
+  forgetSignOutMark,
+  markDeliberateSignOut,
+  Retention,
+  RETENTION_WINDOW_MS,
+  retentionExpired,
+  retentionVerdict,
+  SessionEnd,
+  takeSessionEnd,
+  type RetainedWork,
+} from '../src/sync/retention';
+
+const ANA = 'ana-0000-0000-0000-000000000001';
+const BEN = 'ben-0000-0000-0000-000000000002';
+
+const NOW = Date.parse('2026-09-12T10:00:00.000Z');
+const held = (overrides: Partial<RetainedWork> = {}): RetainedWork => ({
+  ownerId: ANA,
+  retainedAt: new Date(NOW - 60_000).toISOString(),
+  ...overrides,
+});
+
+beforeEach(() => {
+  forgetSignOutMark();
+});
+
+describe('a sign-out somebody asked for', () => {
+  it('still destroys everything, the key included', () => {
+    // The security property. Signing out must leave nothing readable on this
+    // phone, the crypto-erase is what makes ciphertext in the WAL and the free
+    // list unrecoverable, and the sheet in front of the button says exactly
+    // this is about to happen. None of it is softened by the change.
+    expect(destroyedBy(SessionEnd.SignedOut)).toEqual({
+      mirror: true,
+      unsent: true,
+      credentials: true,
+      cache: true,
+      key: true,
+    });
+  });
+
+  it('is what deleting the account gets, because deletion signs out', () => {
+    // `settings/delete-account` erases server-side and then calls the same
+    // `signOut`, so the marked, deliberate ending is the one it reaches. There
+    // is no second path and there must not be one: an account that no longer
+    // exists has nothing to come back for.
+    markDeliberateSignOut(NOW);
+    expect(destroyedBy(takeSessionEnd(NOW))).toEqual(destroyedBy(SessionEnd.SignedOut));
+  });
+});
+
+describe('a session that ended without anybody asking', () => {
+  it('keeps the unsent work and the key that opens it', () => {
+    const scope = destroyedBy(SessionEnd.Lost);
+    // The whole point. A revoked token is not somebody asking to be forgotten,
+    // and the queue and the drafts have reached nobody.
+    expect(scope.unsent).toBe(false);
+    expect(scope.key).toBe(false);
+  });
+
+  it('still drops the ledger the server is holding anyway', () => {
+    // The privacy half of the trade: a readable mirror on a phone nobody is
+    // signed into is cost without benefit, because the next sign-in re-pulls
+    // every row of it. Same for the downloaded images.
+    const scope = destroyedBy(SessionEnd.Lost);
+    expect(scope.mirror).toBe(true);
+    expect(scope.cache).toBe(true);
+  });
+
+  it('keeps the backup credentials, which are also a single copy', () => {
+    // The recovery key exists in one keystore in the world. Destroying it
+    // because a token expired would be the same class of bug as destroying the
+    // queue — an irreversible loss triggered by an event nobody chose.
+    expect(destroyedBy(SessionEnd.Lost).credentials).toBe(false);
+  });
+});
+
+describe('the key and the data it opens', () => {
+  it('are never separated, whichever way the session ended', () => {
+    // Two nonsense states this guards: a queue kept under a destroyed key is a
+    // queue nobody can read, and a key kept over a destroyed queue is a
+    // crypto-erase that erased nothing. `key` must track `unsent` exactly.
+    for (const reason of [SessionEnd.SignedOut, SessionEnd.Lost]) {
+      const scope = destroyedBy(reason);
+      expect(scope.key).toBe(scope.unsent);
+    }
+  });
+});
+
+describe('which ending it was', () => {
+  it('is involuntary unless somebody marked it', () => {
+    // The default has to be the safe one. Every path that is not `signOut` —
+    // and there are four of them inside supabase-js alone — lands here.
+    expect(takeSessionEnd(NOW)).toBe(SessionEnd.Lost);
+  });
+
+  it('is deliberate for the sign-out that marked it', () => {
+    markDeliberateSignOut(NOW);
+    expect(takeSessionEnd(NOW + 50)).toBe(SessionEnd.SignedOut);
+  });
+
+  it('spends the mark, so one sign-out cannot wipe twice', () => {
+    markDeliberateSignOut(NOW);
+    expect(takeSessionEnd(NOW)).toBe(SessionEnd.SignedOut);
+    expect(takeSessionEnd(NOW)).toBe(SessionEnd.Lost);
+  });
+
+  it('goes stale, so a sign-out that failed cannot arm a later loss', () => {
+    // `signOut` can throw before the session actually ends. The mark left
+    // behind must not be spent by a revoked token ten minutes later — that
+    // would be this bug again, wearing a disguise.
+    markDeliberateSignOut(NOW);
+    expect(takeSessionEnd(NOW + 10 * 60_000)).toBe(SessionEnd.Lost);
+  });
+
+  it('is dropped when a session starts', () => {
+    markDeliberateSignOut(NOW);
+    forgetSignOutMark();
+    expect(takeSessionEnd(NOW)).toBe(SessionEnd.Lost);
+  });
+});
+
+describe('who may have the work that was kept', () => {
+  it('is the account that made it, coming back', () => {
+    expect(retentionVerdict(held(), ANA, NOW)).toBe(Retention.Adopt);
+  });
+
+  it('is never anybody else', () => {
+    // The one that must never be got wrong. Draining Ana's queue under Ben's
+    // session would post her spending into whatever groups he can reach — a
+    // worse outcome than the loss this whole change prevents.
+    expect(retentionVerdict(held(), BEN, NOW)).toBe(Retention.Discard);
+  });
+
+  it('is nobody at all when the hold cannot say whose it is', () => {
+    // An empty owner is not a wildcard. Unattributable data is discarded.
+    expect(retentionVerdict(held({ ownerId: '' }), '', NOW)).toBe(Retention.Discard);
+  });
+
+  it('is not asked when nothing is being held', () => {
+    // The common case, and it must not turn into a wipe: a phone that has never
+    // lost a session has no stamp, and finding none is not a reason to delete.
+    expect(retentionVerdict(null, ANA, NOW)).toBe(Retention.Nothing);
+  });
+
+  it('is nobody once the window has passed', () => {
+    const stale = held({ retainedAt: new Date(NOW - RETENTION_WINDOW_MS - 1).toISOString() });
+    expect(retentionVerdict(stale, ANA, NOW)).toBe(Retention.Discard);
+  });
+});
+
+describe('how long a hold may sit', () => {
+  it('survives right up to the window', () => {
+    const almost = held({ retainedAt: new Date(NOW - RETENTION_WINDOW_MS + 1000).toISOString() });
+    expect(retentionExpired(almost, NOW)).toBe(false);
+  });
+
+  it('expires at it', () => {
+    const exactly = held({ retainedAt: new Date(NOW - RETENTION_WINDOW_MS).toISOString() });
+    expect(retentionExpired(exactly, NOW)).toBe(true);
+  });
+
+  it('expires when the stamp will not parse', () => {
+    // A date nobody can read is not a claim on the disk.
+    expect(retentionExpired(held({ retainedAt: 'sometime' }), NOW)).toBe(true);
+  });
+
+  it('does not expire on a clock that has run backwards', () => {
+    // A phone whose clock is wrong is not a reason to destroy somebody's
+    // unsent expenses. The window catches it once the clock is right.
+    const future = held({ retainedAt: new Date(NOW + 5 * 60_000).toISOString() });
+    expect(retentionExpired(future, NOW)).toBe(false);
+  });
+});

--- a/apps/mobile/test/syncEngine.test.ts
+++ b/apps/mobile/test/syncEngine.test.ts
@@ -36,6 +36,7 @@ const h = vi.hoisted(() => ({
     >(),
     cursors: {} as Record<string, number>,
     queue: [] as QueuedMutation[],
+    retained: null as { ownerId: string; retainedAt: string } | null,
   },
 }));
 
@@ -95,6 +96,19 @@ vi.mock('../src/sync/store', () => ({
       h.disk.rows.clear();
       h.disk.cursors = {};
       h.disk.queue = [];
+      h.disk.retained = null;
+    },
+    // The other ending (see src/sync/retention.ts): the ledger goes because the
+    // server will hand it back, the queue stays because nobody else has it, and
+    // the hold is stamped with whose it is.
+    retainUnsent: async (ownerId: string, retainedAt: string) => {
+      h.disk.rows.clear();
+      h.disk.cursors = {};
+      h.disk.retained = { ownerId, retainedAt };
+    },
+    readRetained: async () => h.disk.retained,
+    clearRetained: async () => {
+      h.disk.retained = null;
     },
   }),
 }));
@@ -142,6 +156,7 @@ beforeEach(() => {
   h.disk.rows.clear();
   h.disk.cursors = {};
   h.disk.queue = [];
+  h.disk.retained = null;
 });
 
 describe('runFlush on a fresh install', () => {
@@ -769,5 +784,120 @@ describe('queue and draft controls', () => {
     await expect(engine.readDraft('expense:new')).resolves.toBeNull();
     await expect(engine.listDrafts()).resolves.toEqual([]);
     await expect(engine.clearDraft('expense:new')).resolves.toBeUndefined();
+  });
+});
+
+/**
+ * Two launches of the app across a session that ended on its own, reading the
+ * same "disk" — the shape that proves the queue really survived rather than
+ * merely staying in memory until the process died.
+ */
+describe('a session that ended without anybody asking', () => {
+  const ANA = 'ana-0000-0000-0000-000000000001';
+  const BEN = 'ben-0000-0000-0000-000000000002';
+
+  const unsentExpense = (id: string) => ({
+    clientMutationId: id,
+    kind: 'expense.create' as never,
+    groupId: 'g-goa',
+    clientCreatedAt: '2026-08-09T00:00:00.000Z',
+    payload: { amount: '450' },
+  });
+
+  it('leaves the unsent expense on disk, and takes the ledger it can re-fetch', async () => {
+    offline();
+    const engine = new SyncEngine();
+    h.disk.rows.set('groups:g-goa', {
+      table: 'groups',
+      id: 'g-goa',
+      groupId: 'g-goa',
+      seq: 1,
+      row: { id: 'g-goa' },
+    });
+    h.disk.cursors = { 'g-goa': 1 };
+    await engine.enqueue(unsentExpense('dead-zone-dinner'));
+
+    await engine.retainUnsent(ANA);
+
+    // On disk: the one thing the server has never seen is still there.
+    expect(h.disk.queue.map((item) => item.clientMutationId)).toEqual(['dead-zone-dinner']);
+    expect([...h.disk.rows.keys()]).toEqual([]);
+    expect(h.disk.cursors).toEqual({});
+    // In memory it looks like a signed-out app, because that is what is about to
+    // be rendered — a pending count belonging to nobody must not be on screen.
+    expect(engine.getState().queue).toEqual([]);
+  });
+
+  it('drains that expense when the same person signs back in', async () => {
+    offline();
+    const first = new SyncEngine();
+    await first.enqueue(unsentExpense('dead-zone-dinner'));
+    await first.retainUnsent(ANA);
+
+    // The next launch: same phone, same account, and the hold is theirs.
+    const hold = await first.retainedWork();
+    expect(hold?.ownerId).toBe(ANA);
+
+    const next = new SyncEngine();
+    await next.adoptRetained();
+    await next.hydrate();
+    expect(next.getState().queue.map((item) => item.clientMutationId)).toEqual([
+      'dead-zone-dinner',
+    ]);
+
+    online();
+    h.invoke.mockResolvedValue({
+      data: {
+        outcomes: [{ clientMutationId: 'dead-zone-dinner', status: 'applied' }],
+        changes: [],
+        cursors: { 'g-goa': 3 },
+        serverTime: '2026-08-09T09:27:00.000Z',
+      },
+      error: null,
+    });
+    await next.flush();
+
+    // Sent, acknowledged, and gone from the queue: the expense reached the
+    // ledger it was written for rather than being deleted on the way.
+    expect(h.invoke).toHaveBeenCalled();
+    expect(next.getState().queue).toEqual([]);
+    expect(h.disk.queue).toEqual([]);
+    expect(await next.retainedWork()).toBeNull();
+  });
+
+  it('hands somebody else nothing, however the hold got there', async () => {
+    offline();
+    const engine = new SyncEngine();
+    await engine.enqueue(unsentExpense('anas-dinner'));
+    await engine.retainUnsent(ANA);
+
+    // Ben signing in on Ana's phone. `SyncProvider` asks `retentionVerdict`
+    // before it hydrates, and a mismatch means the wipe runs first — so what
+    // Ben's session can ever see is what `clear` leaves, which is nothing.
+    const bensLaunch = new SyncEngine();
+    const hold = await bensLaunch.retainedWork();
+    expect(hold?.ownerId).toBe(ANA);
+    expect(hold?.ownerId).not.toBe(BEN);
+
+    await bensLaunch.clear();
+    await bensLaunch.hydrate();
+
+    expect(bensLaunch.getState().queue).toEqual([]);
+    expect(h.disk.queue).toEqual([]);
+    expect(await bensLaunch.retainedWork()).toBeNull();
+
+    // And nothing of Ana's is sent under Ben's session.
+    online();
+    h.invoke.mockResolvedValue({
+      data: { outcomes: [], changes: [], cursors: {}, serverTime: 'now' },
+      error: null,
+    });
+    await bensLaunch.flush();
+    const sent = h.invoke.mock.calls.flatMap(
+      (call) =>
+        ((call[1] as { body?: { mutations?: { clientMutationId: string }[] } })?.body?.mutations ??
+          []) as { clientMutationId: string }[],
+    );
+    expect(sent).toEqual([]);
   });
 });


### PR DESCRIPTION
## The diagnosis held, and here is how I checked it

Not from reading the app — from reading the auth client it depends on.
`node_modules/@supabase/auth-js@2.116.0/dist/main/GoTrueClient.js` calls
`_removeSession()` from **five** places, and `_removeSession` ends with
`await this._notifyAllSubscribers('SIGNED_OUT', null)`:

| line | caller | who asked |
| --- | --- | --- |
| 3426 | `_signOut` | the person |
| 4311 | `_callRefreshToken` — non-retryable auth error, access token already expired | nobody |
| 4117 | `_recoverAndRefresh` — stored session fails `_isValidSession` | nobody |
| 2529 | `__loadSession` — same, on the read path | nobody |
| 2724 | `getUser` — JWT names a session the server does not have | nobody |

`lib/auth.tsx`'s `onAuthStateChange` folds all five into one `setSession(null)`,
and `sync/provider.tsx` ran the wipe on `if (!signedIn)`. The wipe
(`driver.ts` `reset()`) deletes `mirror_rows`, **`pending_mutations`**,
`sync_cursors`, `drafts`, then `destroyKey()`. So a revoked refresh token, a
refresh expired past recovery, a remote "sign out my other devices", or an auth
server that has moved silently destroyed every expense the phone had not yet
sent, plus every draft, and then the key that could have opened them.

It is the only caller of the wipe — account deletion and the sign-out sheet both
reach it through `signOut()`, and there is no separate unlink path — so this one
condition was the whole of it.

## What now happens on each way a session can end

| how it ended | mirror + cursors | queue, drafts, receipt bytes | backup credentials | image cache | encryption key |
| --- | --- | --- | --- | --- | --- |
| **Signed out** (the sheet) | destroyed | destroyed | destroyed | destroyed | **crypto-erased** |
| **Account deleted** (signs out through the same call) | destroyed | destroyed | destroyed | destroyed | **crypto-erased** |
| **Token revoked / expired / rejected** | destroyed | **kept**, stamped with its owner | kept | destroyed | **kept** |
| **Signed out from another device** (`scope: 'others'`) | destroyed | **kept**, stamped | kept | destroyed | kept |
| Same owner signs back in, inside the window | re-pulled | drained | — | — | reused |
| **Somebody else signs in** | — | destroyed first | destroyed | destroyed | crypto-erased |
| Nobody signs in for 30 days | — | destroyed on the next launch | destroyed | destroyed | crypto-erased |

The line is: **the device keeps what only it has, and destroys what the server
can give back.** The ledger goes on every path, because the next sign-in re-pulls
it and a readable ledger on a phone nobody is signed into is cost without
benefit. Deliberate sign-out is byte-for-byte the behaviour it had.

The decision itself is a pure function — `destroyedBy(reason)` in
`apps/mobile/src/sync/retention.ts`, following `lib/backup/restorePrompt.ts` as
the precedent. `lib/auth.tsx` marks the one ending it knows about
(`markDeliberateSignOut()`, immediately before `backend.auth.signOut()`); the
mark is consumed once, goes stale after 60s, and is dropped whenever a session
starts, so a `signOut` that threw cannot arm a later involuntary loss.

**No new user-visible strings**, so no i18n surface: the person still lands on
the sign-in door exactly as before. The difference is that their unsent work is
there when they come back.

## The security trade on the encryption key

Stated plainly, because it is a real one and it should not be quiet.

Keeping the queue is worthless if the key that opens it is destroyed, so an
involuntary loss keeps the key. **What that means concretely:** after a session
is lost, this device holds — readable to the app — the expenses and drafts that
were never sent, and this account's receipt bytes and backup recovery key, where
before it held nothing.

What it does **not** hold is the ledger. That goes with the mirror, immediately,
on every path, so the large readable artefact the crypto-erase existed for is
gone either way. The erase is not weakened where it was doing its job; it is
simply no longer fired by an event that is not a departure. The posture is the
same one `rowCipher.ts` already documents: protection against off-device
extraction and backup theft, not against a running compromised device.

Three things bound it, all decided in the pure function and all tested:

1. **Owner-stamped** — see below.
2. **Time-bounded** — `RETENTION_WINDOW_MS` is 30 days, long enough for a trip,
   a replaced SIM, a forgotten password and a support round trip; short enough
   that a phone which has moved on is not holding somebody's expenses a year
   later. Enforced on the next sign-in *and* on a launch onto the sign-in door,
   which is the only moment somebody who never comes back can be noticed.
3. **Fail closed** — no stamp, an empty owner, or a date that will not parse is
   not a claim on the disk, and is discarded rather than adopted. (A stamp in
   the *future* is not expired: a phone with a wrong clock is not a reason to
   destroy anybody's expenses.)

## How a different owner is stopped from replaying the old queue

The hold is written as a single row in a new `retained_work` table, in the same
transaction that drops the mirror — both or neither, because unsent work on disk
with no stamp beside it is work nobody may adopt.

`SyncProvider` then asks `retentionVerdict(retained, signingInAs, now)` **before
it hydrates and before the first `flush`**. The check is identity, not
similarity: anything that is not a plain match of the stored owner id returns
`Discard`, and `clearLocalPrivateData(retained.ownerId)` runs the full wipe —
queue, drafts, receipts, that account's backup credentials, and the key — before
the new session reads a single row. So there is never a moment at which the new
session's engine holds the previous owner's mutations, let alone sends them.

The ADR-006 in-place guest upgrade keeps the same user id, so an upgrade adopts
correctly; a guest whose anonymous session is replaced by a different account
does not.

## Also fixed, in passing

`SyncEngine.clear()` now waits on an in-flight flush the way `forgetGroup`
already does. A pull that was already on the wire reconciles *after* its network
await, so it could write ledger rows back to disk moments after the sign-out wipe
had deleted them — signed-out data arriving through a door the wipe had locked.

## Tests

`apps/mobile/test/sessionRetention.test.ts` (new, 20 cases, pure) covers: a
deliberate sign-out destroys everything including the key; account deletion
reaches the same verdict; an involuntary loss keeps `unsent` and the key; `key`
tracks `unsent` exactly, both ways, so the two nonsense states (an unreadable
queue, an erase that erased nothing) cannot be expressed; the mark defaults to
involuntary, is spent once, and goes stale; and every owner/window branch.

`apps/mobile/test/syncEngine.test.ts` adds three cases against the shared
in-memory disk two engine instances read, which is what makes them two launches
rather than one: the unsent expense survives on disk while the mirror goes; the
same owner signing back in hydrates it and **drains** it to the server; and a
different owner's launch sends nothing of the first owner's.

`apps/mobile/test/localStore.test.ts` adds four against the real driver: the
queue, the drafts and the keystore entry survive `retainUnsent` while rows and
cursors do not; the stamp is written in the same transaction; `clearRetained`
and `reset` both drop it; a phone that never lost a session reports nothing held.

## Gates

`pnpm format`, `pnpm lint`, `pnpm --filter @waves/mobile typecheck`,
`pnpm --filter @waves/mobile test` (105 files, 1420 tests) and
`pnpm --filter @waves/core test` (63 files, 986 tests) all pass.
`packages/db` tests need a local Postgres that is not running, so they were not
run.

## Deliberately not done

- **No "you were signed out" notice.** It would be useful, but it is a screen
  change with new strings in four locales while other branches are in those
  files, and the fix stands without it.
- **No change to `SignOutSheet`.** Its warning is still exactly true of the
  ending it describes.
- **Not device-tested.** The whole decision is pure and covered, but the path
  that arms it — a real refresh token being rejected on a real phone — has not
  been run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jhzmZz5fkjnZZ14YxHGfS
