### PR TITLE
Capture files a bill the way the group form reads one back

### DIFF
--- a/apps/mobile/src/app/capture.tsx
+++ b/apps/mobile/src/app/capture.tsx
@@ -34,9 +34,9 @@ import {
 } from '@waves/ui';
 
 import { GroupMark } from '@/components/GroupMark';
-import { CategoryPicker } from '@/components/Category';
+import { CategoryRow, CategorySheet } from '@/components/Category';
 import { TagEditorSheet } from '@/components/TagEditorSheet';
-import { PaymentMethodPicker } from '@/components/PaymentMethodPicker';
+import { PaymentMethodRow, PaymentMethodSheet } from '@/components/PaymentMethodPicker';
 import { LocationField } from '@/components/LocationField';
 import { ZoomableImage } from '@/components/ZoomableImage';
 import { COMMON_CURRENCIES } from '@/components/CurrencyRate';
@@ -240,8 +240,14 @@ export default function CaptureScreen() {
   // On an edit the category is already the draft's own — treat it as chosen so
   // the description guesser below does not move it out from under the person.
   const [categoryChosen, setCategoryChosen] = useState(() => isEditing);
-  // The create-tag sheet, opened from the "＋ New tag" chip in the picker.
+  // The create-tag sheet, opened from the "＋ New tag" row in the category
+  // sheet.
   const [editingTag, setEditingTag] = useState(false);
+  // The category and payment-rail pickers, opened from their row in the facts
+  // card below rather than drawn as a lane of chips — see that card's own
+  // comment for why.
+  const [pickingCategory, setPickingCategory] = useState(false);
+  const [pickingPayment, setPickingPayment] = useState(false);
   const [date, setDate] = useState<string>(() => dateParam ?? todayIso());
   // A stored bill's path and the OCR text and parsed blob that rode with the
   // draft — kept as-is through an edit so saving never wipes the receipt, the
@@ -299,10 +305,11 @@ export default function CaptureScreen() {
     : t.captures.decideLater;
 
   // Category starts on Food & drink — the most common capture, one fewer tap for
-  // it. The guess then follows the description until a chip is tapped, at which
-  // point it stops moving under the user's finger (the same rule add-expense
-  // uses). Seeding guessedFrom to the initial empty description means the guess
-  // does not fire on mount, so that default survives until the person types.
+  // it. The guess then follows the description until the row is tapped and a
+  // choice made in its sheet, at which point it stops moving under the user's
+  // finger (the same rule add-expense uses). Seeding guessedFrom to the initial
+  // empty description means the guess does not fire on mount, so that default
+  // survives until the person types.
   // Seeded to the carried-in note (or empty) so the category guesser does not
   // fire on mount and overwrite the Food default before the person types.
   const [guessedFrom, setGuessedFrom] = useState<string | null>(() => descParam ?? '');
@@ -310,7 +317,7 @@ export default function CaptureScreen() {
     setGuessedFrom(description);
     // Keep the current category when the description matches no bucket:
     // guessCategory returns null for unrecognised text, and clearing on null
-    // would wipe the Food default (or a prior guess) leaving no chip selected.
+    // would wipe the Food default (or a prior guess) leaving the row blank.
     const guess = guessCategory(description);
     if (guess) {
       setCategory(guess);
@@ -518,106 +525,21 @@ export default function CaptureScreen() {
           onPressCurrency={() => setPickingCurrency(true)}
         />
 
-        {/* Description, as a single underlined field rather than a boxed card —
-            it sits right under the amount so the two things a person always fills
-            in are together, with the mic to speak it instead of type (A5). Group
-            names are handed to the recogniser as hints — a general model mangles
-            Indian names, and a note like "dinner with Ravi" is exactly where they
-            turn up. */}
-        <DescriptionField
-          value={description}
-          onChange={setDescription}
-          placeholder={t.captures.descriptionPlaceholder}
-          accessibilityLabel={t.captures.description}
-          hints={groupNameHints}
-        />
+        {/* The bill, right under the amount — the order add-expense reads a bill
+            in, and for the same reason: scanning one fills in the amount above
+            and the note below, so it belongs before the fields it populates, not
+            after them. It used to sit at the foot of this form, last of
+            everything, which meant the one shortcut that saves the most typing
+            was the one thing a person had to scroll past six other fields to
+            find.
 
-        {/* What it was for. The guess follows the description until a chip is
-            tapped; the chips are the picker, unchanged. */}
-        <View style={{ gap: theme.spacing.sm }}>
-          <Text variant="caption" tone="muted">
-            {t.captures.category}
-          </Text>
-          <CategoryPicker
-            value={category}
-            onChange={(picked, meta) => {
-              setCategory(picked);
-              setCategoryMeta(meta);
-              setCategoryChosen(true);
-            }}
-            onCreate={() => setEditingTag(true)}
-          />
-        </View>
-
-        {/* How it was paid. Single-select tags, icon + word; cash is chosen by
-            default, tapping the chosen one again clears it ("not said" stays a
-            valid answer). UPI only appears where the region settles over it. One
-            row that scrolls sideways rather than wrapping to a second line, so the
-            block keeps a fixed height however many rails the region offers. */}
-        <View style={{ gap: theme.spacing.sm }}>
-          <Text variant="caption" tone="muted">
-            {t.captures.paidWith}
-          </Text>
-          {/* Shared with add-expense; capture lets "not said" stand, so a tap on
-              the chosen chip clears it (allowDeselect). */}
-          <PaymentMethodPicker value={paymentMethod} onChange={setPaymentMethod} allowDeselect />
-        </View>
-
-        {/* Where it happened (A43) — optional, opt-in, never a background track. */}
-        <LocationField value={location} onChange={setLocation} />
-
-        {/* Destination and date, folded into one card of divided rows rather than
-            two stacked cards — the meta a capture carries, grouped so it reads as
-            one block. "Decide later" is the default group: the split, and who is
-            in it, is chosen when the capture is assigned.
-
-            The same `DetailRows` the expense form and the expense screen wear.
-            These two used to stack the field's name over its answer, which made
-            a two-row card three text sizes tall and, more to the point, made a
-            capture's date look nothing like the same date on the form it is
-            assigned into. One line each, name left and answer right.
-
-            The picker is wrapped with its row rather than left as a sibling:
-            `DetailRows` puts a hairline in every gap between its children, so an
-            unfolded date wheel counted as a row of its own would be ruled off
-            from the row that opened it. */}
-        <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
-          <DetailRows>
-            <DetailRow
-              icon={targetGroup ? 'people' : 'people-outline'}
-              iconColor={targetGroup ? theme.color.brand : theme.color.textMuted}
-              label={t.captures.group}
-              value={targetGroupName}
-              placeholder={!targetGroup}
-              onPress={() => setPickingGroup(true)}
-              accessibilityLabel={`${t.captures.group}: ${targetGroupName}`}
-            />
-            <View>
-              <DetailRow
-                icon="calendar-outline"
-                label={t.captures.date}
-                value={showDate(date, locale)}
-                onPress={() => setEditingDate(true)}
-                accessibilityLabel={`${t.captures.date}: ${showDate(date, locale)}`}
-              />
-              {editingDate ? (
-                <DateTimePicker
-                  value={dateFrom(date)}
-                  mode="date"
-                  onChange={applyDate}
-                  // A capture is caught now or in the recent past — a spend cannot
-                  // have happened tomorrow.
-                  maximumDate={new Date()}
-                />
-              ) : null}
-            </View>
-          </DetailRows>
-        </Card>
-
-        {/* The bill, for the times pointing a camera is easier than typing. The
-            photo is kept and its text read on the phone; the amount stays the
-            user's to enter, because reading it needs a group this row does not
-            have yet. */}
+            Simpler than add-expense's pair of buttons on purpose: this capture
+            has no group yet, so there is no metered `scanReceipt` edge function
+            to call and no per-group receipt cap to draw around it — only the
+            on-device camera and OCR (A5), which is `addReceipt` below. Nor is
+            there a gallery to attach an existing photo from; a capture is
+            usually filed at the till, camera in hand, not from an old
+            screenshot. */}
         <Card style={{ gap: theme.spacing.md }}>
           <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
             <Text variant="subheading">{t.captures.receipt}</Text>
@@ -707,6 +629,84 @@ export default function CaptureScreen() {
             <Callout tone="info">{t.captures.couldNotRead}</Callout>
           ) : null}
         </Card>
+
+        {/* Description, as a single underlined field rather than a boxed card —
+            with the mic to speak it instead of type (A5). Group names are handed
+            to the recogniser as hints — a general model mangles Indian names,
+            and a note like "dinner with Ravi" is exactly where they turn up. */}
+        <DescriptionField
+          value={description}
+          onChange={setDescription}
+          placeholder={t.captures.descriptionPlaceholder}
+          accessibilityLabel={t.captures.description}
+          hints={groupNameHints}
+        />
+
+        {/* Where it happened (A43) — optional, opt-in, never a background track. */}
+        <LocationField value={location} onChange={setLocation} />
+
+        {/* What for, paid with, destination and date, folded into one card of
+            divided rows rather than four scattered controls — the facts a
+            capture carries, grouped so it reads as one block, the same
+            `DetailRows` the group expense form and the expense screen wear.
+
+            What for and paid with used to be lanes of chips under the
+            description — a picker each, so choosing them read as a different
+            kind of question from the group and the date sitting in their own
+            card below. Now all four are the same kind of row: a short,
+            already-chosen answer, changed from a sheet. `CategoryRow` and
+            `PaymentMethodRow` are the exact rows add-expense's own facts card
+            uses for the same two fields, so a capture assigned into a group
+            keeps reading as the same two facts rather than restating them in a
+            different shape.
+
+            "Decide later" is the default group: the split, and who is in it, is
+            chosen when the capture is assigned — so this card asks four things
+            about a capture and nothing about splitting, which does not exist
+            here yet.
+
+            The date picker is wrapped with its row rather than left as a
+            sibling: `DetailRows` puts a hairline in every gap between its
+            children, so an unfolded date wheel counted as a row of its own
+            would be ruled off from the row that opened it. */}
+        <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+          <DetailRows>
+            <CategoryRow
+              value={category}
+              meta={categoryMeta}
+              onPress={() => setPickingCategory(true)}
+            />
+            <PaymentMethodRow value={paymentMethod} onPress={() => setPickingPayment(true)} />
+            <DetailRow
+              icon={targetGroup ? 'people' : 'people-outline'}
+              iconColor={targetGroup ? theme.color.brand : theme.color.textMuted}
+              label={t.captures.group}
+              value={targetGroupName}
+              placeholder={!targetGroup}
+              onPress={() => setPickingGroup(true)}
+              accessibilityLabel={`${t.captures.group}: ${targetGroupName}`}
+            />
+            <View>
+              <DetailRow
+                icon="calendar-outline"
+                label={t.captures.date}
+                value={showDate(date, locale)}
+                onPress={() => setEditingDate(true)}
+                accessibilityLabel={`${t.captures.date}: ${showDate(date, locale)}`}
+              />
+              {editingDate ? (
+                <DateTimePicker
+                  value={dateFrom(date)}
+                  mode="date"
+                  onChange={applyDate}
+                  // A capture is caught now or in the recent past — a spend cannot
+                  // have happened tomorrow.
+                  maximumDate={new Date()}
+                />
+              ) : null}
+            </View>
+          </DetailRows>
+        </Card>
       </ScrollView>
 
       <View
@@ -735,6 +735,42 @@ export default function CaptureScreen() {
           onPress={() => void submit()}
         />
       </View>
+
+      {/* What it was for, from the facts card's row. Picking one closes the
+          sheet; "＋ New tag" swaps this sheet for the tag editor rather than
+          stacking one over the other — the same handoff add-expense uses. */}
+      {pickingCategory ? (
+        <CategorySheet
+          value={category}
+          onChange={(picked, meta) => {
+            setCategory(picked);
+            setCategoryMeta(meta);
+            // A tap of their own, so the description guess stops moving it.
+            setCategoryChosen(true);
+            setPickingCategory(false);
+          }}
+          onCreate={() => {
+            setPickingCategory(false);
+            setEditingTag(true);
+          }}
+          onClose={() => setPickingCategory(false)}
+        />
+      ) : null}
+
+      {/* How it was paid, from the facts card's row. `allowDeselect` keeps "not
+          said" reachable: tapping the rail already chosen clears it, exactly as
+          the chip lane this replaced let a second tap on the lit chip do. */}
+      {pickingPayment ? (
+        <PaymentMethodSheet
+          value={paymentMethod}
+          allowDeselect
+          onChange={(picked) => {
+            setPaymentMethod(picked);
+            setPickingPayment(false);
+          }}
+          onClose={() => setPickingPayment(false)}
+        />
+      ) : null}
 
       {/* Currency picker, as a sheet over the form. The shortlist is the same one
           the group expense form offers (COMMON_CURRENCIES), so a person meets the
@@ -824,7 +860,7 @@ export default function CaptureScreen() {
         </View>
       </Modal>
 
-      {/* Make a tag on the spot, from the picker's "＋ New tag" chip. */}
+      {/* Make a tag on the spot, from the category sheet's "＋ New tag" row. */}
       <TagEditorSheet open={editingTag} onClose={() => setEditingTag(false)} />
     </Screen>
   );

--- a/apps/mobile/src/components/PaymentMethodPicker.tsx
+++ b/apps/mobile/src/components/PaymentMethodPicker.tsx
@@ -1,28 +1,31 @@
 /**
- * How a spend was paid — a horizontal row of chips (cash, UPI, card, …).
+ * How a spend was paid — the rail's own glyph and label, wherever the field is
+ * asked or answered.
  *
  * The id is what persists to the free-text `payment_method` column, so any of
  * these is safe to store; the icon and label are UI. Debit wears the filled
- * card so it reads apart from credit's outline at chip size. `upi` is offered
- * only where the rail exists (see `deviceSupportsUpi`); everywhere else the row
- * is the region rails a person would recognise. One row that scrolls sideways
- * rather than wrapping, so the block keeps a fixed height however many rails a
- * region offers.
+ * card so it reads apart from credit's outline. `upi` is offered only where the
+ * rail exists (see `deviceSupportsUpi`); everywhere else the row is the region
+ * rails a person would recognise.
  *
- * Shared so the capture screen, add-expense, and add-person all speak the same
- * language for the same field.
- *
- * `PaymentMethodRow` + `PaymentMethodSheet` are the same rails as a list: a
- * settings row naming the field and showing the rail in force, and the options
- * behind it. Same ids, same labels, same order — only the presentation differs,
- * for forms that read as a list of settings rather than a stack of chip lanes.
+ * `PaymentMethodRow` + `PaymentMethodSheet` are the field as a settings row and
+ * the sheet of options behind it — a settings row naming the field and showing
+ * the rail in force, one per line with a check against the one chosen. Shared
+ * so the capture screen and add-expense both fold "paid with" into the same
+ * card of facts the expense screen states a filed bill's answers in, rather
+ * than each screen drawing its own idea of the same question. Add-expense
+ * always has a rail chosen (cash by default) and only ever swaps it; capture
+ * lets "not said" stand as a real answer — a person who has not decided yet
+ * should not have to guess — so both the row and the sheet carry the same
+ * `allowDeselect` shape `DetailRow`'s own picker siblings use: tapping the rail
+ * already chosen clears it back to unsaid instead of doing nothing.
  */
 
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { Pressable, ScrollView, View } from 'react-native';
+import { View } from 'react-native';
 
 import { type PaymentMethod } from '@waves/core';
-import { iconSize, Text, useTheme } from '@waves/ui';
+import { iconSize, useTheme } from '@waves/ui';
 
 import { DetailRow } from '@/components/DetailRows';
 import { ChoiceRow, SheetOverlay } from '@/components/expense/SheetOverlay';
@@ -38,25 +41,9 @@ const PAYMENT_METHOD_ICONS: Readonly<Record<PaymentMethod, keyof typeof Ionicons
 };
 
 /**
- * Two shapes, one picker. The group add-expense screen always has a method
- * chosen (cash by default) and only ever swaps it, so its `onChange` never sees
- * null. The capture screen lets "not said" be a valid answer — tapping the
- * chosen chip again clears it — so under `allowDeselect` the same tap can hand
- * back null. The discriminated union keeps each caller's `onChange` honest about
- * which it will receive.
- */
-type PaymentMethodPickerProps =
-  | { value: PaymentMethod | null; onChange: (value: PaymentMethod) => void; allowDeselect?: false }
-  | {
-      value: PaymentMethod | null;
-      onChange: (value: PaymentMethod | null) => void;
-      allowDeselect: true;
-    };
-
-/**
  * The rail's name, in the phone's language. A hook rather than a free function
  * because the strings come from context, and every presentation of this field —
- * chips, row, sheet — must name a rail the same way.
+ * row, sheet — must name a rail the same way.
  */
 function usePaymentMethodLabel(): (id: PaymentMethod) => string {
   const { t } = useStrings();
@@ -76,112 +63,72 @@ function usePaymentMethodLabel(): (id: PaymentMethod) => string {
   };
 }
 
-export function PaymentMethodPicker(props: PaymentMethodPickerProps) {
-  const { value } = props;
-  const theme = useTheme();
-  const label = usePaymentMethodLabel();
-  const methods = offeredPaymentMethods({ upiSupported: deviceSupportsUpi(), current: value });
-
-  return (
-    <ScrollView
-      horizontal
-      showsHorizontalScrollIndicator={false}
-      keyboardShouldPersistTaps="handled"
-      contentContainerStyle={{ gap: theme.spacing.sm, paddingRight: theme.spacing.xl }}
-    >
-      {methods.map((method) => {
-        const active = value === method;
-        return (
-          <Pressable
-            key={method}
-            accessibilityRole="radio"
-            accessibilityState={{ selected: active }}
-            accessibilityLabel={label(method)}
-            onPress={() => {
-              if (props.allowDeselect) {
-                props.onChange(active ? null : method);
-              } else {
-                props.onChange(method);
-              }
-            }}
-            style={({ pressed }) => ({
-              flexDirection: 'row',
-              alignItems: 'center',
-              gap: theme.spacing.xs,
-              // Match the category chips: a 44pt floor so the tap target clears
-              // the iOS 44 / Android 48 minimum (padding alone left it ~37pt).
-              minHeight: 44,
-              paddingVertical: theme.spacing.sm,
-              paddingHorizontal: theme.spacing.md,
-              borderRadius: theme.radius.md,
-              borderWidth: 1,
-              borderColor: active ? theme.color.brand : theme.color.border,
-              backgroundColor: active ? theme.color.brandSoft : theme.color.surface,
-              opacity: pressed ? 0.7 : 1,
-            })}
-          >
-            <Ionicons
-              name={PAYMENT_METHOD_ICONS[method]}
-              size={iconSize.md}
-              color={active ? theme.color.brand : theme.color.textMuted}
-            />
-            <Text variant="body" style={{ color: active ? theme.color.brand : theme.color.text }}>
-              {label(method)}
-            </Text>
-          </Pressable>
-        );
-      })}
-    </ScrollView>
-  );
-}
-
 /**
  * The rail in force as one row of a settings list: the rail's glyph, the field's
  * name, the rail's label, a chevron into {@link PaymentMethodSheet}.
  *
  * A {@link DetailRow}, the row the expense screen states a bill's facts in, so
- * "paid with" is asked in the shape it is read back in.
- *
- * Only the non-deselectable shape: a list row has to show *something* on its
- * right, and "not said" is a state the chip lane can express by having nothing
- * lit but a row cannot. The screens that allow "not said" keep the chips.
+ * "paid with" is asked in the shape it is read back in. A null value — capture's
+ * "not said", never reachable from add-expense's always-chosen state — draws
+ * the same placeholder styling {@link DetailRows}'s group row uses for "decide
+ * later": a faint answer rather than a blank one, so the row still says there
+ * is a question here to answer.
  */
 export function PaymentMethodRow({
   value,
   onPress,
 }: {
-  value: PaymentMethod;
+  value: PaymentMethod | null;
   onPress: () => void;
 }) {
   const { t } = useStrings();
   const label = usePaymentMethodLabel();
-  const method = offeredPaymentMethods({ upiSupported: deviceSupportsUpi(), current: value }).find(
-    (it) => it === value,
-  );
+  const method = value
+    ? offeredPaymentMethods({ upiSupported: deviceSupportsUpi(), current: value }).find(
+        (it) => it === value,
+      )
+    : null;
 
   return (
     <DetailRow
-      // A rail the region does not offer still has to draw *some* mark, or the
-      // row loses the column the stack next to it is read down. The wallet is
-      // the field's own glyph, standing in for the answer's.
+      // A rail the region does not offer, or none chosen at all, still has to
+      // draw *some* mark, or the row loses the column the stack next to it is
+      // read down. The wallet is the field's own glyph, standing in for the
+      // answer's.
       icon={method ? PAYMENT_METHOD_ICONS[method] : 'wallet-outline'}
       label={t.captures.paidWith}
-      value={label(value)}
+      value={value ? label(value) : t.captures.paidNotSaid}
+      placeholder={!value}
       onPress={onPress}
     />
   );
 }
 
-/** The same rails as a sheet of options, one per line, checked where chosen. */
-export function PaymentMethodSheet({
-  value,
-  onChange,
-  onClose,
-}: {
-  value: PaymentMethod | null;
-  onChange: (value: PaymentMethod) => void;
-  onClose: () => void;
-}) {
+/**
+ * The same rails as a sheet of options, one per line, checked where chosen.
+ *
+ * Two shapes, like the row above it: add-expense's `onChange` never sees null,
+ * because that screen always has a rail chosen and only ever swaps it. Capture
+ * allows "not said", so under `allowDeselect` tapping the rail already checked
+ * clears it rather than re-choosing the same thing — the sheet's equivalent of
+ * the old chip lane's "tap the lit one again" gesture.
+ */
+type PaymentMethodSheetProps =
+  | {
+      value: PaymentMethod;
+      onChange: (value: PaymentMethod) => void;
+      allowDeselect?: false;
+      onClose: () => void;
+    }
+  | {
+      value: PaymentMethod | null;
+      onChange: (value: PaymentMethod | null) => void;
+      allowDeselect: true;
+      onClose: () => void;
+    };
+
+export function PaymentMethodSheet(props: PaymentMethodSheetProps): React.JSX.Element {
+  const { value, onClose } = props;
   const theme = useTheme();
   const { t } = useStrings();
   const label = usePaymentMethodLabel();
@@ -209,7 +156,13 @@ export function PaymentMethodSheet({
                     />
                   </View>
                 }
-                onPress={() => onChange(method)}
+                onPress={() => {
+                  if (props.allowDeselect) {
+                    props.onChange(active ? null : method);
+                  } else {
+                    props.onChange(method);
+                  }
+                }}
               />
             );
           },

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1570,6 +1570,9 @@ export interface UiStrings {
     payDebit: string;
     payForex: string;
     payUpi: string;
+    /** The "paid with" row's answer when nobody has said — a real answer, not a
+     *  blank, for the one field capture lets stand undecided. */
+    paidNotSaid: string;
     group: string;
     decideLater: string;
     groupPickerTitle: string;
@@ -4283,6 +4286,7 @@ const en: UiStrings = {
     payDebit: 'Debit card',
     payForex: 'Forex',
     payUpi: 'UPI',
+    paidNotSaid: 'Not said',
     group: 'Group',
     decideLater: 'Decide later',
     groupPickerTitle: 'Add to a group',
@@ -6925,6 +6929,7 @@ const ta: UiStrings = {
     payDebit: 'டெபிட் கார்டு',
     payForex: 'அன்னியச் செலாவணி',
     payUpi: 'UPI',
+    paidNotSaid: 'குறிப்பிடவில்லை',
     group: 'குழு',
     decideLater: 'பிறகு முடிவு செய்யலாம்',
     groupPickerTitle: 'ஒரு குழுவில் சேர்க்கவும்',
@@ -9620,6 +9625,7 @@ const hi: UiStrings = {
     payDebit: 'डेबिट कार्ड',
     payForex: 'विदेशी मुद्रा',
     payUpi: 'UPI',
+    paidNotSaid: 'नहीं बताया',
     group: 'समूह',
     decideLater: 'बाद में तय करें',
     groupPickerTitle: 'किसी समूह में जोड़ें',
@@ -12322,6 +12328,7 @@ const ar: UiStrings = {
     payDebit: 'بطاقة خصم',
     payForex: 'عملة أجنبية',
     payUpi: 'UPI',
+    paidNotSaid: 'لم يُذكر',
     group: 'المجموعة',
     decideLater: 'قرّر لاحقًا',
     groupPickerTitle: 'أضِف إلى مجموعة',

--- a/apps/mobile/test/captureFactsCard.test.ts
+++ b/apps/mobile/test/captureFactsCard.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Capture used to ask "what for" and "paid with" as two lanes of chips, sitting
+ * between the description and a separate card that held only the destination
+ * and the date — three different controls for four facts that read as one
+ * question on the group expense form. This is the guard on folding all four
+ * into the one card add-expense already wears, and on the receipt moving up to
+ * where add-expense reads a bill: right under the amount, ahead of the fields
+ * scanning it fills in.
+ *
+ * Source-reading, like `rowIdiom.test.ts` this extends: the screen pulls in
+ * Reanimated and gesture-handler by way of `SheetOverlay`, neither of which
+ * this node-environment suite can mount, and what is worth protecting — which
+ * components a screen reaches for, and in what order it lays them out — is
+ * legible in the text without any of that.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const SRC = join(__dirname, '../src');
+const source = (relativePath: string): string => readFileSync(join(SRC, relativePath), 'utf8');
+
+describe('capture folds what-for, paid-with, group and date into one card', () => {
+  const capture = source('app/capture.tsx');
+
+  it('reaches for the same row + sheet pair add-expense uses for category', () => {
+    expect(capture).toMatch(
+      /import\s*\{\s*CategoryRow,\s*CategorySheet\s*\}\s*from\s*'@\/components\/Category'/,
+    );
+    // The chip lane this replaced — never both at once, or the guess-follows-
+    // typing logic would be feeding two controls that disagree.
+    expect(capture).not.toMatch(/\bCategoryPicker\b/);
+  });
+
+  it('reaches for the same row + sheet pair add-expense uses for payment', () => {
+    expect(capture).toMatch(
+      /import\s*\{\s*PaymentMethodRow,\s*PaymentMethodSheet\s*\}\s*from\s*'@\/components\/PaymentMethodPicker'/,
+    );
+    // The bare chip component this replaced. A bare word-boundary check would
+    // also flag the import line itself, so this only fails once the chip
+    // component is reintroduced as a call (JSX or a value reference), not as
+    // part of the row/sheet identifiers above.
+    expect(capture).not.toMatch(/<PaymentMethodPicker[\s/>]/);
+    expect(capture).not.toMatch(/[^.]PaymentMethodPicker\(/);
+  });
+
+  it('lists what-for, paid-with, the destination and the date in one DetailRows block', () => {
+    const match = capture.match(/<DetailRows>([\s\S]*?)<\/DetailRows>/);
+    expect(match, 'capture should render exactly one DetailRows block').not.toBeNull();
+    const block = match![1]!;
+    expect(block).toMatch(/<CategoryRow/);
+    expect(block).toMatch(/<PaymentMethodRow/);
+    expect(block).toMatch(/label=\{t\.captures\.group\}/);
+    expect(block).toMatch(/label=\{t\.captures\.date\}/);
+  });
+
+  it('never scatters the four facts as chip lanes or stray View labels again', () => {
+    // The two headings a bare `<Text>{t.captures.category}</Text>` /
+    // `{t.captures.paidWith}</Text>` used to sit atop before each field became
+    // a labelled row inside the card — DetailRow now carries the label, so a
+    // sibling heading for either would be the fold coming undone.
+    expect(capture).not.toMatch(/\{t\.captures\.category\}\s*<\/Text>/);
+  });
+
+  it('reads the bill before the fields scanning it fills in, the order add-expense uses', () => {
+    const receiptAt = capture.indexOf('t.captures.receipt');
+    const descriptionAt = capture.indexOf('<DescriptionField');
+    const factsCardAt = capture.indexOf('<DetailRows>');
+    expect(receiptAt).toBeGreaterThan(-1);
+    expect(descriptionAt).toBeGreaterThan(-1);
+    expect(factsCardAt).toBeGreaterThan(-1);
+    expect(receiptAt).toBeLessThan(descriptionAt);
+    expect(descriptionAt).toBeLessThan(factsCardAt);
+  });
+
+  it("keeps paid-with's not-said answer reachable from the sheet, not only the old chip lane", () => {
+    expect(capture).toMatch(/<PaymentMethodSheet[\s\S]*?allowDeselect[\s\S]*?\/>/);
+  });
+});
+
+describe('PaymentMethodRow carries the null "not said" state the chip lane used to', () => {
+  const picker = source('components/PaymentMethodPicker.tsx');
+
+  it('PaymentMethodRow accepts a null value', () => {
+    const match = picker.match(/export function PaymentMethodRow\(\{[\s\S]*?\n\}\)/);
+    expect(match, 'PaymentMethodRow should still be exported').not.toBeNull();
+    expect(match![0]).toMatch(/value:\s*PaymentMethod\s*\|\s*null/);
+  });
+
+  it('draws a real placeholder answer rather than a blank when nothing is said', () => {
+    expect(picker).toMatch(/t\.captures\.paidNotSaid/);
+  });
+
+  it('the standalone chip component is gone now that no screen renders it', () => {
+    expect(picker).not.toMatch(/export function PaymentMethodPicker/);
+  });
+
+  it('PaymentMethodSheet still supports allowDeselect for the caller that needs it', () => {
+    expect(picker).toMatch(/allowDeselect/);
+  });
+});


### PR DESCRIPTION
## What the user asked

Fold capture's scattered "What for / Paid with / Group / Date" fields into one card of named rows, matching add-expense's facts card, and move the receipt up to where add-expense puts it — reusing components, not cloning them.

## What actually still differed after #788

PR #788 already converted capture's Group and Date into `DetailRow`s inside one `DetailRows` card — that half was done. What was still scattered:

- **What for** (category) and **Paid with** (payment method) were still standalone chip lanes (`CategoryPicker`, `PaymentMethodPicker`), each under its own `<Text>` heading, sitting between the description and the Group/Date card — not part of that card, and not the row+sheet idiom add-expense's own `CategoryRow`/`PaymentMethodRow` already use for the same two fields.
- **The receipt** sat last on the screen, after the facts card — the opposite of add-expense, which reads a bill first, right after the amount/description, because scanning one fills those fields in.

So less was missing than a first glance at the screen suggested — the row idiom itself (#788) and half the card (Group, Date) were already there. The gap was: two fields not yet in the card, and the receipt's position.

## What changed

- `CategoryRow`/`CategorySheet` and `PaymentMethodRow`/`PaymentMethodSheet` (already built for add-expense) now back capture's "what for" and "paid with" too, inside the same `DetailRows` card as Group and Date — four rows, one card, in the literal order the user described.
- The receipt card moved to sit right under the amount, before the description — the order add-expense reads a bill in, since scanning fills in the amount and note below it.
- `PaymentMethodRow`/`PaymentMethodSheet` gained a nullable `value` and an `allowDeselect` sheet variant, because capture's payment field lets "not said" stand as a real answer (tapping the chosen chip again used to clear it) and add-expense's row/sheet had no way to say that. Extended the shared component rather than cloning a capture-only row, so add-expense keeps its always-chosen behaviour unchanged and capture keeps the same deselect gesture it always had.
- The now-fully-unused chip picker (`PaymentMethodPicker`) was removed from `components/PaymentMethodPicker.tsx` — nothing calls it any more (add-person has its own inline chips and never used this one).

## What was reused vs. extracted

Reused as-is: `CategoryRow`, `CategorySheet`, `DetailRow`, `DetailRows`, `SheetOverlay`/`ChoiceRow` — all already built for add-expense by #788.

Extended (not cloned): `PaymentMethodRow`/`PaymentMethodSheet` — the one place add-expense's shape didn't cover capture's needs (a nullable answer), so the shared component grew a second, narrower shape rather than capture growing its own copy.

## What I deliberately left alone

- **Capture's receipt UI stays its own, simpler shape** — a single "Add receipt" button plus an on-device OCR readout — rather than borrowing add-expense's scan/attach pair. Add-expense's scan calls a metered `scanReceipt` edge function and checks a per-group receipt cap; capture has no group yet, so neither exists for it. Forcing the two receipt flows into one component would have meant inventing group-shaped behaviour (a cap, a server scan) for a screen that exists specifically because it has no group. Only the *position* changed.
- **Location stayed where it was** relative to the description — the user's ask was about the four named fields and the receipt, not location.
- **Currency was not added to the card.** Add-expense's card has a fourth row (currency) capture's own card does not; the user's description of capture's fields didn't include it, and it's already reachable from the amount header's currency pill, unchanged.

## Keyboard trap (PR #790)

Checked: capture's only in-place "unfold" is the date row's `<DateTimePicker>`, which (unspecified `display`) renders as a native Android dialog, not an inline field — it doesn't raise a software keyboard the way the new-group budget row's amount field does. #790's scroll-to-end fix doesn't apply here; nothing in this change unfolds a text field low on the screen.

## Tests

Added `apps/mobile/test/captureFactsCard.test.ts` in the house source-reading style (`rowIdiom.test.ts`'s pattern): asserts capture imports the row+sheet components rather than the chip pickers, that all four facts sit inside one `DetailRows` block, that the receipt precedes the description and facts card in source order, and that `PaymentMethodRow`/`Sheet` carry the nullable/`allowDeselect` shape while the dead chip export is gone.

## Gates

```
pnpm format            — clean (removed one stray shell-debris file it left behind)
pnpm lint               — 0 errors (1 pre-existing unrelated warning in group/[id]/settings.tsx)
pnpm --filter @waves/mobile typecheck  — clean
pnpm --filter @waves/mobile test       — 110 files / 1461 tests passed
pnpm --filter @waves/core test         — 63 files / 993 tests passed
```

`packages/db` tests need a local Postgres that isn't running here — not run, per instructions.

I could not run this on a device — nothing here has been visually confirmed beyond the test suite and typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jhzmZz5fkjnZZ14YxHGfS