### PR TITLE
Add expense reads its date and category the way the expense screen already does

### DIFF
--- a/apps/mobile/src/app/capture.tsx
+++ b/apps/mobile/src/app/capture.tsx
@@ -43,7 +43,8 @@ import { COMMON_CURRENCIES } from '@/components/CurrencyRate';
 import { AmountHeader } from '@/components/expense/AmountHeader';
 import { DescriptionField } from '@/components/expense/DescriptionField';
 import { ExpenseHeader } from '@/components/expense/ExpenseHeader';
-import { ChoiceRow, FieldRow, SheetOverlay } from '@/components/expense/SheetOverlay';
+import { ChoiceRow, SheetOverlay } from '@/components/expense/SheetOverlay';
+import { DetailRow, DetailRows } from '@/components/DetailRows';
 import { useCreateCapture, useGroups, useHomeSummary, useUpdateCapture } from '@/data/hooks';
 import { groupLabel, GroupType, type GroupRow, type MemberRow } from '@/data/types';
 import { useAuth } from '@/lib/auth';
@@ -568,35 +569,49 @@ export default function CaptureScreen() {
         {/* Destination and date, folded into one card of divided rows rather than
             two stacked cards — the meta a capture carries, grouped so it reads as
             one block. "Decide later" is the default group: the split, and who is
-            in it, is chosen when the capture is assigned. */}
-        <Card style={{ paddingVertical: theme.spacing.xs, gap: 0 }}>
-          <FieldRow
-            icon={targetGroup ? 'people' : 'people-outline'}
-            iconColor={targetGroup ? theme.color.brand : theme.color.textMuted}
-            label={t.captures.group}
-            value={targetGroupName}
-            valueMuted={!targetGroup}
-            onPress={() => setPickingGroup(true)}
-            accessibilityLabel={`${t.captures.group}: ${targetGroupName}`}
-          />
-          <Divider />
-          <FieldRow
-            icon="calendar-outline"
-            label={t.captures.date}
-            value={showDate(date, locale)}
-            onPress={() => setEditingDate(true)}
-            accessibilityLabel={`${t.captures.date}: ${showDate(date, locale)}`}
-          />
-          {editingDate ? (
-            <DateTimePicker
-              value={dateFrom(date)}
-              mode="date"
-              onChange={applyDate}
-              // A capture is caught now or in the recent past — a spend cannot
-              // have happened tomorrow.
-              maximumDate={new Date()}
+            in it, is chosen when the capture is assigned.
+
+            The same `DetailRows` the expense form and the expense screen wear.
+            These two used to stack the field's name over its answer, which made
+            a two-row card three text sizes tall and, more to the point, made a
+            capture's date look nothing like the same date on the form it is
+            assigned into. One line each, name left and answer right.
+
+            The picker is wrapped with its row rather than left as a sibling:
+            `DetailRows` puts a hairline in every gap between its children, so an
+            unfolded date wheel counted as a row of its own would be ruled off
+            from the row that opened it. */}
+        <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+          <DetailRows>
+            <DetailRow
+              icon={targetGroup ? 'people' : 'people-outline'}
+              iconColor={targetGroup ? theme.color.brand : theme.color.textMuted}
+              label={t.captures.group}
+              value={targetGroupName}
+              placeholder={!targetGroup}
+              onPress={() => setPickingGroup(true)}
+              accessibilityLabel={`${t.captures.group}: ${targetGroupName}`}
             />
-          ) : null}
+            <View>
+              <DetailRow
+                icon="calendar-outline"
+                label={t.captures.date}
+                value={showDate(date, locale)}
+                onPress={() => setEditingDate(true)}
+                accessibilityLabel={`${t.captures.date}: ${showDate(date, locale)}`}
+              />
+              {editingDate ? (
+                <DateTimePicker
+                  value={dateFrom(date)}
+                  mode="date"
+                  onChange={applyDate}
+                  // A capture is caught now or in the recent past — a spend cannot
+                  // have happened tomorrow.
+                  maximumDate={new Date()}
+                />
+              ) : null}
+            </View>
+          </DetailRows>
         </Card>
 
         {/* The bill, for the times pointing a camera is easier than typing. The

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -49,7 +49,6 @@ import {
   Callout,
   Card,
   ChipRow,
-  Divider,
   EmptyState,
   iconSize,
   MoneyText,
@@ -71,7 +70,8 @@ import { COMMON_CURRENCIES, CurrencyRate } from '@/components/CurrencyRate';
 import { DescriptionField } from '@/components/expense/DescriptionField';
 import { ExpenseHero } from '@/components/expense/ExpenseHero';
 import { splitIcon } from '@/components/expense/splitIcon';
-import { ChoiceRow, SettingRow, SheetOverlay } from '@/components/expense/SheetOverlay';
+import { ChoiceRow, SheetOverlay } from '@/components/expense/SheetOverlay';
+import { DetailRow, DetailRows } from '@/components/DetailRows';
 import {
   canAddReceipt,
   expenseReceiptPath,
@@ -1799,45 +1799,46 @@ export default function AddExpenseScreen() {
 
             Category is here as well as on the hero badge above: the badge shows
             the guess, which is what you want while typing the note, but it is
-            not a control — this row is where the guess is overruled. */}
-          <Card style={{ paddingVertical: theme.spacing.xs, gap: 0 }}>
-            <SettingRow
-              label={t.captures.date}
-              value={showDate(expenseDate, locale)}
-              leading={
-                <Ionicons
-                  name="calendar-outline"
-                  size={iconSize.md}
-                  color={theme.color.textMuted}
-                />
-              }
-              onPress={() => setEditingDate(true)}
-            />
-            <Divider />
-            <CategoryRow
-              value={category}
-              meta={categoryMeta}
-              onPress={() => setPickingCategory(true)}
-            />
-            <Divider />
-            <PaymentMethodRow value={paymentMethod} onPress={() => setPickingPayment(true)} />
-            <Divider />
-            {/* What it was paid in, as a named row rather than only as the pill
-              in the header. The pill is still there and still works — but it is
-              a hairline outline on a gradient beside a large amount, and "there
-              is no currency selection" is what somebody looking for one
-              reported. This names the field and opens the same sheet. */}
-            <SettingRow
-              label={t.captures.currencyLabel}
-              value={`${currencySymbol(currency)} ${currency}`}
-              leading={
-                // Not `cash-outline`: the rail row directly above wears that
-                // glyph whenever the answer is cash, which is the default — two
-                // rows with the same icon read as one repeated question.
-                <Ionicons name="globe-outline" size={iconSize.md} color={theme.color.textMuted} />
-              }
-              onPress={() => setPickingCurrency(true)}
-            />
+            not a control — this row is where the guess is overruled.
+
+            Literally the same card, now: `DetailRows` inside a `Card` with no
+            padding of its own is the markup the expense screen uses, down to the
+            hairlines it puts in the gaps rather than between siblings. These
+            rows used to be drawn the other way up — the question in full weight,
+            the answer muted beside it — so a bill you had just filed came back
+            reading as a different screen's idea of the same four facts. The
+            answers are what somebody scans for on both, so the answers are the
+            loud half on both. */}
+          <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+            <DetailRows>
+              <DetailRow
+                icon="calendar-outline"
+                label={t.captures.date}
+                value={showDate(expenseDate, locale)}
+                onPress={() => setEditingDate(true)}
+              />
+              <CategoryRow
+                value={category}
+                meta={categoryMeta}
+                onPress={() => setPickingCategory(true)}
+              />
+              <PaymentMethodRow value={paymentMethod} onPress={() => setPickingPayment(true)} />
+              {/* What it was paid in, as a named row rather than only as the pill
+                in the header. The pill is still there and still works — but it is
+                a hairline outline on a gradient beside a large amount, and "there
+                is no currency selection" is what somebody looking for one
+                reported. This names the field and opens the same sheet.
+
+                Not `cash-outline`: the rail row directly above wears that glyph
+                whenever the answer is cash, which is the default — two rows with
+                the same mark read as one repeated question. */}
+              <DetailRow
+                icon="globe-outline"
+                label={t.captures.currencyLabel}
+                value={`${currencySymbol(currency)} ${currency}`}
+                onPress={() => setPickingCurrency(true)}
+              />
+            </DetailRows>
           </Card>
 
           {editingDate ? (

--- a/apps/mobile/src/app/personal/entry.tsx
+++ b/apps/mobile/src/app/personal/entry.tsx
@@ -17,10 +17,11 @@
  * carrying an editor of its own.
  *
  * The fields below the amount are the rows the expense screens use — the same
- * `SettingRow` in the same `Card` that add-expense folds its date, category,
- * rail and currency into. A short answer already filled in, changed from a
- * sheet, read down one column. The private ledger was the last place still
- * asking those questions as stacked captions and chip lanes.
+ * `DetailRows` in the same `Card` that add-expense folds its date, category,
+ * rail and currency into, and that the expense screen states a filed bill's
+ * facts in. A short answer already filled in, changed from a sheet, read down
+ * one column. The private ledger was the last place still asking those
+ * questions as stacked captions and chip lanes.
  *
  * Reached from the Me tab's add buttons, from the ledger's "+", from the
  * recurring list (`repeats=1` to create, `recurringId` to edit), and — with a
@@ -48,7 +49,6 @@ import {
   Button,
   Card,
   directionalIcon,
-  Divider,
   IconButton,
   iconSize,
   Row,
@@ -60,7 +60,8 @@ import {
 } from '@waves/ui';
 
 import { CategoryRow, CategorySheet } from '@/components/Category';
-import { ChoiceRow, SettingRow, SheetOverlay } from '@/components/expense/SheetOverlay';
+import { ChoiceRow, SheetOverlay } from '@/components/expense/SheetOverlay';
+import { DetailRow, DetailRows } from '@/components/DetailRows';
 import { SourceRow, SourceSheet } from '@/components/IncomeSource';
 import { PersonalNoteField } from '@/components/PersonalNoteField';
 import {
@@ -327,48 +328,38 @@ function EntryForm({
             Income asks where the money came from and an expense asks what it was
             spent on. The two are different questions and once shared one picker,
             which is how a salary ended up filed under "Other". */}
-        <Card style={{ paddingVertical: theme.spacing.xs, gap: 0 }}>
-          {loanId ? null : (
-            <>
-              {kind === 'income' ? (
-                <SourceRow value={category} onPress={() => setPicking('what')} />
-              ) : (
-                <CategoryRow value={category} onPress={() => setPicking('what')} />
-              )}
-              <Divider />
-            </>
-          )}
+        <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+          <DetailRows>
+            {loanId ? null : kind === 'income' ? (
+              <SourceRow value={category} onPress={() => setPicking('what')} />
+            ) : (
+              <CategoryRow value={category} onPress={() => setPicking('what')} />
+            )}
 
-          <SettingRow
-            label={repeat ? t.personal.startsOn : t.personal.date}
-            value={showDate(date, locale)}
-            leading={
-              <Ionicons name="calendar-outline" size={iconSize.md} color={theme.color.textMuted} />
-            }
-            onPress={() => setShowDatePicker(true)}
-          />
+            <DetailRow
+              icon="calendar-outline"
+              label={repeat ? t.personal.startsOn : t.personal.date}
+              value={showDate(date, locale)}
+              onPress={() => setShowDatePicker(true)}
+            />
 
-          {canRepeat || editingRule ? (
-            <>
-              <Divider />
-              <SettingRow
+            {canRepeat || editingRule ? (
+              <DetailRow
+                icon={repeat ? 'repeat' : 'repeat-outline'}
+                // Brand green only once it actually repeats: the mark is then
+                // saying something the word beside it also says, which is the
+                // one place a coloured glyph earns its colour on this card.
+                iconColor={repeat ? theme.color.brand : undefined}
                 label={t.personal.repeats}
                 value={
                   repeat
                     ? frequencyLabel(t, repeat.frequency, repeat.interval)
                     : t.personal.repeatsNever
                 }
-                leading={
-                  <Ionicons
-                    name={repeat ? 'repeat' : 'repeat-outline'}
-                    size={iconSize.md}
-                    color={repeat ? theme.color.brand : theme.color.textMuted}
-                  />
-                }
                 onPress={() => setPicking('repeat')}
               />
-            </>
-          ) : null}
+            ) : null}
+          </DetailRows>
         </Card>
 
         {showDatePicker ? (

--- a/apps/mobile/src/app/personal/loans.tsx
+++ b/apps/mobile/src/app/personal/loans.tsx
@@ -35,6 +35,7 @@ import {
   useTheme,
 } from '@waves/ui';
 
+import { DetailRow } from '@/components/DetailRows';
 import {
   localIsoDate,
   todayIso,
@@ -297,22 +298,25 @@ function LoanEditor({
           hints={counterpart.trim() ? [counterpart.trim()] : undefined}
         />
 
-        <Pressable
-          accessibilityRole="button"
-          onPress={() => setShowDate(true)}
+        {/* The same `DetailRow` the expense and personal-entry forms state their
+            date in. This used to be a bare box with the raw value and a glyph
+            on the wrong side and no label at all — a screen reader had nothing
+            to say for it beyond the date itself, which does not say it is a
+            date. */}
+        <View
           style={{
-            flexDirection: 'row',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            paddingVertical: theme.spacing.md,
-            paddingHorizontal: theme.spacing.lg,
             backgroundColor: theme.color.surfaceMuted,
             borderRadius: theme.radius.md,
+            paddingHorizontal: theme.spacing.lg,
           }}
         >
-          <Text variant="body">{startDate}</Text>
-          <Ionicons name="calendar-outline" size={iconSize.md} color={theme.color.textMuted} />
-        </Pressable>
+          <DetailRow
+            icon="calendar-outline"
+            label={t.personal.startsOn}
+            value={startDate}
+            onPress={() => setShowDate(true)}
+          />
+        </View>
         {showDate ? (
           <DateTimePicker
             value={new Date(`${startDate}T00:00:00`)}

--- a/apps/mobile/src/components/Category.tsx
+++ b/apps/mobile/src/components/Category.tsx
@@ -26,7 +26,8 @@ import { Pressable, ScrollView, View } from 'react-native';
 import { guessIcon, normaliseTint, resolveCategory, type CategoryMeta } from '@waves/core';
 import { iconSize, Text, useTheme } from '@waves/ui';
 
-import { ChoiceRow, SettingRow, SheetOverlay } from '@/components/expense/SheetOverlay';
+import { DetailRow } from '@/components/DetailRows';
+import { ChoiceRow, SheetOverlay } from '@/components/expense/SheetOverlay';
 import { useCategoryCatalog } from '@/data/hooks';
 import { useStrings } from '@/i18n';
 
@@ -167,8 +168,14 @@ export function CategoryPicker({
 }
 
 /**
- * The chosen category as one row of a settings list: the field's name, then the
- * tag's own glyph and label, then a chevron into {@link CategorySheet}.
+ * The chosen category as one row of a settings list: the tag's own glyph, the
+ * field's name, the tag's label, then a chevron into {@link CategorySheet}.
+ *
+ * A {@link DetailRow}, which is the row the expense screen states a bill's facts
+ * in — so "what for" is asked on the form in the shape the answer comes back in
+ * afterwards. The glyph leads the row rather than trailing the value, and it
+ * keeps the tag's own ink: the mark here belongs to the answer, not to the
+ * question.
  *
  * The value is read from the person's catalog first — that is where a renamed
  * or re-coloured built-in lives — and only falls back to resolving the stored
@@ -199,16 +206,11 @@ export function CategoryRow({
   const tint = theme.tint[entry ? normaliseTint(entry.tint) : resolved.tint];
 
   return (
-    <SettingRow
+    <DetailRow
+      icon={(entry?.icon ?? resolved.icon) as keyof typeof Ionicons.glyphMap}
+      iconColor={tint.ink}
       label={t.whatFor}
       value={label}
-      leading={
-        <Ionicons
-          name={(entry?.icon ?? resolved.icon) as keyof typeof Ionicons.glyphMap}
-          size={iconSize.md}
-          color={tint.ink}
-        />
-      }
       onPress={onPress}
     />
   );

--- a/apps/mobile/src/components/DetailRows.tsx
+++ b/apps/mobile/src/components/DetailRows.tsx
@@ -28,9 +28,31 @@ import { directionalIcon, iconSize, Row, Text, useTheme } from '@waves/ui';
  * Ionicons glyph name, which is why it is here in the app rather than in
  * @waves/ui: that package takes no icon dependency, by design, and every
  * component there that draws a glyph takes it as a render prop instead.
+ *
+ * It used to have a twin. `SettingRow`, in `expense/SheetOverlay.tsx`, drew the
+ * same pair the other way up — the field's name in full body weight on the
+ * left, the answer muted on the right, the glyph beside the answer — and the
+ * expense form, the capture form (as `FieldRow`, a third shape again) and the
+ * private ledger all wore that one while the expense *screen* wore this. Which
+ * meant filing a bill and reading it back afterwards looked like two different
+ * applications, and a person who had just chosen a date on one screen had to
+ * re-find it on the other.
+ *
+ * They are one row, not two, and this is the way up that survives: what you go
+ * looking for in a stack of facts is the answers, so the answers are the loud
+ * half and the names are the quiet index down the left. That is as true of a
+ * form as of a receipt — the only difference between the two is `onPress`,
+ * which this row already models, and which is what earns the chevron.
+ *
+ * Two things came across from the twin when it was folded in. `iconColor`,
+ * because the glyph is not always the *field's* mark: a category row wears the
+ * tag's own icon in the tag's own ink, and the split row on the expense screen
+ * wears the split's. And the proportional shrink below, which is the bug that
+ * twin had already been through.
  */
 export function DetailRow({
   icon,
+  iconColor,
   label,
   subtitle,
   value,
@@ -41,6 +63,11 @@ export function DetailRow({
   accessibilityLabel,
 }: {
   icon: keyof typeof Ionicons.glyphMap;
+  /** When the glyph belongs to the *answer* rather than to the question — a
+   *  category tag's own ink, brand green for a destination that has been picked
+   *  — say so here. Left off, it is the muted grey every plain field mark
+   *  wears, which is what a row naming a fact rather than colouring one wants. */
+  iconColor?: string;
   label: string;
   /** One line under the label, for a fact whose name does not explain it —
    *  "simplify debts" being the case this exists for. Most rows need none, and
@@ -96,11 +123,21 @@ export function DetailRow({
           // A bare label is as wide as its word and the value takes the rest;
           // a label with a hint under it is the wordy half, so it takes the
           // room instead and the value shrinks around it.
-          flexShrink: subtitle ? 1 : 0,
+          //
+          // Either way it *can* shrink, which it could not before the forms
+          // moved onto this row. Their labels are not nouns like "Date" but
+          // whole questions — "What kind of expense" — and in Tamil or Arabic
+          // either half can outrun a narrow phone on its own. A label pinned at
+          // `flexShrink: 0` simply pushed the value off the end of the row, so
+          // the question and the chevron were drawn with nothing between them.
+          // `minWidth: 0` is what lets a flex child go narrower than its text at
+          // all; without it the shrink is declared and never happens.
+          flexShrink: 1,
+          minWidth: 0,
           flex: subtitle ? 1 : undefined,
         }}
       >
-        <Ionicons name={icon} size={iconSize.md} color={theme.color.textMuted} />
+        <Ionicons name={icon} size={iconSize.md} color={iconColor ?? theme.color.textMuted} />
         <View style={{ gap: 2, flexShrink: 1 }}>
           <Text variant="caption" tone="muted">
             {label}
@@ -112,13 +149,28 @@ export function DetailRow({
           ) : null}
         </View>
       </Row>
-      <Row style={{ alignItems: 'center', gap: theme.spacing.xs, flexShrink: 1 }}>
+      {/* Both halves shrink from a *content* basis, never from the zero basis
+          `flex: 1` means in React Native. With a zero basis there is no free
+          space left to grow back from once the label's own text has taken the
+          row, and the answer settles at zero width — the question and the
+          chevron drawn with nothing between them. A truncated answer is a worse
+          row than a full one; no answer at all is not a row. */}
+      <Row
+        style={{
+          alignItems: 'center',
+          gap: theme.spacing.xs,
+          flexShrink: 1,
+          flexBasis: 'auto',
+          minWidth: 0,
+          justifyContent: 'flex-end',
+        }}
+      >
         {value === undefined ? null : (
           <Text
             variant="body"
             tone={placeholder ? 'muted' : undefined}
             numberOfLines={1}
-            style={{ flexShrink: 1, textAlign: 'right' }}
+            style={{ flexShrink: 1, minWidth: 0, textAlign: 'right' }}
           >
             {value}
           </Text>

--- a/apps/mobile/src/components/IncomeSource.tsx
+++ b/apps/mobile/src/components/IncomeSource.tsx
@@ -29,7 +29,8 @@ import {
 } from '@waves/core';
 import { iconSize, useTheme } from '@waves/ui';
 
-import { ChoiceRow, SettingRow, SheetOverlay } from '@/components/expense/SheetOverlay';
+import { DetailRow } from '@/components/DetailRows';
+import { ChoiceRow, SheetOverlay } from '@/components/expense/SheetOverlay';
 import { useCategoryTags } from '@/data/hooks';
 import { useStrings, type UiStrings } from '@/i18n';
 
@@ -90,6 +91,14 @@ export function SourceGlyph({ id, size = 40 }: { id: string | null; size?: numbe
  * already filled in, changed from a sheet. Drawn as a lane of chips for one and
  * a row for the other, the same form would have looked like two forms depending
  * on which way the money went.
+ *
+ * Identical now down to the glyph. It used to wear {@link SourceGlyph}, the
+ * filled circle a source gets in a *list*, shrunk to 24 and parked beside the
+ * value; the category row beside it wore a bare mark in the tag's ink. Two rows
+ * one above the other in the same card, asking the same question of the same
+ * form, and only one of them had a disc behind its icon. The circle is right
+ * where a source is the subject of its own row, which is the sources list, and
+ * wrong where it is one answer among four.
  */
 export function SourceRow({
   value,
@@ -98,13 +107,17 @@ export function SourceRow({
   value: string | null;
   onPress: () => void;
 }): React.JSX.Element {
+  const theme = useTheme();
   const { t } = useStrings();
   const label = useSourceLabel()(value);
+  const source = incomeSource(value);
+  const tint = source ? theme.tint[source.tint] : theme.tint.mint;
   return (
-    <SettingRow
+    <DetailRow
+      icon={(source?.icon ?? 'cash-outline') as keyof typeof Ionicons.glyphMap}
+      iconColor={tint.ink}
       label={t.personal.source}
       value={label ?? t.personal.sources.other}
-      leading={<SourceGlyph id={value} size={24} />}
       onPress={onPress}
     />
   );

--- a/apps/mobile/src/components/PaymentMethodPicker.tsx
+++ b/apps/mobile/src/components/PaymentMethodPicker.tsx
@@ -24,7 +24,8 @@ import { Pressable, ScrollView, View } from 'react-native';
 import { type PaymentMethod } from '@waves/core';
 import { iconSize, Text, useTheme } from '@waves/ui';
 
-import { ChoiceRow, SettingRow, SheetOverlay } from '@/components/expense/SheetOverlay';
+import { DetailRow } from '@/components/DetailRows';
+import { ChoiceRow, SheetOverlay } from '@/components/expense/SheetOverlay';
 import { deviceSupportsUpi, useStrings } from '@/i18n';
 import { offeredPaymentMethods } from '@/lib/paymentMethods';
 
@@ -135,8 +136,11 @@ export function PaymentMethodPicker(props: PaymentMethodPickerProps) {
 }
 
 /**
- * The rail in force as one row of a settings list: the field's name, the rail's
- * glyph and label, a chevron into {@link PaymentMethodSheet}.
+ * The rail in force as one row of a settings list: the rail's glyph, the field's
+ * name, the rail's label, a chevron into {@link PaymentMethodSheet}.
+ *
+ * A {@link DetailRow}, the row the expense screen states a bill's facts in, so
+ * "paid with" is asked in the shape it is read back in.
  *
  * Only the non-deselectable shape: a list row has to show *something* on its
  * right, and "not said" is a state the chip lane can express by having nothing
@@ -149,7 +153,6 @@ export function PaymentMethodRow({
   value: PaymentMethod;
   onPress: () => void;
 }) {
-  const theme = useTheme();
   const { t } = useStrings();
   const label = usePaymentMethodLabel();
   const method = offeredPaymentMethods({ upiSupported: deviceSupportsUpi(), current: value }).find(
@@ -157,18 +160,13 @@ export function PaymentMethodRow({
   );
 
   return (
-    <SettingRow
+    <DetailRow
+      // A rail the region does not offer still has to draw *some* mark, or the
+      // row loses the column the stack next to it is read down. The wallet is
+      // the field's own glyph, standing in for the answer's.
+      icon={method ? PAYMENT_METHOD_ICONS[method] : 'wallet-outline'}
       label={t.captures.paidWith}
       value={label(value)}
-      leading={
-        method ? (
-          <Ionicons
-            name={PAYMENT_METHOD_ICONS[method]}
-            size={iconSize.md}
-            color={theme.color.textMuted}
-          />
-        ) : null
-      }
       onPress={onPress}
     />
   );

--- a/apps/mobile/src/components/expense/SheetOverlay.tsx
+++ b/apps/mobile/src/components/expense/SheetOverlay.tsx
@@ -1,11 +1,22 @@
 /**
- * The sheet and row primitives the expense forms share.
+ * The sheet primitive the expense forms share, and the row a sheet's choices
+ * are listed in.
  *
  * Both the capture screen and the group add-expense screen present their
  * pickers (currency, destination) as a bottom sheet over the form, and list
  * their choices as a leading glyph + label + check. Pulling them here means the
  * two screens present, dismiss, and read the same rather than each carrying its
  * own copy that could drift apart.
+ *
+ * This file used to also hold the row a sheet's *result* was stated in —
+ * `FieldRow` (name stacked over value) and `SettingRow` (name and value on one
+ * line, the shape this file was named for). Both are gone: every caller of
+ * either now uses `DetailRow` from `@/components/DetailRows`, which is the
+ * shape the expense screen already stated a filed bill's facts in. A field
+ * asked on a form and read back on the receipt now looks like the same
+ * question both times. See that file's header for the fuller reasoning and
+ * for what still stays a different row (`ListRow` in `@waves/ui`, for an entry
+ * you open rather than a fact you're told).
  */
 
 import { type ReactNode } from 'react';
@@ -20,142 +31,10 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 
-import { directionalIcon, iconSize, Row, Text, useTheme } from '@waves/ui';
+import { iconSize, Text, useTheme } from '@waves/ui';
 
 import { useStrings } from '@/i18n';
 import { useBottomClearance } from '@/lib/clearance';
-
-/**
- * A labelled tap-row: a leading icon, the field name over its value, a chevron.
- * The rows an expense's meta (group, date) share, so they read as one block
- * inside a single card rather than a stack of near-identical cards.
- */
-export function FieldRow({
-  icon,
-  iconColor,
-  label,
-  value,
-  valueMuted = false,
-  onPress,
-  accessibilityLabel,
-}: {
-  icon: keyof typeof Ionicons.glyphMap;
-  iconColor?: string;
-  label: string;
-  value: string;
-  valueMuted?: boolean;
-  onPress: () => void;
-  accessibilityLabel: string;
-}): React.JSX.Element {
-  const theme = useTheme();
-  return (
-    <Pressable
-      accessibilityRole="button"
-      accessibilityLabel={accessibilityLabel}
-      onPress={onPress}
-      style={({ pressed }) => ({
-        flexDirection: 'row',
-        alignItems: 'center',
-        gap: theme.spacing.md,
-        paddingVertical: theme.spacing.md,
-        opacity: pressed ? 0.6 : 1,
-      })}
-    >
-      <Ionicons name={icon} size={iconSize.md} color={iconColor ?? theme.color.textMuted} />
-      <View style={{ flex: 1, gap: 2 }}>
-        <Text variant="caption" tone="muted">
-          {label}
-        </Text>
-        <Text variant="subheading" numberOfLines={1} tone={valueMuted ? 'muted' : undefined}>
-          {value}
-        </Text>
-      </View>
-      <Ionicons name="chevron-forward" size={iconSize.md} color={theme.color.textFaint} />
-    </Pressable>
-  );
-}
-
-/**
- * A settings-style tap-row: the field's name on the left, what is currently
- * chosen on the right — its glyph and its label — and a chevron into the sheet
- * that changes it.
- *
- * The one-line sibling of {@link FieldRow}. That one stacks the name over its
- * value, which suits meta a person reads on the way past (which group, which
- * date). This one keeps the pair on a single line, which is what a short answer
- * picked from a sheet wants: a column of names you scan down the left and the
- * answers down the right, so two settings read as a list of two rather than as
- * two more blocks in a long form.
- */
-export function SettingRow({
-  label,
-  value,
-  leading,
-  onPress,
-}: {
-  label: string;
-  value: string;
-  /** The chosen option's glyph, drawn immediately before its label. */
-  leading?: ReactNode;
-  onPress: () => void;
-}): React.JSX.Element {
-  const theme = useTheme();
-  return (
-    <Pressable
-      accessibilityRole="button"
-      accessibilityLabel={`${label}: ${value}`}
-      onPress={onPress}
-      style={({ pressed }) => ({
-        flexDirection: 'row',
-        alignItems: 'center',
-        gap: theme.spacing.md,
-        paddingVertical: theme.spacing.md,
-        opacity: pressed ? 0.6 : 1,
-      })}
-    >
-      {/* Both sides shrink and clip rather than wrap: the names here are whole
-          questions ("What kind of expense") and in Tamil or Arabic either half
-          can outrun a narrow phone. A row that grows to two lines would break
-          the list's rhythm for the one language it happened in.
-
-          They must shrink *in proportion*, which is why the value's side is
-          `flexGrow`/`flexShrink`/`flexBasis: 'auto'` and not the `flex: 1` it
-          started as. `flex: 1` in React Native means a zero flex-basis, so once
-          the label's own text outran the row there was no free space left to
-          grow back from, and the value settled at zero width — the row drew the
-          question and the chevron with nothing between them, which is worse
-          than a truncated answer and exactly what a long Tamil label or a large
-          font scale produced. With a content basis on both halves the shrink is
-          shared and each keeps a readable fraction. `minWidth: 0` on both is
-          what lets either shrink below its text at all. */}
-      <Text variant="body" numberOfLines={1} style={{ flexShrink: 1, minWidth: 0 }}>
-        {label}
-      </Text>
-      <Row
-        style={{
-          gap: theme.spacing.xs,
-          flexGrow: 1,
-          flexShrink: 1,
-          flexBasis: 'auto',
-          minWidth: 0,
-          justifyContent: 'flex-end',
-        }}
-      >
-        {leading}
-        <Text variant="body" tone="muted" numberOfLines={1} style={{ flexShrink: 1, minWidth: 0 }}>
-          {value}
-        </Text>
-      </Row>
-      {/* The chevron is content, not layout: RN mirrors the row itself in RTL
-          but leaves the glyph pointing whichever way it was drawn. */}
-      <Ionicons
-        name={directionalIcon('chevron-forward')}
-        size={iconSize.md}
-        color={theme.color.textFaint}
-      />
-    </Pressable>
-  );
-}
 
 /**
  * A bottom sheet over the form: a dimmed backdrop that closes on tap, a rounded

--- a/apps/mobile/test/rowIdiom.test.ts
+++ b/apps/mobile/test/rowIdiom.test.ts
@@ -1,0 +1,80 @@
+/**
+ * One row states a fact; a different row opens a door. This is the guard on
+ * the first half of that split.
+ *
+ * `DetailRow` (`src/components/DetailRows.tsx`) used to have two rivals drawn
+ * the same job the other way up: `SettingRow` and `FieldRow`, both in
+ * `src/components/expense/SheetOverlay.tsx`. A bill's date read one way on the
+ * expense screen and a different way on the form that filed it, because the
+ * two idioms had never been reconciled. They now have been — every screen that
+ * states a short, already-chosen answer (date, category, payment rail,
+ * currency, income source, a loan's start date) goes through `DetailRow`, and
+ * `SettingRow`/`FieldRow` are gone.
+ *
+ * This reads the call sites as source rather than rendering them: the
+ * components this exercises pull in `react-native`, Reanimated and gesture
+ * handler, none of which this node-environment suite can mount, and the thing
+ * worth protecting — which row a screen imports — is legible in the text
+ * without any of that. A screen that quietly went back to hand-rolling its own
+ * date box would still compile and render; it would just look like a
+ * different app again, which is exactly the regression this test exists to
+ * catch.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const SRC = join(__dirname, '../src');
+const source = (relativePath: string): string => readFileSync(join(SRC, relativePath), 'utf8');
+
+// Every screen and shared row component this conversion touched: the ones
+// that used to import `SettingRow` or `FieldRow` from `SheetOverlay`, and now
+// import `DetailRow` from `DetailRows` instead.
+const CONVERTED = [
+  'app/capture.tsx',
+  'app/group/[id]/add-expense.tsx',
+  'app/personal/entry.tsx',
+  'app/personal/loans.tsx',
+  'components/Category.tsx',
+  'components/PaymentMethodPicker.tsx',
+  'components/IncomeSource.tsx',
+];
+
+describe('a filed fact reads the same way everywhere it is stated', () => {
+  it('imports DetailRow rather than hand-rolling the row', () => {
+    for (const file of CONVERTED) {
+      const text = source(file);
+      expect(text, `${file} should import DetailRow`).toMatch(
+        /import\s*\{[^}]*\bDetailRow\b[^}]*\}\s*from\s*'@\/components\/DetailRows'/,
+      );
+    }
+  });
+
+  it('no longer reaches for the rows DetailRow replaced', () => {
+    for (const file of CONVERTED) {
+      const text = source(file);
+      expect(text, `${file} should not import SettingRow`).not.toMatch(/\bSettingRow\b/);
+      expect(text, `${file} should not import FieldRow`).not.toMatch(/\bFieldRow\b/);
+    }
+  });
+
+  it('SheetOverlay no longer defines the rows it handed off', () => {
+    const text = source('components/expense/SheetOverlay.tsx');
+    expect(text).not.toMatch(/export function SettingRow/);
+    expect(text).not.toMatch(/export function FieldRow/);
+    // What is left: the sheet itself, and the option row a sheet's choices are
+    // listed in — a different job (see DetailRows.tsx's header).
+    expect(text).toMatch(/export function SheetOverlay/);
+    expect(text).toMatch(/export function ChoiceRow/);
+  });
+
+  it('the loan editor names its date field, which the box it replaced did not', () => {
+    const text = source('app/personal/loans.tsx');
+    // The row this became carries an accessible label by construction
+    // (DetailRow's own accessibilityLabel default); this pins the visible
+    // label so a screen reader is not left with the bare date on its own.
+    expect(text).toMatch(/label=\{t\.personal\.startsOn\}/);
+  });
+});


### PR DESCRIPTION
## Why

The user's complaint was concrete: edit-expense (the expense detail screen)
reads its Date/Category/Paid-with rows in a shape they like, and add-expense —
along with every other form that asks the same kind of question — did not
match it. This PR makes the match, and writes down why the three row shapes
in the app exist so nobody re-derives it next time.

## When is each row correct

There are three (arguably three-and-a-half) row idioms in the app, and this
PR keeps all of them — it collapses two of them into one, not all of them
into one.

- **`DetailRow`/`DetailRows`** (`apps/mobile/src/components/DetailRows.tsx`)
  — an **attribute**: a muted label + glyph on the left, the emphasised
  current value on the right, `onPress` optional. Use this whenever a screen
  is *stating a fact about a thing* — a date, a category, a payment rail, a
  currency, a loan's start date — whether that fact is read-only (the expense
  detail screen) or editable in place via a sheet (every form below). The
  answer is what a person scans a stack of these for, so the answer is the
  loud half; the label is the quiet index down the left.

- **`ListRow`** (`@waves/ui`) — an **entry you open**: a name, an optional
  subtitle, a leading glyph/avatar, a trailing chevron or status. Use this
  for a member in a roster, a device in a device list, a picker option in a
  radio list, a door into another screen or sheet. It is not a fact with a
  value; it is a *thing*, and what you do with it is open it (or, in a
  picker, choose it — see `backup.tsx`'s frequency/network rows, which pick
  from a fixed set with a checkmark rather than navigating).

- **A Toggle-driven preference row** (no dedicated component; the pattern
  `notifications.tsx`'s `PrefSection` and the devices/sync screens already
  share) — icon + a two-line title/body on the left, a `Toggle` as the
  trailing control. This is genuinely not `DetailRow` (there is no "value"
  text — the switch state *is* the value) and not `ListRow` (the body wraps
  to two lines, which `ListRow`'s single-line title/subtitle would clip, as
  its own file header already says). It is a real fourth shape, already
  unified across the screens that need it, and this PR leaves it alone.

**What this PR actually unifies:** `DetailRow` had two rivals stating the
exact same job the other way up — `SettingRow` (name left, value right, one
line) and `FieldRow` (name stacked over value), both in
`apps/mobile/src/components/expense/SheetOverlay.tsx`. A person choosing a
date on the add-expense form saw it in `SettingRow`'s shape; the same date on
the expense screen a moment later was in `DetailRow`'s. Nothing about the two
underlying *jobs* was different — both are "a fact, with a value, changed
from a sheet" — so this was drift, not a real distinction, and the fix is to
delete the rival rather than pick a side later. `SettingRow` and `FieldRow`
are now gone from the codebase entirely; every caller uses `DetailRow`.

This does **not** touch the expense detail screen's own label/value
hierarchy — `DetailRow` is unchanged in the direction that screen already
used it (muted label left, emphasised value right); the two prior idioms
folded *into* it, not the other way around.

## Survey

| Screen | Idiom today (before) | Idiom after | Converted? |
|---|---|---|---|
| Add expense (`group/[id]/add-expense.tsx`) | `SettingRow` (date, currency) via hand-rolled `Card` | `DetailRow`/`DetailRows` | **Yes** |
| Capture (`app/capture.tsx`) | `FieldRow` (group, date) | `DetailRow`/`DetailRows` | **Yes** |
| Expense detail (`group/[id]/expense/[expenseId].tsx`) | `DetailRow`/`DetailRows` | unchanged | No — already canonical, untouched |
| Private ledger form (`personal/entry.tsx`) | `SettingRow` (date, repeat) | `DetailRow`/`DetailRows` | **Yes** |
| Category row (`components/Category.tsx`) | `SettingRow` | `DetailRow` | **Yes** |
| Payment method row (`components/PaymentMethodPicker.tsx`) | `SettingRow` | `DetailRow` | **Yes** |
| Income source row (`components/IncomeSource.tsx`) | `SettingRow` (+ a 24px `SourceGlyph` disc the category row's plain glyph didn't match) | `DetailRow` | **Yes** |
| Loans (`personal/loans.tsx`) editor's start-date field | bare `Pressable` box, no label, glyph on the wrong side | `DetailRow` | **Yes** — also fixes a real a11y gap (no accessible label existed before) |
| New group (`app/new-group.tsx`) | `DetailRow`/`DetailRows` | unchanged | No — already converted before this PR (not by us) |
| Group settings (`group/[id]/settings.tsx`) | `ListRow` (members roster), `InfoDisclosure`+`Toggle` (simplify debts) | unchanged | No — both already the correct idiom for their job; also owned by parallel branches (#784, `feat/add-from-another-group`), not touched |
| Settlement (`group/[id]/settle.tsx`) | custom amount-picker cards, avatar radio row, per-expense allocation table | unchanged | No — none of it is a fact-list or a door list; it's an amount chooser, a different job entirely |
| Loans list cards | custom entity card (icon, name, running balance, progress) | unchanged | No — a specialized ledger-entity row, not a fact/door row |
| Budgets (`personal/budgets.tsx`) | custom progress card (list) + segmented tabs/amount field (editor) | unchanged | No — no fact-row candidates in either |
| Recurring (`personal/recurring.tsx`) | custom entity card w/ occurrence strip; editing goes through the already-converted `personal/entry.tsx` | unchanged | No — same reasoning as loans/budgets list cards |
| Account (`settings/account.tsx`) | form inputs/chips; `ProviderRow` (icon+name left, Badge/Button right, no chevron) | unchanged | No — `ProviderRow` is genuinely its own shape: identity + inline status/action, not a field-name/value pair and not a door |
| Notification settings (`settings/notifications.tsx`) | Toggle-preference row (`PrefSection`), explicitly not `ListRow` per its own header comment | unchanged | No — already the correct, already-shared idiom (documented above) |
| Backup (`settings/backup.tsx`) | `ListRow` (frequency/network picker rows, restore door, extra-protection door) | unchanged | No — all genuinely doors or picker rows, `ListRow` is correct |
| Profile (`profile.tsx`) | name/avatar edit form, no row list | unchanged | No — not a fact list |

## What was left alone, and why

- **Group settings, and everything under it** — correct idiom already
  (`ListRow` for the roster, `Toggle` for simplify-debts), and two other
  branches (`#784 feat/add-someone-routes`, `feat/add-from-another-group`)
  are actively working in this exact file. Not touched at all.
- **The Toggle-preference row family** (notifications, devices, sync) — a
  real fourth idiom, already unified across its own screens, already
  documented as deliberately not `ListRow`. Converting it to `DetailRow`
  would mean cramming a two-line wrapping body into a row designed for a
  single-line value, which is exactly the regression its own header comment
  already warns against.
- **`ProviderRow`** in account settings — icon+name *is* the row's identity
  here, not a "field: value" pair, and there's no navigation (no chevron);
  it doesn't fit `DetailRow` or `ListRow` cleanly, and forcing it into either
  would read worse, not more consistent.
- **Settlement, loan/budget/recurring list cards** — these are ledger-entity
  rows (an amount, a sign, a progress bar, a history strip), the same family
  as the expense list row, not a facts-or-doors row. Converting one would be
  uniformity for its own sake.

## A real bug noticed, not fixed here

`personal/loans.tsx`'s start-date field showed the raw ISO string
(`2026-09-12`) rather than running it through the `showDate()` locale
formatter every sibling date field on the app uses. This PR wraps that field
in `DetailRow` (fixing the missing label/glyph position/a11y gap) but
deliberately leaves the displayed text exactly as it was, since reformatting
it is a behaviour change and out of scope for a presentation-only pass.
Worth a follow-up.

## Tests

`apps/mobile/test/rowIdiom.test.ts` — a source-reading test in the house
style (see `personalNoteField.test.ts`, `personalEntry.test.ts`): asserts
every converted screen imports `DetailRow` from `@/components/DetailRows`
and no longer references `SettingRow`/`FieldRow`, and that `SheetOverlay.tsx`
no longer exports either.

## Gates

- `pnpm format` — clean, no changes
- `pnpm lint` — clean
- `pnpm --filter @waves/mobile typecheck` — clean
- `pnpm --filter @waves/mobile test` — 105 files / 1397 tests passing (was
  104/1393; +4 new)
- `pnpm --filter @waves/core test` — 63 files / 986 tests passing, unaffected
- `packages/db` tests **not run** — need a local Postgres that isn't running

## Reused from the earlier, rate-limited run

An earlier agent run at `worktree-agent-a30b65848cb6236c9` (same branch name,
same base commit as this PR's) had already done the add-expense/capture/
personal-entry/Category/PaymentMethodPicker/IncomeSource conversion and the
`DetailRow` extension, with well-reasoned header comments, before it was cut
off mid-typecheck. I read it (not literally copied the worktree — it had
debris files like `void`, `,-`, and a stray file literally named
`readFileSync(join(APP` sitting in its root, none of which came along),
verified each diff against current `main` by hand, applied it via `patch`,
then did the additional work myself: removed the now-dead `SettingRow`/
`FieldRow` from `SheetOverlay.tsx` (that run hadn't gotten to it), surveyed
the rest of the app's screens, converted the loans start-date field, wrote
the test, and ran all the gates.

## Not done

- Did not touch group settings, notifications, backup, settlement, budgets,
  or recurring beyond surveying them — see the table above for why each one
  is either already correct or a different job entirely.
- Did not device-test anything (no device available in this environment).
- Did not run `packages/db` tests (no local Postgres running).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jhzmZz5fkjnZZ14YxHGfS
