### PR TITLE
An unfolded row scrolls itself back above the keyboard

### DIFF
--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -137,6 +137,30 @@ export default function NewGroupScreen() {
   // being changed. Nothing here is required; the point is that the screen reads
   // as already filled in rather than as a form still to be completed.
   const [openAttr, setOpenAttr] = useState<'kind' | 'dates' | 'budget' | null>(null);
+
+  /**
+   * Bring an unfolded row back into view.
+   *
+   * These rows open *in place*, near the foot of a scroll that already has a
+   * pinned button under it — and the budget one raises a numeric keypad in the
+   * same gesture that reveals the field. Android resizes the window for the
+   * keyboard (`adjustResize`), which shrinks this scroll rather than moving it,
+   * so the field that just appeared is left underneath the keypad with nothing
+   * scrolling it back. Nobody can type into what they cannot see.
+   *
+   * Scrolling to the end rather than measuring the row: the only thing below
+   * any of these is the simplify toggle, so the end *is* the unfolded row plus
+   * one row of context, and it needs no layout maths that would go stale the
+   * moment a row above it grows. The delay lets the unfolded content lay out
+   * and the keyboard finish its own resize first — scrolling to an end that has
+   * not happened yet scrolls nowhere.
+   */
+  const scrollRef = useRef<ScrollView>(null);
+  useEffect(() => {
+    if (openAttr === null) return;
+    const id = setTimeout(() => scrollRef.current?.scrollToEnd({ animated: true }), 160);
+    return () => clearTimeout(id);
+  }, [openAttr]);
   const [ghostName, setGhostName] = useState('');
   // People to add on Create — a typed name carries no address, a contact carries
   // whatever the phone had. Same shape either way, so the create loop treats
@@ -443,6 +467,7 @@ export default function NewGroupScreen() {
         <View style={{ width: 44 }} />
       </Row>
       <ScrollView
+        ref={scrollRef}
         style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,


### PR DESCRIPTION
Tapping **Budget** on the new-group screen unfolds the amount field in place and raises the numeric keypad in the same gesture. Android resizes the window for a keyboard rather than moving the view, so the scroll got shorter and the field that had just appeared sat underneath the keypad — you could type, but not see what you were typing.

Reported from a device recording; reproduced by reading the screen rather than by running it (no device here).

Any of the three unfolding rows — Kind, Trip dates, Budget — now scrolls the end into view after the content lays out and the keyboard finishes its resize.

Scrolling to the end rather than measuring the row is deliberate: the only thing below any of them is the simplify toggle, so the end *is* the unfolded row plus a line of context, and there is no layout arithmetic to go stale when a row above it grows.

## Checks

`pnpm --filter @waves/mobile typecheck` clean. Not run on a device — the fix is a scroll call whose effect only shows on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jhzmZz5fkjnZZ14YxHGfS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the new group screen on Android by automatically scrolling opened fields into view when the keyboard appears.
  * Applied to kind, dates, and budget fields to prevent them from being obscured by the keyboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->