### PR TITLE
Review takes Activity's place on the bar, and Activity moves to the dashboard hero

### DIFF
--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -10,6 +10,17 @@ import { Tabs } from 'expo-router';
  * the `animation: 'none'` below — so opening it from the dashboard cut to it in
  * one frame while every other pushed screen slid in. It is a root stack screen
  * now, and pushes like the rest.
+ *
+ * `captures` (labelled "Review" on the bar) replaced `activity` here: the
+ * inbox of expenses waiting to be filed is something every session touches,
+ * where the cross-group feed is something you check in on — so the drafts
+ * screen earned the bar slot and Activity moved to a dashboard control instead
+ * (`(tabs)/index.tsx`'s hero, `app/activity.tsx`). The route this file names is
+ * still `captures`, matching the file it renders (`(tabs)/captures.tsx`,
+ * formerly the root `app/captures.tsx`) — a group folder in parentheses
+ * contributes no path segment, so `/captures` resolves exactly as it did
+ * before the move and every existing push, `navigate` and deep link into it
+ * keeps working unchanged.
  */
 export default function TabsLayout() {
   return (
@@ -44,7 +55,7 @@ export default function TabsLayout() {
     >
       <Tabs.Screen name="index" />
       <Tabs.Screen name="friends" />
-      <Tabs.Screen name="activity" />
+      <Tabs.Screen name="captures" />
       <Tabs.Screen name="me" />
     </Tabs>
   );

--- a/apps/mobile/src/app/(tabs)/captures.tsx
+++ b/apps/mobile/src/app/(tabs)/captures.tsx
@@ -10,6 +10,17 @@
  * fold into a single collapsible "N expenses" row with the running total, and
  * that row's ⋯ can place the whole cluster in one group at once — one answer to
  * "where does this go?" instead of the same answer once per row.
+ *
+ * This is the bar's "Review" tab, promoted from a screen you were pushed onto
+ * (traded places with Activity — see `(tabs)/_layout.tsx` and `app/activity.tsx`).
+ * The route is unchanged: this file still resolves at `/captures`, because a
+ * `(tabs)` group folder contributes no path segment of its own. It is also the
+ * screen `docs/plan-drafts-and-rules.md` names as the one true drafts hub —
+ * whatever arrives by paste, share or statement in a later phase is one more
+ * source feeding these same rows, not a second inbox beside them (the mistake
+ * #565 already undid once). Nothing from that plan is built here; the point of
+ * writing it down is that landing it later should mean adding to this screen,
+ * not rebuilding it.
  */
 
 import { useCallback, useMemo, useRef, useState } from 'react';
@@ -21,7 +32,6 @@ import { Pressable, RefreshControl, ScrollView, useWindowDimensions, View } from
 import { MutationKind, peopleSignatureKey } from '@waves/core';
 import {
   Button,
-  directionalIcon,
   Divider,
   EmptyState,
   IconButton,
@@ -1018,29 +1028,31 @@ export default function CapturesScreen() {
   );
 
   return (
-    <Screen edges={['top', 'bottom']}>
-      {/* The plain back-plus-centred-title bar every pushed screen wears
-          (Friends person, Merge, …), so Drafts reads as one of the family
-          rather than its own thing: a back chevron on the left, the title
-          optically centred, and a 44pt spacer on the right to balance the back
-          button. No leading glyph and no trailing add — starting a capture
-          lives on the dashboard, not here. */}
+    <Screen edges={['top']}>
+      {/* Review is a bar destination now, not a screen somebody was pushed onto
+          — so, like the other three tabs, it wears no back chevron: there is
+          nowhere "back" from a tab, and a chevron that did nothing (or popped
+          somewhere unrelated) would be worse than none. The icon-plus-title
+          row instead matches `ActivityScreen`'s own header, the tab this one
+          traded places with. The waiting count rides under the title exactly
+          as it did before the move.
+
+          `edges` drops `'bottom'`: the screen used to add its own bottom
+          safe-area padding on top of `useTabBarClearance()` below, shrinking
+          the list's own viewport by the inset for no gain — the FlashList's
+          `paddingBottom: clearance` already reserves the room the tab bar
+          needs, top edge is all `Screen` has to add. */}
       <Row
         style={{
           paddingHorizontal: theme.spacing.xl,
           paddingTop: theme.spacing.md,
           alignItems: 'center',
+          gap: theme.spacing.sm,
         }}
       >
-        <IconButton label={t.common.back} onPress={() => router.back()}>
-          <Ionicons
-            name={directionalIcon('chevron-back')}
-            size={iconSize.lg}
-            color={theme.color.text}
-          />
-        </IconButton>
-        <View style={{ flex: 1, alignItems: 'center' }}>
-          <Text variant="heading" numberOfLines={1}>
+        <Ionicons name="file-tray-full-outline" size={iconSize.xl} color={theme.color.brand} />
+        <View style={{ flex: 1 }}>
+          <Text variant="title" numberOfLines={1}>
             {t.captures.title}
           </Text>
           {/* How many are waiting, right under the title — so the screen answers
@@ -1052,7 +1064,6 @@ export default function CapturesScreen() {
             </Text>
           ) : null}
         </View>
-        <View style={{ width: 44 }} />
       </Row>
 
       {/* One virtualized scroll region for every state, the way `ActivityScreen`

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -33,17 +33,10 @@ import {
   useTheme,
 } from '@waves/ui';
 
-import {
-  useCaptures,
-  useGroups,
-  useHomeSummary,
-  usePinnedGroupIds,
-  useSetGroupPin,
-} from '@/data/hooks';
+import { useGroups, useHomeSummary, usePinnedGroupIds, useSetGroupPin } from '@/data/hooks';
 import { orderByPin } from '@/lib/groupPinOrder';
 import { plural, useStrings, type UiStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
-import { foldedCaptureCount } from '@/lib/captureBatch';
 import { useGuestGuard } from '@/lib/guestGuard';
 import { router } from '@/lib/navigation';
 import { usePromptSlot } from '@/lib/promptQueue';
@@ -56,7 +49,6 @@ import { SkeletonList } from '@/components/Skeletons';
 import { useImportedGroupId } from '@/lib/importProgress';
 import { useReducedMotion } from '@/lib/reducedMotion';
 import { useDefaultCurrency } from '@/lib/currency';
-import { captureInboxActionState } from '@/lib/dashboardActions';
 import { QuickAddSheet, useQuickAddActions } from '@/components/QuickAddSheet';
 import { OverflowMenu, type OverflowMenuItem } from '@/components/OverflowMenu';
 import { RestorePrompt } from '@/components/RestorePrompt';
@@ -84,12 +76,6 @@ export default function HomeScreen() {
   const pinnedIds = usePinnedGroupIds();
   const setGroupPin = useSetGroupPin();
   const summary = useHomeSummary(profile?.id ?? null);
-  // Unassigned captures now live as a badged inbox glyph in the toolbar rather
-  // than a section in the feed.
-  const captures = useCaptures();
-  // A voice batch counts as one draft on the inbox glyph, not one per item.
-  const captureCount = foldedCaptureCount(captures.data ?? []);
-  const captureInboxAction = captureInboxActionState(captureCount);
   const guard = useGuestGuard();
   const tour = useTour();
 
@@ -423,8 +409,13 @@ export default function HomeScreen() {
             />
           )}
 
-          {/* The add actions: one white "add expense" pill and the inbox
-                circle. Starting a group moved up to the header cluster. */}
+          {/* The add actions: one white "add expense" pill and, since Review
+                took the drafts inbox onto the bar (a real tab now, always one
+                tap away with its own badge — see `AppTabBar`), a circle for
+                Activity instead. It carries no badge of its own: the feed has
+                no unread concept today, so a badge here would have nothing
+                honest to count — this circle is a shortcut, not a counter.
+                Starting a group moved up to the header cluster. */}
           {/* Buttons and the pager travel together as one block, so the pager
                 sits just under the buttons rather than a full hero-gap away. */}
           <View style={{ gap: theme.spacing.md }}>
@@ -440,11 +431,9 @@ export default function HomeScreen() {
               </TourTarget>
               <Row style={{ marginLeft: 'auto', gap: theme.spacing.sm }}>
                 <HeroCircle
-                  icon="file-tray-outline"
-                  label={t.captures.title}
-                  badge={captureInboxAction.badge}
-                  disabled={captureInboxAction.disabled}
-                  onPress={() => router.navigate('/captures')}
+                  icon="pulse-outline"
+                  label={t.activity}
+                  onPress={() => router.navigate('/activity')}
                 />
               </Row>
             </Row>

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -684,12 +684,12 @@ function AuthGate() {
             <Stack.Screen name="paywall" options={slide} />
           </Stack.Protected>
           <Stack.Screen name="capture" options={slide} />
-          {/* The drafts screen keeps the bottom bar, so a person leaves it by
-              tapping a tab — which should cut straight across the way a tab does,
-              not slide the draft card out first. `none` makes leaving it (and
-              arriving on it) instant, the same treatment the inbox destination
-              had before it became a tab. */}
-          <Stack.Screen name="captures" options={{ animation: 'none' }} />
+          {/* Activity, out of the tab group and onto this stack — the mirror
+              image of the move `captures` made the other way (see
+              `(tabs)/_layout.tsx`). It is reached from the dashboard hero now,
+              not the bar, so it pushes and slides like `profile` and `groups`
+              rather than cutting instantly the way a tab switch does. */}
+          <Stack.Screen name="activity" options={slide} />
           <Stack.Screen name="groups" options={slide} />
           <Stack.Screen name="group/[id]/index" options={slide} />
           <Stack.Screen name="group/[id]/add-expense" options={slide} />
@@ -745,10 +745,10 @@ function AuthGate() {
           <Stack.Screen name="settings/account" />
           <Stack.Screen name="settings/feedback" />
           <Stack.Screen name="settings/delete-account" />
-          {/* The inbox is a tab-navigator destination now (see `(tabs)/inbox`),
-              so it is no longer a screen on this root stack — a tap on it from
-              anywhere is an instant tab swap rather than a push that re-reveals
-              and thaws the whole tab tree. */}
+          {/* The drafts inbox is a tab-navigator destination now (see
+              `(tabs)/captures.tsx`), so it is no longer a screen on this root
+              stack — a tap on it from anywhere is an instant tab swap rather
+              than a push that re-reveals and thaws the whole tab tree. */}
           <Stack.Screen name="voice" options={slide} />
         </Stack.Protected>
         {/* Reachable with or without a session, so they belong to neither

--- a/apps/mobile/src/app/activity.tsx
+++ b/apps/mobile/src/app/activity.tsx
@@ -7,6 +7,7 @@ import { FlashList } from '@shopify/flash-list';
 import {
   Badge,
   Button,
+  directionalIcon,
   EmptyState,
   IconButton,
   iconSize,
@@ -328,6 +329,17 @@ export default function ActivityScreen() {
     <View>
       <Row style={{ paddingTop: theme.spacing.md, justifyContent: 'space-between' }}>
         <Row style={{ alignItems: 'center', gap: theme.spacing.sm }}>
+          {/* Activity pushes now rather than tabs (it moved off the bar to make
+              room for Review, see `(tabs)/_layout.tsx`), so — like every other
+              pushed screen — it needs its own way back. Mirrored with the
+              writing direction, the same as `groups.tsx`'s header. */}
+          <IconButton label={t.common.back} onPress={() => router.back()}>
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.xl}
+              color={theme.color.text}
+            />
+          </IconButton>
           <Ionicons name="pulse" size={iconSize.xl} color={theme.color.brand} />
           <Text variant="title">{t.activity}</Text>
         </Row>

--- a/apps/mobile/src/components/AppTabBar.tsx
+++ b/apps/mobile/src/components/AppTabBar.tsx
@@ -28,8 +28,11 @@ import { Platform, Vibration } from 'react-native';
 
 import { iconSize, PillTabBar, type PillTabAction, type PillTabItem } from '@waves/ui';
 
-import { isRtl, useStrings } from '@/i18n';
+import { useCaptures } from '@/data/hooks';
+import { isRtl, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
+import { foldedCaptureCount } from '@/lib/captureBatch';
+import { captureInboxActionState } from '@/lib/dashboardActions';
 import { router, switchTab } from '@/lib/navigation';
 import { pushToTalk } from '@/lib/pushToTalk';
 import { resolveTabBar, tabBarRouteForSelection } from '@/lib/tabBar';
@@ -61,7 +64,7 @@ function buzz(ms: number): void {
 
 /** Renders the persistent bottom navigation bar and routes tab selections without stacking duplicates. */
 export function AppTabBar() {
-  const { t } = useStrings();
+  const { t, locale } = useStrings();
   const { session } = useAuth();
   // `useSegments` is typed as a union of fixed-length route tuples, so indexing
   // past the first element trips the tuple bounds check under the CI tsconfig.
@@ -78,6 +81,17 @@ export function AppTabBar() {
   // legal line is the one place it used to leak onto a signed-out screen.
   const { hidden, activeKey } = resolveTabBar(segments, !session);
 
+  // The Review tab's badge — the same folded count the dashboard hero's inbox
+  // circle showed before Activity took its place there (see `(tabs)/index.tsx`).
+  // Read here rather than passed down, because the bar is mounted once at the
+  // root and outlives whichever screen is on top of it; reusing
+  // `foldedCaptureCount`/`captureInboxActionState` rather than a second count
+  // is the whole point — a badge that disagreed with the screen it opens would
+  // be worse than none.
+  const captures = useCaptures();
+  const waitingCount = foldedCaptureCount(captures.data ?? []);
+  const captureBadge = captureInboxActionState(waitingCount).badge;
+
   const items = useMemo<PillTabItem[]>(
     () => [
       {
@@ -91,9 +105,20 @@ export function AppTabBar() {
         icon: (color) => <Ionicons name="people" size={iconSize.lg} color={color} />,
       },
       {
-        key: 'activity',
-        label: t.activity,
-        icon: (color) => <Ionicons name="pulse" size={iconSize.lg} color={color} />,
+        key: 'captures',
+        label: t.review,
+        // The visible pill has room for one short word; a screen reader gets
+        // the count too, in the same sentence the inbox's own empty/non-empty
+        // states already speak (`captures.unassignedBody`) — one wording for
+        // "how many are waiting", not a second one invented for the tab.
+        accessibilityLabel:
+          waitingCount > 0
+            ? `${t.review} — ${plural(locale, waitingCount, t.captures.unassignedBody)}`
+            : t.review,
+        icon: (color) => (
+          <Ionicons name="file-tray-full-outline" size={iconSize.lg} color={color} />
+        ),
+        badge: captureBadge,
       },
       {
         key: 'me',
@@ -101,7 +126,16 @@ export function AppTabBar() {
         icon: (color) => <Ionicons name="wallet-outline" size={iconSize.lg} color={color} />,
       },
     ],
-    [t.activity, t.friends, t.home, t.personal.tab],
+    [
+      captureBadge,
+      locale,
+      t.captures.unassignedBody,
+      t.friends,
+      t.home,
+      t.personal.tab,
+      t.review,
+      waitingCount,
+    ],
   );
 
   // All bar destinations are tabs now. `navigate` switches to the existing tab

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -207,8 +207,14 @@ export interface UiStrings {
   /** A small tag on a group whose trip is running today. */
   tagOnTrip: string;
   newGroup: string;
+  /** The Activity screen's own title, still used there (it moved off the bar
+   *  onto a dashboard hero control, `app/activity.tsx`). */
   activity: string;
   friends: string;
+  /** The bar's Review tab — the drafts inbox that replaced Activity there.
+   *  Short on purpose; a tab has room for one word, and a screen reader is
+   *  handed the waiting count separately (see `AppTabBar`). */
+  review: string;
   /** The Friends list sort menu — the header, and its three keys. */
   sort: {
     by: string;
@@ -3211,6 +3217,7 @@ const en: UiStrings = {
   newGroup: 'New group',
   activity: 'Activity',
   friends: 'Friends',
+  review: 'Review',
   sort: { by: 'Sort by', amount: 'Amount', date: 'Recent activity', name: 'Name' },
   addPerson: {
     title: 'Add a person',
@@ -5823,6 +5830,7 @@ const ta: UiStrings = {
   newGroup: 'புதிய குழு',
   activity: 'செயல்பாடு',
   friends: 'நண்பர்கள்',
+  review: 'மறுபார்வை',
   sort: { by: 'வரிசைப்படுத்து', amount: 'தொகை', date: 'சமீபத்திய செயல்பாடு', name: 'பெயர்' },
   addPerson: {
     title: 'ஒருவரைச் சேர்',
@@ -8549,6 +8557,7 @@ const hi: UiStrings = {
   newGroup: 'नया समूह',
   activity: 'गतिविधि',
   friends: 'दोस्त',
+  review: 'समीक्षा',
   sort: { by: 'क्रमबद्ध करें', amount: 'राशि', date: 'हाल की गतिविधि', name: 'नाम' },
   addPerson: {
     title: 'एक व्यक्ति जोड़ें',
@@ -11182,6 +11191,7 @@ const ar: UiStrings = {
   newGroup: 'مجموعة جديدة',
   activity: 'النشاط',
   friends: 'الأصدقاء',
+  review: 'مراجعة',
   sort: { by: 'ترتيب حسب', amount: 'المبلغ', date: 'النشاط الأخير', name: 'الاسم' },
   addPerson: {
     title: 'إضافة شخص',

--- a/apps/mobile/src/lib/dashboardActions.ts
+++ b/apps/mobile/src/lib/dashboardActions.ts
@@ -1,26 +1,20 @@
 /**
- * Small dashboard action decisions kept out of the component so interaction
- * affordances can be pinned without rendering the whole home screen.
+ * The capture inbox's badge math, kept out of any component so it can be
+ * shared and tested without rendering one.
+ *
+ * This used to decide the dashboard's own inbox circle, back when it disabled
+ * and dimmed itself at zero — a visible control that did nothing when tapped.
+ * The circle has since moved onto the bar as the "Review" tab (see
+ * `AppTabBar`), which is always tappable whether or not anything is waiting,
+ * so there is nothing left to disable; what survives here is the one thing
+ * both surfaces needed the same answer to — the badge, absent at zero so there
+ * is never a red dot standing for nothing.
  */
-
 export interface CaptureInboxActionState {
-  /** The badge shown on the inbox glyph; absent at zero so there is no red dot. */
+  /** The badge to show; absent at zero. */
   badge: number | undefined;
-  /** A visible inbox glyph should never be a dead target; empty inbox still opens. */
-  disabled: false;
 }
 
-/**
- * The dashboard's capture inbox button.
- *
- * It used to dim and disable itself at zero, leaving a visible control that did
- * nothing when tapped. Opening the empty inbox is the more honest empty state:
- * a user, rider, traveller or financer can still learn where drafts would land,
- * and the button no longer behaves like the dead gap reported beside the mic.
- */
 export function captureInboxActionState(captureCount: number): CaptureInboxActionState {
-  return {
-    badge: captureCount > 0 ? captureCount : undefined,
-    disabled: false,
-  };
+  return { badge: captureCount > 0 ? captureCount : undefined };
 }

--- a/apps/mobile/src/lib/tabBar.ts
+++ b/apps/mobile/src/lib/tabBar.ts
@@ -43,7 +43,7 @@ export interface TabBarState {
   readonly activeKey: string;
 }
 
-export type TabBarRoute = '/' | '/friends' | '/activity' | '/me';
+export type TabBarRoute = '/' | '/friends' | '/captures' | '/me';
 
 /**
  * The route a bottom-bar tap should navigate to, or null when the destination is
@@ -59,8 +59,8 @@ export function tabBarRouteForSelection(
   switch (selectedKey) {
     case 'friends':
       return '/friends';
-    case 'activity':
-      return '/activity';
+    case 'captures':
+      return '/captures';
     case 'me':
       return '/me';
     default:

--- a/apps/mobile/test/captureBatch.test.ts
+++ b/apps/mobile/test/captureBatch.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import { foldedCaptureCount, voiceBatchId, type HasParsed } from '../src/lib/captureBatch';
+import { captureInboxActionState } from '../src/lib/dashboardActions';
+
+function capture(parsed?: unknown): HasParsed {
+  return { parsed };
+}
+
+describe('voiceBatchId', () => {
+  it('reads the batch id out of a parsed voice capture', () => {
+    expect(voiceBatchId(capture({ voiceBatchId: 'b1' }))).toBe('b1');
+  });
+
+  it('is null for a capture with no batch id, or no parsed blob at all', () => {
+    expect(voiceBatchId(capture())).toBeNull();
+    expect(voiceBatchId(capture({}))).toBeNull();
+    expect(voiceBatchId(capture({ voiceBatchId: '' }))).toBeNull();
+  });
+});
+
+describe('foldedCaptureCount', () => {
+  it('counts an empty inbox as zero', () => {
+    expect(foldedCaptureCount([])).toBe(0);
+  });
+
+  it('counts each standalone capture once', () => {
+    expect(foldedCaptureCount([capture(), capture(), capture()])).toBe(3);
+  });
+
+  it('folds every capture sharing a voice batch id into one', () => {
+    const batch = [
+      capture({ voiceBatchId: 'b1' }),
+      capture({ voiceBatchId: 'b1' }),
+      capture({ voiceBatchId: 'b1' }),
+    ];
+    expect(foldedCaptureCount(batch)).toBe(1);
+  });
+
+  it('mixes standalone captures and several batches without double counting', () => {
+    const rows = [
+      capture(),
+      capture({ voiceBatchId: 'b1' }),
+      capture({ voiceBatchId: 'b1' }),
+      capture({ voiceBatchId: 'b2' }),
+      capture(),
+    ];
+    // 2 standalone + 2 distinct batches = 4, not the 5 raw rows.
+    expect(foldedCaptureCount(rows)).toBe(4);
+  });
+});
+
+/**
+ * The Review tab's badge (`AppTabBar`) and the dashboard hero's inbox card
+ * used to feed this exact pipeline — fold, then decide the badge — and the
+ * badge must never disagree with what the screen it opens is about to show.
+ * Proving the two functions compose correctly here is what backs that claim,
+ * beyond each function's own isolated tests.
+ */
+describe('folded count feeding the badge', () => {
+  it('shows no badge when nothing is waiting — never a bare dot for zero', () => {
+    expect(captureInboxActionState(foldedCaptureCount([])).badge).toBeUndefined();
+  });
+
+  it('badges the folded count, not the raw row count', () => {
+    const rows = [
+      capture({ voiceBatchId: 'b1' }),
+      capture({ voiceBatchId: 'b1' }),
+      capture({ voiceBatchId: 'b1' }),
+      capture(),
+    ];
+    expect(captureInboxActionState(foldedCaptureCount(rows)).badge).toBe(2);
+  });
+});

--- a/apps/mobile/test/dashboardActions.test.ts
+++ b/apps/mobile/test/dashboardActions.test.ts
@@ -2,12 +2,15 @@ import { describe, expect, it } from 'vitest';
 
 import { captureInboxActionState } from '../src/lib/dashboardActions';
 
+// This is the exact function the Review tab's badge reads (`AppTabBar`), so
+// what is proven here — no badge at zero, the real count otherwise — is
+// proven for the tab, not just for the dashboard circle it used to decide.
 describe('captureInboxActionState', () => {
-  it('opens the empty inbox instead of leaving a visible dead control', () => {
-    expect(captureInboxActionState(0)).toEqual({ badge: undefined, disabled: false });
+  it('shows no badge when nothing is waiting — never a bare dot for zero', () => {
+    expect(captureInboxActionState(0)).toEqual({ badge: undefined });
   });
 
-  it('badges waiting drafts while keeping the inbox tappable', () => {
-    expect(captureInboxActionState(3)).toEqual({ badge: 3, disabled: false });
+  it('badges the exact count of waiting drafts', () => {
+    expect(captureInboxActionState(3)).toEqual({ badge: 3 });
   });
 });

--- a/apps/mobile/test/reviewTabRoutes.test.ts
+++ b/apps/mobile/test/reviewTabRoutes.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Where Review and Activity have to live for expo-router to resolve them
+ * right, pinned so a future move of either screen breaks a test rather than
+ * a person's tab bar or dashboard shortcut.
+ *
+ * A `(tabs)` folder is a route GROUP — its parentheses contribute no path
+ * segment — so moving a screen in or out of it changes which navigator owns
+ * it (and so whether the bottom bar highlights it) without changing the URL
+ * that reaches it at all. That is the whole trick this PR relies on:
+ * `/captures` resolves to the same path whether the file sits at
+ * `app/captures.tsx` or `app/(tabs)/captures.tsx`, so every existing
+ * `router.push`/`navigate` call and every `waves://captures` deep link
+ * (`lib/captureNudge/schedule.ts`) keeps working unchanged. `tabBar.test.ts`
+ * covers the navigator-level behaviour this file structure produces
+ * (`resolveTabBar`, `tabBarRouteForSelection`); this file pins the physical
+ * move those tests assume.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const appDir = join(__dirname, '../src/app');
+
+describe('the Review/Activity tab swap', () => {
+  it('moves captures.tsx into the tab group — the URL is unchanged, only the navigator', () => {
+    expect(existsSync(join(appDir, '(tabs)/captures.tsx'))).toBe(true);
+    expect(existsSync(join(appDir, 'captures.tsx'))).toBe(false);
+  });
+
+  it('moves activity.tsx out of the tab group and onto the root stack, the mirror move', () => {
+    expect(existsSync(join(appDir, 'activity.tsx'))).toBe(true);
+    expect(existsSync(join(appDir, '(tabs)/activity.tsx'))).toBe(false);
+  });
+
+  it("lists exactly the four bar destinations, Review in Activity's old slot", () => {
+    const layout = readFileSync(join(appDir, '(tabs)/_layout.tsx'), 'utf8');
+    const names = [...layout.matchAll(/<Tabs\.Screen name="([^"]+)"/g)].map((match) => match[1]);
+    expect(names).toEqual(['index', 'friends', 'captures', 'me']);
+  });
+
+  it('registers Activity as a slid-in root stack screen, not a tab', () => {
+    const rootLayout = readFileSync(join(appDir, '_layout.tsx'), 'utf8');
+    expect(rootLayout).toMatch(/<Stack\.Screen name="activity" options={slide} \/>/);
+    expect(rootLayout).not.toMatch(/<Stack\.Screen name="captures"/);
+  });
+});

--- a/apps/mobile/test/tabBar.test.ts
+++ b/apps/mobile/test/tabBar.test.ts
@@ -6,13 +6,13 @@ describe('tabBarRouteForSelection', () => {
   it('does not navigate when the selected tab is already active', () => {
     expect(tabBarRouteForSelection('index', 'index')).toBeNull();
     expect(tabBarRouteForSelection('friends', 'friends')).toBeNull();
-    expect(tabBarRouteForSelection('activity', 'activity')).toBeNull();
+    expect(tabBarRouteForSelection('captures', 'captures')).toBeNull();
   });
 
   it('maps inactive tab selections to their routes', () => {
     expect(tabBarRouteForSelection('friends', 'index')).toBe('/');
     expect(tabBarRouteForSelection('index', 'friends')).toBe('/friends');
-    expect(tabBarRouteForSelection('index', 'activity')).toBe('/activity');
+    expect(tabBarRouteForSelection('index', 'captures')).toBe('/captures');
     expect(tabBarRouteForSelection('index', 'me')).toBe('/me');
   });
 });
@@ -21,7 +21,14 @@ describe('resolveTabBar', () => {
   it('lights the current tab inside the tabs group', () => {
     expect(resolveTabBar(['(tabs)', 'index'])).toEqual({ hidden: false, activeKey: 'index' });
     expect(resolveTabBar(['(tabs)', 'friends'])).toEqual({ hidden: false, activeKey: 'friends' });
-    expect(resolveTabBar(['(tabs)', 'activity'])).toEqual({ hidden: false, activeKey: 'activity' });
+    // `captures` (the "Review" tab) replaced `activity` in the bar — its file
+    // moved into `(tabs)/captures.tsx`, so a person on it now shows the same
+    // shape as any other tab: `(tabs)` as the root segment, the tab's own file
+    // name as the leaf.
+    expect(resolveTabBar(['(tabs)', 'captures'])).toEqual({
+      hidden: false,
+      activeKey: 'captures',
+    });
     expect(resolveTabBar(['(tabs)', 'me'])).toEqual({ hidden: false, activeKey: 'me' });
   });
 
@@ -32,7 +39,6 @@ describe('resolveTabBar', () => {
   it('shows the bar with nothing current deeper in the app', () => {
     expect(resolveTabBar(['group', '[id]'])).toEqual({ hidden: false, activeKey: '' });
     expect(resolveTabBar(['settings', 'notifications'])).toEqual({ hidden: false, activeKey: '' });
-    expect(resolveTabBar(['captures'])).toEqual({ hidden: false, activeKey: '' });
   });
 
   it('does not light the removed account tab even when on it', () => {
@@ -41,7 +47,18 @@ describe('resolveTabBar', () => {
     // it pushes like any other screen. The bar stays, with nothing lit.
     const state = resolveTabBar(['profile']);
     expect(state.hidden).toBe(false);
-    expect(['index', 'friends', 'activity', 'me']).not.toContain(state.activeKey);
+    expect(['index', 'friends', 'captures', 'me']).not.toContain(state.activeKey);
+  });
+
+  it('shows the bar with nothing lit on Activity, now that it pushes rather than tabs', () => {
+    // Activity swapped places with Drafts: it moved out of `(tabs)` to a root
+    // stack screen (`app/activity.tsx`), reached from the dashboard hero rather
+    // than the bar — the same move Settings made before it. Its root segment is
+    // now `activity` with no `(tabs)` prefix, so it lights no tab, exactly like
+    // `profile` above.
+    const state = resolveTabBar(['activity']);
+    expect(state.hidden).toBe(false);
+    expect(['index', 'friends', 'captures', 'me']).not.toContain(state.activeKey);
   });
 
   it('hides on the full-screen camera and the signed-out screens', () => {

--- a/e2e/capture-assign.yaml
+++ b/e2e/capture-assign.yaml
@@ -26,12 +26,14 @@ appId: app.waves.mobile
 - assertVisible: 'Decide later'
 - tapOn: 'Save capture'
 
-# Back on the dashboard the captures action now carries a count (local-first, no
-# server round-trip). Wait for it, then open the inbox.
+# The drafts inbox is a bar tab now ("Review"), badged with the folded count —
+# it used to be a dashboard hero circle before Activity took that spot. Wait
+# for the dashboard to settle back into view (the save is local-first, no
+# server round-trip needed) before switching to it.
 - extendedWaitUntilVisible:
-    text: 'Captures. 1'
+    text: 'Your groups'
     timeout: 20000
-- tapOn: 'Captures. 1'
+- tapOn: 'Review'
 
 # The waiting capture is listed; assign it to the seeded group.
 - assertVisible: 'Auto to airport'

--- a/packages/ui/src/components/PillTabBar.tsx
+++ b/packages/ui/src/components/PillTabBar.tsx
@@ -10,8 +10,22 @@ import { Text } from './Text';
 export interface PillTabItem {
   key: string;
   label: string;
+  /**
+   * What a screen reader says instead of `label`, when a bare word is not
+   * enough — the Review tab reads its waiting count this way ("Review, 7
+   * waiting") while the pill under it still shows the one short word a tab
+   * has room for. Falls back to `label` when absent, so every existing item
+   * needs no change.
+   */
+  accessibilityLabel?: string;
   /** Receives the resolved colour so icons match the active/inactive state. */
   icon: (color: string, focused: boolean) => ReactNode;
+  /**
+   * A small count drawn over the icon. Undefined renders nothing — never a
+   * bare dot or a zero — so a caller folds "is there anything waiting" into
+   * the same number it passes here rather than this component guessing.
+   */
+  badge?: number;
 }
 
 /**
@@ -399,7 +413,7 @@ const TabItem = memo(function TabItem({
     <Pressable
       accessibilityRole="tab"
       accessibilityState={{ selected: focused }}
-      accessibilityLabel={item.label}
+      accessibilityLabel={item.accessibilityLabel ?? item.label}
       onPress={() => {
         if (!focused) onSelect(item.key);
       }}
@@ -415,21 +429,59 @@ const TabItem = memo(function TabItem({
           transform: [{ scale }],
         }}
       >
-        <View
-          style={{
-            width: INDICATOR_WIDTH,
-            height: INDICATOR_HEIGHT,
-            // A fixed stadium radius, larger than the box, so the ends stay
-            // fully round however the box is measured — half-the-height reads as
-            // square for the frame before layout settles the exact height.
-            borderRadius: 999,
-            alignItems: 'center',
-            justifyContent: 'center',
-            overflow: 'hidden',
-            backgroundColor: focused ? theme.color.brandSoft : 'transparent',
-          }}
-        >
-          {item.icon(ink, focused)}
+        {/* `position: relative` gives the badge below a frame of its own to sit
+            outside without pushing the indicator pill's own layout around. */}
+        <View style={{ position: 'relative' }}>
+          <View
+            style={{
+              width: INDICATOR_WIDTH,
+              height: INDICATOR_HEIGHT,
+              // A fixed stadium radius, larger than the box, so the ends stay
+              // fully round however the box is measured — half-the-height reads as
+              // square for the frame before layout settles the exact height.
+              borderRadius: 999,
+              alignItems: 'center',
+              justifyContent: 'center',
+              overflow: 'hidden',
+              backgroundColor: focused ? theme.color.brandSoft : 'transparent',
+            }}
+          >
+            {item.icon(ink, focused)}
+          </View>
+          {/* Sits at the icon's own corner, not the wider indicator pill's — the
+              pill only exists to carry the focused tint and is nearly twice the
+              icon's width, so anchoring to it would float the badge well clear
+              of the glyph it is meant to be attached to. A negative-margin ring
+              in the bar's own surface colour separates it from whatever sits
+              behind (the bar's flat fill, or the focused pill's soft tint),
+              matching the ring `HeroCircle` draws on the dashboard for the same
+              count. Never rendered at zero — `badge` is `undefined` then, not
+              `0`, so there is no dot with nothing behind it. */}
+          {item.badge ? (
+            <View
+              style={{
+                position: 'absolute',
+                top: -4,
+                right: INDICATOR_WIDTH / 2 - 16,
+                minWidth: 16,
+                height: 16,
+                borderRadius: 8,
+                paddingHorizontal: 3,
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: theme.color.negative,
+                borderWidth: 1.5,
+                borderColor: theme.color.surface,
+              }}
+            >
+              <Text
+                variant="micro"
+                style={{ color: '#FFFFFF', fontSize: 9, lineHeight: 11, fontWeight: '800' }}
+              >
+                {item.badge > 99 ? '99+' : String(item.badge)}
+              </Text>
+            </View>
+          ) : null}
         </View>
         <Text
           variant="micro"


### PR DESCRIPTION
## Before / after the tab bar

Before: **Home · Friends · [mic] · Activity · Personal**
After: **Home · Friends · [mic] · Review · Personal**

Review *is* the existing drafts inbox (`captures.tsx`, "expenses saved without a group yet"), promoted from a pushed screen to a tab. It carries a badge with the folded count of things waiting — `foldedCaptureCount(useCaptures())`, the exact same number the dashboard hero used to show on its inbox circle. No second count was invented; the badge is absent at zero, never a bare dot.

## Where Activity went, and why

The Activity *screen* is unchanged — only its entry point moved, to the dashboard hero's inbox circle (which the drafts inbox no longer needs, now that it's always one tap away on the bar). It carries no badge of its own: Activity has no unread concept today, and I didn't invent one to fill the slot — a badge with nothing honest to count is worse than none.

Under the hood this is a plain file move, nothing more clever: `(tabs)/captures.tsx` and `app/activity.tsx` traded places. A `(tabs)` group folder contributes no path segment, so `/captures` and `/activity` resolve exactly as they did before — every `router.push`/`navigate` call, deep link and local notification into either keeps working unchanged.

Header changes followed from the move, not decoration: Activity gained the back chevron every other pushed screen wears (the same move Settings made once before it — see the comment in `(tabs)/_layout.tsx`); Review lost its own back chevron and centred title, since a tab has nowhere "back" to go, and its header now matches Activity's old icon-plus-title row instead.

## Naming

Went with "Review" — the user's word. It's the honest name for what the tab holds (expenses waiting to be reviewed and filed), and it turns out the app already has this exact translated word (`voice.review`, "the review step for heard expenses"), now promoted to a shared top-level key. All four translations checked against the tab's tight width: `மறுபார்வை` / `समीक्षा` / `مراجعة` land within a character of Activity's own words in the same slot, so no further shortening was needed.

One thing I did **not** change: the screen's own header still says "Saved for later" (`t.captures.title`) — a slight mismatch with the tab's "Review" label. Harmonizing those two is a real, separate call (which name wins?) and not one I made unilaterally.

## Shaping for the drafts-and-rules plan

`docs/plan-drafts-and-rules.md` (#793) names this exact screen as the one true drafts hub future SMS/paste/email sources should feed into — never a second inbox beside it (the mistake #565 already undid once). The screen's header comment now says so. **Nothing from that plan is implemented here** — no source filters, no rules engine, no paste screen.

## Routes verified

- `router.navigate('/captures')` — dashboard hero circle (now retired) and the dead, unimported `UnassignedCapturesCard`
- `router.replace('/captures')` — `voice.tsx`, after a spoken batch with no group
- `waves://captures` — the daily "drafts are waiting" local notification (`captureNudge/schedule.ts`), resolved by `routeForNotification`
- Every bottom-bar tap, via `tabBarRouteForSelection`
- `resolveTabBar` lighting the right tab / no tab for both the new `(tabs)/captures` and the now-plain `activity` route

## Tests

Extended `apps/mobile/test/`:
- `tabBar.test.ts` — new tab set (`captures` in, `activity` out), and the route each now resolves to
- `reviewTabRoutes.test.ts` (new) — pins the physical file layout (`(tabs)/captures.tsx` exists, root `captures.tsx` doesn't, and the mirror for `activity.tsx`) and the tab order in `(tabs)/_layout.tsx`
- `captureBatch.test.ts` (new) — `foldedCaptureCount` fold behaviour plus the exact fold→badge pipeline the tab uses (no badge at zero, folded not raw count otherwise)
- `dashboardActions.test.ts` — updated for `captureInboxActionState`'s simplified shape (its always-`false` `disabled` field is gone now that nothing reads it)

## Gates

- `pnpm format` — clean
- `pnpm lint` — 0 errors (1 pre-existing warning in an unrelated file, `group/[id]/settings.tsx`, not touched here)
- `pnpm --filter @waves/mobile typecheck` — clean
- `pnpm --filter @waves/mobile test` — 112 files / 1474 tests pass
- `pnpm --filter @waves/core test` — 63 files / 993 tests pass
- `packages/db` tests — **not run**, they need a local Postgres that isn't running

## Deliberately not done

- Any part of the drafts-and-rules plan (source filters, rules engine, paste/email UI) — out of scope, called out above
- Harmonizing the screen's own "Saved for later" title with the tab's "Review" label
- Running `e2e/capture-assign.yaml` (Maestro, needs a device/emulator) — I updated it best-effort to tap "Review" instead of the retired dashboard circle text, but could not verify it; its old wait-text didn't match the current label even before this change, so it looks like it was already stale
- No device testing of any kind — I can't run this on a device, only the gates above

https://claude.ai/code/session_015jhzmZz5fkjnZZ14YxHGfS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Replaced the Activity tab with a Review tab for accessing drafts and captures.
  - Added capture-count badges to the Review tab, including folded batch counts.
  - Activity now opens as a dedicated screen with standard slide navigation and a back button.
  - Added numeric tab badges and improved accessibility labels.
  - Moved Settings navigation to standard slide transitions.
- **Bug Fixes**
  - Updated capture assignment flows to open drafts through the Review tab.
  - Added coverage for routing, capture counts, badges, and tab behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->