### PR TITLE
Picking a group while saving an expense hands it to that group's own form

### DIFF
--- a/apps/mobile/src/app/capture.tsx
+++ b/apps/mobile/src/app/capture.tsx
@@ -50,6 +50,7 @@ import { groupLabel, GroupType, type GroupRow, type MemberRow } from '@/data/typ
 import { useAuth } from '@/lib/auth';
 import { useDefaultCurrency } from '@/lib/currency';
 import { plural, useStrings, type UiStrings } from '@/i18n';
+import { assignCaptureHref, captureDraftFields } from '@/lib/captureAssign';
 import { dateFrom, isoDate, showDate } from '@/lib/expenseDay';
 import { captureReceipt, type PickedImage } from '@/lib/image';
 import { router } from '@/lib/navigation';
@@ -144,12 +145,25 @@ const consumedScans = new Set<string>();
  * Catch an expense before it has a group.
  *
  * Deliberately the short version of add-expense: an amount, a note, a category,
- * a date, how it was paid, and optionally a photo of the bill — but no payer,
- * no participants, no split, because none of those exist until the capture is
- * assigned to a group. A group can be *tagged* here as the intended destination
- * (`targetGroupId`), but that only pre-aims it; who splits it, and how, is still
- * decided at assignment. The photo is read on the phone (A5) so its text can
- * ride along as `rawText` for the group form to reuse later.
+ * a date, how it was paid, and optionally a photo of the bill — never a payer
+ * or a split, because those describe how a bill is shared among a group's
+ * members, and there is no group here by default. "Decide later" (`null`) is
+ * that default, and it stays exactly this short.
+ *
+ * Picking a real group in the facts card below is a different thing entirely:
+ * it hands the draft straight to that group's own add-expense form (the same
+ * hand-off the inbox uses to assign a capture — `captureDraftFields` +
+ * `assignCaptureHref`), where payer and split live already. That screen was
+ * the honest place to ask them even before this hand-off existed — assigning a
+ * capture always finished there — so a capture that already knows its group
+ * now walks straight into the same form it was always going to end up on,
+ * carrying everything typed here so far, rather than asking a shorter version
+ * of the same two questions twice in two different shapes. The photo is read
+ * on the phone (A5) so its text can ride along as `rawText` if the capture
+ * stays here (no group); a group hand-off carries neither the photo nor that
+ * text, matching the inbox's own assign, which has never carried them either —
+ * a bill attached at capture time is not yet reachable from the expense the
+ * hand-off is about to create.
  */
 export default function CaptureScreen() {
   const theme = useTheme();
@@ -660,10 +674,12 @@ export default function CaptureScreen() {
             keeps reading as the same two facts rather than restating them in a
             different shape.
 
-            "Decide later" is the default group: the split, and who is in it, is
-            chosen when the capture is assigned — so this card asks four things
-            about a capture and nothing about splitting, which does not exist
-            here yet.
+            "Decide later" is the default group, and with it chosen this card
+            asks four things about a capture and nothing about splitting — there
+            is nobody to split it among yet. Picking any other group from this
+            row's sheet does not stay on this card at all: it hands the draft
+            straight to that group's add-expense form, where who paid and how it
+            is split are asked for real (see this screen's own header comment).
 
             The date picker is wrapped with its row rather than left as a
             sibling: `DetailRows` puts a hairline in every gap between its
@@ -810,7 +826,17 @@ export default function CaptureScreen() {
       {/* Destination picker, as a sheet over the form rather than a route away:
           "Decide later" pinned at the top so the default is always reachable,
           then a running trip if one is on today, the groups used most recently,
-          and the rest — so the group you mean is usually one of the first taps. */}
+          and the rest — so the group you mean is usually one of the first taps.
+
+          Picking "Decide later" is the only choice that stays a choice on this
+          screen — it just records the null destination, same as ever. Picking
+          any real group hands off instead: `captureDraftFields` reads whatever
+          is typed so far off this screen's own state, and `assignCaptureHref`
+          turns that into the exact params the inbox's assign already sends the
+          group's add-expense form, so the two arrive at that screen the same
+          way. Pushed, not replaced — backing out of add-expense with nothing
+          saved returns here with this draft untouched, the group row still
+          reading whatever it read before the tap. */}
       {pickingGroup ? (
         <SheetOverlay title={t.captures.groupPickerTitle} onClose={() => setPickingGroup(false)}>
           <Text variant="caption" tone="muted" style={{ marginBottom: theme.spacing.sm }}>
@@ -823,8 +849,26 @@ export default function CaptureScreen() {
             membersFor={summary.membersFor}
             t={t}
             onPick={(id) => {
-              setTargetGroupId(id);
               setPickingGroup(false);
+              if (id === null) {
+                setTargetGroupId(null);
+                return;
+              }
+              router.push(
+                assignCaptureHref(
+                  captureDraftFields({
+                    captureId,
+                    description,
+                    amount,
+                    category,
+                    categoryMeta,
+                    location,
+                    paymentMethod,
+                    date,
+                  }),
+                  id,
+                ),
+              );
             }}
           />
         </SheetOverlay>

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -4291,7 +4291,7 @@ const en: UiStrings = {
     decideLater: 'Decide later',
     groupPickerTitle: 'Add to a group',
     groupPickerBody:
-      'Tag the group this belongs to. You can still change it — and choose the split — when you assign it.',
+      "Picking a group takes you there to say who paid and how it's split. Decide later leaves it just like this.",
     groupSectionCurrentTrip: 'Current trip',
     groupSectionRecent: 'Recently used',
     groupSectionAll: 'All groups',
@@ -6934,7 +6934,7 @@ const ta: UiStrings = {
     decideLater: 'பிறகு முடிவு செய்யலாம்',
     groupPickerTitle: 'ஒரு குழுவில் சேர்க்கவும்',
     groupPickerBody:
-      'இது சேர வேண்டிய குழுவைக் குறியிடுங்கள். ஒதுக்கும்போது அதை மாற்றலாம் — பங்கீட்டையும் தேர்வு செய்யலாம்.',
+      'ஒரு குழுவைத் தேர்ந்தெடுத்தால், யார் கொடுத்தார், எப்படி பங்கிடுவது என்பதைச் சொல்ல அங்கே அழைத்துச் செல்லும். பிறகு முடிவு செய்யலாம் எனில் இது இப்படியே இருக்கும்.',
     groupSectionCurrentTrip: 'நடப்புப் பயணம்',
     groupSectionRecent: 'சமீபத்தில் பயன்படுத்தியவை',
     groupSectionAll: 'அனைத்துக் குழுக்களும்',
@@ -9630,7 +9630,7 @@ const hi: UiStrings = {
     decideLater: 'बाद में तय करें',
     groupPickerTitle: 'किसी समूह में जोड़ें',
     groupPickerBody:
-      'यह जिस समूह का है उसे चुनें। असाइन करते समय इसे बदल सकते हैं — और बँटवारा भी चुन सकते हैं।',
+      'कोई समूह चुनने पर आप वहाँ पहुँच जाएँगे, जहाँ बताया जाता है किसने भुगतान किया और कैसे बाँटा जाए। बाद में तय करें चुनने पर यह ऐसे ही रहेगा।',
     groupSectionCurrentTrip: 'चल रही यात्रा',
     groupSectionRecent: 'हाल में इस्तेमाल किए',
     groupSectionAll: 'सभी समूह',
@@ -12333,7 +12333,7 @@ const ar: UiStrings = {
     decideLater: 'قرّر لاحقًا',
     groupPickerTitle: 'أضِف إلى مجموعة',
     groupPickerBody:
-      'حدِّد المجموعة التي ينتمي إليها. يمكنك تغييرها — واختيار طريقة التقسيم — عند الإسناد.',
+      'عند اختيار مجموعة، ستُنقَل إليها لتحديد من دفع وكيفية التقسيم. قرّر لاحقًا يُبقيها كما هي.',
     groupSectionCurrentTrip: 'الرحلة الحالية',
     groupSectionRecent: 'المستخدمة مؤخرًا',
     groupSectionAll: 'كل المجموعات',

--- a/apps/mobile/src/lib/captureAssign.ts
+++ b/apps/mobile/src/lib/captureAssign.ts
@@ -3,16 +3,36 @@
  * prefilled from the capture and carrying its id so saving there closes the
  * capture (useAssignCapture) rather than leaving a duplicate behind.
  *
- * One place builds this href so the two callers that assign — the inbox's group
- * picker and the "New group" flow that creates a group then drops the capture
- * into it — hand the form exactly the same params. The caller chooses how to
- * navigate: the picker pushes (back returns to the inbox), the new-group flow
- * replaces (back must not return to the half-made group screen).
+ * One place builds this href so the three callers that assign — the inbox's
+ * group picker, the "New group" flow that creates a group then drops the
+ * capture into it, and the capture screen's own group row (picking a real
+ * group there now means "finish this as a group expense", not merely tagging
+ * a destination) — hand the form exactly the same params. The caller chooses
+ * how to navigate: the inbox picker and the capture screen push (back returns
+ * to where they were), the new-group flow replaces (back must not return to
+ * the half-made group screen).
  */
 
-import type { PaymentMethod } from '@waves/core';
+import type { CategoryMeta, ExpenseLocation, PaymentMethod } from '@waves/core';
 
-import { type CaptureRow } from '@/data/types';
+/**
+ * The fields the hand-off needs, independent of whether they live on a row the
+ * server has already seen. A saved `CaptureRow` satisfies this shape as-is
+ * (structural typing, and it is what the inbox and "New group" flows already
+ * pass); `captureDraftFields` below builds the same shape from a capture that
+ * is still being typed and has never been saved at all — the capture screen's
+ * own hand-off, which fires before Save, not after.
+ */
+export interface CaptureAssignFields {
+  id: string;
+  description: string;
+  amount: string;
+  category: string | null;
+  category_meta: CategoryMeta | null;
+  location: ExpenseLocation | null;
+  payment_method: string | null;
+  expense_date: string;
+}
 
 /** The methods the ledger knows (`PaymentMethod`), as a runtime guard. */
 const PAYMENT_METHODS: readonly string[] = ['cash', 'upi', 'credit', 'debit', 'forex'];
@@ -42,7 +62,7 @@ export function matchesAssignGroupQuery(label: string, query: string): boolean {
   return !needle || fold(label).includes(needle);
 }
 
-export function assignCaptureHref(capture: CaptureRow, groupId: string) {
+export function assignCaptureHref(capture: CaptureAssignFields, groupId: string) {
   return {
     pathname: '/group/[id]/add-expense' as const,
     params: {
@@ -65,5 +85,39 @@ export function assignCaptureHref(capture: CaptureRow, groupId: string) {
         : {}),
       expenseDate: capture.expense_date,
     },
+  };
+}
+
+/**
+ * A capture still being typed, as the shape `assignCaptureHref` needs.
+ *
+ * The capture screen mints its `captureId` up front (before anything is
+ * saved, so a photo can be uploaded under it) whether this is a brand-new
+ * draft or an existing one being edited. Handing off on that id before Save
+ * is pressed is safe either way: on a fresh draft no capture row exists yet,
+ * so the `capture.assign` the add-expense form fires on save matches nothing
+ * server-side and is a silent no-op (the sync edge function's assign only
+ * flips a row that is there); on an existing draft the id is real, so the
+ * same assign closes it exactly as the inbox's own picker would.
+ */
+export function captureDraftFields(draft: {
+  captureId: string;
+  description: string;
+  amount: bigint;
+  category: string | null;
+  categoryMeta: CategoryMeta | null;
+  location: ExpenseLocation | null;
+  paymentMethod: PaymentMethod | null;
+  date: string;
+}): CaptureAssignFields {
+  return {
+    id: draft.captureId,
+    description: draft.description.trim(),
+    amount: draft.amount.toString(),
+    category: draft.category,
+    category_meta: draft.categoryMeta,
+    location: draft.location,
+    payment_method: draft.paymentMethod,
+    expense_date: draft.date,
   };
 }

--- a/apps/mobile/test/captureAssign.test.ts
+++ b/apps/mobile/test/captureAssign.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { CaptureStatus, type CaptureRow } from '../src/data/types';
 import {
   assignCaptureHref,
+  captureDraftFields,
   capturePaymentMethod,
   matchesAssignGroupQuery,
 } from '../src/lib/captureAssign';
@@ -57,6 +58,74 @@ describe('assignCaptureHref', () => {
   it('says nothing about payment when the draft named none', () => {
     const href = assignCaptureHref(capture({ payment_method: null }), 'group-1');
     expect(href.params).not.toHaveProperty('paymentMethod');
+  });
+});
+
+describe('captureDraftFields', () => {
+  // The capture screen's own hand-off: picking a group there before Save is
+  // ever pressed must carry every field already typed, exactly as if the
+  // draft had been saved as a capture first and assigned from the inbox
+  // afterwards — the two are meant to be indistinguishable to the group's
+  // add-expense form.
+  function draft(overrides: Partial<Parameters<typeof captureDraftFields>[0]> = {}) {
+    return {
+      captureId: 'draft-1',
+      description: '  taxi to airport  ',
+      amount: 125000n,
+      category: 'travel',
+      categoryMeta: null,
+      location: { name: 'Terminal 2', lat: 19.0896, lng: 72.8656 },
+      paymentMethod: null,
+      date: '2026-09-08',
+      ...overrides,
+    };
+  }
+
+  it('carries everything typed on the capture screen into the same shape assignCaptureHref expects', () => {
+    expect(captureDraftFields(draft())).toEqual({
+      id: 'draft-1',
+      description: 'taxi to airport',
+      amount: '125000',
+      category: 'travel',
+      category_meta: null,
+      location: { name: 'Terminal 2', lat: 19.0896, lng: 72.8656 },
+      payment_method: null,
+      expense_date: '2026-09-08',
+    });
+  });
+
+  it('feeds straight into assignCaptureHref, before the draft has ever been saved as a capture', () => {
+    const href = assignCaptureHref(
+      captureDraftFields(draft({ paymentMethod: 'credit' })),
+      'group-1',
+    );
+    expect(href).toMatchObject({
+      pathname: '/group/[id]/add-expense',
+      params: {
+        id: 'group-1',
+        // The id a fresh draft hands off with is the one it minted for itself
+        // before Save — never saved anywhere, so the assign this triggers on
+        // save matches no row and is a harmless no-op server-side.
+        captureId: 'draft-1',
+        description: 'taxi to airport',
+        amount: '125000',
+        category: 'travel',
+        location: JSON.stringify({ name: 'Terminal 2', lat: 19.0896, lng: 72.8656 }),
+        paymentMethod: 'credit',
+        expenseDate: '2026-09-08',
+      },
+    });
+  });
+
+  it('says nothing about category, place or payment when none was ever entered', () => {
+    const href = assignCaptureHref(
+      captureDraftFields(draft({ category: null, location: null, paymentMethod: null })),
+      'group-1',
+    );
+    expect(href.params).not.toHaveProperty('categoryMeta');
+    expect(href.params).not.toHaveProperty('location');
+    expect(href.params).not.toHaveProperty('paymentMethod');
+    expect(href.params.category).toBe('');
   });
 });
 

--- a/apps/mobile/test/captureGroupHandoff.test.ts
+++ b/apps/mobile/test/captureGroupHandoff.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Capture never grows a payer or a split of its own — those live on
+ * add-expense, because they describe how a bill is shared among a group's
+ * members, and a capture's whole reason to exist is that there may be no
+ * group yet (A34). Picking a real group in the destination sheet instead
+ * hands the draft straight to that group's add-expense form (the same
+ * hand-off the inbox already uses to assign a capture — `captureAssign.ts`),
+ * so who paid and how it's split are asked there, once, in their one honest
+ * place.
+ *
+ * Source-reading, like `captureFactsCard.test.ts`: the screen pulls in
+ * Reanimated and gesture-handler by way of `SheetOverlay`, which this
+ * node-environment suite cannot mount, but the shape worth protecting — that
+ * only "decide later" ever stays on this screen, and any real group leaves it
+ * for add-expense — is legible in the text without any of that. The exact
+ * fields the hand-off carries are covered at the unit level in
+ * `captureAssign.test.ts` (`captureDraftFields` + `assignCaptureHref`).
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const SRC = join(__dirname, '../src');
+const source = (relativePath: string): string => readFileSync(join(SRC, relativePath), 'utf8');
+
+describe('capture never asks who paid or how it is split itself', () => {
+  const capture = source('app/capture.tsx');
+
+  it('imports no payer or split control — those are add-expense-only', () => {
+    // The vocabulary add-expense's own facts card and payer chooser use. None
+    // of it belongs on this screen: a payer or a split control here, even
+    // hidden behind a group check, would be a place to reimplement the split
+    // engine rather than reuse it (packages/core), which the task guarding
+    // this file forbids outright.
+    expect(capture).not.toMatch(/payerChoices|PayerRow|SplitEntries|splitParams|computeShares/);
+  });
+
+  it('keeps the facts card to exactly what-for, paid-with, destination and date', () => {
+    const match = capture.match(/<DetailRows>([\s\S]*?)<\/DetailRows>/);
+    expect(match, 'capture should render exactly one DetailRows block').not.toBeNull();
+    const block = match![1]!;
+    // Four rows, not six: no fifth "who paid" or sixth "split" row ever joins
+    // this block, whatever the destination row currently reads.
+    const rows = block.match(/<(CategoryRow|PaymentMethodRow|DetailRow)\b/g) ?? [];
+    expect(rows).toHaveLength(4);
+  });
+
+  it('hands off to add-expense, not to itself, the moment a real group is picked', () => {
+    // GroupPicker's onPick: null (Decide later) is the only branch that stays
+    // on this screen and merely records the choice; anything else pushes to
+    // the group's own add-expense form via the exact builder the inbox's
+    // assign already uses, so the two hand-offs cannot drift apart.
+    const onPick = capture.match(/onPick=\{\(id\) => \{[\s\S]*?\n {12}\}\}/);
+    expect(onPick, 'capture should wire GroupPicker.onPick').not.toBeNull();
+    const body = onPick![0]!;
+    expect(body).toMatch(/if \(id === null\) \{\s*setTargetGroupId\(null\);\s*return;\s*\}/);
+    expect(body).toMatch(/router\.push\(\s*assignCaptureHref\(\s*captureDraftFields\(/);
+  });
+
+  it("builds the hand-off from this screen's own live draft, not a saved row", () => {
+    expect(capture).toMatch(
+      /import \{ assignCaptureHref, captureDraftFields \} from '@\/lib\/captureAssign';/,
+    );
+    const call = capture.match(/captureDraftFields\(\{[\s\S]*?\}\)/);
+    expect(call, 'capture should call captureDraftFields with its own state').not.toBeNull();
+    for (const field of [
+      'captureId',
+      'description',
+      'amount',
+      'category',
+      'categoryMeta',
+      'location',
+      'paymentMethod',
+      'date',
+    ]) {
+      expect(call![0]).toMatch(new RegExp(`\\b${field}\\b`));
+    }
+  });
+});


### PR DESCRIPTION
## What was missing, and where

Save an expense (`apps/mobile/src/app/capture.tsx`) lets you pick a destination group, but never asks who paid or how to split — those rows genuinely do not exist on this screen. That is not an oversight: **a capture with a group tag is still just a capture.** I checked `useCreateCapture`/`useUpdateCapture` and the sync edge function (`supabase/functions/sync/index.ts`) — `targetGroupId` only writes a `target_group_id` column on the open capture row; nothing posts an expense, and the row stays in the inbox exactly like an untagged one. The split cannot be decided here because a capture is not an expense: the split engine lives in `packages/core` and only ever runs against a real expense write.

So the honest place to ask "who paid, how is it split" was never this screen — it is add-expense, and **it already gets there**. Assigning a capture from the inbox (`apps/mobile/src/lib/captureAssign.ts`, used by `captures.tsx` and `new-group.tsx`) already hands off to the group's own add-expense form, prefilled from the capture, and *that* form is where payer/split live. The gap the user was hitting wasn't a missing control — it was that picking a group during capture didn't take you to that already-built hand-off; it just quietly tagged the row and left you on the short form.

## Option chosen: (b) hand off to add-expense

Picking a real group in the destination sheet now pushes straight to that group's add-expense form — the exact same hand-off the inbox uses — before Save is ever pressed. "Decide later" is untouched: it's the only choice that stays on this screen.

I ruled out (a) reveal-in-place because there is nowhere honest to put the answer: a payer/split chosen at capture time would have to live on the capture row until assignment, but assignment already always re-opens add-expense fresh and nothing reads those fields back — it would be a control that lies, exactly what the task guarding this asked me not to build. (b) instead reuses machinery that already exists and is already trusted for this exact transition.

One consequence worth stating plainly: this removes the "pick a group but stay parked in the inbox" pre-aim from *this* screen's own picker. That capability still exists in full from the inbox's own assign picker (`captures.tsx`), which still pre-selects whatever group was tagged earlier. Given the user's own framing — "should we just have it as the group experience... I want that" — I read this as the intended simplification, not a regression: "Decide later" remains for genuine deferral.

## Reused vs. extracted

- **Reused as-is**: add-expense itself, its payer/split UI, the split engine in `packages/core`, and `assignCaptureHref` — the exact href builder the inbox assign flow already calls.
- **Extracted**: `assignCaptureHref`'s parameter type widened from a saved `CaptureRow` to a structural `CaptureAssignFields` interface, and a new `captureDraftFields` in `captureAssign.ts` that builds that same shape from the capture screen's own live (possibly unsaved) state. Nothing about add-expense or the split engine was touched or duplicated.
- Handing off on a not-yet-saved draft's minted id is safe: if Save is later pressed in add-expense, the resulting `capture.assign` mutation matches no row server-side (`assignCapture` in the sync edge function only flips a row that exists) — a silent no-op, not an error.

## Left alone

- The existing photo/rawText/OCR data captured before a group is picked is **not** carried into the hand-off — this matches the inbox's own existing assign flow, which has never carried a capture's photo onto the resulting expense either. Not a new gap, and out of scope here.
- Currency is likewise not carried (pre-existing behaviour of `assignCaptureHref`); the expense keeps the group's own currency, as it always has for inbox assignment.
- No schema or split-engine changes. No new capture columns.

## Gates

- `pnpm format` — clean
- `pnpm lint` — clean (one pre-existing unrelated warning in `group/[id]/settings.tsx`, untouched by this PR)
- `pnpm --filter @waves/mobile typecheck` — clean
- `pnpm --filter @waves/mobile test` — 111 files / 1468 tests pass
- `pnpm --filter @waves/core test` — 63 files / 993 tests pass
- `packages/db` tests **not run** — needs a local Postgres that isn't running here

## Tests added

- `captureAssign.test.ts`: `captureDraftFields` produces the exact shape `assignCaptureHref` expects, carries every already-typed field into the hand-off params, and correctly omits fields never entered.
- `captureGroupHandoff.test.ts` (new, source-reading like `captureFactsCard.test.ts` since this screen can't be mounted in the vitest node environment): no payer/split vocabulary is ever imported into capture.tsx; the facts card stays at exactly four rows regardless of the destination; `onPick` only ever stays local for `null` and otherwise calls `assignCaptureHref(captureDraftFields(...))`.

## Not done / not claimed

I cannot run this on a device — I have not seen the hand-off animate, and haven't confirmed the picked-group case on a physical keyboard/emulator. Typecheck, lint, and the two test suites above are what I verified.

https://claude.ai/code/session_015jhzmZz5fkjnZZ14YxHGfS