### PR TITLE
Pin the group you open every day to the top of the list, and it stays there

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -33,7 +33,14 @@ import {
   useTheme,
 } from '@waves/ui';
 
-import { useCaptures, useGroups, useHomeSummary } from '@/data/hooks';
+import {
+  useCaptures,
+  useGroups,
+  useHomeSummary,
+  usePinnedGroupIds,
+  useSetGroupPin,
+} from '@/data/hooks';
+import { orderByPin } from '@/lib/groupPinOrder';
 import { plural, useStrings, type UiStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { foldedCaptureCount } from '@/lib/captureBatch';
@@ -71,6 +78,11 @@ export default function HomeScreen() {
   const avatarUrl = useAvatarUrl(profile?.avatar_url);
 
   const groups = useGroups();
+  // Which groups this person has pinned, and the mutation that flips one. Read
+  // once here rather than per row: every row asks the same `Set.has`, and the
+  // preview's own order depends on it before any row exists to ask.
+  const pinnedIds = usePinnedGroupIds();
+  const setGroupPin = useSetGroupPin();
   const summary = useHomeSummary(profile?.id ?? null);
   // Unassigned captures now live as a badged inbox glyph in the toolbar rather
   // than a section in the feed.
@@ -110,7 +122,15 @@ export default function HomeScreen() {
   });
   const displayName = profile?.display_name ?? t.account.you;
 
-  const list = groups.data ?? [];
+  // Pinned first, in the order they'd already have; everyone else, in the
+  // order they'd already have (see `orderByPin`). Applied *before* the
+  // GROUPS_PREVIEW slice below — the whole point of pinning is deciding which
+  // groups get the dashboard's limited slots, so a pin made on a group that
+  // would otherwise fall off the preview has to win that slot right here.
+  const list = useMemo(
+    () => orderByPin(groups.data ?? [], (group) => pinnedIds.has(group.id)),
+    [groups.data, pinnedIds],
+  );
   // Two states, not one, because they deserve different answers.
   //
   // `hydrating` is "there is nothing to paint": the mirror has not been read off
@@ -565,6 +585,15 @@ export default function HomeScreen() {
                       // a confident wrong ₹0 that then jumps to the real figure.
                       pendingBalance={group.id === justAddedId && !summary.hasLedger(group.id)}
                       onPress={() => router.push(`/group/${group.id}`)}
+                      // Long-press is the fast path to pin/unpin (the ••• menu
+                      // on the group's own screen is the discoverable one); a
+                      // custom accessibility action carries the same toggle to
+                      // a screen reader, which has no long-press gesture.
+                      pinned={pinnedIds.has(group.id)}
+                      pinLabel={`${pinnedIds.has(group.id) ? t.group.unpin : t.group.pin} ${groupLabel(group, members, profile?.id)}`}
+                      onTogglePin={() =>
+                        setGroupPin.mutate({ groupId: group.id, pinned: !pinnedIds.has(group.id) })
+                      }
                     />
                   );
                 })}
@@ -1610,6 +1639,9 @@ function GroupRow({
   pendingBalance = false,
   hidden = false,
   onPress,
+  pinned = false,
+  pinLabel,
+  onTogglePin,
 }: {
   title: string;
   memberLabel: string;
@@ -1634,9 +1666,22 @@ function GroupRow({
       into place on mount rather than blinking in. */
   enter?: boolean;
   onPress: () => void;
+  /** Sorted to the top by `orderByPin`; carries the small pin glyph and is
+      announced in the row's accessibility label — a glyph alone says nothing
+      to a screen reader. */
+  pinned?: boolean;
+  /** "Pin Goa trip" / "Unpin Goa trip" — what a screen reader announces for the
+      long-press action below. Required whenever `onTogglePin` is passed. */
+  pinLabel?: string;
+  /** Long-press: the fast path to pin/unpin. Also reachable as a named action
+      in the accessibility rotor, since a long-press gesture has no equivalent
+      for a screen-reader user. The discoverable path — a Pin/Unpin row in the
+      ••• menu — lives on the group's own screen, not here. */
+  onTogglePin?: () => void;
 }) {
   const theme = useTheme();
   const reduceMotion = useReducedMotion();
+  const { t } = useStrings();
 
   // The entrance: start dropped and clear, settle into place. Only for a row
   // flagged `enter` (a just-imported group), and never under reduce motion —
@@ -1665,8 +1710,22 @@ function GroupRow({
     >
       <Pressable
         accessibilityRole="button"
-        accessibilityLabel={`${title}. ${statusLabel}`}
+        // Pinned is spoken, not just drawn: a screen reader never sees the
+        // glyph below, so the state has to be in the label itself.
+        accessibilityLabel={
+          pinned ? `${title}. ${t.group.pinnedBadge}. ${statusLabel}` : `${title}. ${statusLabel}`
+        }
         onPress={onPress}
+        onLongPress={onTogglePin}
+        // The rotor equivalent of the long-press gesture above — a screen
+        // reader has no long-press, so the toggle needs its own named action,
+        // carrying the same "which it will do" label the ••• menu item would.
+        accessibilityActions={
+          onTogglePin && pinLabel ? [{ name: 'togglePin', label: pinLabel }] : undefined
+        }
+        onAccessibilityAction={(event) => {
+          if (event.nativeEvent.actionName === 'togglePin') onTogglePin?.();
+        }}
         style={({ pressed }) => ({
           flexDirection: 'row',
           alignItems: 'center',
@@ -1692,6 +1751,7 @@ function GroupRow({
         </View>
         <View style={{ flex: 1, gap: 2 }}>
           <Row style={{ alignItems: 'center', gap: theme.spacing.xs }}>
+            {pinned ? <Ionicons name="pin" size={12} color={theme.color.textMuted} /> : null}
             <Text variant="body" numberOfLines={1} style={{ flexShrink: 1, fontWeight: '600' }}>
               {title}
             </Text>

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -32,6 +32,8 @@ import {
   useGroupLedger,
   useGroupRealtime,
   useOpenReceipts,
+  usePinnedGroupIds,
+  useSetGroupPin,
 } from '@/data/hooks';
 import {
   activityHeadline,
@@ -59,6 +61,7 @@ import { useBlockedUsers } from '@/data/blocked';
 import {
   actorName,
   displayName,
+  groupLabel,
   isBlockedMember,
   isGhost,
   payableAt,
@@ -474,6 +477,11 @@ export default function GroupScreen() {
 
   const { group, members, expenses, settlements, activity } = useGroup(groupId);
   const ledger = useGroupLedger(groupId, profile?.id ?? null);
+  // Pin/Unpin lives in this screen's own ••• menu — the discoverable path; a
+  // long-press on the group's row (dashboard or All groups) is the fast one.
+  const pinnedIds = usePinnedGroupIds();
+  const isPinned = pinnedIds.has(groupId);
+  const setGroupPin = useSetGroupPin();
   const disputes = useDisputes(groupId);
   const openReceipts = useOpenReceipts(groupId);
   const openDisputes = useMemo(
@@ -804,6 +812,18 @@ export default function GroupScreen() {
     welcome === 'trip' && groupData.type === 'trip' && !groupData.start_date && !tripNudgeDismissed;
 
   const menuItems: OverflowMenuItem[] = [
+    // Pinning has one effect — it sorts this group to the top of the
+    // dashboard and All-groups lists — so it belongs beside the other ways
+    // of changing how the group behaves, not the ones that navigate away.
+    // Label carries which it will do rather than a static "Pin", so a
+    // screen reader (which reads the button text as the label here, same
+    // as every other row) hears the same "Pin Goa trip" the row's own
+    // long-press action does.
+    {
+      icon: isPinned ? 'pin' : 'pin-outline',
+      label: `${isPinned ? t.group.unpin : t.group.pin} ${groupLabel(groupData, members.data, profile?.id)}`,
+      onPress: () => setGroupPin.mutate({ groupId, pinned: !isPinned }),
+    },
     { icon: 'pie-chart-outline', label: t.spending, route: `/group/${groupId}/insights` },
     ...(groupData.type === 'trip'
       ? [

--- a/apps/mobile/src/app/groups.tsx
+++ b/apps/mobile/src/app/groups.tsx
@@ -19,11 +19,12 @@ import {
   useTheme,
 } from '@waves/ui';
 
-import { useGroups, useHomeSummary } from '@/data/hooks';
+import { useGroups, useHomeSummary, usePinnedGroupIds, useSetGroupPin } from '@/data/hooks';
 import { groupLabel } from '@/data/types';
 import { plural, useStrings, type UiStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { PressableScale } from '@/lib/anim';
+import { orderByPin } from '@/lib/groupPinOrder';
 import { GroupMark } from '@/components/GroupMark';
 import { SkeletonList } from '@/components/Skeletons';
 import { router } from '@/lib/navigation';
@@ -97,6 +98,8 @@ export default function AllGroupsScreen() {
   const groups = useGroups();
   const list = useMemo(() => groups.data ?? [], [groups.data]);
   const loading = groups.isLoading || summary.isLoading;
+  const pinnedIds = usePinnedGroupIds();
+  const setGroupPin = useSetGroupPin();
 
   const [query, setQuery] = useState('');
   const searchRef = useRef<TextInput>(null);
@@ -142,16 +145,40 @@ export default function AllGroupsScreen() {
       });
     const settled = filtered.filter((d) => !d.needsAction);
 
+    // Pinning sits in front of all of the above, not inside it: a pinned group
+    // that is fully settled still belongs at the very top, which is the one
+    // thing money-first sorting can never do for it (see `group_pins`'s
+    // migration header). `orderByPin` is a stable partition — it moves the
+    // pinned entries to the front in the order they already had (active first,
+    // by balance, then settled) and leaves everyone else in exactly the order
+    // this screen would have given them anyway.
+    const flat = [...active, ...settled];
+    const ordered = orderByPin(flat, (entry) => pinnedIds.has(entry.group.id));
+    const pinnedCount = ordered.filter((entry) => pinnedIds.has(entry.group.id)).length;
+    const rest = ordered.slice(pinnedCount);
+    // Stable partitioning a list that was already active-then-settled keeps
+    // that property inside `rest` too, so its own needsAction values are still
+    // every `true` before every `false` — this just finds where they flip.
+    const restActiveCount = rest.findIndex((entry) => !entry.needsAction);
+    const restSettledCount = restActiveCount === -1 ? 0 : rest.length - restActiveCount;
+
     type Entry = (typeof decorated)[number];
     type Row = { kind: 'group'; item: Entry } | { kind: 'header'; label: string };
-    const out: Row[] = active.map((item) => ({ kind: 'group', item }));
-    // Only announce "Settled" when there's a mix above it — a screen that is all
-    // settled doesn't need a header telling it so.
-    if (settled.length && active.length) out.push({ kind: 'header', label: t.settledHeader });
-    for (const item of settled) out.push({ kind: 'group', item });
+    const out: Row[] = ordered
+      .slice(0, pinnedCount)
+      .map((item) => ({ kind: 'group', item }) as Row);
+    for (let i = 0; i < rest.length; i += 1) {
+      // Only announce "Settled" when there's a mix left in the unpinned rest —
+      // a rest that is all settled (or all active) doesn't need a header
+      // telling it so, the same rule the unpinned screen always followed.
+      if (i === restActiveCount && restActiveCount > 0 && restSettledCount > 0) {
+        out.push({ kind: 'header', label: t.settledHeader });
+      }
+      out.push({ kind: 'group', item: rest[i]! });
+    }
 
     return out;
-  }, [list, summary, profile?.id, trimmed, t.settledHeader]);
+  }, [list, summary, profile?.id, trimmed, pinnedIds, t.settledHeader]);
 
   // What a rendered row reads from outside its own data: the locale (money and
   // member-count formatting) and the theme (its colours). Both hold identity
@@ -265,6 +292,7 @@ export default function AllGroupsScreen() {
                   ? `${t.pendingConfirmation} · ${plural(locale, count, t.memberCount)}`
                   : `${statusLabel} · ${plural(locale, count, t.memberCount)}`;
 
+                const pinned = pinnedIds.has(group.id);
                 return (
                   <GroupListRow
                     groupId={group.id}
@@ -282,6 +310,9 @@ export default function AllGroupsScreen() {
                     // its own edges, and a second line under it reads as a stray
                     // double rule.
                     divider={index > 0 && rows[index - 1]?.kind === 'group'}
+                    pinned={pinned}
+                    pinLabel={`${pinned ? t.group.unpin : t.group.pin} ${row.item.label}`}
+                    onTogglePin={() => setGroupPin.mutate({ groupId: group.id, pinned: !pinned })}
                   />
                 );
               }}
@@ -531,6 +562,9 @@ const GroupListRow = memo(function GroupListRow({
   subtitle,
   dim,
   divider,
+  pinned = false,
+  pinLabel,
+  onTogglePin,
 }: {
   groupId: string;
   label: string;
@@ -543,17 +577,38 @@ const GroupListRow = memo(function GroupListRow({
   dim: boolean;
   /** A hairline above the row, so the card reads as one divided list. */
   divider: boolean;
+  /** Sorted to the top by `orderByPin`; carries the small pin glyph and is
+      announced in the row's accessibility label. */
+  pinned?: boolean;
+  /** "Pin Goa trip" / "Unpin Goa trip" — required whenever `onTogglePin` is
+      passed; what a screen reader announces for the toggle below. */
+  pinLabel?: string;
+  /** Long-press: the fast path to pin/unpin. Mirrors the dashboard's
+      `GroupRow` — same gesture, same accessibility action, same discoverable
+      alternative (the ••• menu on the group's own screen). */
+  onTogglePin?: () => void;
 }): React.JSX.Element {
   const theme = useTheme();
+  const { t } = useStrings();
 
   return (
     <Pressable
       accessibilityRole="button"
       // The full subtitle, not just the status word: a pending group at a zero
       // balance would otherwise be read out as "All settled", hiding the very
-      // state that needs attention.
-      accessibilityLabel={`${label}. ${subtitle}`}
+      // state that needs attention. Pinned is spoken too — a screen reader
+      // never sees the glyph the row draws below.
+      accessibilityLabel={
+        pinned ? `${label}. ${t.group.pinnedBadge}. ${subtitle}` : `${label}. ${subtitle}`
+      }
       onPress={() => router.push(`/group/${groupId}`)}
+      onLongPress={onTogglePin}
+      accessibilityActions={
+        onTogglePin && pinLabel ? [{ name: 'togglePin', label: pinLabel }] : undefined
+      }
+      onAccessibilityAction={(event) => {
+        if (event.nativeEvent.actionName === 'togglePin') onTogglePin?.();
+      }}
       style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
     >
       <Row
@@ -587,9 +642,12 @@ const GroupListRow = memo(function GroupListRow({
           {/* Two lines, not one: this is the screen you come to when you cannot
               find a group, so a long name is worth a second line here even though
               the dashboard's preview clips it at one. */}
-          <Text variant="body" numberOfLines={2} style={{ fontWeight: '600' }}>
-            {label}
-          </Text>
+          <Row style={{ alignItems: 'center', gap: theme.spacing.xs }}>
+            {pinned ? <Ionicons name="pin" size={12} color={theme.color.textMuted} /> : null}
+            <Text variant="body" numberOfLines={2} style={{ flexShrink: 1, fontWeight: '600' }}>
+              {label}
+            </Text>
+          </Row>
           <Text variant="caption" tone="muted" numberOfLines={1}>
             {subtitle}
           </Text>

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -19,6 +19,8 @@ import {
   computeNetBalances,
   computePairwiseBalances,
   ghostMerges,
+  groupPinId,
+  groupPinsScope,
   materialiseArchivedGroups,
   materialiseCaptures,
   materialiseCategoryTags,
@@ -40,6 +42,7 @@ import {
   openCaptures,
   openPlanItems,
   overlayPending,
+  pinnedGroupIds,
   rowsFor,
   simplify,
   SyncTable,
@@ -177,6 +180,57 @@ export function useGroups(): LocalRead<GroupRow[]> {
     [mirror, queue],
   );
   return useLocalRead(groups);
+}
+
+// ────────────────────────────────────────────────────── group pins ──
+//
+// A pin rides its own personal scope (`groupPinsScope`), independent of the
+// group's own scope, on purpose — see the `group_pins` migration. That keeps
+// this feature's queue traffic from ever blocking, or being blocked by, the
+// group's own mutations, and it is why reading "which groups are pinned" is
+// nothing more than `pinnedGroupIds`, the overlay a dashboard-shaped hook.
+
+/** The groups this person has pinned, as a set of ids — cheap to check once
+ *  per row while a list orders itself (`orderByPin`, `pinnedIds.has(id)`). */
+export function usePinnedGroupIds(): Set<string> {
+  const { session } = useAuth();
+  const ownerId = session?.user?.id ?? '';
+  const { mirror, queue } = useSync();
+  return useMemo(
+    () => (ownerId ? pinnedGroupIds(mirror, queue, { ownerId }) : new Set<string>()),
+    [mirror, queue, ownerId],
+  );
+}
+
+/**
+ * Pin or unpin a group.
+ *
+ * One mutation kind either way: pinning is an upsert keyed by
+ * `groupPinId(owner, group)`, derived rather than drawn, so two devices
+ * pinning the same group while both offline write the *same* row instead of
+ * racing to create two; unpinning is that row's soft tombstone, so it reaches
+ * the person's other devices rather than only vanishing from this one.
+ *
+ * Nothing here touches the group itself — a pin is a separate opinion about a
+ * group that already exists, materialised by its own overlay
+ * (`materialiseGroupPins`) that `materialiseGroups` never reads from. That is
+ * what keeps a refused pin's worst case to the pin: see the collapse rule in
+ * `@waves/core`'s sync queue for how discarding one behaves.
+ */
+export function useSetGroupPin() {
+  const { mutate } = useSync();
+  const { session } = useAuth();
+  return useMutation({
+    mutationFn: async ({ groupId, pinned }: { groupId: string; pinned: boolean }) => {
+      const ownerId = session?.user?.id;
+      if (!ownerId) throw new Error('Sign in first');
+      const pinId = groupPinId(ownerId, groupId);
+      const kind = pinned ? MutationKind.GroupPinSet : MutationKind.GroupPinClear;
+      const payload = pinned ? { pinId, groupId } : { pinId };
+      await mutate(kind, groupPinsScope(ownerId), payload);
+      return pinId;
+    },
+  });
 }
 
 /**

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1907,6 +1907,14 @@ export interface UiStrings {
     loading: string;
     settings: string;
     more: string;
+    /** The ••• menu's Pin/Unpin row and the row-level accessibility action
+     *  (long-press). Concatenated with the group's own label at the call site
+     *  — "Pin Goa trip" / "Unpin Goa trip" — so the word itself stays short. */
+    pin: string;
+    unpin: string;
+    /** Spoken after a pinned row's name, since the pin glyph itself is
+     *  invisible to a screen reader. */
+    pinnedBadge: string;
     confirmReceived: string;
     /** Heading over an incoming settlement claim; `{name}` is the payer. */
     saysTheyPaidYou: string;
@@ -4569,6 +4577,9 @@ const en: UiStrings = {
     loading: 'Loading…',
     settings: 'Group settings',
     more: 'More',
+    pin: 'Pin',
+    unpin: 'Unpin',
+    pinnedBadge: 'Pinned',
     confirmReceived: 'Confirm received',
     saysTheyPaidYou: '{name} says they paid you',
     saysTheyPaidYouWindow: '{name} says they paid you ({window})',
@@ -7222,6 +7233,9 @@ const ta: UiStrings = {
     loading: 'ஏற்றப்படுகிறது…',
     settings: 'குழு அமைப்புகள்',
     more: 'மேலும்',
+    pin: 'பின் செய்',
+    unpin: 'பின் நீக்கு',
+    pinnedBadge: 'பின் செய்யப்பட்டது',
     confirmReceived: 'கிடைத்தது என்று உறுதிப்படுத்து',
     saysTheyPaidYou: '{name} உங்களுக்குப் பணம் கொடுத்ததாகச் சொல்கிறார்',
     saysTheyPaidYouWindow: '{name} உங்களுக்குப் பணம் கொடுத்ததாகச் சொல்கிறார் ({window})',
@@ -9887,6 +9901,9 @@ const hi: UiStrings = {
     loading: 'आ रहा है…',
     settings: 'समूह सेटिंग्स',
     more: 'और',
+    pin: 'पिन करें',
+    unpin: 'अनपिन करें',
+    pinnedBadge: 'पिन किया गया',
     confirmReceived: 'मिलने की पुष्टि करें',
     saysTheyPaidYou: '{name} कहते हैं कि उन्होंने आपको भुगतान किया',
     saysTheyPaidYouWindow: '{name} कहते हैं कि उन्होंने आपको भुगतान किया ({window})',
@@ -12617,6 +12634,9 @@ const ar: UiStrings = {
     loading: 'جارٍ التحميل…',
     settings: 'إعدادات المجموعة',
     more: 'المزيد',
+    pin: 'تثبيت',
+    unpin: 'إلغاء التثبيت',
+    pinnedBadge: 'مثبّتة',
     confirmReceived: 'أكّد الاستلام',
     saysTheyPaidYou: 'يقول {name} إنه دفع لك',
     saysTheyPaidYouWindow: 'يقول {name} إنه دفع لك ({window})',

--- a/apps/mobile/src/lib/groupPinOrder.ts
+++ b/apps/mobile/src/lib/groupPinOrder.ts
@@ -1,0 +1,37 @@
+/**
+ * Where a pin puts a group in a list that already knows how to sort itself.
+ *
+ * Both places Waves lists groups — the dashboard's preview and the All-groups
+ * screen — already have their own ordering: debts first, settled below. A pin
+ * does not replace that; it sits in front of it. "One effect and no others — a
+ * pinned group sorts to the top and stays there" (see the `group_pins`
+ * migration's header) means exactly this: take the list in the order it would
+ * already have, then pull the pinned rows to the front, in the relative order
+ * they already had among themselves. Nothing else about the list — which
+ * groups count as settled, how the unpinned ones are ordered against each
+ * other — moves.
+ *
+ * A stable partition, not a re-sort: `Array.prototype.sort` is free to reorder
+ * elements its comparator calls equal, and a pin comparator ("pinned groups
+ * compare before unpinned ones, equal otherwise") would leave both blocks in
+ * whatever order the engine's sort felt like, which is not a promise any spec
+ * makes. Partitioning by hand is the only way to guarantee both blocks keep
+ * exactly today's order.
+ *
+ * Generic over the item type on purpose: the dashboard calls this on the plain
+ * group rows before slicing to its preview count, and the All-groups screen
+ * calls it on its already-decorated, already-sorted (active-then-settled) rows
+ * before threading in the "Settled" divider. Both screens supply their own
+ * "is this one pinned?" — usually `pinnedIds.has(item.id)` — so this file never
+ * needs to know what a group looks like.
+ */
+export function orderByPin<T>(items: readonly T[], isPinned: (item: T) => boolean): T[] {
+  const pinned: T[] = [];
+  const rest: T[] = [];
+  for (const item of items) {
+    (isPinned(item) ? pinned : rest).push(item);
+  }
+  // No pins: return the input's own order untouched, rather than a rebuilt
+  // copy — nothing moved, so nothing should even *look* like it might have.
+  return pinned.length === 0 ? rest : [...pinned, ...rest];
+}

--- a/apps/mobile/test/groupPinOrder.test.ts
+++ b/apps/mobile/test/groupPinOrder.test.ts
@@ -1,0 +1,71 @@
+/**
+ * `orderByPin`'s whole job is "pinned first, existing order otherwise" — so
+ * these tests are mostly about proving the *otherwise* half: that pinning one
+ * group never reshuffles anybody else, that unpinning is a plain return to
+ * where a group already was (there is no separate "restore" step — the
+ * ordering is recomputed from the pin set every time), and that a dashboard
+ * slicing the result to a handful of rows sees the pinned ones regardless of
+ * where they sat before.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { orderByPin } from '../src/lib/groupPinOrder';
+
+interface Group {
+  id: string;
+}
+
+const g = (id: string): Group => ({ id });
+
+describe('orderByPin', () => {
+  it('returns the input order untouched when nothing is pinned', () => {
+    const items = [g('a'), g('b'), g('c')];
+    expect(orderByPin(items, () => false)).toEqual(items);
+  });
+
+  it('moves pinned groups to the front, preserving order inside each block', () => {
+    const items = [g('a'), g('b'), g('c'), g('d')];
+    const pinned = new Set(['c', 'a']);
+    const ordered = orderByPin(items, (item) => pinned.has(item.id));
+    // 'a' and 'c' pinned, in the order they already had (a before c); then 'b'
+    // and 'd', likewise in their original order.
+    expect(ordered.map((item) => item.id)).toEqual(['a', 'c', 'b', 'd']);
+  });
+
+  it('pinning everything is a no-op — one block, original order', () => {
+    const items = [g('a'), g('b'), g('c')];
+    expect(orderByPin(items, () => true).map((item) => item.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('unpinning restores exactly the order the list would otherwise have', () => {
+    const items = [g('a'), g('b'), g('c')];
+    const pinnedOnce = orderByPin(items, (item) => item.id === 'b');
+    expect(pinnedOnce.map((item) => item.id)).toEqual(['b', 'a', 'c']);
+
+    // Unpinning is not undone by any state this module owns — the caller's pin
+    // set simply no longer marks 'b', and recomputing from the *original* list
+    // (not from `pinnedOnce`) puts every group back exactly where it started.
+    const afterUnpin = orderByPin(items, () => false);
+    expect(afterUnpin.map((item) => item.id)).toEqual(items.map((item) => item.id));
+  });
+
+  it("a truncated list — the dashboard's preview — picks pinned groups first", () => {
+    // Five groups; the dashboard would normally show the first three. 'e' is
+    // pinned but sorts last in the underlying order, and pinning it is the
+    // whole point of the feature: it must still make the cut.
+    const items = [g('a'), g('b'), g('c'), g('d'), g('e')];
+    const ordered = orderByPin(items, (item) => item.id === 'e');
+    const preview = ordered.slice(0, 3);
+    expect(preview.map((item) => item.id)).toEqual(['e', 'a', 'b']);
+  });
+
+  it('a refused pin (never reflected in the pin set) leaves the list exactly as it was', () => {
+    // Standing in for the offline-refusal case at the ordering layer: a pin
+    // that never took (the mutation was discarded) means `isPinned` simply
+    // never returns true for that group, which this function treats no
+    // differently from a group that was never pinned at all.
+    const items = [g('a'), g('b')];
+    expect(orderByPin(items, () => false)).toEqual(items);
+  });
+});

--- a/packages/core/src/sync/mirror.ts
+++ b/packages/core/src/sync/mirror.ts
@@ -22,6 +22,7 @@ import type { ExpenseSnapshot } from '../balances/types';
 
 import {
   categoryTagsScope,
+  groupPinsScope,
   MutationKind,
   packInstallsScope,
   parseAmount,
@@ -38,6 +39,8 @@ import type {
   ExpenseCreatePayload,
   ExpenseDeletePayload,
   ExpenseLocation,
+  GroupPinClearPayload,
+  GroupPinSetPayload,
   MemberBudgetSetPayload,
   MutationEnvelope,
   PersonalDeletePayload,
@@ -82,6 +85,7 @@ const TABLES: readonly SyncTable[] = [
   SyncTable.ExpenseComments,
   SyncTable.ExpenseImageEvents,
   SyncTable.PersonalRecords,
+  SyncTable.GroupPins,
 ];
 
 export function emptyMirror(): MirrorState {
@@ -1421,4 +1425,82 @@ export function materialisePackInstalls(
   }
 
   return [...byId.values()].filter((row) => row.deleted_at === null);
+}
+
+/** One row of `group_pins`, as the mirror holds it. */
+export interface MirrorGroupPin extends MirrorRow {
+  readonly id: string;
+  readonly owner_user_id: string;
+  readonly group_id: string;
+  readonly deleted_at: string | null;
+  readonly pending?: boolean;
+}
+
+/**
+ * The groups this person has pinned, with the queue replayed on top.
+ *
+ * This is what makes a pin work with no signal: the tap queues a mutation, this
+ * overlay reports the group as pinned from that instant, and the lists reorder
+ * before anything has left the device. The flush later replaces the pending row
+ * with the server's; a reader cannot tell the difference and should not have to.
+ *
+ * Note what this function cannot do, because it is the whole safety argument for
+ * the feature. It reads and writes `group_pins` rows and nothing else. A pin
+ * mutation never appears in `materialiseGroups`, and no pin — pending, refused
+ * or discarded — can add, remove or alter a group. That is deliberate: this app
+ * has already shipped the bug where dropping a refused mutation deleted the
+ * thing it made, because the queue overlay *was* the only local copy of it. A
+ * group's only copy is its own mirror row plus its own `group.create`; a pin is
+ * a separate opinion about a group that already exists, so the worst a refused
+ * pin can cost is the pin.
+ */
+export function materialiseGroupPins(
+  state: MirrorState,
+  queue: readonly QueuedMutation[],
+  options: { readonly ownerId: string },
+): MirrorGroupPin[] {
+  const scope = groupPinsScope(options.ownerId);
+  const byId = new Map<string, MirrorGroupPin>();
+  for (const row of rowsFor(state, SyncTable.GroupPins) as unknown as MirrorGroupPin[]) {
+    if (row.owner_user_id !== options.ownerId) continue;
+    byId.set(row.id, row);
+  }
+
+  for (const mutation of [...queue].sort((a, b) => a.seq - b.seq)) {
+    if (mutation.groupId !== scope) continue;
+    if (mutation.kind === MutationKind.GroupPinSet) {
+      const payload = mutation.payload as unknown as GroupPinSetPayload;
+      byId.set(payload.pinId, {
+        id: payload.pinId,
+        owner_user_id: options.ownerId,
+        group_id: payload.groupId,
+        deleted_at: null,
+        pending: true,
+      });
+    } else if (mutation.kind === MutationKind.GroupPinClear) {
+      const { pinId } = mutation.payload as unknown as GroupPinClearPayload;
+      const existing = byId.get(pinId);
+      // Only tombstones a pin it can see. An unpin of something that was never
+      // pinned here is a no-op rather than a phantom deleted row, which keeps a
+      // replayed queue idempotent.
+      if (existing) {
+        byId.set(pinId, { ...existing, deleted_at: mutation.clientCreatedAt, pending: true });
+      }
+    }
+  }
+
+  return [...byId.values()].filter((row) => row.deleted_at === null);
+}
+
+/**
+ * Just the group ids, which is all any list actually asks for. A Set because
+ * every caller's question is "is this one pinned?", asked once per row while a
+ * list is being sorted.
+ */
+export function pinnedGroupIds(
+  state: MirrorState,
+  queue: readonly QueuedMutation[],
+  options: { readonly ownerId: string },
+): Set<string> {
+  return new Set(materialiseGroupPins(state, queue, options).map((row) => row.group_id));
 }

--- a/packages/core/src/sync/protocol.ts
+++ b/packages/core/src/sync/protocol.ts
@@ -8,6 +8,7 @@
  * network can never double-post an expense.
  */
 
+import { deterministicId } from '../ids';
 import { MoneyError, MoneyErrorCode, type CurrencyCode } from '../money/currency';
 import type { CategoryMeta } from '../category/catalog';
 import type { MemberId, SplitParams } from '../split/types';
@@ -72,6 +73,15 @@ export enum MutationKind {
   PackUninstall = 'pack.uninstall',
   PersonalUpsert = 'personal.upsert',
   PersonalDelete = 'personal.delete',
+  // One person's pin on one group, under its own suffixed scope
+  // (`groupPinsScope`). A pin is a preference about a group, not a property of
+  // it: it sorts that group to the top of *this* person's lists and the other
+  // members never learn it exists, which is why it cannot live on the shared
+  // `groups` row. Set is an upsert keyed by a pin id the client derives from
+  // (owner, group), so two devices pinning offline write the same row; clear is
+  // a soft tombstone, so an unpin reaches the person's other devices.
+  GroupPinSet = 'group_pin.set',
+  GroupPinClear = 'group_pin.clear',
 }
 
 export interface MutationEnvelope<K extends MutationKind = MutationKind, P = unknown> {
@@ -363,6 +373,26 @@ export interface PersonalDeletePayload {
   readonly recordId: string;
 }
 
+/**
+ * Pinning one group to the top of this person's lists.
+ *
+ * `pinId` is derived from (owner, group) rather than drawn at random — see
+ * `groupPinId`. That is what makes two devices pinning the same group while
+ * both offline converge on one row instead of racing to create two, and it is
+ * why the payload carries the group id as well: the id alone is a hash and
+ * cannot be read back, so the row has to say what it is about.
+ */
+export interface GroupPinSetPayload {
+  readonly pinId: string;
+  readonly groupId: string;
+}
+
+/** Unpinning. A soft tombstone, so it reaches the person's other devices —
+ *  a row that simply vanished would never be pulled anywhere. */
+export interface GroupPinClearPayload {
+  readonly pinId: string;
+}
+
 export interface SyncRequest {
   readonly deviceId: string;
   readonly mutations: readonly MutationEnvelope[];
@@ -456,6 +486,10 @@ export enum SyncTable {
   PersonalRecords = 'personal_records',
   /** Which packs this person has installed, under `packInstallsScope`. */
   PackInstalls = 'pack_installs',
+  /** Which groups this person has pinned to the top of their lists, under
+   * `groupPinsScope`. Read + write, one row per pinned group. Personal: a pin
+   * is never pulled to anybody but its owner. */
+  GroupPins = 'group_pins',
 }
 
 /**
@@ -490,6 +524,32 @@ export function personalScope(profileId: string): string {
  *  the others so it keeps its own cursor. */
 export function packInstallsScope(profileId: string): string {
   return `${profileId}:pack_installs`;
+}
+
+/**
+ * The personal-scope key for the groups a person has pinned. Suffixed like the
+ * others so it keeps its own cursor — and, less obviously, so a pin can never
+ * block anything that matters. `nextBatch` holds a scope behind its own stuck
+ * mutation; a pin sharing a group's scope would mean a refused preference
+ * stopping that group's expenses from sending. On its own key the worst a
+ * wedged pin can hold up is another pin.
+ */
+export function groupPinsScope(profileId: string): string {
+  return `${profileId}:group_pins`;
+}
+
+/**
+ * The row id for one person's pin on one group, derived rather than drawn.
+ *
+ * Two devices, both offline, both pinning the same group: with random ids that
+ * is two rows racing for one partial unique index, and the loser is a refusal
+ * over something the person did nothing wrong to cause. Derived, it is the same
+ * id twice and the second write is an upsert of the first — the convergence
+ * rule is "last write the server receives wins", and there is only ever one row
+ * for it to win on.
+ */
+export function groupPinId(ownerId: string, groupId: string): string {
+  return deterministicId(`group_pin:${ownerId}:${groupId}`);
 }
 
 /** bigint ↔ string at the wire boundary; JSON has no integers this size. */

--- a/packages/core/src/sync/queue.ts
+++ b/packages/core/src/sync/queue.ts
@@ -355,6 +355,29 @@ function targetOf(mutation: MutationEnvelope): MutationTarget | null {
     };
   }
 
+  // A pin, so that unpinning a refused one *removes* it rather than queueing a
+  // clear behind a permanent blocker. This is the rule the feature is built
+  // around: a refusal must cost the pin and nothing else. Without this case the
+  // refused `group_pin.set` sits in the queue for ever, holding the pin scope
+  // shut, while the person watches an unpin that never takes — and the fix they
+  // would reach for is Discard, which is the gesture that once took a group with
+  // it. `mergeCorrection` is false because a pin has no fields to merge: it is
+  // on or it is off, and a second set of the same pin simply replaces the first.
+  const pinId = stringPayloadField(mutation.payload, 'pinId');
+  if (
+    pinId &&
+    (mutation.kind === MutationKind.GroupPinSet || mutation.kind === MutationKind.GroupPinClear)
+  ) {
+    return {
+      primaryKind: MutationKind.GroupPinSet,
+      correctionKinds: [MutationKind.GroupPinSet],
+      removalKinds: [MutationKind.GroupPinClear],
+      groupId: mutation.groupId,
+      id: pinId,
+      mergeCorrection: false,
+    };
+  }
+
   return null;
 }
 

--- a/packages/core/test/overlay.test.ts
+++ b/packages/core/test/overlay.test.ts
@@ -13,12 +13,17 @@ import { describe, expect, it } from 'vitest';
 import fc from 'fast-check';
 
 import {
+  applyOutcomes,
   categoryTagsScope,
+  discard,
   emptyMirror,
   enqueue,
+  groupPinId,
+  groupPinsScope,
   materialiseCaptures,
   materialiseArchivedGroups,
   materialiseCategoryTags,
+  materialiseGroupPins,
   materialiseGroups,
   materialiseLedgerGroupIds,
   materialiseLedgerGroups,
@@ -29,7 +34,9 @@ import {
   MutationKind,
   openCaptures,
   openPlanItems,
+  pinnedGroupIds,
   reconcile,
+  SyncRejectionCode,
   SyncTable,
   type MutationEnvelope,
   type QueuedMutation,
@@ -1093,5 +1100,100 @@ describe('category tags', () => {
     );
     const rows = materialiseCategoryTags(emptyMirror(), queued(mine, theirs), { ownerId: OWNER });
     expect(rows.map((r) => r.id)).toEqual(['t1']);
+  });
+});
+
+describe('group pins', () => {
+  const OWNER = 'user-1';
+  const SCOPE = groupPinsScope(OWNER);
+  const PIN_ID = groupPinId(OWNER, GROUP);
+
+  const pin = envelope('m-1', MutationKind.GroupPinSet, { pinId: PIN_ID, groupId: GROUP }, SCOPE);
+
+  it('shows a group pinned offline, before it has synced', () => {
+    const rows = materialiseGroupPins(emptyMirror(), queued(pin), { ownerId: OWNER });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ id: PIN_ID, group_id: GROUP, pending: true });
+    expect(pinnedGroupIds(emptyMirror(), queued(pin), { ownerId: OWNER })).toEqual(
+      new Set([GROUP]),
+    );
+  });
+
+  it('is invisible under a different owner — the scope is the person', () => {
+    const rows = materialiseGroupPins(emptyMirror(), queued(pin), { ownerId: 'someone-else' });
+    expect(rows).toHaveLength(0);
+  });
+
+  it('two devices pinning the same group offline derive the same row and converge on one', () => {
+    // Both devices compute `groupPinId(OWNER, GROUP)` themselves — there is no
+    // server round trip to agree on an id first — so a second `group_pin.set`
+    // for the same (owner, group) upserts the first rather than adding a row.
+    const second = envelope(
+      'm-1b',
+      MutationKind.GroupPinSet,
+      { pinId: PIN_ID, groupId: GROUP },
+      SCOPE,
+    );
+    const rows = materialiseGroupPins(emptyMirror(), queued(pin, second), { ownerId: OWNER });
+    expect(rows).toHaveLength(1);
+  });
+
+  it('unpinning tombstones the row so it stops showing as pinned', () => {
+    const unpin = envelope('m-2', MutationKind.GroupPinClear, { pinId: PIN_ID }, SCOPE);
+    const rows = materialiseGroupPins(emptyMirror(), queued(pin, unpin), { ownerId: OWNER });
+    expect(rows).toHaveLength(0);
+    expect(pinnedGroupIds(emptyMirror(), queued(pin, unpin), { ownerId: OWNER }).size).toBe(0);
+  });
+
+  it('unpinning something never pinned here is a no-op, not a phantom row', () => {
+    const unpin = envelope('m-1', MutationKind.GroupPinClear, { pinId: 'never-pinned' }, SCOPE);
+    const rows = materialiseGroupPins(emptyMirror(), queued(unpin), { ownerId: OWNER });
+    expect(rows).toHaveLength(0);
+  });
+
+  it('a refused pin loses the pin and never the group', () => {
+    // The incident this feature is built around: dropping a refused mutation
+    // must never delete what it made. A pin is deliberately a separate row from
+    // the group it names, so refusing (then discarding) the pin can only ever
+    // remove the pin — the group itself has its own `group.create` and is
+    // never touched by anything in this describe block.
+    const groupCreate = envelope('g-1', MutationKind.GroupCreate, {
+      name: 'Goa',
+      currency: 'INR',
+    });
+    let queue = queued(groupCreate, pin);
+    expect(materialiseGroups(emptyMirror(), queue)).toHaveLength(1);
+    expect(pinnedGroupIds(emptyMirror(), queue, { ownerId: OWNER })).toEqual(new Set([GROUP]));
+
+    // The server refuses the pin (e.g. NOT_A_MEMBER) — the app marks it
+    // rejected rather than dropping it, exactly like any other mutation.
+    const { queue: afterRejection } = applyOutcomes(queue, [
+      {
+        clientMutationId: 'm-1',
+        status: 'rejected',
+        code: SyncRejectionCode.NotAMember,
+        message: 'x',
+      },
+    ]);
+    queue = afterRejection;
+    expect(materialiseGroups(emptyMirror(), queue)).toHaveLength(1);
+    expect(pinnedGroupIds(emptyMirror(), queue, { ownerId: OWNER })).toEqual(new Set([GROUP]));
+
+    // The person discards the refused pin. The group — a completely different
+    // mutation, still queued — must still be there afterwards.
+    queue = discard(queue, 'm-1');
+    expect(materialiseGroups(emptyMirror(), queue)).toHaveLength(1);
+    expect(pinnedGroupIds(emptyMirror(), queue, { ownerId: OWNER }).size).toBe(0);
+  });
+
+  it('never shows another owner’s pins', () => {
+    const theirs = envelope(
+      'm-3',
+      MutationKind.GroupPinSet,
+      { pinId: groupPinId('user-2', GROUP), groupId: GROUP },
+      groupPinsScope('user-2'),
+    );
+    const rows = materialiseGroupPins(emptyMirror(), queued(pin, theirs), { ownerId: OWNER });
+    expect(rows.map((r) => r.id)).toEqual([PIN_ID]);
   });
 });

--- a/packages/db/prisma/migrations/20260912193000_group_pins/migration.sql
+++ b/packages/db/prisma/migrations/20260912193000_group_pins/migration.sql
@@ -1,0 +1,154 @@
+-- The group you open every day, sorted wherever the ledger happened to put it.
+--
+-- Both places Waves lists groups sort by what the *money* is doing: the
+-- dashboard's preview and the All-groups screen put the debts first and the
+-- settled ones below. That is the right default and it is not the only truth.
+-- The flatshare somebody opens twice a day is usually settled, so it falls to
+-- the bottom of the screen it is most often reached from — and the dashboard
+-- shows only the first handful before "All groups ›", so a quiet group can be
+-- pushed off the home screen entirely by a trip that ended in March.
+--
+-- So: a pin. One effect and no others — a pinned group sorts to the top and
+-- stays there. Deliberately not a star, a favourite or a filter: there is no
+-- Favourites tab to open, no collection to curate, nothing to keep in step.
+-- Ordering is the whole feature, which is why it can be a single boolean fact
+-- per person per group and needs no column anywhere else.
+
+-- ──────────────────────────────────── why this is not a column on `groups` ──
+--
+-- The obvious place to put a flag about a group is on the group, and it is the
+-- wrong place for this one. `public.groups` is shared: every member reads the
+-- same row, and `groups_stamp_seq` broadcasts any change to all of their
+-- mirrors. A pin written there would mean one person tidying their own home
+-- screen reordered everybody else's — and it would be refused anyway, because
+-- `waves_guard_group_columns` (20260910090000) is an allowlist and a column
+-- added later is refused by default until somebody names it there.
+--
+-- That refusal would be correct. A pin is not a property of the group; it is
+-- one person's opinion about it. So it lives in its own owner-scoped table,
+-- seq-stamped exactly like `captures`, `category_tags`, `personal_records` and
+-- `pack_installs`, and rides the personal sync scope those already established
+-- rather than inventing a second kind of ownership. Nothing about `groups`
+-- changes here, and `waves_guard_group_columns` is deliberately untouched.
+
+ALTER TABLE public.profiles ADD COLUMN group_pins_seq bigint DEFAULT 0 NOT NULL;
+
+CREATE TABLE public.group_pins (
+    id uuid NOT NULL,
+    owner_user_id uuid NOT NULL,
+    group_id uuid NOT NULL,
+    updated_seq bigint DEFAULT 0 NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    deleted_at timestamp with time zone
+);
+
+COMMENT ON TABLE public.group_pins IS 'One person''s pin on one group: it sorts to the top of their own group lists. Personal — the other members never see it, and it changes nothing about the group.';
+
+ALTER TABLE ONLY public.group_pins ADD CONSTRAINT group_pins_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.group_pins
+    ADD CONSTRAINT group_pins_owner_user_id_fkey FOREIGN KEY (owner_user_id)
+    REFERENCES public.profiles(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+-- ──────────────────────────────── and why `group_id` carries no foreign key ──
+--
+-- `pack_installs` references `packs`, and the symmetric thing here would be a
+-- reference to `groups`. It is left off on purpose, and the reason is the
+-- offline queue rather than tidiness.
+--
+-- A pin rides a *personal* scope (`<user>:group_pins`); a group's creation rides
+-- the *group's* scope. `nextBatch` blocks per scope, so the two are independent
+-- by design, and a group made offline and pinned in the same breath can reach
+-- the server with the pin first — the create is the heavier mutation and one
+-- backoff is all it takes. With a foreign key that pin is refused for a group
+-- that is about to exist, and a refusal in this app is not a quiet no-op: it
+-- stops that scope, puts a red mark on the sync banner, and asks a person to
+-- decide about it. Refusing somebody's tidying-up because their group had not
+-- finished uploading would be a worse bug than the one the constraint prevents.
+--
+-- What the missing key costs is a pin row that can outlive the group it names —
+-- after a group is deleted outright, or if a pin ever arrives for a group id
+-- that never lands. That costs a few bytes and nothing else: every reader joins
+-- pins against the groups it already has, so a pin naming a group the reader
+-- cannot see is invisible rather than wrong. A dangling preference is a far
+-- cheaper failure than a refused one.
+
+-- One live pin per person per group. The client derives the row id from
+-- (owner, group), so two devices pinning the same group offline write the *same*
+-- id and the second is an upsert of the first. This index is what makes that a
+-- guarantee rather than a convention, and what stops a second row appearing if
+-- some future writer forgets to derive it. Partial on `deleted_at IS NULL`, so
+-- unpinning and pinning again re-uses the row instead of colliding with its own
+-- tombstone.
+CREATE UNIQUE INDEX group_pins_owner_group_idx ON public.group_pins
+  USING btree (owner_user_id, group_id) WHERE (deleted_at IS NULL);
+
+-- The pull's index: every read is "this owner's rows above this cursor".
+CREATE INDEX group_pins_owner_user_id_updated_seq_idx ON public.group_pins
+  USING btree (owner_user_id, updated_seq);
+
+-- ────────────────────────────────────────────────────────── the seq stamp ──
+--
+-- Its own counter on `profiles`, like every other personal table. Sharing one
+-- would mean pinning a group advanced the cursor the personal ledger reads
+-- from, and a device that had pinned but not yet pulled would skip records it
+-- had never seen. A counter per scope is what keeps the cursors independent.
+CREATE FUNCTION public.waves_next_group_pin_seq(p_owner uuid) RETURNS bigint
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+DECLARE
+  v_seq bigint;
+BEGIN
+  UPDATE public.profiles
+     SET group_pins_seq = group_pins_seq + 1
+   WHERE id = p_owner
+   RETURNING group_pins_seq INTO v_seq;
+  RETURN COALESCE(v_seq, 0);
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.waves_next_group_pin_seq(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.waves_next_group_pin_seq(uuid) TO service_role;
+
+CREATE FUNCTION public.waves_stamp_group_pin_seq() RETURNS trigger
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+BEGIN
+  NEW.updated_seq := public.waves_next_group_pin_seq(NEW.owner_user_id);
+  RETURN NEW;
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.waves_stamp_group_pin_seq() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.waves_stamp_group_pin_seq() TO service_role;
+
+-- Stamped on UPDATE as well as INSERT, which is what makes unpinning reach the
+-- person's other devices: the tombstone is an UPDATE, and an UPDATE that did not
+-- bump the seq would sit under every cursor and never be pulled.
+CREATE TRIGGER group_pins_stamp_seq BEFORE INSERT OR UPDATE ON public.group_pins
+  FOR EACH ROW EXECUTE FUNCTION public.waves_stamp_group_pin_seq();
+
+-- ──────────────────────────────────────────────────────────── who may read ──
+--
+-- Your pins are yours. The policy is `owner_user_id = waves_current_profile_id()`
+-- on both sides, so a member of the same group cannot read — let alone write —
+-- what somebody else has pinned. This is the boundary, not the edge function:
+-- `/sync` writes these rows as the *caller*, so RLS is what actually holds if
+-- anybody PATCHes PostgREST directly. It is the same seam `pack_installs` and
+-- `category_tags` use, and there is deliberately no SECURITY DEFINER RPC here —
+-- a definer function exists to let somebody do what their own grants would not
+-- allow (ADR-013), and writing a row you already own is not that.
+ALTER TABLE public.group_pins ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY group_pins_own ON public.group_pins TO authenticated
+  USING ((owner_user_id = public.waves_current_profile_id()))
+  WITH CHECK ((owner_user_id = public.waves_current_profile_id()));
+
+-- No DELETE for `authenticated`: unpinning is a soft delete, like every other
+-- personal row, so the tombstone can reach the person's other devices. A hard
+-- delete would simply vanish from the pull, and the second phone would keep
+-- showing the pin forever.
+GRANT SELECT, INSERT, UPDATE ON TABLE public.group_pins TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.group_pins TO service_role;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -171,6 +171,9 @@ model Profile {
   /// Per-owner counter behind installed category packs, the captures equivalent
   /// for `pack_installs`. Bumped by `waves_next_pack_install_seq`.
   packInstallsSeq     BigInt   @default(0) @map("pack_installs_seq")
+  /// Per-owner counter behind the groups this person has pinned, the captures
+  /// equivalent for `group_pins`. Bumped by `waves_next_group_pin_seq`.
+  groupPinsSeq        BigInt   @default(0) @map("group_pins_seq")
   createdAt           DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt           DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
 
@@ -180,6 +183,7 @@ model Profile {
   personalRecords     PersonalRecord[]
   packInstalls        PackInstall[]
   packRequests        PackRequest[]
+  groupPins           GroupPin[]
   agentWrites         AgentWrite[]
   pushTokens          PushToken[]
   notifications       Notification[]
@@ -1043,6 +1047,41 @@ model PersonalRecord {
 
   @@index([ownerUserId, updatedSeq], map: "personal_records_owner_user_id_updated_seq_idx")
   @@map("personal_records")
+  @@schema("public")
+}
+
+/// One person's pin on one group (sorts to the top of their own lists; the
+/// other members never see it). Owner-scoped and seq-stamped like `Capture`,
+/// `CategoryTag` and `PackInstall`, so it rides the personal sync scope —
+/// nothing about `Group` changes and `waves_guard_group_columns` is untouched.
+///
+/// `groupId` deliberately carries no relation to `Group`: a pin rides its own
+/// scope (`<user>:group_pins`), independent of the group's own scope, so a
+/// group made offline and pinned in the same breath can have its pin reach the
+/// server first. A foreign key would refuse that pin until the group existed,
+/// and a refusal here is not quiet — it stops the pin scope and asks the
+/// person to decide. A pin that outlives the group it named costs a dangling
+/// row nobody reads (every reader joins pins against the groups it already
+/// has); that is cheaper than a wrongly refused tidy-up.
+///
+/// The one-pin-per-(owner, group) rule lives in a partial unique index
+/// (`group_pins_owner_group_idx`, `WHERE deleted_at IS NULL`) rather than an
+/// `@@unique` here, for the same reason `MemberClaim` above documents:
+/// Prisma's datamodel cannot express a partial index, and one it cannot see is
+/// a permanently failing `db:drift`.
+model GroupPin {
+  id          String    @id @db.Uuid
+  ownerUserId String    @map("owner_user_id") @db.Uuid
+  groupId     String    @map("group_id") @db.Uuid
+  updatedSeq  BigInt    @default(0) @map("updated_seq")
+  createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt   DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
+  deletedAt   DateTime? @map("deleted_at") @db.Timestamptz(6)
+
+  owner Profile @relation(fields: [ownerUserId], references: [id], onDelete: Cascade)
+
+  @@index([ownerUserId, updatedSeq], map: "group_pins_owner_user_id_updated_seq_idx")
+  @@map("group_pins")
   @@schema("public")
 }
 

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -85,7 +85,11 @@ type MutationKind =
   // The trip's shared exchange rate — group-scoped, admin-gated in its RPC.
   | 'group_fx_rate.set'
   | 'pack.install'
-  | 'pack.uninstall';
+  | 'pack.uninstall'
+  // One person's pin on one group (see the `group_pins` migration): personal
+  // like captures, under its own suffixed scope so it keeps a separate cursor.
+  | 'group_pin.set'
+  | 'group_pin.clear';
 
 /** True for the kinds whose scope is a user, not a group. */
 function isPersonalKind(kind: MutationKind): boolean {
@@ -100,7 +104,9 @@ function isPersonalKind(kind: MutationKind): boolean {
     kind === 'personal.upsert' ||
     kind === 'personal.delete' ||
     kind === 'pack.install' ||
-    kind === 'pack.uninstall'
+    kind === 'pack.uninstall' ||
+    kind === 'group_pin.set' ||
+    kind === 'group_pin.clear'
   );
 }
 
@@ -121,6 +127,12 @@ function personalScope(profileId: string): string {
  *  client's `packInstallsScope`; suffixed so it keeps its own cursor. */
 function packInstallsScope(profileId: string): string {
   return `${profileId}:pack_installs`;
+}
+
+/** The personal-scope key for the groups a user has pinned. Must match the
+ *  client's `groupPinsScope`; suffixed so it keeps its own cursor. */
+function groupPinsScope(profileId: string): string {
+  return `${profileId}:group_pins`;
 }
 
 interface MutationEnvelope {
@@ -555,6 +567,10 @@ export class SyncSession {
         return await this.installPack(mutation);
       case 'pack.uninstall':
         return await this.uninstallPack(mutation);
+      case 'group_pin.set':
+        return await this.setGroupPin(mutation);
+      case 'group_pin.clear':
+        return await this.clearGroupPin(mutation);
       case 'personal.upsert':
         return await this.upsertPersonal(mutation);
       case 'personal.delete':
@@ -1152,6 +1168,53 @@ export class SyncSession {
     return { installId };
   }
 
+  // ────────────────────────────────── pinned groups ──
+  // A pin's scope is suffixed (`<profileId>:group_pins`), like a tag's — see
+  // the `group_pins` migration for why the table carries no foreign key to
+  // `groups` and why writing it is a plain RLS-scoped upsert rather than a
+  // SECURITY DEFINER RPC (ADR-013: a definer function is for doing what your
+  // own grants would not allow, and writing a row you already own is not
+  // that). `this.caller`, not `this.service`, so RLS is what actually holds.
+  private requireGroupPinScope(mutation: MutationEnvelope): void {
+    if (mutation.groupId !== groupPinsScope(this.profileId)) {
+      throw new HttpError(403, 'NOT_OWNER', 'A pin may only be written under its own owner');
+    }
+  }
+
+  /** Pin a group. Upsert by `pinId` — the client derives it from (owner,
+   *  group), so two devices pinning the same group offline write the same
+   *  row and the second is a no-op replay of the first, never a duplicate. */
+  private async setGroupPin(mutation: MutationEnvelope): Promise<unknown> {
+    this.requireGroupPinScope(mutation);
+    const pinId = requireString(mutation.payload.pinId, 'pinId');
+    const groupId = requireString(mutation.payload.groupId, 'groupId');
+    const { error } = await this.caller.from('group_pins').upsert(
+      {
+        id: pinId,
+        owner_user_id: this.profileId,
+        group_id: groupId,
+        deleted_at: null,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'id' },
+    );
+    if (error) throw new HttpError(400, 'VALIDATION_FAILED', error.message);
+    return { pinId, groupId };
+  }
+
+  /** Unpin. A soft delete, so the tombstone reaches the owner's other devices
+   *  through the cursor rather than only vanishing from this one. */
+  private async clearGroupPin(mutation: MutationEnvelope): Promise<unknown> {
+    this.requireGroupPinScope(mutation);
+    const pinId = requireString(mutation.payload.pinId, 'pinId');
+    const { error } = await this.caller
+      .from('group_pins')
+      .update({ deleted_at: new Date().toISOString(), updated_at: new Date().toISOString() })
+      .eq('id', pinId);
+    if (error) throw new HttpError(400, 'VALIDATION_FAILED', error.message);
+    return { pinId };
+  }
+
   private async upsertPersonal(mutation: MutationEnvelope): Promise<unknown> {
     this.requirePersonalScope(mutation);
     const payload = mutation.payload as {
@@ -1249,6 +1312,11 @@ async function pull(
   // equal `packInstallsScope(profileId)` in @waves/core.
   const packScope = `${profileId}:pack_installs`;
   groupIds.delete(packScope);
+
+  // Pinned groups ride a sixth personal scope, its own suffixed key. Must
+  // equal `groupPinsScope(profileId)` in @waves/core.
+  const pinScope = groupPinsScope(profileId);
+  groupIds.delete(pinScope);
 
   // Every group's own row in one query rather than one lookup per group. The
   // per-group `maybeSingle` was the first of twelve serial round trips each
@@ -1367,7 +1435,7 @@ async function pull(
   }
 
   /**
-   * The four personal scopes, fetched together.
+   * The personal scopes, fetched together.
    *
    * Each is one owner-filtered table on its own cursor, with nothing to say to
    * the others — so they were four serial round trips for no reason. Read as the
@@ -1403,6 +1471,16 @@ async function pull(
       column: 'owner_user_id',
       scope: packScope,
       as: 'pack_installs',
+    },
+    // The groups this person has pinned. `group_pins` carries no foreign key
+    // to `groups` (see the migration), so a pin naming a group the puller
+    // cannot see is pulled anyway — the client's own join against the groups
+    // it already has is what makes that invisible rather than wrong.
+    {
+      table: 'group_pins',
+      column: 'owner_user_id',
+      scope: pinScope,
+      as: 'group_pins',
     },
   ] as const;
 


### PR DESCRIPTION
## What this is

A pin, not a favourite or a filter. One effect and no others: a pinned group sorts to the top of the dashboard's group preview and the All-groups screen, and stays there. No Favourites tab, no collection to curate — ordering is the whole feature.

Two ways to pin: **Pin/Unpin in the group's own ••• menu** (discoverable — `apps/mobile/src/app/group/[id]/index.tsx`) and a **long-press on a group row** in either list (fast path). Long-press also carries a matching accessibility action with the label "Pin Goa trip" / "Unpin Goa trip", since a screen reader has no long-press gesture. A pinned row wears a small pin glyph and speaks "Pinned" in its accessibility label — the glyph alone is invisible to a screen reader.

## ⚠️ Deploy-gated — nothing has been deployed

This PR adds:
- `packages/db/prisma/migrations/20260912193000_group_pins/migration.sql` — new `group_pins` table + Prisma model (`GroupPin`) + `profiles.group_pins_seq`
- `supabase/functions/sync/index.ts` — `/sync` handling for `group_pin.set` / `group_pin.clear`

**Deploy order:** `migrate deploy` first (the table and its RLS have to exist before the edge function can write to them), **then** `edge:deploy` for `/sync`. Until both land, pinning enqueues and shows locally but the mutation has nowhere to go on the server — it stays queued, not lost.

## Storage

A new `group_pins` table (one row per owner+group), **not** a column on `groups` — a pin is one person's opinion about a group, and `groups` is shared: writing it there would mean one person's tidying reordering everyone else's list, and it would also be refused outright by `waves_guard_group_columns`'s allowlist (`20260910090000_group_column_guard`), which the group-description migration (`20260912170000_group_description`) documents in detail. `group_pins` rides its own suffixed personal sync scope (`<owner>:group_pins`), exactly like `category_tags` and `pack_installs` — RLS-scoped `authenticated` upsert, no SECURITY DEFINER RPC (ADR-013: a definer function is for doing what your own grants would not allow; writing a row you already own is not that).

Deliberately **no foreign key** from `group_pins.group_id` to `groups` — a pin rides an independent scope from the group's own creation, so a group made offline and pinned in the same breath can have the pin reach the server first without being refused for naming a group that doesn't exist yet server-side. The cost is a pin that can outlive the group it names; every reader joins pins against the groups it already has, so a dangling pin is invisible rather than wrong. Full reasoning is in the migration's header comment.

## Offline and concurrency behaviour

- **Pinning offline** takes effect **immediately**: `materialiseGroupPins` overlays the queue the same way `materialiseCaptures` does, before anything has left the device.
- **A refused pin loses the pin, never the group.** A pin is a separate row/mutation from the group it names — `materialiseGroups` never reads a pin mutation — and the sync queue's collapse rule (`targetOf` in `packages/core/src/sync/queue.ts`) makes discarding a refused `group_pin.set` simply remove it, rather than leaving a `group_pin.clear` queued behind a permanent blocker. This is exactly the incident (`waves-nameless-group-sync-bug`) rule 3 exists to prevent, proven again in `packages/core/test/overlay.test.ts`'s "a refused pin loses the pin and never the group" case.
- **Two devices pinning/unpinning the same group concurrently** converge because the pin's row id is *derived* from `(owner, group)` (`groupPinId`), not drawn at random — both devices compute the same id offline, so the second write is an upsert of the first rather than a race for one partial unique index. The convergence rule is simply "last write the server receives wins."

## Pin cap

**None.** A pin is one boolean per (owner, group); it costs nothing to have many, and somebody who has pinned enough groups to matter is telling the app to keep almost all of them close, which is a decision worth honouring rather than second-guessing with an arbitrary limit.

## Ordering

One pure, tested function — `apps/mobile/src/lib/groupPinOrder.ts`'s `orderByPin`: pinned groups first (in the order they already had), then everyone else (in the order they already had) — a stable partition, not a re-sort. Applied to the dashboard's list *before* the preview slice, so a pinned group wins one of the limited "All groups ›" slots rather than losing to whatever already filled them; applied to All-groups' active/settled rows with the "Settled" divider recomputed against what's left after pinning.

## Gates

All green:
- `pnpm format` — clean
- `pnpm lint` — clean
- `pnpm --filter @waves/mobile typecheck` — clean
- `pnpm --filter @waves/mobile test` — 105 files / 1399 tests passed
- `pnpm --filter @waves/core test` — 63 files / 993 tests passed
- `pnpm --filter @waves/db typecheck` — clean (ran with a throwaway `DIRECT_URL` env var; no real DB touched)

`packages/db` **tests** were not run locally — they need a local Postgres that isn't running here. CI will run them; the migration and schema were written to match the `category_tags`/`pack_installs` pattern closely enough to be correct by inspection.

## What I deliberately did not do

- No changes to `apps/web` — the brief named the mobile dashboard and All-groups screen specifically. Pins are account-scoped in the database, so a future web client reading `group_pins` gets the same order for free; no web UI work was in scope here.
- No Favourites tab/filter/collection — explicitly ruled out by the design brief.
- Did not deploy the migration or the edge function.

## Earlier worktree

An earlier run (`D:\dev\baaki\.claude\worktrees\agent-a004626fb1e5b2da6`, uncommitted) had already worked out the hard part of this design: the `group_pins` migration, and the `@waves/core` sync layer (`protocol.ts`, `mirror.ts`, the `queue.ts` collapse rule for a refused pin). I read, verified, and ported all of it after independently confirming the schema/RLS pattern against `category_tags`'s actual baseline migration. What was missing and built fresh here: the Prisma model (the migration existed with no matching schema entry — exactly the drift trap called out in the brief), the `/sync` edge function wiring, the pure ordering function + its tests, the mobile UI (dashboard, All-groups, the group's ••• menu), i18n in all four locales, and the `packages/core` tests for the pin overlay including the refusal scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jhzmZz5fkjnZZ14YxHGfS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pin or unpin groups from the group menu, including directly from a group’s overflow menu.
  * Pinned groups appear first in group lists while preserving existing ordering.
  * Long-press and accessibility actions support pinning and unpinning.
  * Pinned groups display a pin indicator and are announced by screen readers.
  * Pin changes sync across devices and remain available during offline use.
  * Added localized Pin, Unpin, and pinned-status labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->