### PR TITLE
Paste a bank message into Review, and read the inbox only if a build asked to

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -98,6 +98,20 @@ function googleSignInPlugin(): [string, { iosUrlScheme: string }] | undefined {
   ];
 }
 
+/**
+ * Whether this build declares `android.permission.READ_SMS`.
+ *
+ * The same one-spelling switch `plugins/withSmsReader.js` reads, recorded into
+ * `extra` so the running app can tell without guessing. Asking the native module
+ * whether it loaded is not the same question: the module autolinks into every
+ * Android build, and a build without the manifest entry would get as far as the
+ * system permission dialog before failing — which is precisely the dialog a
+ * default build must never show. `src/lib/smsFeature.ts` reads this.
+ */
+function smsReaderBuild(): boolean {
+  return process.env.WAVES_SMS_READER === '1';
+}
+
 export default ({ config: fromAppJson }: ConfigContext): ExpoConfig => {
   // `app.json` arrives here already parsed, rather than being imported: that is
   // the shape `expo-doctor` recognises as "the dynamic config uses the static
@@ -117,6 +131,7 @@ export default ({ config: fromAppJson }: ConfigContext): ExpoConfig => {
   const iosKey = googleMapsKey('ios');
   const withPush: ExpoConfig = {
     ...config,
+    extra: { ...config.extra, smsReader: smsReaderBuild() },
     android: androidKey
       ? { ...androidBase, config: { ...androidBase?.config, googleMaps: { apiKey: androidKey } } }
       : androidBase,

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -124,6 +124,7 @@
       "./plugins/withGradleMemory",
       "./plugins/withSideBySideDebug",
       "./plugins/withReleaseSigning",
+      "./plugins/withSmsReader",
       "./plugins/withWavesWidgets",
       "./plugins/withWavesWear",
       "@bacons/apple-targets",

--- a/apps/mobile/plugins/withSmsReader.js
+++ b/apps/mobile/plugins/withSmsReader.js
@@ -1,0 +1,83 @@
+/**
+ * `READ_SMS` in the manifest — only when a build deliberately asks for it.
+ *
+ * WHY THIS IS A BUILD-TIME SWITCH AND NOT A RUNTIME ONE. Google Play scans the
+ * uploaded artefact's merged manifest. A declared `READ_SMS` is a *restricted*
+ * permission: holding it without an approved core use case from the Permissions
+ * Declaration Form gets an app removed from Play, not merely an update
+ * rejected, and "we never actually call it" is not a defence the scanner can
+ * hear. A feature flag, however honest, is invisible to it — the permission is
+ * either in the binary or it is not. So the Play artefact must not contain it,
+ * full stop, and that decision has to be made where the manifest is written.
+ *
+ * See `docs/plan-drafts-and-rules.md` §1.2 for the policy, and
+ * `docs/GOOGLE-PLAY.md` for the same rule in this repo's own words.
+ *
+ * HOW IT IS TURNED ON. One environment variable, at prebuild time:
+ *
+ *     WAVES_SMS_READER=1 npx expo prebuild --platform android
+ *
+ * Anything else — unset, `0`, `true`, `yes` — is off. Exactly one spelling is
+ * accepted on purpose: a permission this consequential should never be turned
+ * on by a value somebody typed loosely.
+ *
+ * WHAT "OFF" MEANS, PRECISELY. Off, this plugin registers no mod at all and
+ * returns the config object it was handed. It does not add an empty edit, it
+ * does not normalise anything, it does not touch `android.permissions`. A
+ * default build's `AndroidManifest.xml` is therefore byte-for-byte what it
+ * would be with this plugin absent from `app.json` — which is the property
+ * `apps/mobile/test/smsReaderPlugin.test.ts` pins, and the one a reviewer
+ * should re-check by diffing two prebuilds.
+ *
+ * The runtime half is separate and *also* mandatory: `src/lib/smsFeature.ts`
+ * gates every entry point on the `sms_inbox_read` feature flag and on this
+ * build having the permission at all. Two independent gates, neither one
+ * standing in for the other.
+ */
+
+const { withAndroidManifest } = require('expo/config-plugins');
+
+const PERMISSION = 'android.permission.READ_SMS';
+
+/** The one spelling that turns the reader on. */
+function readerEnabled(env) {
+  return env?.WAVES_SMS_READER === '1';
+}
+
+/**
+ * Add `READ_SMS` to a parsed manifest, once.
+ *
+ * Takes and returns the manifest object `withAndroidManifest` hands over (the
+ * xml2js shape: `{ manifest: { 'uses-permission': [{ $: { 'android:name' } }] } }`).
+ * Idempotent, because prebuild can run twice over the same `android/` tree and
+ * a duplicated `<uses-permission>` is a merge warning nobody reads.
+ */
+function manifestWithReadSms(androidManifest) {
+  const manifest = androidManifest?.manifest;
+  if (!manifest) throw new Error('withSmsReader: no <manifest> element to add READ_SMS to');
+
+  const existing = Array.isArray(manifest['uses-permission']) ? manifest['uses-permission'] : [];
+  if (existing.some((entry) => entry?.$?.['android:name'] === PERMISSION)) return androidManifest;
+
+  return {
+    ...androidManifest,
+    manifest: {
+      ...manifest,
+      'uses-permission': [...existing, { $: { 'android:name': PERMISSION } }],
+    },
+  };
+}
+
+module.exports = function withSmsReader(config) {
+  // The whole point: with the switch off, nothing is registered, so there is no
+  // mod to produce a diff and no code path that could add the permission by
+  // accident.
+  if (!readerEnabled(process.env)) return config;
+
+  return withAndroidManifest(config, (manifestConfig) => {
+    manifestConfig.modResults = manifestWithReadSms(manifestConfig.modResults);
+    return manifestConfig;
+  });
+};
+
+module.exports._internals = { PERMISSION, readerEnabled, manifestWithReadSms };

--- a/apps/mobile/src/app/(tabs)/captures.tsx
+++ b/apps/mobile/src/app/(tabs)/captures.tsx
@@ -18,9 +18,12 @@
  * screen `docs/plan-drafts-and-rules.md` names as the one true drafts hub —
  * whatever arrives by paste, share or statement in a later phase is one more
  * source feeding these same rows, not a second inbox beside them (the mistake
- * #565 already undid once). Nothing from that plan is built here; the point of
- * writing it down is that landing it later should mean adding to this screen,
- * not rebuilding it.
+ * #565 already undid once). The first of those sources has now landed: the
+ * header's chat glyph opens `captures/paste`, where bank messages are pasted
+ * (or, on a build that has the reader, read) and become `captures` rows that
+ * arrive in this very list. No filter, no second tab, no new row shape — that
+ * is phase 2's business, and the point of this one is that it needed none of
+ * it.
  */
 
 import { useCallback, useMemo, useRef, useState } from 'react';
@@ -1064,6 +1067,18 @@ export default function CapturesScreen() {
             </Text>
           ) : null}
         </View>
+        {/* The second way a draft gets here: a bank message. A single labelled
+            glyph rather than a ⋯ holding one item — an overflow with nothing to
+            overflow hides the only thing in it. When the plan's later phases
+            add their own header actions, this is the one that folds behind the
+            ⋯ with them. */}
+        <IconButton label={t.captures.fromMessage} onPress={() => router.push('/captures/paste')}>
+          <Ionicons
+            name="chatbubble-ellipses-outline"
+            size={iconSize.md}
+            color={theme.color.text}
+          />
+        </IconButton>
       </Row>
 
       {/* One virtualized scroll region for every state, the way `ActivityScreen`
@@ -1095,7 +1110,18 @@ export default function CapturesScreen() {
                 title={t.captures.emptyTitle}
                 body={t.captures.emptyBody}
                 action={
-                  <Button label={t.captures.captureCta} onPress={() => router.push('/capture')} />
+                  // Two ways in, with the ranking said by weight rather than by
+                  // order alone: type one out, or hand over the messages your
+                  // bank already sent you. The second is quiet because it is
+                  // the less obvious of the two, not the lesser.
+                  <View style={{ gap: theme.spacing.xs, alignItems: 'center' }}>
+                    <Button label={t.captures.captureCta} onPress={() => router.push('/capture')} />
+                    <Button
+                      label={t.captures.fromMessage}
+                      variant="ghost"
+                      onPress={() => router.push('/captures/paste')}
+                    />
+                  </View>
                 }
               />
             </View>

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -684,6 +684,12 @@ function AuthGate() {
             <Stack.Screen name="paywall" options={slide} />
           </Stack.Protected>
           <Stack.Screen name="capture" options={slide} />
+          {/* The Review tab lives at `(tabs)/captures.tsx` and resolves at
+              `/captures`; these two are pushed on top of it, so a `captures/`
+              folder beside the tab group is exactly right and collides with
+              nothing. */}
+          <Stack.Screen name="captures/paste" options={slide} />
+          <Stack.Screen name="captures/messages" options={slide} />
           {/* Activity, out of the tab group and onto this stack — the mirror
               image of the move `captures` made the other way (see
               `(tabs)/_layout.tsx`). It is reached from the dashboard hero now,

--- a/apps/mobile/src/app/captures/messages.tsx
+++ b/apps/mobile/src/app/captures/messages.tsx
@@ -1,0 +1,242 @@
+/**
+ * The prominent disclosure, before Android is ever asked.
+ *
+ * Google Play requires that a sensitive permission be explained *in the app's
+ * own words*, in a screen a person has to pass, before the system dialog is
+ * raised. A `rationale` string attached to `PermissionsAndroid.request` is not
+ * that — it is the system's dialog with a sentence in it, shown at the moment
+ * the choice is already being demanded. So this screen exists, it says what is
+ * read and what becomes of it, it names what the *next* dialog will ask, and
+ * "Not now" leaves with nothing having happened.
+ *
+ * IT IS NOT NORMALLY REACHABLE. `useSmsInboxReader` is asked again here rather
+ * than trusted from the screen that pushed: a deep link, a stale back stack, or
+ * the flag being switched off while this was open must all end the same way,
+ * and the one thing that must never happen is a system permission prompt on a
+ * build or a phone that was not meant to see one. With the gates shut, this
+ * renders nothing and pops.
+ *
+ * WHAT IT DOES WITH WHAT IT READS. Hands it to the paste screen through
+ * `smsReadBridge` — an in-memory, read-once handoff — and pops. Nothing is
+ * written to disk here, nothing goes into a route param, and a draft made from
+ * a read message carries no message body at all (`lib/smsDrafts.ts`).
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { ScrollView, View } from 'react-native';
+
+import {
+  Button,
+  Callout,
+  Card,
+  IconButton,
+  iconSize,
+  Row,
+  Screen,
+  Text,
+  useTheme,
+} from '@waves/ui';
+
+import { useStrings, type UiStrings } from '@/i18n';
+import { useBottomClearance } from '@/lib/clearance';
+import { router } from '@/lib/navigation';
+import { useSmsInboxReader } from '@/lib/smsFeature';
+import { offerReadMessages } from '@/lib/smsReadBridge';
+import { readSms, SmsReadFailure } from '@/lib/smsReader';
+
+/** How far back a read reaches. A month, unless a person narrows it. */
+const WINDOWS = [7, 30] as const;
+const DEFAULT_DAYS = 30;
+
+const today = (): string => new Date().toISOString().slice(0, 10);
+const daysAgo = (days: number): string =>
+  new Date(Date.now() - days * 86_400_000).toISOString().slice(0, 10);
+
+/** Why the inbox could not be read, said in a way a person can act on. */
+function readFailureMessage(reason: SmsReadFailure, t: UiStrings): string {
+  switch (reason) {
+    case SmsReadFailure.Denied:
+      return t.smsImport.permissionDenied;
+    case SmsReadFailure.Blocked:
+      return t.smsImport.permissionBlocked;
+    case SmsReadFailure.Unsupported:
+      return t.smsImport.readUnsupported;
+    case SmsReadFailure.Unavailable:
+      return t.smsImport.readUnavailable;
+    case SmsReadFailure.Failed:
+      return t.smsImport.readFailed;
+  }
+}
+
+/** One promise, with a glyph: what is read, where it happens, what is kept. */
+function Bullet({
+  icon,
+  children,
+}: {
+  icon: keyof typeof Ionicons.glyphMap;
+  children: string;
+}): React.JSX.Element {
+  const theme = useTheme();
+  return (
+    <Row style={{ gap: theme.spacing.md, alignItems: 'flex-start' }}>
+      <View
+        style={{
+          width: 34,
+          height: 34,
+          borderRadius: theme.radius.md,
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: theme.color.brandSoft,
+        }}
+      >
+        <Ionicons name={icon} size={iconSize.md} color={theme.color.brand} />
+      </View>
+      <Text variant="caption" tone="muted" style={{ flex: 1, marginTop: 6 }}>
+        {children}
+      </Text>
+    </Row>
+  );
+}
+
+export default function ReadMessagesScreen(): React.JSX.Element | null {
+  const theme = useTheme();
+  const clearance = useBottomClearance(theme.spacing.xl);
+  const { t } = useStrings();
+  const offered = useSmsInboxReader();
+
+  const [days, setDays] = useState<number>(DEFAULT_DAYS);
+  const [reading, setReading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Both gates, re-checked here. Leaving is the only safe answer, and it is
+  // done in an effect rather than during render so the router is not navigated
+  // mid-commit.
+  useEffect(() => {
+    if (!offered) router.back();
+  }, [offered]);
+
+  const allow = useCallback(async (): Promise<void> => {
+    if (reading) return;
+    setReading(true);
+    setError(null);
+    try {
+      // The system dialog is raised inside here — after this screen, never
+      // instead of it. `permissionRationale` is what Android then shows.
+      const result = await readSms(
+        { from: daysAgo(days), to: today() },
+        t.smsImport.permissionRationale,
+      );
+      if (!result.ok) {
+        setError(readFailureMessage(result.reason, t));
+        return;
+      }
+      if (result.messages.length === 0) {
+        setError(t.smsImport.readNothing);
+        return;
+      }
+      offerReadMessages(result.messages);
+      router.back();
+    } catch {
+      // `readSms` describes its own failures rather than throwing, so this is
+      // the belt on the braces: a native module that throws where it promised
+      // a callback must still leave a sentence, not a white screen.
+      setError(readFailureMessage(SmsReadFailure.Failed, t));
+    } finally {
+      setReading(false);
+    }
+  }, [days, reading, t]);
+
+  if (!offered) return null;
+
+  return (
+    <Screen edges={['top']}>
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: clearance,
+          gap: theme.spacing.xl,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        <Row style={{ paddingTop: theme.spacing.md, alignItems: 'center' }}>
+          <IconButton label={t.common.close} onPress={() => router.back()}>
+            <Ionicons name="close" size={iconSize.xl} color={theme.color.text} />
+          </IconButton>
+        </Row>
+
+        {/* The illustration: one large mark rather than an image asset, which
+            would need four locales' worth of nothing and a dark variant. */}
+        <View style={{ alignItems: 'center', gap: theme.spacing.md }}>
+          <View
+            style={{
+              width: 88,
+              height: 88,
+              borderRadius: theme.radius.xl,
+              alignItems: 'center',
+              justifyContent: 'center',
+              backgroundColor: theme.color.brandSoft,
+            }}
+          >
+            <Ionicons name="chatbubbles-outline" size={44} color={theme.color.brand} />
+          </View>
+          <Text variant="title" align="center">
+            {t.smsImport.disclosure.title}
+          </Text>
+          <Text variant="caption" tone="muted" align="center">
+            {t.smsImport.disclosure.intro}
+          </Text>
+        </View>
+
+        <Card style={{ gap: theme.spacing.lg }}>
+          <Bullet icon="search-outline">{t.smsImport.disclosure.readsWhat}</Bullet>
+          <Bullet icon="phone-portrait-outline">{t.smsImport.disclosure.staysHere}</Bullet>
+          <Bullet icon="lock-closed-outline">{t.smsImport.disclosure.neverSent}</Bullet>
+        </Card>
+
+        {/* How far back. A month by default: far enough to be worth doing, near
+            enough that the answer is about this month's spending. */}
+        <View style={{ gap: theme.spacing.sm }}>
+          <Text variant="micro" tone="muted" style={{ textTransform: 'uppercase' }}>
+            {t.smsImport.datesSection}
+          </Text>
+          <Row style={{ gap: theme.spacing.sm }}>
+            {WINDOWS.map((window) => (
+              <Button
+                key={window}
+                label={window === 7 ? t.smsImport.last7 : t.smsImport.last30}
+                variant={days === window ? 'primary' : 'secondary'}
+                size="sm"
+                onPress={() => setDays(window)}
+              />
+            ))}
+          </Row>
+          <Text variant="micro" tone="muted">
+            {t.smsImport.readWindowNote}
+          </Text>
+        </View>
+
+        {/* Names the dialog that comes next, so the system prompt is a thing
+            they were told about rather than a thing that happened to them. */}
+        <Callout tone="info">{t.smsImport.disclosure.nextScreen}</Callout>
+
+        {error ? <Callout tone="negative">{error}</Callout> : null}
+
+        <View style={{ gap: theme.spacing.sm }}>
+          <Button
+            label={reading ? t.smsImport.reading : t.smsImport.permissionRationale.allow}
+            onPress={() => void allow()}
+            disabled={reading}
+          />
+          {/* Quiet, and it really does nothing: no permission is asked for, and
+              pasting is still the whole feature on the screen behind this. */}
+          <Button
+            label={t.smsImport.permissionRationale.notNow}
+            variant="ghost"
+            onPress={() => router.back()}
+          />
+        </View>
+      </ScrollView>
+    </Screen>
+  );
+}

--- a/apps/mobile/src/app/captures/paste.tsx
+++ b/apps/mobile/src/app/captures/paste.tsx
@@ -1,0 +1,553 @@
+/**
+ * Bank messages into drafts.
+ *
+ * This is the SMS feature, and on an iPhone it is the whole of it. iOS has no
+ * API that reads Messages at any tier, and Android's `READ_SMS` is restricted —
+ * held without an approved core use case it is grounds for removal from Play,
+ * not a rejected update (`docs/plan-drafts-and-rules.md` §1). So the honest
+ * design is the one where a person hands the messages over, and it is complete
+ * on its own rather than a fallback for a reader that is not there.
+ *
+ * A build made with `WAVES_SMS_READER=1`, on Android, for somebody in the
+ * `sms_inbox_read` treatment arm, gets one extra button here: it leads to a
+ * disclosure screen (`./messages`), never straight to the system prompt.
+ * Everything downstream of that button — the found list, the ticking, the
+ * writing — is this screen, unchanged.
+ *
+ * WHERE THINGS GO. Each ticked payment becomes a `captures` row: an expense
+ * with no group yet, which is what the Review tab has held since A34. Not a
+ * second inbox (#565 undid that once already), not an expense in a group —
+ * nothing here knows who was there, and the parser deliberately does not guess
+ * at a split.
+ *
+ * WHAT IS NOT SENT. Parsing is on-device (ADR-013): a bank message carries an
+ * account tail, a balance and sometimes a one-time password. The text of a
+ * pasted message rides along as `rawText` the way a scanned receipt's OCR does
+ * — a person put it there themselves. The text of a *read* message never does;
+ * `lib/smsDrafts.ts` is where that is decided, and a test pins it. And nothing
+ * on this screen reports anything at all: no Sentry event, no Clarity event,
+ * not even a count. A paste that parses badly is said to the person in front of
+ * it, and to nobody else.
+ *
+ * WHY IT IS A FLASHLIST. A month of statements is a hundred rows, and this is
+ * the screen the plan points the backfill at. The paste box and the intro ride
+ * as the list header so there is one scroll region rather than a list nested in
+ * a ScrollView, which does not virtualise at all.
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { FlashList } from '@shopify/flash-list';
+import * as Clipboard from 'expo-clipboard';
+import { useFocusEffect } from 'expo-router';
+import { Pressable, TextInput, View } from 'react-native';
+
+import { proposeFromSms, type ExpenseCandidate, type SmsMessage } from '@waves/core';
+import {
+  Badge,
+  Button,
+  Callout,
+  Card,
+  Divider,
+  EmptyState,
+  IconButton,
+  iconSize,
+  MoneyText,
+  Row,
+  Screen,
+  SectionHeader,
+  Text,
+  useTheme,
+} from '@waves/ui';
+
+import { dayHeading } from '@/data/activity';
+import { useCaptures, useCreateCapture } from '@/data/hooks';
+import { plural, useStrings, type UiStrings } from '@/i18n';
+import { useAuth } from '@/lib/auth';
+import { useBottomClearance } from '@/lib/clearance';
+import { friendlyError } from '@/lib/errors';
+import { useGuestGuard } from '@/lib/guestGuard';
+import { router } from '@/lib/navigation';
+import { smsCaptureId } from '@/lib/smsCaptureId';
+import {
+  bodiesByKey,
+  planSmsDrafts,
+  splitMessages,
+  unreadableCount,
+  type SmsDraftProvenance,
+} from '@/lib/smsDrafts';
+import { useSmsInboxReader } from '@/lib/smsFeature';
+import { takeReadMessages } from '@/lib/smsReadBridge';
+
+/** A day heading, or one payment under it. */
+type FoundItem =
+  | { kind: 'day'; key: string; at: string }
+  | { kind: 'candidate'; key: string; candidate: ExpenseCandidate };
+
+/**
+ * One found payment: a tick, the shop, the amount.
+ *
+ * The date is not on the row — the day heading above it already carries that,
+ * which is the point of grouping. What the row's second line carries instead is
+ * everything that would make a person hesitate: which bank said it, which card
+ * it was, and — the one that matters most on a trip — whether the day came from
+ * the message or was only the day it arrived.
+ */
+function FoundRow({
+  candidate,
+  picked,
+  locale,
+  t,
+  onToggle,
+}: {
+  candidate: ExpenseCandidate;
+  picked: boolean;
+  locale: string;
+  t: UiStrings;
+  onToggle: () => void;
+}): React.JSX.Element {
+  const theme = useTheme();
+  const title = candidate.merchant ?? t.smsImport.cardPayment;
+  const parts: string[] = [];
+  if (candidate.sender) parts.push(candidate.sender);
+  if (candidate.accountTail) parts.push(`⋯${candidate.accountTail}`);
+  if (candidate.dateInferred) parts.push(t.smsImport.dateNotInMessage);
+  const subtitle = parts.join(' · ');
+
+  return (
+    <Pressable
+      accessibilityRole="checkbox"
+      accessibilityState={{ checked: picked }}
+      accessibilityLabel={`${title}, ${picked ? t.smsImport.selected : t.smsImport.notSelected}`}
+      onPress={onToggle}
+      style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}
+    >
+      <Row
+        style={{
+          gap: theme.spacing.md,
+          alignItems: 'center',
+          paddingVertical: theme.spacing.sm,
+          minHeight: 52,
+        }}
+      >
+        {/* Never colour alone: the tick is a different glyph, not just a
+            different shade, and the a11y state says it a third way (#191). */}
+        <Ionicons
+          name={picked ? 'checkbox' : 'square-outline'}
+          size={iconSize.xxl}
+          color={picked ? theme.color.brand : theme.color.textFaint}
+        />
+        <View style={{ flex: 1, minWidth: 0, gap: 2 }}>
+          <Text variant="subheading" numberOfLines={1}>
+            {title}
+          </Text>
+          {subtitle ? (
+            <Text variant="micro" tone="muted" numberOfLines={1}>
+              {subtitle}
+            </Text>
+          ) : null}
+        </View>
+        <View style={{ alignItems: 'flex-end', gap: 2 }}>
+          <MoneyText
+            amount={candidate.amount.minor}
+            currency={candidate.amount.currency}
+            locale={locale}
+            variant="subheading"
+          />
+          {/* A message we only half understood is not pre-ticked, and says so
+              rather than simply sitting there unticked for no visible reason. */}
+          {candidate.preselect ? null : <Badge label={t.smsImport.checkThis} />}
+        </View>
+      </Row>
+    </Pressable>
+  );
+}
+
+export default function PasteMessagesScreen(): React.JSX.Element {
+  const theme = useTheme();
+  const clearance = useBottomClearance(theme.spacing.xl);
+  const { t, locale } = useStrings();
+  const { session } = useAuth();
+  const ownerId = session?.user?.id ?? '';
+  const guard = useGuestGuard();
+  const createCapture = useCreateCapture();
+  const captures = useCaptures();
+  // Both gates, asked once: Android, a build that declares the permission, and
+  // the treatment arm. False everywhere else, including every iPhone.
+  const readerOffered = useSmsInboxReader();
+
+  const [blob, setBlob] = useState('');
+  // Messages read from the inbox, kept apart from the pasted ones so each keeps
+  // its real received time — a dateless bank SMS is filed on the day it
+  // arrived, which a paste (received "now") cannot know. Held in state for the
+  // life of this screen and written to disk by nothing.
+  const [readMessages, setReadMessages] = useState<readonly SmsMessage[]>([]);
+  // Explicit ticks, over the parser's own pre-selection. Absent means "whatever
+  // `preselect` said", so a person who ticks nothing still gets the sensible set.
+  const [ticks, setTicks] = useState<Record<string, boolean>>({});
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [added, setAdded] = useState<number | null>(null);
+
+  // The disclosure screen leaves what it read here and pops. On focus rather
+  // than on mount: this screen is never unmounted while the disclosure is up,
+  // so a mount effect would have run long before there was anything to collect.
+  // `takeReadMessages` reads and clears in one step, so a later visit — or a
+  // second focus after nothing happened — picks up nothing.
+  useFocusEffect(
+    useCallback(() => {
+      const handed = takeReadMessages();
+      if (handed && handed.length > 0) {
+        setReadMessages((current) => [...current, ...handed]);
+        setError(null);
+      }
+    }, []),
+  );
+
+  const pastedBlocks = useMemo(() => splitMessages(blob), [blob]);
+  const pasted = useMemo(
+    () =>
+      pastedBlocks.map((body) => ({
+        body,
+        // A pasted message carries no arrival time of its own, so "now" stands
+        // in — and every candidate built from one that named no date is marked
+        // `dateInferred`, which the row says out loud.
+        receivedAt: new Date().toISOString(),
+      })),
+    [pastedBlocks],
+  );
+
+  // Read first, so that when the same message is both read and pasted the read
+  // one wins the dedupe — and therefore the stricter no-body rule applies.
+  const candidates = useMemo(
+    () => proposeFromSms([...readMessages, ...pasted]),
+    [readMessages, pasted],
+  );
+
+  // Which of these came out of the inbox. Computed from the read messages alone
+  // rather than inferred from what is missing, so a body can never be attached
+  // to a read draft by an accident of ordering.
+  const readKeys = useMemo(
+    () => new Set(proposeFromSms(readMessages).map((item) => item.dedupeKey)),
+    [readMessages],
+  );
+
+  const bodies = useMemo(() => bodiesByKey(pasted), [pasted]);
+
+  // Drafts already waiting in Review, by the key of the message behind them.
+  // Named rather than hidden: a re-paste that silently showed fewer rows than
+  // the person pasted would read as the parser having failed.
+  //
+  // This is the *visible* half of the guarantee and only covers drafts still
+  // open — `useCaptures` drops the ones already filed into a group. The durable
+  // half is the id: `smsCaptureId` derives it from the message, so a payment
+  // that has since become an expense is written again as the same row id, and
+  // `capture.create` answers that with the success it already achieved rather
+  // than a second draft. Re-pasting a whole month is safe; it just cannot say
+  // "already added" about the part of it that has since been filed.
+  const alreadyKeys = useMemo(() => {
+    const keys = new Set<string>();
+    for (const row of captures.data ?? []) {
+      const key = (row.parsed as SmsDraftProvenance | null)?.dedupeKey;
+      if (typeof key === 'string') keys.add(key);
+    }
+    return keys;
+  }, [captures.data]);
+
+  const fresh = useMemo(
+    () => candidates.filter((item) => !alreadyKeys.has(item.dedupeKey)),
+    [candidates, alreadyKeys],
+  );
+  const alreadyCount = candidates.length - fresh.length;
+  // How many pasted blocks produced nothing. Only pasted ones are counted: a
+  // read window sweeps up every message in it, most of which are not payments,
+  // and "412 of those were not payments" would be noise rather than news.
+  const notPayments = useMemo(() => unreadableCount(pastedBlocks), [pastedBlocks]);
+
+  const chosen = useMemo(() => {
+    const keys = new Set<string>();
+    for (const item of fresh) {
+      if (ticks[item.dedupeKey] ?? item.preselect) keys.add(item.dedupeKey);
+    }
+    return keys;
+  }, [fresh, ticks]);
+
+  const feed = useMemo((): FoundItem[] => {
+    const items: FoundItem[] = [];
+    let day = '';
+    for (const candidate of fresh) {
+      const candidateDay = candidate.at.slice(0, 10);
+      if (candidateDay !== day) {
+        day = candidateDay;
+        items.push({ kind: 'day', key: `day-${candidateDay}`, at: candidate.at });
+      }
+      items.push({ kind: 'candidate', key: candidate.dedupeKey, candidate });
+    }
+    return items;
+  }, [fresh]);
+
+  const toggle = useCallback((key: string, next: boolean): void => {
+    setTicks((current) => ({ ...current, [key]: next }));
+  }, []);
+
+  const paste = useCallback(async (): Promise<void> => {
+    const text = await Clipboard.getStringAsync();
+    if (!text.trim()) return;
+    setBlob((current) => (current ? `${current}\n\n${text}` : text));
+  }, []);
+
+  /**
+   * Write the ticked payments as drafts.
+   *
+   * Each id is derived from the message (`smsCaptureId`), so pasting the same
+   * statement next week produces the same ids and the second run writes nothing
+   * — the database is what enforces that, not this screen's memory of it. Each
+   * draft is its own attempt: one that refuses does not take the others down,
+   * and the count that is reported is the count that actually landed.
+   */
+  const add = useCallback(async (): Promise<void> => {
+    if (saving) return;
+    if (guard.blockWrite()) return;
+    if (!ownerId) return;
+
+    const drafts = planSmsDrafts({ candidates: fresh, chosen, readKeys, bodies });
+    if (drafts.length === 0) return;
+
+    setSaving(true);
+    setError(null);
+    let placed = 0;
+    try {
+      for (const draft of drafts) {
+        const captureId = await smsCaptureId(ownerId, draft.dedupeKey);
+        await createCapture.mutateAsync({
+          captureId,
+          description: draft.description,
+          category: draft.category,
+          expenseDate: draft.expenseDate,
+          currency: draft.currency,
+          amount: draft.amount,
+          rawText: draft.rawText,
+          parsed: { ...draft.parsed },
+        });
+        placed += 1;
+      }
+      setAdded(placed);
+      setBlob('');
+      setTicks({});
+      setReadMessages([]);
+    } catch (caught) {
+      setAdded(placed > 0 ? placed : null);
+      setError(friendlyError(caught, t.captures.couldNotSave, 'smsImport.addDrafts'));
+    } finally {
+      setSaving(false);
+    }
+  }, [
+    bodies,
+    chosen,
+    createCapture,
+    fresh,
+    guard,
+    ownerId,
+    readKeys,
+    saving,
+    t.captures.couldNotSave,
+  ]);
+
+  const header = (
+    <View style={{ gap: theme.spacing.lg, paddingBottom: theme.spacing.md }}>
+      <Row style={{ paddingTop: theme.spacing.md, alignItems: 'center' }}>
+        <IconButton label={t.common.close} onPress={() => router.back()}>
+          <Ionicons name="close" size={iconSize.xl} color={theme.color.text} />
+        </IconButton>
+        <Text variant="subheading" style={{ marginLeft: theme.spacing.md, flex: 1 }}>
+          {t.smsImport.title}
+        </Text>
+      </Row>
+
+      <Card style={{ gap: theme.spacing.sm }}>
+        <Text variant="caption" tone="muted">
+          {t.smsImport.howToDrafts}
+        </Text>
+        {/* Why there is no switch for this. Said only where it is true: a build
+            that can read the inbox has the button below instead, and the
+            sentence would contradict it. */}
+        {readerOffered ? null : (
+          <Text variant="micro" tone="muted">
+            {t.smsImport.whyNotAutomatic}
+          </Text>
+        )}
+      </Card>
+
+      {readerOffered ? (
+        <View style={{ gap: theme.spacing.sm }}>
+          <Button
+            label={t.smsImport.readMessages}
+            variant="secondary"
+            onPress={() => router.push('/captures/messages')}
+            icon={
+              <Ionicons name="chatbubbles-outline" size={iconSize.md} color={theme.color.brand} />
+            }
+          />
+          <Text variant="micro" tone="muted">
+            {t.smsImport.readOnAndroid}
+          </Text>
+          {readMessages.length > 0 ? (
+            <Text variant="micro" tone="muted">
+              {plural(locale, readMessages.length, t.smsImport.readCount)}
+            </Text>
+          ) : null}
+        </View>
+      ) : null}
+
+      <View style={{ gap: theme.spacing.sm }}>
+        <SectionHeader title={t.smsImport.messagesSection} />
+        <Card style={{ gap: theme.spacing.sm }}>
+          <TextInput
+            value={blob}
+            onChangeText={setBlob}
+            multiline
+            autoCapitalize="none"
+            accessibilityLabel={t.smsImport.pasteLabel}
+            placeholder={t.smsImport.pastePlaceholder}
+            placeholderTextColor={theme.color.textFaint}
+            style={{
+              minHeight: 140,
+              fontSize: 15,
+              color: theme.color.text,
+              textAlignVertical: 'top',
+            }}
+          />
+          <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+            <Text variant="micro" tone="muted">
+              {pastedBlocks.length === 0
+                ? t.smsImport.nothingPasted
+                : plural(locale, pastedBlocks.length, t.smsImport.messageCount)}
+            </Text>
+            <Button label={t.smsImport.paste} variant="ghost" onPress={() => void paste()} />
+          </Row>
+        </Card>
+      </View>
+
+      {/* Only over a list that has something in it. With nothing found, the
+          empty state below carries the same two sentences and this would say
+          them twice. */}
+      {fresh.length > 0 ? (
+        <View style={{ gap: theme.spacing.xs }}>
+          {/* An eyebrow over a question, not a noun over a list: the list has
+              one thing to ask and the button below is the answer. */}
+          <Text variant="micro" tone="muted" style={{ textTransform: 'uppercase' }}>
+            {t.smsImport.foundSection}
+          </Text>
+          <Text variant="heading">{t.smsImport.foundQuestion}</Text>
+          {/* Everything the parser could not use, said plainly. A screen that
+              quietly shows four rows for six messages reads as broken. */}
+          {notPayments > 0 ? (
+            <Text variant="micro" tone="muted">
+              {plural(locale, notPayments, t.smsImport.someNotParsed)}
+            </Text>
+          ) : null}
+          {alreadyCount > 0 ? (
+            <Text variant="micro" tone="muted">
+              {plural(locale, alreadyCount, t.smsImport.alreadyAdded)}
+            </Text>
+          ) : null}
+        </View>
+      ) : null}
+    </View>
+  );
+
+  const footer = (
+    <View style={{ gap: theme.spacing.md, paddingTop: theme.spacing.lg }}>
+      {error ? <Callout tone="negative">{error}</Callout> : null}
+      {added !== null ? (
+        <Callout tone="positive">{plural(locale, added, t.smsImport.addedDraftCount)}</Callout>
+      ) : null}
+      <Button
+        label={
+          saving
+            ? t.smsImport.adding
+            : chosen.size === 0
+              ? t.smsImport.nothingSelected
+              : plural(locale, chosen.size, t.smsImport.addDraftCount)
+        }
+        onPress={() => void add()}
+        disabled={chosen.size === 0 || saving}
+      />
+    </View>
+  );
+
+  const renderItem = useCallback(
+    ({ item }: { item: FoundItem }) => {
+      if (item.kind === 'day') {
+        return (
+          <Text
+            variant="micro"
+            tone="muted"
+            style={{
+              textTransform: 'uppercase',
+              marginTop: theme.spacing.md,
+              marginBottom: theme.spacing.xs,
+            }}
+          >
+            {dayHeading(locale, item.at)}
+          </Text>
+        );
+      }
+      const picked = chosen.has(item.candidate.dedupeKey);
+      return (
+        <View>
+          <FoundRow
+            candidate={item.candidate}
+            picked={picked}
+            locale={locale}
+            t={t}
+            onToggle={() => toggle(item.candidate.dedupeKey, !picked)}
+          />
+          <Divider />
+        </View>
+      );
+    },
+    [chosen, locale, t, theme.spacing.md, theme.spacing.xs, toggle],
+  );
+
+  return (
+    <Screen edges={['top']}>
+      <FlashList
+        data={feed}
+        keyExtractor={(item) => item.key}
+        renderItem={renderItem}
+        getItemType={(item) => item.kind}
+        // The group-ledger settings: `extraData` because a tick changes a row
+        // that FlashList would otherwise recycle unchanged, and the drop
+        // distance so a pasted month scrolls without blanking.
+        extraData={chosen}
+        drawDistance={1500}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: clearance,
+        }}
+        ListHeaderComponent={header}
+        ListFooterComponent={footer}
+        ListEmptyComponent={
+          // Nothing handed over yet is not an empty result; it is a screen
+          // waiting to be used, and the paste box above already says so.
+          pastedBlocks.length === 0 && readMessages.length === 0 ? null : (
+            <EmptyState
+              title={t.smsImport.nothingToImport}
+              // Why there is nothing, in the honest order: because you have
+              // them already, or because none of it was a payment. Never a
+              // blank list with no account of itself.
+              body={
+                alreadyCount > 0
+                  ? plural(locale, alreadyCount, t.smsImport.alreadyAdded)
+                  : t.smsImport.nothingLikeAPayment
+              }
+            />
+          )
+        }
+      />
+    </Screen>
+  );
+}

--- a/apps/mobile/src/app/captures/paste.tsx
+++ b/apps/mobile/src/app/captures/paste.tsx
@@ -14,6 +14,22 @@
  * Everything downstream of that button — the found list, the ticking, the
  * writing — is this screen, unchanged.
  *
+ * WHO THIS IS FOR. Somebody who has never used an expense app, and may never
+ * have deliberately copied text on a phone before. Everything on the screen is
+ * measured against that: no codes, no jargon, no rule about blank lines to get
+ * wrong, and never a guess dressed up as a fact.
+ *
+ * - The sender is a telecom routing header (`JM-ICICIT-S`), so it is turned
+ *   into "ICICI Bank" by `lib/smsPlain.ts` — and when that table does not know
+ *   the id, the line is simply not there. A code on screen is worse than a
+ *   blank.
+ * - A merchant that is plainly not a name — a phone number, a bare "VPA" —
+ *   does not become the title. "Payment from Axis Bank" is less specific and
+ *   entirely true, which is the trade this screen always makes.
+ * - A row the parser was unsure of says *what* it was unsure of, in a sentence,
+ *   and every pasted row can be opened to read the message it was made from.
+ *   "Check this" with nothing to check against is not a warning, it is a worry.
+ *
  * WHERE THINGS GO. Each ticked payment becomes a `captures` row: an expense
  * with no group yet, which is what the Review tab has held since A34. Not a
  * second inbox (#565 undid that once already), not an expense in a group —
@@ -24,10 +40,12 @@
  * account tail, a balance and sometimes a one-time password. The text of a
  * pasted message rides along as `rawText` the way a scanned receipt's OCR does
  * — a person put it there themselves. The text of a *read* message never does;
- * `lib/smsDrafts.ts` is where that is decided, and a test pins it. And nothing
- * on this screen reports anything at all: no Sentry event, no Clarity event,
- * not even a count. A paste that parses badly is said to the person in front of
- * it, and to nobody else.
+ * `lib/smsDrafts.ts` is where that is decided, and a test pins it. The same
+ * function decides what may be *shown*, so the message a person can open on a
+ * row is exactly the message that will be kept, and a read one is neither. And
+ * nothing on this screen reports anything at all: no Sentry event, no Clarity
+ * event, not even a count. A paste that parses badly is said to the person in
+ * front of it, and to nobody else.
  *
  * WHY IT IS A FLASHLIST. A month of statements is a hundred rows, and this is
  * the screen the plan points the backfill at. The paste box and the intro ride
@@ -42,7 +60,12 @@ import * as Clipboard from 'expo-clipboard';
 import { useFocusEffect } from 'expo-router';
 import { Pressable, TextInput, View } from 'react-native';
 
-import { proposeFromSms, type ExpenseCandidate, type SmsMessage } from '@waves/core';
+import {
+  proposeFromSms,
+  SMS_LOW_CONFIDENCE,
+  type ExpenseCandidate,
+  type SmsMessage,
+} from '@waves/core';
 import {
   Badge,
   Button,
@@ -55,7 +78,6 @@ import {
   MoneyText,
   Row,
   Screen,
-  SectionHeader,
   Text,
   useTheme,
 } from '@waves/ui';
@@ -71,95 +93,230 @@ import { router } from '@/lib/navigation';
 import { smsCaptureId } from '@/lib/smsCaptureId';
 import {
   bodiesByKey,
+  bodyForDisplay,
   planSmsDrafts,
   splitMessages,
   unreadableCount,
   type SmsDraftProvenance,
 } from '@/lib/smsDrafts';
 import { useSmsInboxReader } from '@/lib/smsFeature';
+import { bankFromSender, bankFromText, merchantName } from '@/lib/smsPlain';
 import { takeReadMessages } from '@/lib/smsReadBridge';
 
-/** A day heading, or one payment under it. */
+/**
+ * A day heading, or one payment under it.
+ *
+ * The body rides on the item rather than being looked up in the renderer, so
+ * the rule about which bodies may be seen is applied once, where the list is
+ * built, instead of at every recycle.
+ */
 type FoundItem =
   | { kind: 'day'; key: string; at: string }
-  | { kind: 'candidate'; key: string; candidate: ExpenseCandidate };
+  | { kind: 'candidate'; key: string; candidate: ExpenseCandidate; body: string | null };
+
+/** A comfortable target for a thumb that is not aiming carefully. */
+const ROW_MIN_HEIGHT = 60;
 
 /**
- * One found payment: a tick, the shop, the amount.
+ * What to call this payment, and who said so.
  *
- * The date is not on the row — the day heading above it already carries that,
- * which is the point of grouping. What the row's second line carries instead is
- * everything that would make a person hesitate: which bank said it, which card
- * it was, and — the one that matters most on a trip — whether the day came from
- * the message or was only the day it arrived.
+ * Never the raw sender and never a merchant that is obviously not a merchant —
+ * both judgements live in `lib/smsPlain.ts` and are pinned by its test. The
+ * order of the fallbacks is the order of decreasing specificity and constant
+ * truthfulness: the shop if we have one, otherwise the bank, otherwise the
+ * plainest thing that is still certainly true.
+ */
+function describe(
+  candidate: ExpenseCandidate,
+  body: string | null,
+  t: UiStrings,
+): { title: string; from: string | null } {
+  const bank = bankFromSender(candidate.sender) ?? bankFromText(body);
+  const shop = merchantName(candidate.merchant);
+  if (shop) return { title: shop, from: bank };
+  if (bank) return { title: t.smsImport.paymentFromBank.replace('{bank}', bank), from: null };
+  return { title: t.smsImport.aPayment, from: null };
+}
+
+/**
+ * Why a row is not already ticked, in words.
+ *
+ * `preselect` is false for exactly two reasons and this says which: a message
+ * that named no day, and a message the parser only half understood. A flag
+ * without a reason asks a person to check something they cannot see.
+ */
+function doubts(candidate: ExpenseCandidate, t: UiStrings): string[] {
+  const reasons: string[] = [];
+  if (candidate.dateInferred) reasons.push(t.smsImport.dateNotInMessage);
+  if (candidate.confidence < SMS_LOW_CONFIDENCE) reasons.push(t.smsImport.hardToRead);
+  return reasons;
+}
+
+/**
+ * One found payment: a tick, who it was, the amount — and, underneath, the
+ * message it was made from.
+ *
+ * The date is not on the row; the day heading above it carries that, which is
+ * the point of grouping. The second line carries who the bank says it was and
+ * which card, in words rather than in the bank's own shorthand.
+ *
+ * The whole row toggles the tick, so the target is the row and not the little
+ * box. "Read the message" is a separate, smaller target underneath precisely so
+ * that reaching for it cannot tick anything by accident.
  */
 function FoundRow({
   candidate,
+  body,
   picked,
+  open,
   locale,
   t,
   onToggle,
+  onOpen,
 }: {
   candidate: ExpenseCandidate;
+  body: string | null;
   picked: boolean;
+  open: boolean;
   locale: string;
   t: UiStrings;
   onToggle: () => void;
+  onOpen: () => void;
 }): React.JSX.Element {
   const theme = useTheme();
-  const title = candidate.merchant ?? t.smsImport.cardPayment;
+  const { title, from } = describe(candidate, body, t);
   const parts: string[] = [];
-  if (candidate.sender) parts.push(candidate.sender);
-  if (candidate.accountTail) parts.push(`⋯${candidate.accountTail}`);
-  if (candidate.dateInferred) parts.push(t.smsImport.dateNotInMessage);
+  if (from) parts.push(from);
+  if (candidate.accountTail)
+    parts.push(t.smsImport.cardEnding.replace('{tail}', candidate.accountTail));
   const subtitle = parts.join(' · ');
+  const reasons = doubts(candidate, t);
 
   return (
-    <Pressable
-      accessibilityRole="checkbox"
-      accessibilityState={{ checked: picked }}
-      accessibilityLabel={`${title}, ${picked ? t.smsImport.selected : t.smsImport.notSelected}`}
-      onPress={onToggle}
-      style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}
-    >
-      <Row
+    <View>
+      <Pressable
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: picked }}
+        accessibilityLabel={`${title}, ${picked ? t.smsImport.selected : t.smsImport.notSelected}`}
+        onPress={onToggle}
+        style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}
+      >
+        <Row
+          style={{
+            gap: theme.spacing.md,
+            alignItems: 'center',
+            paddingVertical: theme.spacing.md,
+            minHeight: ROW_MIN_HEIGHT,
+          }}
+        >
+          {/* Never colour alone: the tick is a different glyph, not just a
+              different shade, and the a11y state says it a third way (#191). */}
+          <Ionicons
+            name={picked ? 'checkbox' : 'square-outline'}
+            size={iconSize.jumbo}
+            color={picked ? theme.color.brand : theme.color.textFaint}
+          />
+          <View style={{ flex: 1, minWidth: 0, gap: 2 }}>
+            <Text variant="subheading" numberOfLines={2}>
+              {title}
+            </Text>
+            {subtitle ? (
+              <Text variant="caption" tone="muted" numberOfLines={1}>
+                {subtitle}
+              </Text>
+            ) : null}
+            {/* An icon as well as the words, so the uncertainty is not carried
+                by colour (#191) — and the words themselves, so "check this"
+                names something a person can actually go and check. */}
+            {reasons.map((reason) => (
+              <Row key={reason} gap={theme.spacing.xs} style={{ alignItems: 'flex-start' }}>
+                <Ionicons
+                  name="alert-circle-outline"
+                  size={iconSize.sm}
+                  color={theme.color.warning}
+                  style={{ marginTop: 2 }}
+                />
+                <Text variant="caption" tone="muted" style={{ flex: 1 }}>
+                  {reason}
+                </Text>
+              </Row>
+            ))}
+          </View>
+          <View style={{ alignItems: 'flex-end', gap: theme.spacing.xs }}>
+            <MoneyText
+              amount={candidate.amount.minor}
+              currency={candidate.amount.currency}
+              locale={locale}
+              variant="subheading"
+            />
+            {/* A row "select all" swept in is still marked, so nobody is
+                carried past a doubt without seeing it. */}
+            {candidate.preselect ? null : <Badge label={t.smsImport.checkThis} />}
+          </View>
+        </Row>
+      </Pressable>
+
+      {/* Only ever a pasted message. `bodyForDisplay` is the same function that
+          decides what may be stored, so what can be read here is exactly what
+          will be kept — and a message read out of the inbox is neither. */}
+      {body ? (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityState={{ expanded: open }}
+          onPress={onOpen}
+          hitSlop={8}
+          style={({ pressed }) => ({
+            alignSelf: 'flex-start',
+            paddingVertical: theme.spacing.sm,
+            opacity: pressed ? 0.7 : 1,
+          })}
+        >
+          <Row gap={theme.spacing.xs}>
+            <Ionicons
+              name={open ? 'chevron-up' : 'chevron-down'}
+              size={iconSize.sm}
+              color={theme.color.brand}
+            />
+            <Text variant="caption" tone="brand">
+              {open ? t.smsImport.hideMessage : t.smsImport.showMessage}
+            </Text>
+          </Row>
+        </Pressable>
+      ) : null}
+      {open && body ? (
+        <Card flat style={{ padding: theme.spacing.lg, marginBottom: theme.spacing.md }}>
+          <Text variant="caption" tone="muted" selectable>
+            {body}
+          </Text>
+        </Card>
+      ) : null}
+    </View>
+  );
+}
+
+/** One line of the three-step path in, for somebody who has never done this. */
+function Step({ index, text }: { index: number; text: string }): React.JSX.Element {
+  const theme = useTheme();
+  return (
+    <Row gap={theme.spacing.md} style={{ alignItems: 'flex-start' }}>
+      <View
         style={{
-          gap: theme.spacing.md,
+          width: 22,
+          height: 22,
+          borderRadius: theme.radius.pill,
+          backgroundColor: theme.color.brandSoft,
           alignItems: 'center',
-          paddingVertical: theme.spacing.sm,
-          minHeight: 52,
+          justifyContent: 'center',
         }}
       >
-        {/* Never colour alone: the tick is a different glyph, not just a
-            different shade, and the a11y state says it a third way (#191). */}
-        <Ionicons
-          name={picked ? 'checkbox' : 'square-outline'}
-          size={iconSize.xxl}
-          color={picked ? theme.color.brand : theme.color.textFaint}
-        />
-        <View style={{ flex: 1, minWidth: 0, gap: 2 }}>
-          <Text variant="subheading" numberOfLines={1}>
-            {title}
-          </Text>
-          {subtitle ? (
-            <Text variant="micro" tone="muted" numberOfLines={1}>
-              {subtitle}
-            </Text>
-          ) : null}
-        </View>
-        <View style={{ alignItems: 'flex-end', gap: 2 }}>
-          <MoneyText
-            amount={candidate.amount.minor}
-            currency={candidate.amount.currency}
-            locale={locale}
-            variant="subheading"
-          />
-          {/* A message we only half understood is not pre-ticked, and says so
-              rather than simply sitting there unticked for no visible reason. */}
-          {candidate.preselect ? null : <Badge label={t.smsImport.checkThis} />}
-        </View>
-      </Row>
-    </Pressable>
+        <Text variant="micro" tone="brand">
+          {String(index)}
+        </Text>
+      </View>
+      <Text variant="caption" style={{ flex: 1 }}>
+        {text}
+      </Text>
+    </Row>
   );
 }
 
@@ -185,6 +342,8 @@ export default function PasteMessagesScreen(): React.JSX.Element {
   // Explicit ticks, over the parser's own pre-selection. Absent means "whatever
   // `preselect` said", so a person who ticks nothing still gets the sensible set.
   const [ticks, setTicks] = useState<Record<string, boolean>>({});
+  // Which rows have their message open. Per row, and forgotten on leaving.
+  const [opened, setOpened] = useState<Record<string, boolean>>({});
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [added, setAdded] = useState<number | null>(null);
@@ -272,6 +431,8 @@ export default function PasteMessagesScreen(): React.JSX.Element {
     return keys;
   }, [fresh, ticks]);
 
+  const allChosen = fresh.length > 0 && chosen.size === fresh.length;
+
   const feed = useMemo((): FoundItem[] => {
     const items: FoundItem[] = [];
     let day = '';
@@ -281,19 +442,56 @@ export default function PasteMessagesScreen(): React.JSX.Element {
         day = candidateDay;
         items.push({ kind: 'day', key: `day-${candidateDay}`, at: candidate.at });
       }
-      items.push({ kind: 'candidate', key: candidate.dedupeKey, candidate });
+      items.push({
+        kind: 'candidate',
+        key: candidate.dedupeKey,
+        candidate,
+        body: bodyForDisplay(candidate.dedupeKey, bodies, readKeys),
+      });
     }
     return items;
-  }, [fresh]);
+  }, [bodies, fresh, readKeys]);
 
   const toggle = useCallback((key: string, next: boolean): void => {
     setTicks((current) => ({ ...current, [key]: next }));
   }, []);
 
+  const openMessage = useCallback((key: string): void => {
+    setOpened((current) => ({ ...current, [key]: !current[key] }));
+  }, []);
+
+  /**
+   * One control, two states — the Wallet pattern.
+   *
+   * "Select all" takes the uncertain rows too. Somebody who asks for all of
+   * them has asked for all of them, and quietly holding two back would be the
+   * screen overruling a person who said what they wanted. What it must not do
+   * is sweep them in *invisibly*, so the "Check this" mark and the sentence
+   * under each one stay exactly as they were: still selectable, still
+   * questioned, and one tap away from being put back.
+   */
+  const toggleAll = useCallback((): void => {
+    const next: Record<string, boolean> = {};
+    for (const item of fresh) next[item.dedupeKey] = !allChosen;
+    setTicks((current) => ({ ...current, ...next }));
+  }, [allChosen, fresh]);
+
+  /** Typing or pasting again puts the screen back to work, so "done" clears. */
+  const edit = useCallback((text: string): void => {
+    setBlob(text);
+    setAdded(null);
+    setError(null);
+  }, []);
+
   const paste = useCallback(async (): Promise<void> => {
     const text = await Clipboard.getStringAsync();
     if (!text.trim()) return;
+    // Joined with a blank line, which is the separator this screen no longer
+    // asks anybody to know about: `splitMessages` finds the boundaries itself,
+    // and the Paste button puts the clearest one in for free.
     setBlob((current) => (current ? `${current}\n\n${text}` : text));
+    setAdded(null);
+    setError(null);
   }, []);
 
   /**
@@ -334,6 +532,7 @@ export default function PasteMessagesScreen(): React.JSX.Element {
       setAdded(placed);
       setBlob('');
       setTicks({});
+      setOpened({});
       setReadMessages([]);
     } catch (caught) {
       setAdded(placed > 0 ? placed : null);
@@ -353,26 +552,38 @@ export default function PasteMessagesScreen(): React.JSX.Element {
     t.captures.couldNotSave,
   ]);
 
+  // Nothing handed over and nothing done yet: the one moment the three steps
+  // are worth the room. They go away the instant there is anything to look at.
+  const firstRun = blob.length === 0 && readMessages.length === 0 && added === null;
+  const done = added !== null && error === null && fresh.length === 0;
+
   const header = (
     <View style={{ gap: theme.spacing.lg, paddingBottom: theme.spacing.md }}>
       <Row style={{ paddingTop: theme.spacing.md, alignItems: 'center' }}>
         <IconButton label={t.common.close} onPress={() => router.back()}>
           <Ionicons name="close" size={iconSize.xl} color={theme.color.text} />
         </IconButton>
-        <Text variant="subheading" style={{ marginLeft: theme.spacing.md, flex: 1 }}>
+        {/* `marginStart`, not `marginLeft`: the title sits beside the close
+            button on both sides of the world. */}
+        <Text variant="heading" style={{ marginStart: theme.spacing.md, flex: 1 }}>
           {t.smsImport.title}
         </Text>
       </Row>
 
-      <Card style={{ gap: theme.spacing.sm }}>
-        <Text variant="caption" tone="muted">
-          {t.smsImport.howToDrafts}
-        </Text>
+      <Card style={{ gap: theme.spacing.md }}>
+        <Text variant="body">{t.smsImport.howToDrafts}</Text>
+        {firstRun ? (
+          <View style={{ gap: theme.spacing.sm }}>
+            <Step index={1} text={t.smsImport.howToSteps.open} />
+            <Step index={2} text={t.smsImport.howToSteps.copy} />
+            <Step index={3} text={t.smsImport.howToSteps.comeBack} />
+          </View>
+        ) : null}
         {/* Why there is no switch for this. Said only where it is true: a build
             that can read the inbox has the button below instead, and the
             sentence would contradict it. */}
         {readerOffered ? null : (
-          <Text variant="micro" tone="muted">
+          <Text variant="caption" tone="muted">
             {t.smsImport.whyNotAutomatic}
           </Text>
         )}
@@ -388,11 +599,11 @@ export default function PasteMessagesScreen(): React.JSX.Element {
               <Ionicons name="chatbubbles-outline" size={iconSize.md} color={theme.color.brand} />
             }
           />
-          <Text variant="micro" tone="muted">
+          <Text variant="caption" tone="muted">
             {t.smsImport.readOnAndroid}
           </Text>
           {readMessages.length > 0 ? (
-            <Text variant="micro" tone="muted">
+            <Text variant="caption" tone="muted">
               {plural(locale, readMessages.length, t.smsImport.readCount)}
             </Text>
           ) : null}
@@ -400,11 +611,10 @@ export default function PasteMessagesScreen(): React.JSX.Element {
       ) : null}
 
       <View style={{ gap: theme.spacing.sm }}>
-        <SectionHeader title={t.smsImport.messagesSection} />
         <Card style={{ gap: theme.spacing.sm }}>
           <TextInput
             value={blob}
-            onChangeText={setBlob}
+            onChangeText={edit}
             multiline
             autoCapitalize="none"
             accessibilityLabel={t.smsImport.pasteLabel}
@@ -412,20 +622,34 @@ export default function PasteMessagesScreen(): React.JSX.Element {
             placeholderTextColor={theme.color.textFaint}
             style={{
               minHeight: 140,
-              fontSize: 15,
+              fontSize: 16,
               color: theme.color.text,
               textAlignVertical: 'top',
             }}
           />
           <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
-            <Text variant="micro" tone="muted">
+            <Text variant="caption" tone="muted">
               {pastedBlocks.length === 0
                 ? t.smsImport.nothingPasted
                 : plural(locale, pastedBlocks.length, t.smsImport.messageCount)}
             </Text>
-            <Button label={t.smsImport.paste} variant="ghost" onPress={() => void paste()} />
+            {/* The only control while the box is empty, so it leads rather than
+                sits in the corner as a ghost. */}
+            <Button
+              label={t.smsImport.paste}
+              variant={blob.length === 0 ? 'secondary' : 'ghost'}
+              onPress={() => void paste()}
+            />
           </Row>
         </Card>
+        {/* The blank-line rule, demoted. `splitMessages` finds the boundaries
+            on its own now, so this is a hint offered once something has
+            actually gone unread — never an instruction to get wrong up front. */}
+        {notPayments > 0 ? (
+          <Text variant="micro" tone="muted">
+            {t.smsImport.runTogether}
+          </Text>
+        ) : null}
       </View>
 
       {/* Only over a list that has something in it. With nothing found, the
@@ -433,21 +657,34 @@ export default function PasteMessagesScreen(): React.JSX.Element {
           them twice. */}
       {fresh.length > 0 ? (
         <View style={{ gap: theme.spacing.xs }}>
-          {/* An eyebrow over a question, not a noun over a list: the list has
-              one thing to ask and the button below is the answer. */}
-          <Text variant="micro" tone="muted" style={{ textTransform: 'uppercase' }}>
-            {t.smsImport.foundSection}
+          {/* The count is the headline and the control sits beside it — one
+              button with two labels rather than two buttons (Wallet). The
+              count is live, and the button at the foot says the same number
+              back as the thing it is about to do. */}
+          <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+            <Text variant="title" style={{ flex: 1 }}>
+              {chosen.size === 0
+                ? t.smsImport.nothingSelected
+                : plural(locale, chosen.size, t.smsImport.chosenCount)}
+            </Text>
+            <Button
+              label={allChosen ? t.smsImport.unselectAll : t.smsImport.selectAll}
+              variant="ghost"
+              onPress={toggleAll}
+            />
+          </Row>
+          <Text variant="caption" tone="muted">
+            {plural(locale, fresh.length, t.smsImport.foundCount)}
           </Text>
-          <Text variant="heading">{t.smsImport.foundQuestion}</Text>
           {/* Everything the parser could not use, said plainly. A screen that
               quietly shows four rows for six messages reads as broken. */}
           {notPayments > 0 ? (
-            <Text variant="micro" tone="muted">
+            <Text variant="caption" tone="muted">
               {plural(locale, notPayments, t.smsImport.someNotParsed)}
             </Text>
           ) : null}
           {alreadyCount > 0 ? (
-            <Text variant="micro" tone="muted">
+            <Text variant="caption" tone="muted">
               {plural(locale, alreadyCount, t.smsImport.alreadyAdded)}
             </Text>
           ) : null}
@@ -462,17 +699,23 @@ export default function PasteMessagesScreen(): React.JSX.Element {
       {added !== null ? (
         <Callout tone="positive">{plural(locale, added, t.smsImport.addedDraftCount)}</Callout>
       ) : null}
-      <Button
-        label={
-          saving
-            ? t.smsImport.adding
-            : chosen.size === 0
-              ? t.smsImport.nothingSelected
-              : plural(locale, chosen.size, t.smsImport.addDraftCount)
-        }
-        onPress={() => void add()}
-        disabled={chosen.size === 0 || saving}
-      />
+      {/* Where they went, and a way to go there. A screen that says "added" and
+          leaves a person on the same page has told them half of it. */}
+      {done ? (
+        <Button label={t.smsImport.openReview} onPress={() => router.replace('/captures')} />
+      ) : (
+        <Button
+          label={
+            saving
+              ? t.smsImport.adding
+              : chosen.size === 0
+                ? t.smsImport.nothingSelected
+                : plural(locale, chosen.size, t.smsImport.addDraftCount)
+          }
+          onPress={() => void add()}
+          disabled={chosen.size === 0 || saving}
+        />
+      )}
     </View>
   );
 
@@ -498,17 +741,24 @@ export default function PasteMessagesScreen(): React.JSX.Element {
         <View>
           <FoundRow
             candidate={item.candidate}
+            body={item.body}
             picked={picked}
+            open={opened[item.candidate.dedupeKey] ?? false}
             locale={locale}
             t={t}
             onToggle={() => toggle(item.candidate.dedupeKey, !picked)}
+            onOpen={() => openMessage(item.candidate.dedupeKey)}
           />
           <Divider />
         </View>
       );
     },
-    [chosen, locale, t, theme.spacing.md, theme.spacing.xs, toggle],
+    [chosen, locale, openMessage, opened, t, theme.spacing.md, theme.spacing.xs, toggle],
   );
+
+  // One object so a tick *or* an opened message re-renders a row FlashList
+  // would otherwise recycle unchanged.
+  const listState = useMemo(() => ({ chosen, opened }), [chosen, opened]);
 
   return (
     <Screen edges={['top']}>
@@ -520,7 +770,7 @@ export default function PasteMessagesScreen(): React.JSX.Element {
         // The group-ledger settings: `extraData` because a tick changes a row
         // that FlashList would otherwise recycle unchanged, and the drop
         // distance so a pasted month scrolls without blanking.
-        extraData={chosen}
+        extraData={listState}
         drawDistance={1500}
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
@@ -532,8 +782,9 @@ export default function PasteMessagesScreen(): React.JSX.Element {
         ListFooterComponent={footer}
         ListEmptyComponent={
           // Nothing handed over yet is not an empty result; it is a screen
-          // waiting to be used, and the paste box above already says so.
-          pastedBlocks.length === 0 && readMessages.length === 0 ? null : (
+          // waiting to be used, and the paste box above already says so. Nor is
+          // a finished run: the footer is already saying where those went.
+          (pastedBlocks.length === 0 && readMessages.length === 0) || done ? null : (
             <EmptyState
               title={t.smsImport.nothingToImport}
               // Why there is nothing, in the honest order: because you have

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -2530,7 +2530,6 @@ export interface UiStrings {
     title: string;
     howTo: string;
     whyNotAutomatic: string;
-    messagesSection: string;
     pasteLabel: string;
     pastePlaceholder: string;
     nothingPasted: string;
@@ -2544,11 +2543,9 @@ export interface UiStrings {
     last30: string;
     datePlaceholder: string;
     dateFieldLabel: string;
-    foundSection: string;
     nothingToImport: string;
     nothingLikeAPayment: string;
     allAnotherCurrency: string;
-    cardPayment: string;
     selected: string;
     notSelected: string;
     checkThis: string;
@@ -2585,8 +2582,42 @@ export interface UiStrings {
      * so the older sentence's "this trip" would be a lie on it.
      */
     howToDrafts: string;
-    /** The found list's own title — a question, because the answer is one tap. */
-    foundQuestion: string;
+    /**
+     * The way in for somebody who has never copied text on a phone. Three short
+     * lines, shown only until something has been pasted, and never again.
+     */
+    howToSteps: {
+      open: string;
+      copy: string;
+      comeBack: string;
+    };
+    /**
+     * The live headline over the list. `nothingSelected` above is the word for
+     * none of them — the same phrase the button at the foot wears, deliberately.
+     */
+    chosenCount: PluralForms;
+    /** How many payments were found in what was handed over. */
+    foundCount: PluralForms;
+    /** One control, two labels (Apple Wallet). Never two buttons. */
+    selectAll: string;
+    unselectAll: string;
+    /**
+     * Titles for a payment whose merchant is missing or is plainly not a name.
+     * Less specific than a shop and entirely true, which is the trade.
+     */
+    paymentFromBank: string;
+    aPayment: string;
+    /** "card ending 4471" — the account tail in words rather than as "⋯4471". */
+    cardEnding: string;
+    /** The second reason a row is not pre-ticked; the first is `dateNotInMessage`. */
+    hardToRead: string;
+    /** Opening a row to read the message it was made from. */
+    showMessage: string;
+    hideMessage: string;
+    /** The blank-line rule, demoted to a hint and said only when it may help. */
+    runTogether: string;
+    /** Where the payments went, offered as somewhere to go. */
+    openReview: string;
     /** Said plainly rather than hidden: how many pasted blocks were not a payment. */
     someNotParsed: PluralForms;
     /** How many of the payments found are already waiting in Review. */
@@ -5156,14 +5187,13 @@ const en: UiStrings = {
     wavesVersionOut: 'Waves {latest} is out',
   },
   smsImport: {
-    title: 'Import from messages',
+    title: 'Add from bank messages',
     howTo:
       'Open your messages app, select the bank messages from this trip, copy them, and paste them here. Waves reads them on this phone — nothing is sent anywhere until you confirm an expense.',
     whyNotAutomatic:
-      'Waves cannot read your inbox by itself. iPhones give no app that access, and on Android it is reserved for whichever app you use as your messages app.',
-    messagesSection: 'The messages',
+      'Waves cannot read your messages on its own, so you copy across the ones you want.',
     pasteLabel: 'Paste bank messages',
-    pastePlaceholder: 'Paste here.\n\nLeave a blank line between messages.',
+    pastePlaceholder: 'Paste your bank messages here',
     nothingPasted: 'Nothing pasted yet',
     messageCount: { one: '{n} message', other: '{n} messages' },
     paste: 'Paste',
@@ -5176,12 +5206,10 @@ const en: UiStrings = {
     last30: 'Last 30 days',
     datePlaceholder: 'YYYY-MM-DD',
     dateFieldLabel: '{label} date, year month day',
-    foundSection: 'What was found',
-    nothingToImport: 'Nothing to import',
+    nothingToImport: 'No payments in that',
     nothingLikeAPayment:
-      'None of those messages looked like a payment inside these dates. Reminders, one-time passwords and money coming in are all left out on purpose.',
+      'None of that looked like a payment. Reminders, one-time passwords and money coming in are all left out on purpose.',
     allAnotherCurrency: 'Every payment found was in another currency.',
-    cardPayment: 'Card payment',
     selected: 'selected',
     notSelected: 'not selected',
     checkThis: 'Check this',
@@ -5199,7 +5227,7 @@ const en: UiStrings = {
         '{n} expenses added. They are saved on this phone and will sync when there is a connection.',
     },
     adding: 'Adding…',
-    nothingSelected: 'Nothing selected',
+    nothingSelected: 'Nothing chosen yet',
     addCount: { one: 'Add {n} expense', other: 'Add {n} expenses' },
     readMessages: 'Read my messages',
     reading: 'Reading…',
@@ -5224,10 +5252,29 @@ const en: UiStrings = {
       allow: 'Allow',
       notNow: 'Not now',
     },
-    dateNotInMessage: 'date not in the message',
+    dateNotInMessage: 'The message did not say which day this was.',
     howToDrafts:
-      'Open your messages app, pick the bank messages you want, copy them, and paste them here. Waves reads them on this phone and turns each payment into a draft you can file into a group later.',
-    foundQuestion: 'Add these to Review?',
+      'Copy a payment message from your messages app and paste it here. Waves reads it on this phone and puts the payment in Review for you.',
+    howToSteps: {
+      open: 'Open your messages app.',
+      copy: 'Press and hold a bank message, then tap Copy.',
+      comeBack: 'Come back here and tap Paste.',
+    },
+    chosenCount: { one: '{n} chosen', other: '{n} chosen' },
+    foundCount: {
+      one: 'We found {n} payment in what you pasted.',
+      other: 'We found {n} payments in what you pasted.',
+    },
+    selectAll: 'Select all',
+    unselectAll: 'Unselect all',
+    paymentFromBank: 'Payment from {bank}',
+    aPayment: 'Payment from your bank',
+    cardEnding: 'card ending {tail}',
+    hardToRead: 'Some of this message was hard to read.',
+    showMessage: 'Read the message',
+    hideMessage: 'Hide the message',
+    runTogether: 'If two messages ran together, leave a blank line between them.',
+    openReview: 'Open Review',
     someNotParsed: {
       one: '{n} of those did not look like a payment, so it was left out.',
       other: '{n} of those did not look like payments, so they were left out.',
@@ -5236,11 +5283,11 @@ const en: UiStrings = {
       one: '{n} is already waiting in Review.',
       other: '{n} are already waiting in Review.',
     },
-    addDraftCount: { one: 'Add {n} draft', other: 'Add {n} drafts' },
+    addDraftCount: { one: 'Add {n} to Review', other: 'Add {n} to Review' },
     addedDraftCount: {
-      one: '{n} draft is waiting in Review. It is saved on this phone and will sync when there is a connection.',
+      one: '{n} payment is waiting in Review. It is saved on this phone and will sync when there is a connection.',
       other:
-        '{n} drafts are waiting in Review. They are saved on this phone and will sync when there is a connection.',
+        '{n} payments are waiting in Review. They are saved on this phone and will sync when there is a connection.',
     },
     readWindowNote:
       'Waves only looks at this stretch of your inbox. Everything older stays untouched.',
@@ -7888,14 +7935,13 @@ const ta: UiStrings = {
     wavesVersionOut: 'Waves {latest} வெளியாகிவிட்டது',
   },
   smsImport: {
-    title: 'செய்திகளிலிருந்து இறக்குமதி',
+    title: 'வங்கிச் செய்திகளிலிருந்து சேர்',
     howTo:
       'உங்கள் செய்தி செயலியைத் திறந்து, இந்தப் பயணத்தின் வங்கிச் செய்திகளைத் தேர்ந்தெடுத்து, நகலெடுத்து இங்கே ஒட்டுங்கள். Waves அவற்றை இந்த ஃபோனிலேயே படிக்கும் — நீங்கள் ஒரு செலவை உறுதி செய்யும் வரை எதுவும் எங்கும் அனுப்பப்படாது.',
     whyNotAutomatic:
-      'Waves-ஆல் உங்கள் இன்பாக்ஸைத் தானாகப் படிக்க முடியாது. iPhone எந்தச் செயலிக்கும் அந்த அனுமதியைத் தராது; Android இல் அது உங்கள் செய்தி செயலிக்கு மட்டுமே உரியது.',
-    messagesSection: 'செய்திகள்',
+      'Waves-ஆல் உங்கள் செய்திகளைத் தானாகப் படிக்க முடியாது, எனவே வேண்டியவற்றை நீங்களே நகலெடுத்துத் தாருங்கள்.',
     pasteLabel: 'வங்கிச் செய்திகளை ஒட்டு',
-    pastePlaceholder: 'இங்கே ஒட்டவும்.\n\nசெய்திகளுக்கு இடையே ஒரு காலி வரி விடவும்.',
+    pastePlaceholder: 'உங்கள் வங்கிச் செய்திகளை இங்கே ஒட்டுங்கள்',
     nothingPasted: 'இன்னும் எதுவும் ஒட்டப்படவில்லை',
     messageCount: { one: '{n} செய்தி', other: '{n} செய்திகள்' },
     paste: 'ஒட்டு',
@@ -7908,12 +7954,10 @@ const ta: UiStrings = {
     last30: 'கடந்த 30 நாட்கள்',
     datePlaceholder: 'YYYY-MM-DD',
     dateFieldLabel: '{label} தேதி, ஆண்டு மாதம் நாள்',
-    foundSection: 'கிடைத்தவை',
-    nothingToImport: 'இறக்குமதி செய்ய எதுவும் இல்லை',
+    nothingToImport: 'அதில் கொடுப்பனவுகள் எதுவும் இல்லை',
     nothingLikeAPayment:
-      'அந்தச் செய்திகளில் எதுவும் இந்தத் தேதிகளுக்குள் ஒரு கொடுப்பனவாகத் தெரியவில்லை. நினைவூட்டல்கள், ஒருமுறைக் கடவுச்சொற்கள், வரும் பணம் — இவை வேண்டுமென்றே விடப்படுகின்றன.',
+      'அதில் எதுவும் ஒரு கொடுப்பனவாகத் தெரியவில்லை. நினைவூட்டல்கள், ஒருமுறைக் கடவுச்சொற்கள், வரும் பணம் — இவை வேண்டுமென்றே விடப்படுகின்றன.',
     allAnotherCurrency: 'கிடைத்த ஒவ்வொரு கொடுப்பனவும் வேறு நாணயத்தில் இருந்தது.',
-    cardPayment: 'அட்டைக் கொடுப்பனவு',
     selected: 'தேர்ந்தெடுக்கப்பட்டது',
     notSelected: 'தேர்ந்தெடுக்கப்படவில்லை',
     checkThis: 'இதைச் சரிபார்',
@@ -7931,7 +7975,7 @@ const ta: UiStrings = {
         '{n} செலவுகள் சேர்க்கப்பட்டன. அவை இந்த ஃபோனில் சேமிக்கப்பட்டுள்ளன, இணைப்பு கிடைத்ததும் ஒத்திசைக்கும்.',
     },
     adding: 'சேர்க்கிறது…',
-    nothingSelected: 'எதுவும் தேர்ந்தெடுக்கப்படவில்லை',
+    nothingSelected: 'இன்னும் எதுவும் தேர்ந்தெடுக்கப்படவில்லை',
     addCount: { one: '{n} செலவைச் சேர்', other: '{n} செலவுகளைச் சேர்' },
     readMessages: 'என் செய்திகளைப் படி',
     reading: 'படிக்கிறது…',
@@ -7957,10 +8001,33 @@ const ta: UiStrings = {
       allow: 'அனுமதி',
       notNow: 'இப்போது வேண்டாம்',
     },
-    dateNotInMessage: 'செய்தியில் தேதி இல்லை',
+    dateNotInMessage: 'இது எந்த நாள் என்று செய்தி சொல்லவில்லை.',
     howToDrafts:
-      'உங்கள் செய்தி செயலியைத் திறந்து, வேண்டிய வங்கிச் செய்திகளைத் தேர்ந்தெடுத்து, நகலெடுத்து இங்கே ஒட்டுங்கள். Waves அவற்றை இந்த ஃபோனிலேயே படித்து, ஒவ்வொரு கொடுப்பனவையும் பிறகு ஒரு குழுவில் சேர்க்கக்கூடிய வரைவாக மாற்றும்.',
-    foundQuestion: 'இவற்றை மறுபார்வையில் சேர்க்கவா?',
+      'உங்கள் செய்தி செயலியிலிருந்து ஒரு கொடுப்பனவுச் செய்தியை நகலெடுத்து இங்கே ஒட்டுங்கள். Waves அதை இந்த ஃபோனிலேயே படித்து, அந்தக் கொடுப்பனவை மறுபார்வையில் வைக்கும்.',
+    howToSteps: {
+      open: 'உங்கள் செய்தி செயலியைத் திறங்கள்.',
+      copy: 'ஒரு வங்கிச் செய்தியை அழுத்திப் பிடித்து, நகலெடு என்பதைத் தட்டுங்கள்.',
+      comeBack: 'இங்கே திரும்பி வந்து ஒட்டு என்பதைத் தட்டுங்கள்.',
+    },
+    chosenCount: {
+      one: '{n} தேர்ந்தெடுக்கப்பட்டது',
+      other: '{n} தேர்ந்தெடுக்கப்பட்டவை',
+    },
+    foundCount: {
+      one: 'நீங்கள் ஒட்டியதில் {n} கொடுப்பனவு கிடைத்தது.',
+      other: 'நீங்கள் ஒட்டியதில் {n} கொடுப்பனவுகள் கிடைத்தன.',
+    },
+    selectAll: 'எல்லாவற்றையும் தேர்ந்தெடு',
+    unselectAll: 'தேர்வை நீக்கு',
+    paymentFromBank: '{bank} மூலம் கொடுப்பனவு',
+    aPayment: 'உங்கள் வங்கியிலிருந்து ஒரு கொடுப்பனவு',
+    cardEnding: '{tail} இல் முடியும் அட்டை',
+    hardToRead: 'இந்தச் செய்தியின் சில பகுதிகளைப் படிப்பது கடினமாக இருந்தது.',
+    showMessage: 'செய்தியைப் படி',
+    hideMessage: 'செய்தியை மறை',
+    runTogether:
+      'இரண்டு செய்திகள் ஒன்றாகச் சேர்ந்துவிட்டால், அவற்றுக்கு இடையே ஒரு காலி வரி விடுங்கள்.',
+    openReview: 'மறுபார்வையைத் திற',
     someNotParsed: {
       one: 'அவற்றில் {n} கொடுப்பனவாகத் தெரியவில்லை, அது விடப்பட்டது.',
       other: 'அவற்றில் {n} கொடுப்பனவாகத் தெரியவில்லை, அவை விடப்பட்டன.',
@@ -7969,11 +8036,14 @@ const ta: UiStrings = {
       one: '{n} ஏற்கனவே மறுபார்வையில் காத்திருக்கிறது.',
       other: '{n} ஏற்கனவே மறுபார்வையில் காத்திருக்கின்றன.',
     },
-    addDraftCount: { one: '{n} வரைவைச் சேர்', other: '{n} வரைவுகளைச் சேர்' },
+    addDraftCount: {
+      one: '{n} ஐ மறுபார்வையில் சேர்',
+      other: '{n} ஐ மறுபார்வையில் சேர்',
+    },
     addedDraftCount: {
-      one: '{n} வரைவு மறுபார்வையில் காத்திருக்கிறது. அது இந்த ஃபோனில் சேமிக்கப்பட்டுள்ளது, இணைப்பு கிடைத்ததும் ஒத்திசைக்கும்.',
+      one: '{n} கொடுப்பனவு மறுபார்வையில் காத்திருக்கிறது. அது இந்த ஃபோனில் சேமிக்கப்பட்டுள்ளது, இணைப்பு கிடைத்ததும் ஒத்திசைக்கும்.',
       other:
-        '{n} வரைவுகள் மறுபார்வையில் காத்திருக்கின்றன. அவை இந்த ஃபோனில் சேமிக்கப்பட்டுள்ளன, இணைப்பு கிடைத்ததும் ஒத்திசைக்கும்.',
+        '{n} கொடுப்பனவுகள் மறுபார்வையில் காத்திருக்கின்றன. அவை இந்த ஃபோனில் சேமிக்கப்பட்டுள்ளன, இணைப்பு கிடைத்ததும் ஒத்திசைக்கும்.',
     },
     readWindowNote:
       'உங்கள் இன்பாக்ஸில் இந்தப் பகுதியை மட்டுமே Waves பார்க்கும். அதற்கு முந்தையவை தொடப்படாது.',
@@ -10574,14 +10644,13 @@ const hi: UiStrings = {
     wavesVersionOut: 'Waves {latest} आ गया है',
   },
   smsImport: {
-    title: 'संदेशों से आयात',
+    title: 'बैंक संदेशों से जोड़ें',
     howTo:
       'अपना मैसेज ऐप खोलें, इस यात्रा के बैंक संदेश चुनें, कॉपी करें और यहाँ पेस्ट करें। Waves उन्हें इसी फ़ोन पर पढ़ता है — जब तक आप कोई खर्च पक्का नहीं करते, कुछ भी कहीं नहीं भेजा जाता।',
     whyNotAutomatic:
-      'Waves आपका इनबॉक्स खुद नहीं पढ़ सकता। iPhone किसी भी ऐप को यह पहुँच नहीं देता, और Android पर यह सिर्फ़ उसी ऐप के लिए है जिसे आप मैसेज ऐप की तरह इस्तेमाल करते हैं।',
-    messagesSection: 'संदेश',
+      'Waves आपके संदेश खुद नहीं पढ़ सकता, इसलिए जो चाहिए वे आप ही कॉपी करके लाते हैं।',
     pasteLabel: 'बैंक संदेश पेस्ट करें',
-    pastePlaceholder: 'यहाँ पेस्ट करें।\n\nसंदेशों के बीच एक खाली पंक्ति छोड़ें।',
+    pastePlaceholder: 'अपने बैंक संदेश यहाँ पेस्ट करें',
     nothingPasted: 'अभी कुछ पेस्ट नहीं किया',
     messageCount: { one: '{n} संदेश', other: '{n} संदेश' },
     paste: 'पेस्ट',
@@ -10593,12 +10662,10 @@ const hi: UiStrings = {
     last30: 'पिछले 30 दिन',
     datePlaceholder: 'YYYY-MM-DD',
     dateFieldLabel: '{label} तारीख़, साल महीना दिन',
-    foundSection: 'क्या मिला',
-    nothingToImport: 'आयात करने को कुछ नहीं',
+    nothingToImport: 'उसमें कोई भुगतान नहीं',
     nothingLikeAPayment:
-      'इन तारीखों के भीतर उन संदेशों में से कोई भुगतान जैसा नहीं लगा। याद दिलाने वाले संदेश, वन-टाइम पासवर्ड और आने वाला पैसा जान-बूझकर छोड़े जाते हैं।',
+      'उसमें से कुछ भी भुगतान जैसा नहीं लगा। याद दिलाने वाले संदेश, वन-टाइम पासवर्ड और आने वाला पैसा जान-बूझकर छोड़े जाते हैं।',
     allAnotherCurrency: 'जो भी भुगतान मिला वह दूसरी मुद्रा में था।',
-    cardPayment: 'कार्ड भुगतान',
     selected: 'चुना गया',
     notSelected: 'नहीं चुना',
     checkThis: 'इसे जाँचें',
@@ -10615,7 +10682,7 @@ const hi: UiStrings = {
       other: '{n} खर्च जुड़े। ये इसी फ़ोन पर सेव हैं और कनेक्शन मिलते ही सिंक हो जाएँगे।',
     },
     adding: 'जोड़ रहे हैं…',
-    nothingSelected: 'कुछ नहीं चुना',
+    nothingSelected: 'अभी कुछ नहीं चुना',
     addCount: { one: '{n} खर्च जोड़ें', other: '{n} खर्च जोड़ें' },
     readMessages: 'मेरे संदेश पढ़ें',
     reading: 'पढ़ रहे हैं…',
@@ -10640,10 +10707,29 @@ const hi: UiStrings = {
       allow: 'अनुमति दें',
       notNow: 'अभी नहीं',
     },
-    dateNotInMessage: 'संदेश में तारीख नहीं थी',
+    dateNotInMessage: 'संदेश में यह नहीं लिखा कि यह किस दिन हुआ।',
     howToDrafts:
-      'अपना मैसेज ऐप खोलें, जो बैंक संदेश चाहिए उन्हें चुनें, कॉपी करें और यहाँ पेस्ट करें। Waves उन्हें इसी फ़ोन पर पढ़ता है और हर भुगतान को एक ड्राफ़्ट बना देता है, जिसे बाद में किसी समूह में डाला जा सकता है।',
-    foundQuestion: 'इन्हें समीक्षा में जोड़ें?',
+      'अपने मैसेज ऐप से कोई भुगतान वाला संदेश कॉपी करके यहाँ पेस्ट करें। Waves उसे इसी फ़ोन पर पढ़ता है और वह भुगतान आपके लिए समीक्षा में रख देता है।',
+    howToSteps: {
+      open: 'अपना मैसेज ऐप खोलें।',
+      copy: 'किसी बैंक संदेश को दबाकर रखें, फिर कॉपी दबाएँ।',
+      comeBack: 'यहाँ वापस आकर पेस्ट दबाएँ।',
+    },
+    chosenCount: { one: '{n} चुना', other: '{n} चुने' },
+    foundCount: {
+      one: 'आपने जो पेस्ट किया उसमें {n} भुगतान मिला।',
+      other: 'आपने जो पेस्ट किया उसमें {n} भुगतान मिले।',
+    },
+    selectAll: 'सब चुनें',
+    unselectAll: 'चुनाव हटाएँ',
+    paymentFromBank: '{bank} से भुगतान',
+    aPayment: 'आपके बैंक से एक भुगतान',
+    cardEnding: '{tail} पर ख़त्म होने वाला कार्ड',
+    hardToRead: 'इस संदेश का कुछ हिस्सा पढ़ना मुश्किल था।',
+    showMessage: 'संदेश पढ़ें',
+    hideMessage: 'संदेश छिपाएँ',
+    runTogether: 'अगर दो संदेश आपस में जुड़ गए हों, तो उनके बीच एक खाली पंक्ति छोड़ दें।',
+    openReview: 'समीक्षा खोलें',
     someNotParsed: {
       one: 'उनमें से {n} भुगतान जैसा नहीं लगा, इसलिए छोड़ दिया गया।',
       other: 'उनमें से {n} भुगतान जैसे नहीं लगे, इसलिए छोड़ दिए गए।',
@@ -10652,11 +10738,11 @@ const hi: UiStrings = {
       one: '{n} पहले से समीक्षा में इंतज़ार कर रहा है।',
       other: '{n} पहले से समीक्षा में इंतज़ार कर रहे हैं।',
     },
-    addDraftCount: { one: '{n} ड्राफ़्ट जोड़ें', other: '{n} ड्राफ़्ट जोड़ें' },
+    addDraftCount: { one: '{n} को समीक्षा में जोड़ें', other: '{n} को समीक्षा में जोड़ें' },
     addedDraftCount: {
-      one: '{n} ड्राफ़्ट समीक्षा में इंतज़ार कर रहा है। यह इसी फ़ोन पर सेव है और कनेक्शन मिलते ही सिंक हो जाएगा।',
+      one: '{n} भुगतान समीक्षा में इंतज़ार कर रहा है। यह इसी फ़ोन पर सेव है और कनेक्शन मिलते ही सिंक हो जाएगा।',
       other:
-        '{n} ड्राफ़्ट समीक्षा में इंतज़ार कर रहे हैं। ये इसी फ़ोन पर सेव हैं और कनेक्शन मिलते ही सिंक हो जाएँगे।',
+        '{n} भुगतान समीक्षा में इंतज़ार कर रहे हैं। ये इसी फ़ोन पर सेव हैं और कनेक्शन मिलते ही सिंक हो जाएँगे।',
     },
     readWindowNote:
       'Waves आपके इनबॉक्स का सिर्फ़ इतना हिस्सा देखता है। इससे पुराना सब कुछ अछूता रहता है।',
@@ -13431,14 +13517,12 @@ const ar: UiStrings = {
     wavesVersionOut: 'صدر Waves {latest}',
   },
   smsImport: {
-    title: 'استيراد من الرسائل',
+    title: 'الإضافة من رسائل البنك',
     howTo:
       'افتح تطبيق الرسائل، واختر رسائل البنك الخاصة بهذه الرحلة، وانسخها والصقها هنا. يقرأها Waves على هذا الهاتف — ولا يُرسل أي شيء إلى أي مكان حتى تؤكّد مصروفًا.',
-    whyNotAutomatic:
-      'لا يستطيع Waves قراءة صندوق رسائلك من تلقاء نفسه. لا يمنح iPhone هذه الصلاحية لأي تطبيق، وفي أندرويد تقتصر على التطبيق الذي تستخدمه للرسائل.',
-    messagesSection: 'الرسائل',
+    whyNotAutomatic: 'لا يستطيع Waves قراءة رسائلك من تلقاء نفسه، لذلك تنسخ أنت ما تريده منها.',
     pasteLabel: 'ألصق رسائل البنك',
-    pastePlaceholder: 'ألصق هنا.\n\nاترك سطرًا فارغًا بين كل رسالة وأخرى.',
+    pastePlaceholder: 'ألصق رسائل بنكك هنا',
     nothingPasted: 'لم يُلصق شيء بعد',
     messageCount: {
       zero: 'لا رسائل',
@@ -13458,12 +13542,10 @@ const ar: UiStrings = {
     last30: 'آخر 30 يومًا',
     datePlaceholder: 'YYYY-MM-DD',
     dateFieldLabel: 'تاريخ {label}، سنة شهر يوم',
-    foundSection: 'ما وُجد',
-    nothingToImport: 'لا شيء للاستيراد',
+    nothingToImport: 'لا مدفوعات في ذلك',
     nothingLikeAPayment:
-      'لم تبدُ أي من تلك الرسائل دفعةً داخل هذه التواريخ. التذكيرات وكلمات المرور لمرة واحدة والأموال الواردة كلها مستبعدة عن قصد.',
+      'لم يبدُ أي من ذلك دفعةً. التذكيرات وكلمات المرور لمرة واحدة والأموال الواردة كلها مستبعدة عن قصد.',
     allAnotherCurrency: 'كل دفعة وُجدت كانت بعملة أخرى.',
-    cardPayment: 'دفعة بالبطاقة',
     selected: 'محدَّد',
     notSelected: 'غير محدَّد',
     checkThis: 'تحقّق من هذا',
@@ -13488,7 +13570,7 @@ const ar: UiStrings = {
       other: 'أُضيف {n} مصروف. إنها محفوظة على هذا الهاتف وستُزامَن عند توفّر اتصال.',
     },
     adding: 'جارٍ الإضافة…',
-    nothingSelected: 'لم يُحدَّد شيء',
+    nothingSelected: 'لم يُختَر شيء بعد',
     addCount: {
       zero: 'لا شيء لإضافته',
       one: 'أضف مصروفًا واحدًا',
@@ -13523,10 +13605,40 @@ const ar: UiStrings = {
       allow: 'السماح',
       notNow: 'ليس الآن',
     },
-    dateNotInMessage: 'التاريخ غير مذكور في الرسالة',
+    dateNotInMessage: 'لم تذكر الرسالة في أي يوم كان هذا.',
     howToDrafts:
-      'افتح تطبيق الرسائل، واختر رسائل البنك التي تريدها، وانسخها والصقها هنا. يقرأها Waves على هذا الهاتف ويحوّل كل دفعة إلى مسوّدة يمكنك إضافتها إلى مجموعة لاحقًا.',
-    foundQuestion: 'أتضيف هذه إلى المراجعة؟',
+      'انسخ رسالة دفع من تطبيق الرسائل وألصقها هنا. يقرأها Waves على هذا الهاتف ويضع الدفعة في المراجعة نيابةً عنك.',
+    howToSteps: {
+      open: 'افتح تطبيق الرسائل.',
+      copy: 'اضغط مطوّلًا على رسالة من البنك ثم اختر نسخ.',
+      comeBack: 'عُد إلى هنا واضغط لصق.',
+    },
+    chosenCount: {
+      zero: 'لم يُختَر شيء',
+      one: 'واحدة مختارة',
+      two: 'اثنتان مختارتان',
+      few: '{n} مختارة',
+      many: '{n} مختارة',
+      other: '{n} مختارة',
+    },
+    foundCount: {
+      zero: 'لم نجد أي دفعة فيما ألصقته.',
+      one: 'وجدنا دفعة واحدة فيما ألصقته.',
+      two: 'وجدنا دفعتين فيما ألصقته.',
+      few: 'وجدنا {n} دفعات فيما ألصقته.',
+      many: 'وجدنا {n} دفعة فيما ألصقته.',
+      other: 'وجدنا {n} دفعة فيما ألصقته.',
+    },
+    selectAll: 'تحديد الكل',
+    unselectAll: 'إلغاء تحديد الكل',
+    paymentFromBank: 'دفعة من {bank}',
+    aPayment: 'دفعة من بنكك',
+    cardEnding: 'بطاقة تنتهي بـ {tail}',
+    hardToRead: 'كان جزء من هذه الرسالة صعب القراءة.',
+    showMessage: 'اقرأ الرسالة',
+    hideMessage: 'أخفِ الرسالة',
+    runTogether: 'إذا التصقت رسالتان معًا، اترك سطرًا فارغًا بينهما.',
+    openReview: 'افتح المراجعة',
     someNotParsed: {
       zero: 'لم يُستبعد شيء.',
       one: 'واحدة منها لم تبدُ دفعة، فاستُبعدت.',
@@ -13545,19 +13657,19 @@ const ar: UiStrings = {
     },
     addDraftCount: {
       zero: 'لا شيء لإضافته',
-      one: 'أضف مسوّدة واحدة',
-      two: 'أضف مسوّدتين',
-      few: 'أضف {n} مسوّدات',
-      many: 'أضف {n} مسوّدة',
-      other: 'أضف {n} مسوّدة',
+      one: 'أضف واحدة إلى المراجعة',
+      two: 'أضف اثنتين إلى المراجعة',
+      few: 'أضف {n} إلى المراجعة',
+      many: 'أضف {n} إلى المراجعة',
+      other: 'أضف {n} إلى المراجعة',
     },
     addedDraftCount: {
-      zero: 'لم تُضف أي مسوّدة.',
-      one: 'مسوّدة واحدة تنتظر في المراجعة. إنها محفوظة على هذا الهاتف وستُزامَن عند توفّر اتصال.',
-      two: 'مسوّدتان تنتظران في المراجعة. إنهما محفوظتان على هذا الهاتف وستُزامَنان عند توفّر اتصال.',
-      few: '{n} مسوّدات تنتظر في المراجعة. إنها محفوظة على هذا الهاتف وستُزامَن عند توفّر اتصال.',
-      many: '{n} مسوّدة تنتظر في المراجعة. إنها محفوظة على هذا الهاتف وستُزامَن عند توفّر اتصال.',
-      other: '{n} مسوّدة تنتظر في المراجعة. إنها محفوظة على هذا الهاتف وستُزامَن عند توفّر اتصال.',
+      zero: 'لم تُضف أي دفعة.',
+      one: 'دفعة واحدة تنتظر في المراجعة. إنها محفوظة على هذا الهاتف وستُزامَن عند توفّر اتصال.',
+      two: 'دفعتان تنتظران في المراجعة. إنهما محفوظتان على هذا الهاتف وستُزامَنان عند توفّر اتصال.',
+      few: '{n} دفعات تنتظر في المراجعة. إنها محفوظة على هذا الهاتف وستُزامَن عند توفّر اتصال.',
+      many: '{n} دفعة تنتظر في المراجعة. إنها محفوظة على هذا الهاتف وستُزامَن عند توفّر اتصال.',
+      other: '{n} دفعة تنتظر في المراجعة. إنها محفوظة على هذا الهاتف وستُزامَن عند توفّر اتصال.',
     },
     readWindowNote: 'لا ينظر Waves إلا في هذا الجزء من صندوق رسائلك، ويبقى كل ما هو أقدم دون مساس.',
     disclosure: {

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1570,6 +1570,9 @@ export interface UiStrings {
   captures: {
     title: string;
     captureCta: string;
+    /** The Review tab's second way in: a bank message, pasted (or, on a build that
+     *  has the reader, read). Leads to `captures/paste`. */
+    fromMessage: string;
     paidWith: string;
     payCash: string;
     payCredit: string;
@@ -2576,6 +2579,42 @@ export interface UiStrings {
     };
     /** Note under a candidate whose date was inferred, not read from the text. */
     dateNotInMessage: string;
+    /**
+     * The drafts version of `howTo`. This screen files drafts for later rather
+     * than expenses into a group, and it has no trip to bound the messages by,
+     * so the older sentence's "this trip" would be a lie on it.
+     */
+    howToDrafts: string;
+    /** The found list's own title — a question, because the answer is one tap. */
+    foundQuestion: string;
+    /** Said plainly rather than hidden: how many pasted blocks were not a payment. */
+    someNotParsed: PluralForms;
+    /** How many of the payments found are already waiting in Review. */
+    alreadyAdded: PluralForms;
+    /**
+     * The primary button, and what it says once they land. A draft is not an
+     * expense, so these are not `addCount`/`addedCount` — those say "expense"
+     * and belong to the per-group import this screen replaced.
+     */
+    addDraftCount: PluralForms;
+    addedDraftCount: PluralForms;
+    /** Under the window chips on the read screen — why there is a window at all. */
+    readWindowNote: string;
+    /**
+     * The disclosure shown BEFORE Android's own permission dialog, in the app's
+     * own words. Google Play requires a prominent disclosure for a sensitive
+     * permission, and a rationale attached to the system prompt is not one —
+     * `permissionRationale` above is what that system dialog then says.
+     */
+    disclosure: {
+      title: string;
+      intro: string;
+      readsWhat: string;
+      staysHere: string;
+      neverSent: string;
+      /** Names what the *next* screen asks, so the system dialog is no surprise. */
+      nextScreen: string;
+    };
   };
   /** Splitting one bill line by line, on one phone or several. */
   itemize: {
@@ -4287,6 +4326,7 @@ const en: UiStrings = {
   captures: {
     title: 'Saved for later',
     captureCta: 'Save an expense',
+    fromMessage: 'Add from a message',
     paidWith: 'Paid with',
     payCash: 'Cash',
     payCredit: 'Credit card',
@@ -5185,6 +5225,37 @@ const en: UiStrings = {
       notNow: 'Not now',
     },
     dateNotInMessage: 'date not in the message',
+    howToDrafts:
+      'Open your messages app, pick the bank messages you want, copy them, and paste them here. Waves reads them on this phone and turns each payment into a draft you can file into a group later.',
+    foundQuestion: 'Add these to Review?',
+    someNotParsed: {
+      one: '{n} of those did not look like a payment, so it was left out.',
+      other: '{n} of those did not look like payments, so they were left out.',
+    },
+    alreadyAdded: {
+      one: '{n} is already waiting in Review.',
+      other: '{n} are already waiting in Review.',
+    },
+    addDraftCount: { one: 'Add {n} draft', other: 'Add {n} drafts' },
+    addedDraftCount: {
+      one: '{n} draft is waiting in Review. It is saved on this phone and will sync when there is a connection.',
+      other:
+        '{n} drafts are waiting in Review. They are saved on this phone and will sync when there is a connection.',
+    },
+    readWindowNote:
+      'Waves only looks at this stretch of your inbox. Everything older stays untouched.',
+    disclosure: {
+      title: 'Let Waves read your bank messages',
+      intro:
+        'Instead of copying them over one by one, Waves can look through the bank messages already on this phone and turn the payments into drafts for you.',
+      readsWhat: 'It reads message text looking for payments — an amount, a shop and a date.',
+      staysHere:
+        'The reading happens on this phone. The message itself is never saved and never sent to Waves.',
+      neverSent:
+        'Only the drafts you keep are synced, and nothing is added to a group until you say so.',
+      nextScreen:
+        'On the next screen Android asks whether Waves may read your messages. You can say no — pasting them still works.',
+    },
   },
   itemize: {
     title: 'Split by item',
@@ -6931,6 +7002,7 @@ const ta: UiStrings = {
   captures: {
     title: 'பிறகுக்காகச் சேமித்தவை',
     captureCta: 'ஒரு செலவைச் சேமியுங்கள்',
+    fromMessage: 'செய்தியிலிருந்து சேர்',
     paidWith: 'எப்படிச் செலுத்தினீர்கள்',
     payCash: 'பணம்',
     payCredit: 'கிரெடிட் கார்டு',
@@ -7886,6 +7958,37 @@ const ta: UiStrings = {
       notNow: 'இப்போது வேண்டாம்',
     },
     dateNotInMessage: 'செய்தியில் தேதி இல்லை',
+    howToDrafts:
+      'உங்கள் செய்தி செயலியைத் திறந்து, வேண்டிய வங்கிச் செய்திகளைத் தேர்ந்தெடுத்து, நகலெடுத்து இங்கே ஒட்டுங்கள். Waves அவற்றை இந்த ஃபோனிலேயே படித்து, ஒவ்வொரு கொடுப்பனவையும் பிறகு ஒரு குழுவில் சேர்க்கக்கூடிய வரைவாக மாற்றும்.',
+    foundQuestion: 'இவற்றை மறுபார்வையில் சேர்க்கவா?',
+    someNotParsed: {
+      one: 'அவற்றில் {n} கொடுப்பனவாகத் தெரியவில்லை, அது விடப்பட்டது.',
+      other: 'அவற்றில் {n} கொடுப்பனவாகத் தெரியவில்லை, அவை விடப்பட்டன.',
+    },
+    alreadyAdded: {
+      one: '{n} ஏற்கனவே மறுபார்வையில் காத்திருக்கிறது.',
+      other: '{n} ஏற்கனவே மறுபார்வையில் காத்திருக்கின்றன.',
+    },
+    addDraftCount: { one: '{n} வரைவைச் சேர்', other: '{n} வரைவுகளைச் சேர்' },
+    addedDraftCount: {
+      one: '{n} வரைவு மறுபார்வையில் காத்திருக்கிறது. அது இந்த ஃபோனில் சேமிக்கப்பட்டுள்ளது, இணைப்பு கிடைத்ததும் ஒத்திசைக்கும்.',
+      other:
+        '{n} வரைவுகள் மறுபார்வையில் காத்திருக்கின்றன. அவை இந்த ஃபோனில் சேமிக்கப்பட்டுள்ளன, இணைப்பு கிடைத்ததும் ஒத்திசைக்கும்.',
+    },
+    readWindowNote:
+      'உங்கள் இன்பாக்ஸில் இந்தப் பகுதியை மட்டுமே Waves பார்க்கும். அதற்கு முந்தையவை தொடப்படாது.',
+    disclosure: {
+      title: 'உங்கள் வங்கிச் செய்திகளைப் படிக்க Waves-க்கு அனுமதி',
+      intro:
+        'ஒவ்வொன்றாக நகலெடுப்பதற்குப் பதிலாக, இந்த ஃபோனில் ஏற்கனவே உள்ள வங்கிச் செய்திகளை Waves பார்த்து, கொடுப்பனவுகளை வரைவுகளாக மாற்றித் தரும்.',
+      readsWhat: 'கொடுப்பனவைத் தேடிச் செய்தியின் உரையைப் படிக்கும் — தொகை, கடை, தேதி.',
+      staysHere:
+        'படிப்பது இந்த ஃபோனிலேயே நடக்கும். செய்தி எங்கும் சேமிக்கப்படாது, Waves-க்கும் அனுப்பப்படாது.',
+      neverSent:
+        'நீங்கள் வைத்துக்கொள்ளும் வரைவுகள் மட்டுமே ஒத்திசைக்கப்படும், நீங்கள் சொல்லும் வரை எதுவும் ஒரு குழுவில் சேராது.',
+      nextScreen:
+        'அடுத்த திரையில், உங்கள் செய்திகளை Waves படிக்கலாமா என்று Android கேட்கும். வேண்டாம் எனச் சொல்லலாம் — ஒட்டுவது அப்போதும் வேலை செய்யும்.',
+    },
   },
   itemize: {
     title: 'பொருள் வாரியாகப் பிரி',
@@ -9628,6 +9731,7 @@ const hi: UiStrings = {
   captures: {
     title: 'बाद के लिए सहेजे',
     captureCta: 'एक खर्च सहेजें',
+    fromMessage: 'संदेश से जोड़ें',
     paidWith: 'कैसे चुकाया',
     payCash: 'नकद',
     payCredit: 'क्रेडिट कार्ड',
@@ -10537,6 +10641,36 @@ const hi: UiStrings = {
       notNow: 'अभी नहीं',
     },
     dateNotInMessage: 'संदेश में तारीख नहीं थी',
+    howToDrafts:
+      'अपना मैसेज ऐप खोलें, जो बैंक संदेश चाहिए उन्हें चुनें, कॉपी करें और यहाँ पेस्ट करें। Waves उन्हें इसी फ़ोन पर पढ़ता है और हर भुगतान को एक ड्राफ़्ट बना देता है, जिसे बाद में किसी समूह में डाला जा सकता है।',
+    foundQuestion: 'इन्हें समीक्षा में जोड़ें?',
+    someNotParsed: {
+      one: 'उनमें से {n} भुगतान जैसा नहीं लगा, इसलिए छोड़ दिया गया।',
+      other: 'उनमें से {n} भुगतान जैसे नहीं लगे, इसलिए छोड़ दिए गए।',
+    },
+    alreadyAdded: {
+      one: '{n} पहले से समीक्षा में इंतज़ार कर रहा है।',
+      other: '{n} पहले से समीक्षा में इंतज़ार कर रहे हैं।',
+    },
+    addDraftCount: { one: '{n} ड्राफ़्ट जोड़ें', other: '{n} ड्राफ़्ट जोड़ें' },
+    addedDraftCount: {
+      one: '{n} ड्राफ़्ट समीक्षा में इंतज़ार कर रहा है। यह इसी फ़ोन पर सेव है और कनेक्शन मिलते ही सिंक हो जाएगा।',
+      other:
+        '{n} ड्राफ़्ट समीक्षा में इंतज़ार कर रहे हैं। ये इसी फ़ोन पर सेव हैं और कनेक्शन मिलते ही सिंक हो जाएँगे।',
+    },
+    readWindowNote:
+      'Waves आपके इनबॉक्स का सिर्फ़ इतना हिस्सा देखता है। इससे पुराना सब कुछ अछूता रहता है।',
+    disclosure: {
+      title: 'Waves को अपने बैंक संदेश पढ़ने दें',
+      intro:
+        'एक-एक करके कॉपी करने के बजाय, Waves इसी फ़ोन पर मौजूद बैंक संदेशों को देख सकता है और भुगतानों को आपके लिए ड्राफ़्ट बना सकता है।',
+      readsWhat: 'यह भुगतान ढूँढ़ने के लिए संदेश का टेक्स्ट पढ़ता है — रकम, दुकान और तारीख़।',
+      staysHere: 'पढ़ना इसी फ़ोन पर होता है। संदेश न कभी सेव होता है, न Waves को भेजा जाता है।',
+      neverSent:
+        'सिर्फ़ वही ड्राफ़्ट सिंक होते हैं जो आप रखते हैं, और जब तक आप न कहें कुछ भी किसी समूह में नहीं जुड़ता।',
+      nextScreen:
+        'अगली स्क्रीन पर Android पूछेगा कि Waves आपके संदेश पढ़ सकता है या नहीं। आप मना कर सकते हैं — पेस्ट करना तब भी काम करता है।',
+    },
   },
   itemize: {
     title: 'चीज़-वार बाँटें',
@@ -12332,6 +12466,7 @@ const ar: UiStrings = {
   captures: {
     title: 'محفوظة لوقت لاحق',
     captureCta: 'احفظ مصروفًا',
+    fromMessage: 'أضف من رسالة',
     paidWith: 'طريقة الدفع',
     payCash: 'نقدًا',
     payCredit: 'بطاقة ائتمان',
@@ -13389,6 +13524,53 @@ const ar: UiStrings = {
       notNow: 'ليس الآن',
     },
     dateNotInMessage: 'التاريخ غير مذكور في الرسالة',
+    howToDrafts:
+      'افتح تطبيق الرسائل، واختر رسائل البنك التي تريدها، وانسخها والصقها هنا. يقرأها Waves على هذا الهاتف ويحوّل كل دفعة إلى مسوّدة يمكنك إضافتها إلى مجموعة لاحقًا.',
+    foundQuestion: 'أتضيف هذه إلى المراجعة؟',
+    someNotParsed: {
+      zero: 'لم يُستبعد شيء.',
+      one: 'واحدة منها لم تبدُ دفعة، فاستُبعدت.',
+      two: 'اثنتان منها لم تبدوا دفعتين، فاستُبعدتا.',
+      few: '{n} منها لم تبدُ دفعات، فاستُبعدت.',
+      many: '{n} منها لم تبدُ دفعات، فاستُبعدت.',
+      other: '{n} منها لم تبدُ دفعات، فاستُبعدت.',
+    },
+    alreadyAdded: {
+      zero: 'لا شيء منها في المراجعة بعد.',
+      one: 'واحدة منها تنتظر في المراجعة بالفعل.',
+      two: 'اثنتان منها تنتظران في المراجعة بالفعل.',
+      few: '{n} منها تنتظر في المراجعة بالفعل.',
+      many: '{n} منها تنتظر في المراجعة بالفعل.',
+      other: '{n} منها تنتظر في المراجعة بالفعل.',
+    },
+    addDraftCount: {
+      zero: 'لا شيء لإضافته',
+      one: 'أضف مسوّدة واحدة',
+      two: 'أضف مسوّدتين',
+      few: 'أضف {n} مسوّدات',
+      many: 'أضف {n} مسوّدة',
+      other: 'أضف {n} مسوّدة',
+    },
+    addedDraftCount: {
+      zero: 'لم تُضف أي مسوّدة.',
+      one: 'مسوّدة واحدة تنتظر في المراجعة. إنها محفوظة على هذا الهاتف وستُزامَن عند توفّر اتصال.',
+      two: 'مسوّدتان تنتظران في المراجعة. إنهما محفوظتان على هذا الهاتف وستُزامَنان عند توفّر اتصال.',
+      few: '{n} مسوّدات تنتظر في المراجعة. إنها محفوظة على هذا الهاتف وستُزامَن عند توفّر اتصال.',
+      many: '{n} مسوّدة تنتظر في المراجعة. إنها محفوظة على هذا الهاتف وستُزامَن عند توفّر اتصال.',
+      other: '{n} مسوّدة تنتظر في المراجعة. إنها محفوظة على هذا الهاتف وستُزامَن عند توفّر اتصال.',
+    },
+    readWindowNote: 'لا ينظر Waves إلا في هذا الجزء من صندوق رسائلك، ويبقى كل ما هو أقدم دون مساس.',
+    disclosure: {
+      title: 'اسمح لـ Waves بقراءة رسائل بنكك',
+      intro:
+        'بدلًا من نسخها واحدة واحدة، يمكن لـ Waves أن يتصفّح رسائل البنك الموجودة على هذا الهاتف ويحوّل المدفوعات إلى مسوّدات نيابةً عنك.',
+      readsWhat: 'يقرأ نص الرسائل بحثًا عن المدفوعات — مبلغ ومتجر وتاريخ.',
+      staysHere: 'القراءة تجري على هذا الهاتف. الرسالة نفسها لا تُحفظ أبدًا ولا تُرسل إلى Waves.',
+      neverSent:
+        'لا يُزامَن إلا ما تحتفظ به من مسوّدات، ولا يُضاف شيء إلى مجموعة حتى تقول أنت ذلك.',
+      nextScreen:
+        'في الشاشة التالية سيسألك أندرويد إن كان يحقّ لـ Waves قراءة رسائلك. يمكنك الرفض — واللصق يظل يعمل.',
+    },
   },
   itemize: {
     title: 'التقسيم حسب الصنف',

--- a/apps/mobile/src/lib/smsCaptureId.ts
+++ b/apps/mobile/src/lib/smsCaptureId.ts
@@ -1,0 +1,40 @@
+/**
+ * A capture id that is the same every time for the same bank message.
+ *
+ * Normal captures get a random id; the point of `clientMutationId` is that a
+ * retry after a flaky network cannot double-post (ADR-005). An import needs
+ * something stronger, because the duplicate does not come from a retry — it
+ * comes from a person. They paste last month's messages again next week, and
+ * the second paste has no memory of the first.
+ *
+ * So the id is derived from the message itself, through `dedupeKey` — the
+ * bank's own reference where there is one, amount-plus-day-plus-merchant where
+ * there is not. `captures.id` is the primary key, and `capture.create` answers
+ * a second arrival of an id the caller already owns with the success it already
+ * achieved rather than a second row (see `createCapture` in
+ * `supabase/functions/sync/index.ts`, which is deliberately not an upsert — a
+ * draft since filed into a group must not be resurrected as `open`). So a
+ * re-paste is a no-op at the only layer that actually decides: the database.
+ *
+ * The owner is part of the seed because two people on one phone pasting the
+ * same statement are two people's drafts, not one.
+ *
+ * This is the module the deleted `lib/importId.ts` was, rebuilt for captures
+ * rather than expenses. The digest-shaping half lives in `./uuid8` for the same
+ * reason it did then: importing expo-crypto drags React Native in with it, and
+ * a well-formed id that is not *stable* de-duplicates nothing while looking
+ * perfectly fine.
+ */
+
+import * as Crypto from 'expo-crypto';
+
+import { uuidFromDigest } from '@/lib/uuid8';
+
+/** The stable id for the draft one bank message becomes, for one person. */
+export async function smsCaptureId(ownerId: string, key: string): Promise<string> {
+  const digest = await Crypto.digestStringAsync(
+    Crypto.CryptoDigestAlgorithm.SHA256,
+    `waves:sms-draft:${ownerId}:${key}`,
+  );
+  return uuidFromDigest(digest);
+}

--- a/apps/mobile/src/lib/smsDrafts.ts
+++ b/apps/mobile/src/lib/smsDrafts.ts
@@ -39,6 +39,8 @@ import {
   type SmsMessage,
 } from '@waves/core';
 
+import { merchantName } from './smsPlain';
+
 /** Where a draft's message came from. The two are not treated alike. */
 export type SmsDraftChannel = 'paste' | 'inbox';
 
@@ -100,19 +102,92 @@ export interface PlanSmsDraftsInput {
 }
 
 /**
- * Messages are separated by a blank line.
+ * A line that looks like the first line of a *new* message.
  *
- * A single SMS wraps over several lines of its own, so splitting on every
- * newline would cut most of them in half — and half a message parses to either
- * nothing or, worse, a smaller amount. The count is shown before anything is
- * parsed so a bad paste is visible rather than silently producing two
- * candidates from six messages.
+ * Two shapes, both put there by the messages app rather than by the bank: a DLT
+ * sender header (`JM-ICICIT-S`, with or without the punctuation after it) and a
+ * date stamp of the kind a copy-several-messages action stamps each one with.
+ */
+const STARTS_A_MESSAGE =
+  /^(?:[A-Z]{2}-[A-Z][A-Z0-9]{2,9}(?:-[A-Z])?\b|\d{1,2}[/-]\d{1,2}[/-]\d{2,4}\b|\d{1,2}:\d{2}\s*(?:[AaPp][Mm])?\s*[-–—]\s)/;
+
+/** Split before every line that announces a new message. */
+function splitAtStarts(block: string): string[] {
+  const lines = block.split('\n');
+  const parts: string[] = [];
+  let current: string[] = [];
+  const flush = (): void => {
+    const joined = current.join('\n').trim();
+    if (joined) parts.push(joined);
+    current = [];
+  };
+  for (const line of lines) {
+    if (STARTS_A_MESSAGE.test(line.trim()) && current.some((held) => held.trim())) flush();
+    current.push(line);
+  }
+  flush();
+  return parts;
+}
+
+/** How many of these pieces the parser can read as a transaction at all. */
+function readableCount(parts: readonly string[]): number {
+  let readable = 0;
+  for (const part of parts) {
+    if (parseSms(part)) readable += 1;
+  }
+  return readable;
+}
+
+/**
+ * One pasted block, cut up only if cutting it up demonstrably reads better.
+ *
+ * The blank line between messages used to be a rule a person had to know, which
+ * is exactly the sort of rule somebody gets wrong and then feels stupid about.
+ * It is now a hint: three ways of cutting the block are tried — leave it whole,
+ * cut at the lines that announce a new message, cut at every line — and the one
+ * that yields the most *readable* messages wins.
+ *
+ * Ties go to the coarser split, deliberately. A single SMS wraps over several
+ * lines, and half a message parses either to nothing or, worse, to a smaller
+ * amount; so this can only ever find more messages than leaving the block
+ * alone, never fewer. That one-way property is what makes it safe to do without
+ * asking.
+ */
+function bestSplit(block: string): string[] {
+  let best = [block];
+  let bestScore = readableCount(best);
+
+  for (const attempt of [splitAtStarts(block), block.split('\n')]) {
+    const parts = attempt.map((part) => part.trim()).filter((part) => part.length > 0);
+    if (parts.length < 2) continue;
+    const score = readableCount(parts);
+    if (score > bestScore) {
+      best = parts;
+      bestScore = score;
+    }
+  }
+
+  return best;
+}
+
+/**
+ * A paste, as messages.
+ *
+ * A blank line is still the clearest separator and the one the Paste button
+ * writes for you, but nothing here depends on a person knowing that — see
+ * {@link bestSplit}. The count is shown before anything is parsed so a paste
+ * that came out wrong is visible rather than silently producing two candidates
+ * from six messages.
  */
 export function splitMessages(blob: string): string[] {
-  return blob
+  const blocks = blob
     .split(/\n\s*\n+/)
     .map((part) => part.trim())
     .filter((part) => part.length > 0);
+
+  const messages: string[] = [];
+  for (const block of blocks) messages.push(...bestSplit(block));
+  return messages;
 }
 
 /**
@@ -158,6 +233,25 @@ export function bodiesByKey(messages: readonly SmsMessage[]): Map<string, string
   return bodies;
 }
 
+/**
+ * The body a person may be shown for one candidate, or null.
+ *
+ * The same rule as {@link planSmsDrafts}'s `rawText`, in one function so that
+ * "what you can read on the screen" and "what gets written down" cannot drift
+ * apart: a read message's body is neither stored nor displayed, because the one
+ * copy of it lives in the phone's own Messages app and that is enough. A pasted
+ * message's body is both, because the person put it there and will want to
+ * check it against the row this screen made of it.
+ */
+export function bodyForDisplay(
+  key: string,
+  bodies: ReadonlyMap<string, string> | undefined,
+  readKeys: ReadonlySet<string> | undefined,
+): string | null {
+  if (readKeys?.has(key)) return null;
+  return bodies?.get(key) ?? null;
+}
+
 /** The ticked candidates, as drafts. Order is the candidates' own. */
 export function planSmsDrafts(input: PlanSmsDraftsInput): SmsDraft[] {
   const drafts: SmsDraft[] = [];
@@ -168,14 +262,18 @@ export function planSmsDrafts(input: PlanSmsDraftsInput): SmsDraft[] {
     // matter what the caller passed in `bodies`.
     const read = input.readKeys?.has(candidate.dedupeKey) ?? false;
     const channel: SmsDraftChannel = read ? 'inbox' : 'paste';
-    const rawText = read ? null : (input.bodies?.get(candidate.dedupeKey) ?? null);
+    const rawText = bodyForDisplay(candidate.dedupeKey, input.bodies, input.readKeys);
 
     // The merchant is the description, the way it is for every other capture.
     // With no merchant the draft has no name — the amount and the day are what
     // the message gave us, and inventing "Card payment" as *stored* text would
     // put a word into the ledger the bank never said. The screen shows that
     // wording; the row keeps the truth.
-    const description = candidate.merchant?.trim() ?? '';
+    //
+    // `merchantName` is the same guard the row's title uses, so a payment shown
+    // as "Payment from Axis Bank" cannot arrive in Review named "9215676766".
+    // A person ticks what they read.
+    const description = merchantName(candidate.merchant) ?? '';
 
     drafts.push({
       dedupeKey: candidate.dedupeKey,

--- a/apps/mobile/src/lib/smsDrafts.ts
+++ b/apps/mobile/src/lib/smsDrafts.ts
@@ -1,0 +1,200 @@
+/**
+ * Bank messages → drafts in the Review tab.
+ *
+ * The parsing is `packages/core/src/sms/parse.ts` and the writing is
+ * `useCreateCapture`; this is the bit in between, kept pure so the one rule
+ * that matters can be pinned by a test rather than trusted to a screen.
+ *
+ * THE RULE. A message that a person *pasted* is something they chose to hand
+ * over, and its text rides along as `rawText` exactly as a scanned receipt's
+ * OCR does — the capture form can show it, and an edit can correct against it.
+ * A message this app *read out of the inbox* is not that. Nobody handed it
+ * over; the app went and got it. So a read draft syncs its parsed fields — what
+ * it cost, roughly what for, when — and its body is never written down at all:
+ * not into the capture, not into the queue, not to the server. The phone's own
+ * Messages app is where that text lives, and one copy of it is enough.
+ *
+ * That is enforced structurally rather than by remembering: `planSmsDrafts`
+ * ignores `bodies` outright for anything in `readKeys`, so a caller that passes
+ * them by mistake still cannot leak one. `test/smsDrafts.test.ts` pins both
+ * halves, and checks the whole serialised draft for the text rather than only
+ * the field it is supposed to be in.
+ *
+ * THE SECOND RULE, same reason, and it is a prohibition rather than a design:
+ * **nothing on this path reports anything to Sentry, Clarity or any analytics.**
+ * Not the body, and not the merchant or the amount either. `docs/plan-drafts-
+ * and-rules.md` §10 wants the parser's hit rate measured one day; when that is
+ * built it may carry counts and confidence buckets and nothing else, and it
+ * will be a deliberate addition rather than something already half-wired here.
+ * The safest version of "never send the text" is a path with no reporter on it.
+ */
+
+import {
+  dedupeKey,
+  guessCategory,
+  parseSms,
+  TransactionDirection,
+  type CategoryId,
+  type ExpenseCandidate,
+  type SmsMessage,
+} from '@waves/core';
+
+/** Where a draft's message came from. The two are not treated alike. */
+export type SmsDraftChannel = 'paste' | 'inbox';
+
+/**
+ * What a draft remembers about the message behind it, stored in the capture's
+ * `parsed` jsonb — the same untyped field `voiceBatchId` already rides in, so
+ * this needs no column and no migration.
+ *
+ * Everything here is a *fact about* the message, never the message: who sent
+ * it, the bank's own reference (as the dedupe key), how much of it was
+ * understood, and the last few digits of the card so two cards can be told
+ * apart. A body is not on this list and must never be added to it.
+ */
+export interface SmsDraftProvenance {
+  readonly source: 'sms';
+  readonly channel: SmsDraftChannel;
+  /** Sender id, e.g. "AD-HDFCBK" — so a person can see which bank it was. */
+  readonly sender: string | null;
+  readonly dedupeKey: string;
+  readonly confidence: number;
+  readonly accountTail: string | null;
+  /** True when the message named no date and its arrival time was used. */
+  readonly dateInferred: boolean;
+}
+
+/** One draft, ready to be handed to `useCreateCapture` as a `CaptureInput`. */
+export interface SmsDraft {
+  readonly dedupeKey: string;
+  readonly description: string;
+  readonly category: CategoryId | null;
+  /** 'YYYY-MM-DD', the day the bank said — or the day the message arrived. */
+  readonly expenseDate: string;
+  readonly currency: string;
+  readonly amount: bigint;
+  /** The message, on the paste path only. Null on the read path, always. */
+  readonly rawText: string | null;
+  readonly parsed: SmsDraftProvenance;
+}
+
+export interface PlanSmsDraftsInput {
+  readonly candidates: readonly ExpenseCandidate[];
+  /** The dedupe keys the person has ticked. Nothing unticked is written. */
+  readonly chosen: ReadonlySet<string>;
+  /**
+   * The keys that came out of the phone's own inbox, from a read.
+   *
+   * Per candidate rather than per batch, because one list can hold both: a
+   * person can read the inbox and then paste something the window missed. And
+   * deliberately conservative — a message that was *both* read and pasted
+   * counts as read, so the stricter rule wins whenever the two overlap.
+   */
+  readonly readKeys?: ReadonlySet<string>;
+  /**
+   * Message bodies by dedupe key, from {@link bodiesByKey}. Supplied by the
+   * paste screen and **ignored for anything in `readKeys`** — the rule is
+   * enforced here rather than asked of the caller.
+   */
+  readonly bodies?: ReadonlyMap<string, string>;
+}
+
+/**
+ * Messages are separated by a blank line.
+ *
+ * A single SMS wraps over several lines of its own, so splitting on every
+ * newline would cut most of them in half — and half a message parses to either
+ * nothing or, worse, a smaller amount. The count is shown before anything is
+ * parsed so a bad paste is visible rather than silently producing two
+ * candidates from six messages.
+ */
+export function splitMessages(blob: string): string[] {
+  return blob
+    .split(/\n\s*\n+/)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+}
+
+/**
+ * How many pasted blocks the parser could not read as a spend at all.
+ *
+ * Counted per block rather than as "blocks minus candidates", because those two
+ * differ for reasons that are not failures: two copies of one message collapse
+ * into a single candidate, and money coming in is dropped on purpose. Calling
+ * either of those "did not look like a payment" would be a lie told to somebody
+ * already wondering why their paste came up short.
+ *
+ * A refund or a salary credit does count as unreadable here, which is the
+ * honest reading of the sentence this feeds: they were left out.
+ */
+export function unreadableCount(bodies: readonly string[]): number {
+  let unreadable = 0;
+  for (const body of bodies) {
+    const parsed = parseSms(body);
+    if (!parsed || parsed.direction !== TransactionDirection.Debit) unreadable += 1;
+  }
+  return unreadable;
+}
+
+/**
+ * Bodies indexed by the key the candidate for that message will carry.
+ *
+ * Built by re-parsing rather than by threading the body through core: an
+ * `ExpenseCandidate` deliberately does not carry the text it came from, so
+ * nothing that logs, serialises or reports a candidate can take a message body
+ * with it by accident. Re-running a pure parser over a handful of pasted blocks
+ * costs nothing and keeps that property.
+ */
+export function bodiesByKey(messages: readonly SmsMessage[]): Map<string, string> {
+  const bodies = new Map<string, string>();
+  for (const message of messages) {
+    const parsed = parseSms(message.body);
+    if (!parsed) continue;
+    const key = dedupeKey(parsed, parsed.occurredAt ?? message.receivedAt);
+    // First wins, matching `proposeFromSms`, which keeps the first of a
+    // duplicate pair and drops the rest.
+    if (!bodies.has(key)) bodies.set(key, message.body);
+  }
+  return bodies;
+}
+
+/** The ticked candidates, as drafts. Order is the candidates' own. */
+export function planSmsDrafts(input: PlanSmsDraftsInput): SmsDraft[] {
+  const drafts: SmsDraft[] = [];
+  for (const candidate of input.candidates) {
+    if (!input.chosen.has(candidate.dedupeKey)) continue;
+
+    // The one line the whole file exists for: a read draft has no body, no
+    // matter what the caller passed in `bodies`.
+    const read = input.readKeys?.has(candidate.dedupeKey) ?? false;
+    const channel: SmsDraftChannel = read ? 'inbox' : 'paste';
+    const rawText = read ? null : (input.bodies?.get(candidate.dedupeKey) ?? null);
+
+    // The merchant is the description, the way it is for every other capture.
+    // With no merchant the draft has no name — the amount and the day are what
+    // the message gave us, and inventing "Card payment" as *stored* text would
+    // put a word into the ledger the bank never said. The screen shows that
+    // wording; the row keeps the truth.
+    const description = candidate.merchant?.trim() ?? '';
+
+    drafts.push({
+      dedupeKey: candidate.dedupeKey,
+      description,
+      category: description ? guessCategory(description) : null,
+      expenseDate: candidate.at.slice(0, 10),
+      currency: candidate.amount.currency,
+      amount: candidate.amount.minor,
+      rawText,
+      parsed: {
+        source: 'sms',
+        channel,
+        sender: candidate.sender,
+        dedupeKey: candidate.dedupeKey,
+        confidence: candidate.confidence,
+        accountTail: candidate.accountTail,
+        dateInferred: candidate.dateInferred,
+      },
+    });
+  }
+  return drafts;
+}

--- a/apps/mobile/src/lib/smsFeature.ts
+++ b/apps/mobile/src/lib/smsFeature.ts
@@ -1,0 +1,77 @@
+/**
+ * The two gates the inbox reader has to pass, and the one rule that decides
+ * whether pasting is offered at all.
+ *
+ * `sms_inbox_read` has sat in `feature_flags` since the baseline migration with
+ * `enabled=false`, read by nothing. This file is what makes it real. It is not
+ * a second flag mechanism: the variant still comes from `lib/flags.tsx`, which
+ * is the one place this app asks the server what is switched on.
+ *
+ * TWO GATES, AND NEITHER SUBSTITUTES FOR THE OTHER.
+ *
+ *   1. **Build.** `plugins/withSmsReader.js` puts `android.permission.READ_SMS`
+ *      in the manifest only when `WAVES_SMS_READER=1` was set at prebuild.
+ *      Google Play scans the manifest of the artefact it is given, and a
+ *      restricted permission held without an approved core use case is grounds
+ *      for removal — so a runtime switch is no help at all here, and the
+ *      default artefact simply must not contain the permission.
+ *      `app.config.ts` records the same decision in `extra.smsReader` so the
+ *      running app can read it back rather than guess.
+ *
+ *   2. **Runtime.** `sms_inbox_read` decides whether a phone that *could* read
+ *      the inbox is offered the option. Off is the fallback for everything:
+ *      no session, no flag row, a failed fetch (`lib/flags.tsx` says why).
+ *
+ * The variant is compared against `'treatment'` rather than merely asked
+ * whether the person is enrolled. The flag's arms are `{control, treatment}`,
+ * and "enrolled at all" would hand the reader to the control group too —
+ * which is both a broken experiment and a wider exposure of a restricted
+ * permission than anybody asked for. `useFlagVariant` returning null (outside
+ * the rollout) means "behave as the app did before the flag existed", which is
+ * exactly: paste only.
+ *
+ * Pasting itself is gated by neither. It needs no permission, works on iPhone,
+ * and is the whole feature on iOS.
+ */
+
+import Constants from 'expo-constants';
+import { Platform } from 'react-native';
+
+import { useFlagVariant } from '@/lib/flags';
+
+/** The flag row seeded in the baseline migration. */
+export const SMS_INBOX_READ_FLAG = 'sms_inbox_read';
+
+/** The arm that gets the reader. The other arm is the app as it ships today. */
+const TREATMENT = 'treatment';
+
+/**
+ * Does the binary this is running in declare `READ_SMS`?
+ *
+ * Read from the config rather than probed: the native module autolinks into
+ * every Android build whether or not the manifest declares the permission, so
+ * "the module is there" answers a different question. Wrapped because
+ * `expoConfig` is null in a few hosts (a bare runtime, some test harnesses) and
+ * a missing key must read as "no", never as a crash on a screen that only
+ * wanted to decide whether to draw a button.
+ */
+export function smsReaderInBuild(): boolean {
+  try {
+    return (Constants.expoConfig?.extra as { smsReader?: unknown } | undefined)?.smsReader === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Whether this phone may be offered "read my messages" at all.
+ *
+ * Android, a build that declares the permission, and the treatment arm — all
+ * three, every time. Called by the paste screen (to decide whether to show the
+ * entry point) and by the disclosure screen itself (so a deep link or a stale
+ * back-stack cannot reach the permission prompt after the flag is turned off).
+ */
+export function useSmsInboxReader(): boolean {
+  const variant = useFlagVariant(SMS_INBOX_READ_FLAG);
+  return Platform.OS === 'android' && smsReaderInBuild() && variant === TREATMENT;
+}

--- a/apps/mobile/src/lib/smsPlain.ts
+++ b/apps/mobile/src/lib/smsPlain.ts
@@ -1,0 +1,213 @@
+/**
+ * Plain words for what a bank message says.
+ *
+ * A bank SMS is written for a machine as much as for a person: the sender is a
+ * telecom routing header, the "merchant" is whatever the parser could pull out
+ * of a sentence, and neither is safe to print at a grandmother. This module is
+ * the one place that decides what a person is allowed to *see*, and its whole
+ * rule is: **when we do not know, we say nothing.** A code on the screen is
+ * worse than a blank, because a blank is honestly empty and a code looks like
+ * information the reader is failing to understand.
+ *
+ * Nothing here parses money, dates or direction — that is
+ * `packages/core/src/sms/parse.ts`, and this deliberately does not reach into
+ * it. These are pure string judgements, so `test/smsPlain.test.ts` can pin
+ * every one of them without a device.
+ *
+ * WHY IT LIVES IN THE APP AND NOT IN CORE. A candidate is a fact; a name is a
+ * presentation choice, and the table below is a list of Indian banks that will
+ * grow every time somebody's bank is missing. Core should not have to be
+ * released for that.
+ */
+
+/**
+ * India's DLT sender format is `XX-HEADER` or `XX-HEADER-S`.
+ *
+ * `XX` is an operator-and-circle code the carrier prepends (JM, AX, VM, AD, BP,
+ * …) — it says which network carried the message and nothing about who sent it.
+ * `HEADER` is the sender id the bank registered. The trailing single letter is
+ * the message category: `-S` service, `-T` transactional, `-P` promotional,
+ * `-G` government. So `JM-ICICIT-S` carries exactly one useful token, `ICICIT`,
+ * and the other two are routing.
+ */
+const OPERATOR_PREFIX = /^[A-Z]{2}-/;
+const CATEGORY_SUFFIX = /-[A-Z]$/;
+
+/**
+ * Registered sender ids, longest-first where one is a prefix of another.
+ *
+ * Matched on the *start* of the stripped id, because banks register several
+ * headers off one stem (ICICIB, ICICIT, ICICIN) and a new one appearing is not
+ * a reason to show a code. Anything not on this list is unknown, and unknown
+ * shows nothing at all.
+ */
+const SENDER_NAMES: readonly (readonly [RegExp, string])[] = [
+  [/^HDFC/, 'HDFC Bank'],
+  [/^ICICI/, 'ICICI Bank'],
+  [/^AXIS/, 'Axis Bank'],
+  [/^(?:SBI|ATMSBI|SBICRD|SBIINB|SBIUPI)/, 'State Bank of India'],
+  [/^KOTAK/, 'Kotak Mahindra Bank'],
+  [/^INDUS/, 'IndusInd Bank'],
+  [/^YES(?:BNK|BK|BANK)?/, 'Yes Bank'],
+  [/^PNB/, 'Punjab National Bank'],
+  [/^(?:BOB|BARB)/, 'Bank of Baroda'],
+  [/^(?:CANBNK|CANARA|CNRB)/, 'Canara Bank'],
+  [/^(?:UNIONB|UBIN|UNIONBK)/, 'Union Bank of India'],
+  [/^IDFC/, 'IDFC First Bank'],
+  [/^IDBI/, 'IDBI Bank'],
+  [/^RBL/, 'RBL Bank'],
+  [/^(?:FEDBNK|FEDERAL|FDRL)/, 'Federal Bank'],
+  [/^(?:INDBNK|INDIANB|IDIB)/, 'Indian Bank'],
+  [/^(?:CENTBK|CBIN|CENTBNK)/, 'Central Bank of India'],
+  [/^(?:AUBANK|AUFINB)/, 'AU Small Finance Bank'],
+  [/^BANDHAN/, 'Bandhan Bank'],
+  [/^(?:CITI|CITIBK)/, 'Citibank'],
+  [/^HSBC/, 'HSBC'],
+  [/^(?:SCBANK|SCBIND|STANC|SCBL)/, 'Standard Chartered'],
+  [/^AMEX/, 'American Express'],
+  [/^DBSBNK/, 'DBS Bank'],
+  [/^PAYTM/, 'Paytm'],
+  [/^PHONEPE/, 'PhonePe'],
+  [/^(?:GPAY|GOOGLEPAY)/, 'Google Pay'],
+  [/^(?:AMZN|AMAZONPAY)/, 'Amazon Pay'],
+  [/^SLICE/, 'slice'],
+  [/^JUPITER/, 'Jupiter'],
+  [/^(?:ONECRD|ONECARD)/, 'OneCard'],
+];
+
+/**
+ * The bank's own name as it is written in the body of its messages.
+ *
+ * A pasted message carries no sender — the clipboard does not hold one — so the
+ * only place left to look is the text, and a bank alert almost always names
+ * itself in it ("ICICI Bank Acct XX123 debited…"). Word-bounded so that a shop
+ * called "Citi Bakery" is not read as Citibank.
+ */
+const NAMES_IN_TEXT: readonly (readonly [RegExp, string])[] = [
+  [/\bHDFC\b/i, 'HDFC Bank'],
+  [/\bICICI\b/i, 'ICICI Bank'],
+  [/\bAXIS\s*BANK\b/i, 'Axis Bank'],
+  [/\b(?:SBI|State\s+Bank\s+of\s+India)\b/i, 'State Bank of India'],
+  [/\bKOTAK\b/i, 'Kotak Mahindra Bank'],
+  [/\bINDUSIND\b/i, 'IndusInd Bank'],
+  [/\bYES\s*BANK\b/i, 'Yes Bank'],
+  [/\b(?:PNB|Punjab\s+National)\b/i, 'Punjab National Bank'],
+  [/\bBank\s+of\s+Baroda\b/i, 'Bank of Baroda'],
+  [/\bCANARA\b/i, 'Canara Bank'],
+  [/\bUNION\s+BANK\b/i, 'Union Bank of India'],
+  [/\bIDFC\b/i, 'IDFC First Bank'],
+  [/\bIDBI\b/i, 'IDBI Bank'],
+  [/\bRBL\b/i, 'RBL Bank'],
+  [/\bFEDERAL\s+BANK\b/i, 'Federal Bank'],
+  [/\bINDIAN\s+BANK\b/i, 'Indian Bank'],
+  [/\bCENTRAL\s+BANK\s+OF\s+INDIA\b/i, 'Central Bank of India'],
+  [/\bAU\s+SMALL\s+FINANCE\b/i, 'AU Small Finance Bank'],
+  [/\bBANDHAN\s+BANK\b/i, 'Bandhan Bank'],
+  [/\bCITI\s*BANK\b/i, 'Citibank'],
+  [/\bHSBC\b/i, 'HSBC'],
+  [/\bSTANDARD\s+CHARTERED\b/i, 'Standard Chartered'],
+  [/\bAMERICAN\s+EXPRESS\b/i, 'American Express'],
+  [/\bDBS\s+BANK\b/i, 'DBS Bank'],
+  [/\bPAYTM\b/i, 'Paytm'],
+  [/\bPHONEPE\b/i, 'PhonePe'],
+];
+
+/**
+ * `JM-ICICIT-S` → `ICICI Bank`. An id nobody recognises → `null`.
+ *
+ * Null rather than the raw string on purpose. `AX-AIRDUE-S` is a phone bill
+ * reminder routed through the same machinery as a bank alert; printing its
+ * header would put a telecom code under a payment and teach a person that this
+ * screen speaks in codes.
+ */
+export function bankFromSender(sender: string | null | undefined): string | null {
+  if (!sender) return null;
+  const id = sender.trim().toUpperCase().replace(OPERATOR_PREFIX, '').replace(CATEGORY_SUFFIX, '');
+  // A numeric sender is somebody's phone, not a registered bank header.
+  if (!/^[A-Z]/.test(id)) return null;
+  for (const [pattern, name] of SENDER_NAMES) {
+    if (pattern.test(id)) return name;
+  }
+  return null;
+}
+
+/** The bank named in the message itself, for a paste that carries no sender. */
+export function bankFromText(body: string | null | undefined): string | null {
+  if (!body) return null;
+  for (const [pattern, name] of NAMES_IN_TEXT) {
+    if (pattern.test(body)) return name;
+  }
+  return null;
+}
+
+/**
+ * Words the parser sometimes hands back as a "merchant" that are not a name.
+ *
+ * Every one of these is a fragment of bank grammar — the word before the thing
+ * it was looking for — and showing it as the title of a payment says "you paid
+ * VPA", which is nonsense a person cannot act on.
+ */
+const NOT_A_NAME = new Set([
+  'A',
+  'AC',
+  'ACCT',
+  'ACCOUNT',
+  'AN',
+  'ATM',
+  'BANK',
+  'CARD',
+  'CREDIT',
+  'CREDITED',
+  'DEBIT',
+  'DEBITED',
+  'IMPS',
+  'INFO',
+  'INR',
+  'NA',
+  'NEFT',
+  'OTP',
+  'PAYMENT',
+  'POS',
+  'REF',
+  'RRN',
+  'RS',
+  'RTGS',
+  'THE',
+  'TXN',
+  'UPI',
+  'VPA',
+  'YOUR',
+]);
+
+/**
+ * The merchant, if it is plausibly the name of somebody who was paid.
+ *
+ * This is a *display* guard, not a parser fix: `packages/core/src/sms/parse.ts`
+ * owns the extraction and is being sharpened separately. What it cannot do is
+ * promise never to be wrong, and a title is the one place on this screen where
+ * being wrong is indistinguishable from being right — "9215676766" printed
+ * where a shop's name goes reads as a shop called 9215676766.
+ *
+ * Rejected, and why:
+ * - nothing but digits and punctuation — an account number or a phone number;
+ * - a run of six or more digits at the front — "919951860002 Axis Bank", which
+ *   is a phone number with the bank's name stuck to it;
+ * - no letters at all;
+ * - a single bank-grammar word (see {@link NOT_A_NAME});
+ * - the bank's own name, which is who *sent* the message, not who was paid.
+ *
+ * The last of those asks for the word "bank" as well as a match, so that a
+ * wallet somebody really did pay ("PAYTM") survives and "Axis Bank" does not.
+ */
+export function merchantName(raw: string | null | undefined): string | null {
+  const name = raw?.trim();
+  if (!name) return null;
+  if (name.length < 2) return null;
+  if (!/\p{L}/u.test(name)) return null;
+  if (/^[+\d][\d\s().-]*$/.test(name)) return null;
+  if (/^\d{6,}/.test(name)) return null;
+  if (NOT_A_NAME.has(name.toUpperCase().replace(/[^A-Z]/g, ''))) return null;
+  // "Axis Bank" is who sent the message, not who was paid.
+  if (/\bbank\b/i.test(name) && bankFromText(name) !== null) return null;
+  return name;
+}

--- a/apps/mobile/src/lib/smsReadBridge.ts
+++ b/apps/mobile/src/lib/smsReadBridge.ts
@@ -1,0 +1,41 @@
+/**
+ * A one-shot handoff between the disclosure screen and the paste screen.
+ *
+ * The messages Android hands back cannot ride in route params: a navigation
+ * param is a string in a URL, it is logged by the router in development, and it
+ * would put bank message bodies into a place nobody audits. They cannot live in
+ * React state either, because the screen that asked for them is off-screen
+ * while the disclosure screen is up.
+ *
+ * So, the same module-singleton pattern `contactPickerBridge` uses — with one
+ * difference that matters here: this holds message bodies, so it is emptied the
+ * instant it is read (`takeReadMessages` reads and clears in one step) and
+ * again on `clearReadMessages` when the disclosure screen is abandoned. Nothing
+ * it holds is ever written to disk, and nothing it holds outlives the
+ * navigation that carries it back.
+ */
+
+import type { SmsMessage } from '@waves/core';
+
+let pending: SmsMessage[] | null = null;
+
+/** Leave the read messages for the screen that asked, then `router.back()`. */
+export function offerReadMessages(messages: readonly SmsMessage[]): void {
+  pending = [...messages];
+}
+
+/**
+ * Take what was read and clear it in the same step, so a second render — or a
+ * later, unrelated visit to the paste screen — can never pick the same bodies
+ * up again.
+ */
+export function takeReadMessages(): SmsMessage[] | null {
+  const messages = pending;
+  pending = null;
+  return messages;
+}
+
+/** Drop anything held without reading it. */
+export function clearReadMessages(): void {
+  pending = null;
+}

--- a/apps/mobile/src/lib/smsReader.ts
+++ b/apps/mobile/src/lib/smsReader.ts
@@ -1,0 +1,275 @@
+/**
+ * Reading bank SMS off the phone, on Android, with the user's permission.
+ *
+ * The paste screen is the feature (`app/captures/paste.tsx`), and on iPhone it
+ * is the whole of it: iOS has no API that reads Messages at any tier. This
+ * module is the Android path laid on top — a one-tap read of the inbox that
+ * fills the same candidate list a paste does.
+ *
+ * IT IS NOT REACHABLE BY DEFAULT, and that is enforced twice over, in
+ * `lib/smsFeature.ts`: the manifest declares `READ_SMS` only in a build made
+ * with `WAVES_SMS_READER=1` (Play scans the artefact, so this half cannot be a
+ * runtime switch), and the `sms_inbox_read` flag decides whether a phone that
+ * could read is offered the option. A person also passes a disclosure screen —
+ * `app/captures/messages.tsx`, in the app's own words — before Android's
+ * dialog is ever raised.
+ *
+ * Three rules shape everything here:
+ *
+ *   - Nothing read ever leaves the device. The messages go straight to
+ *     `proposeFromSms`, which parses on-device (ADR-013). A bank SMS carries an
+ *     account tail, a balance and sometimes a one-time password; the whole
+ *     point of parsing locally is that none of that is worth sending anywhere.
+ *
+ *   - Nothing read is ever persisted, either. A draft made from a *read*
+ *     message carries its parsed fields and no `rawText` — see
+ *     `lib/smsDrafts.ts`, which is where that is decided and pinned by a test.
+ *     A *pasted* message is different: the person put it there themselves, and
+ *     it keeps the behaviour every other capture has.
+ *
+ *   - It can never crash the app. The inbox reader is a native module that does
+ *     not exist on iOS, in Expo Go, or in any build that did not include it, so
+ *     it is loaded lazily behind a non-throwing check and every failure — no
+ *     module, no permission, a read that errors — degrades to a described
+ *     result the screen turns into a sentence, never an exception at launch or
+ *     at the tap (the native-module rule the other `lib/*` wrappers follow).
+ *
+ * The logic is split from the wiring: `readSmsInbox` takes every side effect as
+ * an injected dependency so all of it is unit-tested without a device, and
+ * `readSms` is the thin production entry that supplies the real ones.
+ */
+
+import type { SmsMessage } from '@waves/core';
+
+export interface SmsWindow {
+  /** Inclusive 'YYYY-MM-DD'. The trip's dates, usually. */
+  readonly from: string;
+  readonly to: string;
+}
+
+export enum SmsReadFailure {
+  Unsupported = 'unsupported',
+  Unavailable = 'unavailable',
+  Denied = 'denied',
+  Blocked = 'blocked',
+  Failed = 'failed',
+}
+
+export type SmsReadResult =
+  { ok: true; messages: SmsMessage[] } | { ok: false; reason: SmsReadFailure; message?: string };
+
+/** A row as `react-native-get-sms-android` hands it back. */
+export interface RawSms {
+  readonly _id?: number | string;
+  readonly address?: string | null;
+  readonly body?: string | null;
+  /** Epoch milliseconds the message was received. */
+  readonly date?: number | string | null;
+}
+
+/** The single method this feature needs off the native module. */
+export interface NativeSmsModule {
+  list(
+    filter: string,
+    fail: (error: string) => void,
+    success: (count: number, smsListJson: string) => void,
+  ): void;
+}
+
+/** What a permission request resolves to, flattened to the three we act on. */
+export enum PermissionOutcome {
+  Granted = 'granted',
+  Denied = 'denied',
+  Blocked = 'blocked',
+}
+
+export interface SmsReaderDeps {
+  readonly platformOS: string;
+  /** Loads the native module lazily; returns null when it is not in this build. */
+  readonly loadModule: () => NativeSmsModule | null;
+  readonly requestPermission: () => Promise<PermissionOutcome>;
+  /** Cap so a decade-long inbox cannot be walked in a single read. */
+  readonly maxCount?: number;
+}
+
+const DEFAULT_MAX_COUNT = 500;
+const DAY_MS = 86_400_000;
+
+/** A native call that never answers is failed rather than left hanging forever. */
+const READ_TIMEOUT_MS = 15_000;
+
+/**
+ * The native `list` filter for a date window.
+ *
+ * Widened by a day on each side and left to `proposeFromSms` to filter
+ * authoritatively. The native `date` is when the message was *received*, which
+ * can differ from when the payment happened by a timezone or a delayed SMS —
+ * and dropping a message here that the parser would have kept is the one
+ * mistake that loses an expense with no trace. A too-wide prefetch costs
+ * nothing; a too-narrow one is silent.
+ */
+export function buildSmsFilter(window: SmsWindow, maxCount = DEFAULT_MAX_COUNT): string {
+  const min = Date.parse(`${window.from}T00:00:00.000Z`);
+  const max = Date.parse(`${window.to}T23:59:59.999Z`);
+  const filter: Record<string, unknown> = { box: 'inbox', maxCount };
+  if (Number.isFinite(min)) filter.minDate = min - DAY_MS;
+  if (Number.isFinite(max)) filter.maxDate = max + DAY_MS;
+  return JSON.stringify(filter);
+}
+
+/**
+ * One raw row → the shape `proposeFromSms` reads, or null when it has no body.
+ * The received time carries through so the parser can place a dateless message
+ * (a bank SMS that names no date) on the day it actually arrived.
+ */
+export function mapSmsRow(raw: RawSms): SmsMessage | null {
+  const body = typeof raw.body === 'string' ? raw.body : '';
+  if (!body.trim()) return null;
+
+  const ms = typeof raw.date === 'string' ? Number(raw.date) : raw.date;
+  const receivedAt =
+    typeof ms === 'number' && Number.isFinite(ms) && ms > 0
+      ? new Date(ms).toISOString()
+      : new Date().toISOString();
+
+  const sender = typeof raw.address === 'string' && raw.address.trim() ? raw.address : undefined;
+  return sender ? { body, receivedAt, sender } : { body, receivedAt };
+}
+
+/** Parse the native JSON payload into messages, tolerating a malformed blob. */
+export function parseSmsList(json: string): SmsMessage[] {
+  let rows: unknown;
+  try {
+    rows = JSON.parse(json);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(rows)) return [];
+
+  const out: SmsMessage[] = [];
+  for (const row of rows) {
+    if (row && typeof row === 'object') {
+      const message = mapSmsRow(row as RawSms);
+      if (message) out.push(message);
+    }
+  }
+  return out;
+}
+
+/**
+ * Read the inbox for a window, or say why it could not.
+ *
+ * The order is deliberate: platform first (an iPhone can never do this), then
+ * the module (a build without it never can either), and only then the
+ * permission prompt — asking for `READ_SMS` on a phone that has no reader to
+ * use it would train the user to grant a permission that does nothing.
+ */
+export async function readSmsInbox(window: SmsWindow, deps: SmsReaderDeps): Promise<SmsReadResult> {
+  if (deps.platformOS !== 'android') {
+    return { ok: false, reason: SmsReadFailure.Unsupported };
+  }
+
+  let native: NativeSmsModule | null;
+  try {
+    native = deps.loadModule();
+  } catch {
+    native = null;
+  }
+  if (!native || typeof native.list !== 'function') {
+    return { ok: false, reason: SmsReadFailure.Unavailable };
+  }
+
+  const outcome = await deps.requestPermission();
+  if (outcome === PermissionOutcome.Denied) return { ok: false, reason: SmsReadFailure.Denied };
+  if (outcome === PermissionOutcome.Blocked) return { ok: false, reason: SmsReadFailure.Blocked };
+
+  const filter = buildSmsFilter(window, deps.maxCount ?? DEFAULT_MAX_COUNT);
+
+  return new Promise<SmsReadResult>((resolve) => {
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const done = (result: SmsReadResult): void => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      resolve(result);
+    };
+    // A native module that answers with neither callback must not leave the
+    // screen loading forever.
+    timer = setTimeout(() => done({ ok: false, reason: SmsReadFailure.Failed }), READ_TIMEOUT_MS);
+    try {
+      native.list(
+        filter,
+        (error) => done({ ok: false, reason: SmsReadFailure.Failed, message: error }),
+        (_count, json) => done({ ok: true, messages: parseSmsList(json) }),
+      );
+    } catch (error) {
+      done({
+        ok: false,
+        reason: SmsReadFailure.Failed,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  });
+}
+
+/**
+ * The words shown in the Android runtime-permission dialog for READ_SMS.
+ *
+ * Threaded in from the screen rather than hardcoded here: this file is reached
+ * on a background path with no `useStrings`, so the caller passes the reader's
+ * own language, the same way the other non-hook lib helpers receive strings.
+ */
+export interface SmsPermissionRationale {
+  readonly title: string;
+  readonly message: string;
+  readonly allow: string;
+  readonly notNow: string;
+}
+
+/**
+ * The real device wiring for `readSmsInbox`.
+ *
+ * Everything native is reached through `require` inside the callbacks, not at
+ * module load: `react-native-get-sms-android` is absent on iOS, in Expo Go and
+ * in any build that did not bundle it, and a top-level import would take the
+ * whole app down at launch on those. The module specifier is held in a variable
+ * so the type checker treats a missing module as `any` rather than an error —
+ * this package is intentionally optional.
+ */
+export async function readSms(
+  window: SmsWindow,
+  rationale: SmsPermissionRationale,
+): Promise<SmsReadResult> {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { Platform, PermissionsAndroid } = require('react-native') as typeof import('react-native');
+
+  return readSmsInbox(window, {
+    platformOS: Platform.OS,
+    loadModule: () => {
+      try {
+        const specifier = 'react-native-get-sms-android';
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const mod = require(specifier) as { default?: NativeSmsModule } & NativeSmsModule;
+        return (mod?.default ?? mod) as NativeSmsModule;
+      } catch {
+        return null;
+      }
+    },
+    requestPermission: async () => {
+      try {
+        const status = await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.READ_SMS, {
+          title: rationale.title,
+          message: rationale.message,
+          buttonPositive: rationale.allow,
+          buttonNegative: rationale.notNow,
+        });
+        if (status === PermissionsAndroid.RESULTS.GRANTED) return PermissionOutcome.Granted;
+        if (status === PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN) return PermissionOutcome.Blocked;
+        return PermissionOutcome.Denied;
+      } catch {
+        return PermissionOutcome.Denied;
+      }
+    },
+  });
+}

--- a/apps/mobile/src/lib/voiceExpense.ts
+++ b/apps/mobile/src/lib/voiceExpense.ts
@@ -14,7 +14,13 @@
  * and the group are cheap and certain here, and everyone gets them.
  */
 
-import { CATEGORIES, isCurrencyCode, minorUnitScale, type CategoryId } from '@waves/core';
+import {
+  CATEGORIES,
+  isCurrencyCode,
+  minorUnitScale,
+  normaliseDigits,
+  type CategoryId,
+} from '@waves/core';
 
 /** Above this, a voice parse is more likely corrupted or misheard than safe to book. */
 export const MAX_VOICE_AMOUNT_MAJOR = 1_000_000_000;
@@ -1131,20 +1137,14 @@ export function detectBalanceQuery(transcript: string): VoiceBalanceQuery | null
 
 /**
  * Native numerals to ASCII, so "५०० रुपये" and "௫" and "٥" all read as numbers.
- * Devanagari, Tamil, Arabic-Indic and Eastern-Arabic (Persian/Urdu) digits are
- * the ones this app's four locales and their neighbours actually type or speak.
+ *
+ * The table moved to `@waves/core` when the SMS parser needed the same one: the
+ * bank messages this app reads are written in the same scripts its users speak
+ * in, and two copies of a numeral table is two places for a script to go
+ * missing. Re-exported under the name this module has always used so nothing
+ * that imports it from here has to move.
  */
-const NATIVE_DIGIT_BLOCKS: readonly number[] = [0x0966, 0x0be6, 0x0660, 0x06f0];
-
-export function normalizeDigits(text: string): string {
-  return text.replace(/[०-९௦-௯٠-٩۰-۹]/g, (ch) => {
-    const code = ch.codePointAt(0) ?? 0;
-    for (const base of NATIVE_DIGIT_BLOCKS) {
-      if (code >= base && code <= base + 9) return String(code - base);
-    }
-    return ch;
-  });
-}
+export const normalizeDigits = normaliseDigits;
 
 function normalizeCurrencyPrefixes(text: string): string {
   return text.replace(/\b(rp|idr)\.?\s*(?=\d)/gi, '$1 ');

--- a/apps/mobile/test/smsDrafts.test.ts
+++ b/apps/mobile/test/smsDrafts.test.ts
@@ -13,7 +13,13 @@ import { describe, expect, it } from 'vitest';
 
 import { proposeFromSms, type SmsMessage } from '@waves/core';
 
-import { bodiesByKey, planSmsDrafts, splitMessages, unreadableCount } from '@/lib/smsDrafts';
+import {
+  bodiesByKey,
+  bodyForDisplay,
+  planSmsDrafts,
+  splitMessages,
+  unreadableCount,
+} from '@/lib/smsDrafts';
 
 const SWIGGY = 'Rs.1,250.00 debited from a/c XX4471 on 02-03-26 at SWIGGY. UPI Ref: 412703998812';
 const CAFE = 'Rs.240 debited at BLUE TOKAI on 03-03-26. Ref: 998877665544';
@@ -47,6 +53,26 @@ describe('splitting a paste into messages', () => {
   it('gives nothing for nothing', () => {
     expect(splitMessages('')).toEqual([]);
     expect(splitMessages('   \n  \n ')).toEqual([]);
+  });
+
+  // The blank line used to be a rule a person had to know. It is now a hint:
+  // cutting a block up only wins when the finer cut reads *better*, so this can
+  // find messages the old splitter ran together and can never lose one.
+  it('separates two messages a person pasted with no blank line', () => {
+    expect(splitMessages(`${SWIGGY}\n${CAFE}`)).toEqual([SWIGGY, CAFE]);
+  });
+
+  it('cuts at the sender header a messages app stamps on each one', () => {
+    const lump = `JM-ICICIT-S\n${SWIGGY}\nAX-AXISBK-S\n${CAFE}`;
+    expect(splitMessages(lump)).toEqual([`JM-ICICIT-S\n${SWIGGY}`, `AX-AXISBK-S\n${CAFE}`]);
+  });
+
+  it('leaves a message that wraps over several lines whole', () => {
+    // The safety property: a tie goes to the coarser cut, so half a message —
+    // which parses to nothing, or worse to a smaller amount — is never made.
+    const wrapped =
+      'Rs.1,250.00 debited from a/c XX4471\non 02-03-26 at SWIGGY.\nUPI Ref: 412703998812';
+    expect(splitMessages(wrapped)).toEqual([wrapped]);
   });
 });
 
@@ -152,8 +178,9 @@ describe('what a draft is made of', () => {
   });
 
   it('leaves a message with no shop unnamed rather than inventing a word', () => {
-    // The screen shows "Card payment"; the row keeps the truth, because a
-    // description is a thing a person typed or a bank said.
+    // The screen says "Payment from HDFC Bank", which is true of the message;
+    // the row keeps the truth, because a description is a thing a person typed
+    // or a bank said.
     const bare = proposeFromSms([sms('Rs.500 debited on 02-03-26')]);
     const [draft] = planSmsDrafts({
       candidates: bare,
@@ -167,6 +194,47 @@ describe('what a draft is made of', () => {
     const one = planSmsDrafts({ candidates, chosen: new Set([candidates[0]!.dedupeKey]) });
     expect(one).toHaveLength(1);
     expect(planSmsDrafts({ candidates, chosen: new Set() })).toEqual([]);
+  });
+
+  it('does not file a phone number as the name of a shop', () => {
+    // A person ticks a row that reads "Payment from your bank". It must not
+    // arrive in Review called 9215676766 — the same guard decides both, so
+    // what was read and what was kept cannot drift apart.
+    //
+    // The junk merchant is handed in directly rather than coaxed out of the
+    // parser. Both layers now refuse a bare number, and an earlier version of
+    // this test asserted the *parser* still produced one as its setup — so
+    // tightening the parser broke a test about the app-layer guard, which was
+    // never what it was measuring. Two defences, tested where each one lives.
+    const [real] = proposeFromSms([sms('Rs.300 debited on 02-03-26 to SWIGGY')]);
+    const junk = { ...real!, merchant: '9215676766' };
+    const [draft] = planSmsDrafts({
+      candidates: [junk],
+      chosen: new Set([junk.dedupeKey]),
+    });
+    expect(draft?.description).toBe('');
+    expect(draft?.category).toBeNull();
+  });
+});
+
+describe('the message a person may read is the message that will be kept', () => {
+  const messages = [sms(SWIGGY)];
+  const key = proposeFromSms(messages)[0]!.dedupeKey;
+  const bodies = bodiesByKey(messages);
+
+  it('hands back a pasted body', () => {
+    expect(bodyForDisplay(key, bodies, new Set())).toBe(SWIGGY);
+  });
+
+  it('hands back nothing for a message read out of the inbox', () => {
+    // Not merely "is not stored" — not shown either, and by the same function,
+    // so the disclosure's promise cannot be undone by a screen.
+    expect(bodyForDisplay(key, bodies, new Set([key]))).toBeNull();
+  });
+
+  it('hands back nothing when there is no body to hand back', () => {
+    expect(bodyForDisplay('amt:INR:1:2026-03-02:?', bodies, undefined)).toBeNull();
+    expect(bodyForDisplay(key, undefined, undefined)).toBeNull();
   });
 });
 

--- a/apps/mobile/test/smsDrafts.test.ts
+++ b/apps/mobile/test/smsDrafts.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Bank messages into drafts, and the one rule that cannot be allowed to drift.
+ *
+ * A message a person *pasted* keeps its text: they put it there, and a capture
+ * carries `rawText` for exactly this reason already (a scanned receipt's OCR
+ * rides in the same field). A message this app *read out of the phone's inbox*
+ * does not, ever — the parsed facts sync and the body is never written down at
+ * all. The disclosure screen promises that in words; this is what makes it
+ * true, and what will fail if somebody later "tidies up" the asymmetry.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { proposeFromSms, type SmsMessage } from '@waves/core';
+
+import { bodiesByKey, planSmsDrafts, splitMessages, unreadableCount } from '@/lib/smsDrafts';
+
+const SWIGGY = 'Rs.1,250.00 debited from a/c XX4471 on 02-03-26 at SWIGGY. UPI Ref: 412703998812';
+const CAFE = 'Rs.240 debited at BLUE TOKAI on 03-03-26. Ref: 998877665544';
+
+const sms = (body: string, receivedAt = '2026-03-02T10:00:00.000Z'): SmsMessage => ({
+  body,
+  receivedAt,
+  sender: 'AD-HDFCBK',
+});
+
+const allOf = (messages: readonly SmsMessage[]) => {
+  const candidates = proposeFromSms(messages);
+  return { candidates, chosen: new Set(candidates.map((item) => item.dedupeKey)) };
+};
+
+describe('splitting a paste into messages', () => {
+  it('splits on blank lines, not on every newline', () => {
+    // A single SMS wraps; splitting per line would halve most of them, and half
+    // a message parses to a smaller amount rather than to nothing.
+    expect(splitMessages('one\nstill one\n\ntwo\n\n\nthree')).toEqual([
+      'one\nstill one',
+      'two',
+      'three',
+    ]);
+  });
+
+  it('drops the empty tail a trailing newline leaves', () => {
+    expect(splitMessages('\n\n one \n\n  \n\n')).toEqual(['one']);
+  });
+
+  it('gives nothing for nothing', () => {
+    expect(splitMessages('')).toEqual([]);
+    expect(splitMessages('   \n  \n ')).toEqual([]);
+  });
+});
+
+describe('a pasted message keeps its text', () => {
+  const messages = [sms(SWIGGY)];
+  const { candidates, chosen } = allOf(messages);
+
+  it('carries the body as rawText', () => {
+    const [draft] = planSmsDrafts({
+      candidates,
+      chosen,
+      bodies: bodiesByKey(messages),
+    });
+    expect(draft?.rawText).toBe(SWIGGY);
+    expect(draft?.parsed.channel).toBe('paste');
+  });
+
+  it('and is marked as having come from a message', () => {
+    const [draft] = planSmsDrafts({ candidates, chosen, bodies: bodiesByKey(messages) });
+    expect(draft?.parsed.source).toBe('sms');
+    expect(draft?.parsed.sender).toBe('AD-HDFCBK');
+    expect(draft?.parsed.accountTail).toBe('4471');
+    expect(draft?.parsed.dedupeKey).toBe('ref:412703998812');
+  });
+});
+
+describe('a message read from the inbox never carries its text', () => {
+  const messages = [sms(SWIGGY)];
+  const { candidates, chosen } = allOf(messages);
+  const readKeys = new Set(candidates.map((item) => item.dedupeKey));
+
+  it('leaves rawText null', () => {
+    const [draft] = planSmsDrafts({ candidates, chosen, readKeys });
+    expect(draft?.rawText).toBeNull();
+    expect(draft?.parsed.channel).toBe('inbox');
+  });
+
+  it('ignores bodies it was handed by mistake', () => {
+    // The rule is enforced here rather than asked of the caller: a screen that
+    // built a body map for its pasted half and passed it for the whole list
+    // must still not be able to leak one.
+    const [draft] = planSmsDrafts({
+      candidates,
+      chosen,
+      readKeys,
+      bodies: bodiesByKey(messages),
+    });
+    expect(draft?.rawText).toBeNull();
+  });
+
+  it('puts no part of the message body anywhere in what will be synced', () => {
+    // The payload that reaches `/sync` is this draft, field for field. Rather
+    // than name the one field, look for the text anywhere in it: a future field
+    // that started carrying the body would fail here too.
+    const drafts = planSmsDrafts({
+      candidates,
+      chosen,
+      readKeys,
+      bodies: bodiesByKey(messages),
+    });
+    const wire = JSON.stringify(drafts, (_key, value) =>
+      typeof value === 'bigint' ? value.toString() : value,
+    );
+    expect(wire).not.toContain('debited');
+    expect(wire).not.toContain('XX4471');
+    expect(wire).not.toContain('a/c');
+    // What it *does* carry is the facts: the shop, the amount, the day.
+    expect(wire).toContain('SWIGGY');
+    expect(wire).toContain('125000');
+    expect(wire).toContain('2026-03-02');
+  });
+
+  it('treats a message that was both read and pasted as read', () => {
+    // The conservative reading, deliberately: if this app went and got it, the
+    // stricter rule applies however else it also arrived.
+    const both = [sms(SWIGGY), sms(SWIGGY)];
+    const proposed = proposeFromSms(both);
+    const [draft] = planSmsDrafts({
+      candidates: proposed,
+      chosen: new Set(proposed.map((item) => item.dedupeKey)),
+      readKeys: new Set([proposed[0]!.dedupeKey]),
+      bodies: bodiesByKey(both),
+    });
+    expect(draft?.rawText).toBeNull();
+  });
+});
+
+describe('what a draft is made of', () => {
+  const messages = [sms(SWIGGY), sms(CAFE, '2026-03-03T10:00:00.000Z')];
+  const { candidates, chosen } = allOf(messages);
+  const drafts = planSmsDrafts({ candidates, chosen, bodies: bodiesByKey(messages) });
+
+  it('takes the shop as the description and guesses a category from it', () => {
+    const swiggy = drafts.find((draft) => draft.description === 'SWIGGY');
+    expect(swiggy?.category).toBe('food');
+  });
+
+  it('files it on the day the bank said, in minor units', () => {
+    const swiggy = drafts.find((draft) => draft.description === 'SWIGGY');
+    expect(swiggy?.expenseDate).toBe('2026-03-02');
+    expect(swiggy?.amount).toBe(125000n);
+    expect(swiggy?.currency).toBe('INR');
+  });
+
+  it('leaves a message with no shop unnamed rather than inventing a word', () => {
+    // The screen shows "Card payment"; the row keeps the truth, because a
+    // description is a thing a person typed or a bank said.
+    const bare = proposeFromSms([sms('Rs.500 debited on 02-03-26')]);
+    const [draft] = planSmsDrafts({
+      candidates: bare,
+      chosen: new Set(bare.map((item) => item.dedupeKey)),
+    });
+    expect(draft?.description).toBe('');
+    expect(draft?.category).toBeNull();
+  });
+
+  it('writes only what was ticked', () => {
+    const one = planSmsDrafts({ candidates, chosen: new Set([candidates[0]!.dedupeKey]) });
+    expect(one).toHaveLength(1);
+    expect(planSmsDrafts({ candidates, chosen: new Set() })).toEqual([]);
+  });
+});
+
+describe('what could not be read, counted honestly', () => {
+  it('counts a block the parser refused', () => {
+    expect(unreadableCount([SWIGGY, 'Your OTP is 4471. Rs.1,250 will be debited.'])).toBe(1);
+  });
+
+  it('counts money coming in — it was left out, and the screen says so', () => {
+    expect(unreadableCount(['Rs.2,000 credited to a/c XX4471 from RAVI on 02-03-26'])).toBe(1);
+  });
+
+  it('does not count a duplicate as a failure', () => {
+    // Two copies of one message collapse into one candidate. "Blocks minus
+    // candidates" would call the second copy unreadable, which it is not.
+    expect(unreadableCount([SWIGGY, SWIGGY])).toBe(0);
+  });
+});
+
+describe('bodies, indexed by the key their candidate will carry', () => {
+  it('lines up with what proposeFromSms produced', () => {
+    const messages = [sms(SWIGGY), sms(CAFE, '2026-03-03T10:00:00.000Z')];
+    const bodies = bodiesByKey(messages);
+    for (const candidate of proposeFromSms(messages)) {
+      expect(bodies.get(candidate.dedupeKey)).toBeTypeOf('string');
+    }
+  });
+
+  it('holds nothing for a message that is not a payment', () => {
+    expect(bodiesByKey([sms('Your OTP is 4471. Rs.1,250 will be debited.')]).size).toBe(0);
+  });
+
+  it('keeps the first of a duplicate pair, as the proposer does', () => {
+    const bodies = bodiesByKey([sms(SWIGGY), sms(`${SWIGGY} (resent)`)]);
+    expect(bodies.size).toBe(1);
+    expect([...bodies.values()][0]).toBe(SWIGGY);
+  });
+});

--- a/apps/mobile/test/smsPlain.test.ts
+++ b/apps/mobile/test/smsPlain.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Plain words for what a bank message says.
+ *
+ * Every case here came off a real screenshot of the paste screen: rows headed
+ * `919951860002 Axis Bank` and `9215676766`, subtitled `JM-ICICIT-S` and
+ * `AX-AIRDUE-S`. The rule these pin is the same one in both directions — when
+ * this module does not know, it says nothing, because a code shown to a person
+ * is worse than a blank.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { bankFromSender, bankFromText, merchantName } from '@/lib/smsPlain';
+
+describe('a sender header becomes a bank', () => {
+  it('strips the operator prefix and the message-type suffix', () => {
+    expect(bankFromSender('JM-ICICIT-S')).toBe('ICICI Bank');
+    expect(bankFromSender('AX-AXISBK-S')).toBe('Axis Bank');
+    expect(bankFromSender('AD-HDFCBK')).toBe('HDFC Bank');
+    expect(bankFromSender('VM-SBIINB-T')).toBe('State Bank of India');
+  });
+
+  it('takes a header with no operator prefix at all', () => {
+    expect(bankFromSender('HDFCBK')).toBe('HDFC Bank');
+    expect(bankFromSender('kotakb')).toBe('Kotak Mahindra Bank');
+  });
+
+  it('says nothing for a sender it does not recognise', () => {
+    // A phone bill reminder rides the same rails as a bank alert. Printing
+    // "AIRDUE" under a payment would teach a person that this screen speaks in
+    // codes, which is exactly the habit being unlearned here.
+    expect(bankFromSender('AX-AIRDUE-S')).toBeNull();
+    expect(bankFromSender('VK-SOMEONE')).toBeNull();
+  });
+
+  it('says nothing for a number, which is somebody phoning, not a bank', () => {
+    expect(bankFromSender('919951860002')).toBeNull();
+    expect(bankFromSender('9215676766')).toBeNull();
+  });
+
+  it('says nothing for nothing', () => {
+    expect(bankFromSender(null)).toBeNull();
+    expect(bankFromSender('')).toBeNull();
+  });
+});
+
+describe('a pasted message names its own bank', () => {
+  it('finds the bank in the text, where a paste has no sender to give', () => {
+    expect(bankFromText('ICICI Bank Acct XX123 debited for Rs 450')).toBe('ICICI Bank');
+    expect(bankFromText('Rs.1,250 debited from your Axis Bank card')).toBe('Axis Bank');
+  });
+
+  it('does not read a shop as a bank', () => {
+    expect(bankFromText('Rs.200 paid at CITI BAKERY')).toBeNull();
+    expect(bankFromText('Rs.90 paid at CAFE')).toBeNull();
+  });
+});
+
+describe('a merchant is only shown when it is plausibly a name', () => {
+  it('keeps a name', () => {
+    expect(merchantName('SWIGGY')).toBe('SWIGGY');
+    expect(merchantName('Blue Tokai Coffee')).toBe('Blue Tokai Coffee');
+    expect(merchantName(' AMAZON.IN ')).toBe('AMAZON.IN');
+  });
+
+  it('keeps a wallet somebody really did pay', () => {
+    expect(merchantName('PAYTM')).toBe('PAYTM');
+  });
+
+  it('refuses a phone number', () => {
+    expect(merchantName('9215676766')).toBeNull();
+    expect(merchantName('+91 99518 60002')).toBeNull();
+  });
+
+  it('refuses a number with a bank stuck to it', () => {
+    expect(merchantName('919951860002 Axis Bank')).toBeNull();
+  });
+
+  it('refuses a fragment of bank grammar', () => {
+    for (const junk of ['VPA', 'A', 'UPI', 'REF', 'a/c', 'Your']) {
+      expect(merchantName(junk)).toBeNull();
+    }
+  });
+
+  it('refuses the bank that sent the message, which is not who was paid', () => {
+    expect(merchantName('Axis Bank')).toBeNull();
+    expect(merchantName('HDFC Bank')).toBeNull();
+  });
+
+  it('keeps a real place whose name happens to contain a bank word', () => {
+    expect(merchantName('Bank Street Cafe')).toBe('Bank Street Cafe');
+  });
+
+  it('says nothing for nothing', () => {
+    expect(merchantName(null)).toBeNull();
+    expect(merchantName('   ')).toBeNull();
+    expect(merchantName('...')).toBeNull();
+  });
+});

--- a/apps/mobile/test/smsReader.test.ts
+++ b/apps/mobile/test/smsReader.test.ts
@@ -1,0 +1,331 @@
+/**
+ * The Android inbox reader.
+ *
+ * It is one native call wrapped in a lot of refusals, and the refusals are the
+ * point: on the wrong platform, in a build without the module, with the
+ * permission denied or blocked, or when the read itself errors, it must come
+ * back with a described result the screen can turn into a sentence — never an
+ * exception, because an exception here is a crash at the exact moment somebody
+ * tapped a button asking for their bank messages.
+ *
+ * Every side effect is injected, so the whole matrix runs without a device.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { proposeFromSms } from '@waves/core';
+
+import {
+  buildSmsFilter,
+  mapSmsRow,
+  parseSmsList,
+  PermissionOutcome,
+  readSmsInbox,
+  type NativeSmsModule,
+  type SmsReaderDeps,
+  type SmsWindow,
+} from '@/lib/smsReader';
+
+const WINDOW: SmsWindow = { from: '2026-07-01', to: '2026-07-08' };
+
+/** A native module whose `list` replies with a canned success payload. */
+function moduleReturning(rows: unknown): NativeSmsModule {
+  return {
+    list: (_filter, _fail, success) =>
+      success(Array.isArray(rows) ? rows.length : 0, JSON.stringify(rows)),
+  };
+}
+
+function deps(over: Partial<SmsReaderDeps> = {}): SmsReaderDeps {
+  return {
+    platformOS: 'android',
+    loadModule: () => moduleReturning([]),
+    requestPermission: async () => PermissionOutcome.Granted,
+    ...over,
+  };
+}
+
+// ─────────────────────────────────────────────────── the pure pieces ──
+
+describe('buildSmsFilter', () => {
+  it('asks the inbox for the window, widened a day each side', () => {
+    const filter = JSON.parse(buildSmsFilter(WINDOW));
+    expect(filter.box).toBe('inbox');
+    expect(filter.maxCount).toBe(500);
+    // 2026-07-01T00:00Z minus a day, 2026-07-08T23:59:59.999Z plus a day.
+    expect(filter.minDate).toBe(Date.parse('2026-06-30T00:00:00.000Z'));
+    expect(filter.maxDate).toBe(Date.parse('2026-07-09T23:59:59.999Z'));
+  });
+
+  it('honours a custom cap', () => {
+    expect(JSON.parse(buildSmsFilter(WINDOW, 25)).maxCount).toBe(25);
+  });
+
+  it('omits an unparseable bound rather than sending NaN', () => {
+    const filter = JSON.parse(buildSmsFilter({ from: 'not-a-date', to: '2026-07-08' }));
+    expect('minDate' in filter).toBe(false);
+    expect(filter.maxDate).toBe(Date.parse('2026-07-09T23:59:59.999Z'));
+  });
+});
+
+describe('mapSmsRow', () => {
+  it('carries body, received time and sender across', () => {
+    const message = mapSmsRow({
+      body: 'Rs 500 debited',
+      date: 1_751_356_800_000,
+      address: 'HDFCBK',
+    });
+    expect(message).toEqual({
+      body: 'Rs 500 debited',
+      receivedAt: new Date(1_751_356_800_000).toISOString(),
+      sender: 'HDFCBK',
+    });
+  });
+
+  it('accepts a stringified epoch', () => {
+    const message = mapSmsRow({ body: 'x', date: '1751356800000' });
+    expect(message?.receivedAt).toBe(new Date(1_751_356_800_000).toISOString());
+  });
+
+  it('drops a message with no body', () => {
+    expect(mapSmsRow({ body: '   ', date: 1 })).toBeNull();
+    expect(mapSmsRow({ date: 1 })).toBeNull();
+  });
+
+  it('falls back to now when the date is missing or junk, without throwing', () => {
+    const before = Date.now();
+    const message = mapSmsRow({ body: 'x', date: null });
+    const stamp = Date.parse(message!.receivedAt);
+    expect(stamp).toBeGreaterThanOrEqual(before);
+    expect(mapSmsRow({ body: 'x', date: 'nonsense' })?.receivedAt).toBeTruthy();
+  });
+
+  it('leaves the sender off when there is no address', () => {
+    expect(mapSmsRow({ body: 'x', date: 1 })).not.toHaveProperty('sender');
+    expect(mapSmsRow({ body: 'x', date: 1, address: '  ' })).not.toHaveProperty('sender');
+  });
+});
+
+describe('parseSmsList', () => {
+  it('maps a well-formed payload and skips bodiless rows', () => {
+    const messages = parseSmsList(
+      JSON.stringify([
+        { body: 'Rs 500 debited', date: 1 },
+        { body: '', date: 2 },
+        { date: 3 },
+        { body: 'Rs 90 spent', date: 4 },
+      ]),
+    );
+    expect(messages.map((m) => m.body)).toEqual(['Rs 500 debited', 'Rs 90 spent']);
+  });
+
+  it('returns nothing for malformed JSON', () => {
+    expect(parseSmsList('{not json')).toEqual([]);
+  });
+
+  it('returns nothing for a non-array', () => {
+    expect(parseSmsList(JSON.stringify({ body: 'x' }))).toEqual([]);
+  });
+});
+
+// ─────────────────────────────────────────────── readSmsInbox matrix ──
+
+describe('readSmsInbox — refusals', () => {
+  it('is unsupported off Android', async () => {
+    const res = await readSmsInbox(WINDOW, deps({ platformOS: 'ios' }));
+    expect(res).toEqual({ ok: false, reason: 'unsupported' });
+  });
+
+  it('is unavailable when the module is not in this build', async () => {
+    const res = await readSmsInbox(WINDOW, deps({ loadModule: () => null }));
+    expect(res).toEqual({ ok: false, reason: 'unavailable' });
+  });
+
+  it('is unavailable — not a crash — when loading the module throws', async () => {
+    const res = await readSmsInbox(
+      WINDOW,
+      deps({
+        loadModule: () => {
+          throw new Error('native side blew up');
+        },
+      }),
+    );
+    expect(res).toEqual({ ok: false, reason: 'unavailable' });
+  });
+
+  it('is unavailable when the module has no list method', async () => {
+    const res = await readSmsInbox(WINDOW, deps({ loadModule: () => ({}) as NativeSmsModule }));
+    expect(res).toEqual({ ok: false, reason: 'unavailable' });
+  });
+
+  it('reports a plain denial', async () => {
+    const res = await readSmsInbox(
+      WINDOW,
+      deps({ requestPermission: async () => PermissionOutcome.Denied }),
+    );
+    expect(res).toEqual({ ok: false, reason: 'denied' });
+  });
+
+  it('reports a blocked (never-ask-again) permission distinctly', async () => {
+    const res = await readSmsInbox(
+      WINDOW,
+      deps({ requestPermission: async () => PermissionOutcome.Blocked }),
+    );
+    expect(res).toEqual({ ok: false, reason: 'blocked' });
+  });
+
+  it('does not ask for permission before the module is known to exist', async () => {
+    const requestPermission = vi.fn(async () => PermissionOutcome.Granted);
+    await readSmsInbox(WINDOW, deps({ loadModule: () => null, requestPermission }));
+    expect(requestPermission).not.toHaveBeenCalled();
+  });
+});
+
+describe('readSmsInbox — reading', () => {
+  it('returns the parsed messages on success', async () => {
+    const rows = [
+      { body: 'Rs 500 debited at SWIGGY', date: 1_751_356_800_000, address: 'HDFCBK' },
+      { body: 'Rs 90 spent at CCD', date: 1_751_443_200_000, address: 'HDFCBK' },
+    ];
+    const res = await readSmsInbox(WINDOW, deps({ loadModule: () => moduleReturning(rows) }));
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.messages).toHaveLength(2);
+  });
+
+  it('passes the window filter through to the native call', async () => {
+    let seen = '';
+    const module: NativeSmsModule = {
+      list: (filter, _fail, success) => {
+        seen = filter;
+        success(0, '[]');
+      },
+    };
+    await readSmsInbox(WINDOW, deps({ loadModule: () => module, maxCount: 42 }));
+    const parsed = JSON.parse(seen);
+    expect(parsed.maxCount).toBe(42);
+    expect(parsed.minDate).toBe(Date.parse('2026-06-30T00:00:00.000Z'));
+  });
+
+  it('surfaces a read failure with its message', async () => {
+    const module: NativeSmsModule = {
+      list: (_filter, fail) => fail('cursor closed'),
+    };
+    const res = await readSmsInbox(WINDOW, deps({ loadModule: () => module }));
+    expect(res).toEqual({ ok: false, reason: 'failed', message: 'cursor closed' });
+  });
+
+  it('turns a synchronous throw from list into a failure, not a crash', async () => {
+    const module: NativeSmsModule = {
+      list: () => {
+        throw new Error('binder died');
+      },
+    };
+    const res = await readSmsInbox(WINDOW, deps({ loadModule: () => module }));
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.reason).toBe('failed');
+      expect(res.message).toBe('binder died');
+    }
+  });
+
+  it('resolves once even if the native side calls back twice', async () => {
+    const module: NativeSmsModule = {
+      list: (_filter, fail, success) => {
+        success(1, JSON.stringify([{ body: 'Rs 500 debited', date: 1 }]));
+        success(1, JSON.stringify([{ body: 'Rs 999 debited', date: 2 }]));
+        fail('late error');
+      },
+    };
+    const res = await readSmsInbox(WINDOW, deps({ loadModule: () => module }));
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.messages[0]?.body).toBe('Rs 500 debited');
+  });
+
+  it('returns an empty list for an empty inbox', async () => {
+    const res = await readSmsInbox(WINDOW, deps({ loadModule: () => moduleReturning([]) }));
+    expect(res).toEqual({ ok: true, messages: [] });
+  });
+});
+
+// ─────────────────────────────────────── the whole path, end to end ──
+
+describe('read → propose, over the trip window', () => {
+  it('surfaces a dated debit inside the trip and drops what does not belong', async () => {
+    const rows = [
+      // A clean debit, inside the window — the one we want.
+      {
+        body: 'Rs 1,250.00 debited at ANJAPPAR on 04-Jul-26. UPI Ref 412345678901',
+        date: Date.parse('2026-07-04T13:00:00.000Z'),
+        address: 'AD-HDFCBK',
+      },
+      // A credit — money coming in is never an expense.
+      {
+        body: 'Rs 5,000 credited to your account on 05-Jul-26',
+        date: Date.parse('2026-07-05T09:00:00.000Z'),
+        address: 'AD-HDFCBK',
+      },
+      // An OTP quoting a real amount — the dangerous false positive.
+      {
+        body: 'Rs 800 is your OTP. Do not share it.',
+        date: Date.parse('2026-07-04T10:00:00.000Z'),
+        address: 'VM-HDFCBK',
+      },
+      // A real debit, but received months after the trip window closed.
+      {
+        body: 'Rs 300 debited at METRO on 02-Aug-26',
+        date: Date.parse('2026-08-02T10:00:00.000Z'),
+        address: 'AD-HDFCBK',
+      },
+    ];
+
+    const read = await readSmsInbox(WINDOW, deps({ loadModule: () => moduleReturning(rows) }));
+    expect(read.ok).toBe(true);
+    if (!read.ok) return;
+
+    const candidates = proposeFromSms(read.messages, { from: WINDOW.from, to: WINDOW.to });
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.merchant).toBe('ANJAPPAR');
+    expect(candidates[0]?.amount.minor).toBe(125000n);
+    expect(candidates[0]?.direction).toBe('debit');
+  });
+
+  it('places a dateless message on the day it was received, so the window still holds', async () => {
+    const rows = [
+      {
+        body: 'Rs 640 spent at BLUE TOKAI',
+        date: Date.parse('2026-07-03T08:00:00.000Z'),
+        address: 'AD-ICICIB',
+      },
+    ];
+    const read = await readSmsInbox(WINDOW, deps({ loadModule: () => moduleReturning(rows) }));
+    if (!read.ok) throw new Error('expected a successful read');
+
+    const inside = proposeFromSms(read.messages, { from: WINDOW.from, to: WINDOW.to });
+    expect(inside).toHaveLength(1);
+    expect(inside[0]?.dateInferred).toBe(true);
+
+    // The same message, asked for a window that ends before it arrived, is gone.
+    const outside = proposeFromSms(read.messages, { from: '2026-06-01', to: '2026-06-30' });
+    expect(outside).toHaveLength(0);
+  });
+
+  it('drops what has already been imported', async () => {
+    const rows = [
+      {
+        body: 'Rs 1,250.00 debited at ANJAPPAR on 04-Jul-26. UPI Ref 412345678901',
+        date: Date.parse('2026-07-04T13:00:00.000Z'),
+        address: 'AD-HDFCBK',
+      },
+    ];
+    const read = await readSmsInbox(WINDOW, deps({ loadModule: () => moduleReturning(rows) }));
+    if (!read.ok) throw new Error('expected a successful read');
+
+    const alreadyImported = new Set(['ref:412345678901']);
+    const candidates = proposeFromSms(read.messages, {
+      from: WINDOW.from,
+      to: WINDOW.to,
+      alreadyImported,
+    });
+    expect(candidates).toHaveLength(0);
+  });
+});

--- a/apps/mobile/test/smsReaderPlugin.test.ts
+++ b/apps/mobile/test/smsReaderPlugin.test.ts
@@ -1,0 +1,124 @@
+/**
+ * The build-time half of the SMS gate.
+ *
+ * This is a compliance test, not a preference. `READ_SMS` is a restricted
+ * permission: held in a Play artefact without an approved core use case, the
+ * consequence is removal, and Play decides by scanning the merged manifest, not
+ * by watching what the app does at runtime. So the property that has to hold is
+ * blunt — *a default build's manifest must be exactly what it is today* — and
+ * the way this plugin achieves it is blunt too: with the switch off it
+ * registers no mod at all, so there is nothing that could produce a diff.
+ *
+ * The reference-equality assertion below is the whole point. A plugin that
+ * returned a copied config, or registered a mod that happened to make no
+ * change, would pass a weaker test and still be one refactor away from writing
+ * the permission into a store build.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const withSmsReader = require('../plugins/withSmsReader.js') as ((config: unknown) => unknown) & {
+  _internals: {
+    PERMISSION: string;
+    readerEnabled: (env: Record<string, string | undefined>) => boolean;
+    manifestWithReadSms: (manifest: unknown) => { manifest: { 'uses-permission': unknown[] } };
+  };
+};
+
+const { PERMISSION, readerEnabled, manifestWithReadSms } = withSmsReader._internals;
+
+/** A manifest shaped the way `withAndroidManifest` hands one over. */
+const manifestWith = (...permissions: string[]) => ({
+  manifest: {
+    $: { 'xmlns:android': 'http://schemas.android.com/apk/res/android' },
+    'uses-permission': permissions.map((name) => ({ $: { 'android:name': name } })),
+    application: [{ $: { 'android:name': '.MainApplication' } }],
+  },
+});
+
+const names = (result: { manifest: { 'uses-permission': unknown[] } }): string[] =>
+  result.manifest['uses-permission'].map(
+    (entry) => (entry as { $: Record<string, string> }).$['android:name'],
+  );
+
+describe('the switch', () => {
+  it('is on for exactly one spelling', () => {
+    expect(readerEnabled({ WAVES_SMS_READER: '1' })).toBe(true);
+  });
+
+  it('is off for everything else, including the plausible ones', () => {
+    for (const value of [undefined, '', '0', 'true', 'TRUE', 'yes', 'on', ' 1']) {
+      expect(readerEnabled({ WAVES_SMS_READER: value })).toBe(false);
+    }
+    expect(readerEnabled({})).toBe(false);
+  });
+});
+
+describe('a default build', () => {
+  it('gets the config back untouched — the same object, with no mod added', () => {
+    delete process.env.WAVES_SMS_READER;
+    const config = { name: 'Waves', android: { permissions: [] as string[] } };
+    // Identity, deliberately. Anything else — a copy, or a registered mod that
+    // makes no change — would still be a build whose manifest this plugin has
+    // had its hands on, and the promise is that it has not.
+    expect(withSmsReader(config)).toBe(config);
+    expect(config).not.toHaveProperty('mods');
+  });
+
+  it('leaves android.permissions alone', () => {
+    delete process.env.WAVES_SMS_READER;
+    const config = { android: { permissions: ['android.permission.CAMERA'] } };
+    withSmsReader(config);
+    expect(config.android.permissions).toEqual(['android.permission.CAMERA']);
+  });
+
+  it('is off for a value that only looks like the switch', () => {
+    process.env.WAVES_SMS_READER = 'true';
+    const config = { name: 'Waves' };
+    expect(withSmsReader(config)).toBe(config);
+    delete process.env.WAVES_SMS_READER;
+  });
+});
+
+describe('a build that asked for the reader', () => {
+  it('registers an android manifest mod', () => {
+    process.env.WAVES_SMS_READER = '1';
+    const patched = withSmsReader({ name: 'Waves' }) as {
+      mods?: { android?: { manifest?: unknown } };
+    };
+    expect(typeof patched.mods?.android?.manifest).toBe('function');
+    delete process.env.WAVES_SMS_READER;
+  });
+
+  it('adds READ_SMS and nothing else', () => {
+    const before = manifestWith('android.permission.INTERNET');
+    const after = manifestWithReadSms(before);
+    expect(names(after)).toEqual(['android.permission.INTERNET', PERMISSION]);
+    expect(PERMISSION).toBe('android.permission.READ_SMS');
+  });
+
+  it('adds it to a manifest that declares nothing', () => {
+    expect(names(manifestWithReadSms(manifestWith()))).toEqual([PERMISSION]);
+  });
+
+  it('is idempotent — prebuild can run twice over the same tree', () => {
+    const once = manifestWithReadSms(manifestWith('android.permission.INTERNET'));
+    const twice = manifestWithReadSms(once);
+    expect(twice).toBe(once);
+    expect(names(twice)).toHaveLength(2);
+  });
+
+  it('does not mutate the manifest it was given', () => {
+    const before = manifestWith('android.permission.INTERNET');
+    manifestWithReadSms(before);
+    expect(names(before)).toEqual(['android.permission.INTERNET']);
+  });
+
+  it('fails loudly rather than silently on a manifest it does not recognise', () => {
+    // A silent no-op here is the failure that matters in the *other* direction:
+    // a build that asked for the reader and quietly did not get the permission
+    // would show a system prompt that can never be granted.
+    expect(() => manifestWithReadSms({})).toThrow(/READ_SMS/);
+  });
+});

--- a/docs/sms-parser-corpus.md
+++ b/docs/sms-parser-corpus.md
@@ -1,0 +1,161 @@
+# The SMS corpus these results were measured against
+
+61 bodies written to match documented institution formats — **not captured from
+any real device or inbox**. Kept so that a parser change can be measured against
+the same set rather than against a new one that happens to pass. See
+[sms-parser-coverage.md](sms-parser-coverage.md) for the results.
+
+`null` in the **expected** column means the parser must reject it. Those twelve
+matter most: a wrong rejection loses a transaction the person can paste again,
+but a wrong acceptance writes a ledger entry nobody made.
+
+**1–25** are the original India-first set, measured on
+`packages/core/src/sms/parse.ts` at commit `01b5f678`, September 2026. Their
+numbering has not changed. **26–61** were added when the parser was
+internationalised, and cover the hazards that only appear outside one country:
+the decimal comma, three- and zero-decimal currencies, month-first dates,
+non-Latin numerals, right-to-left text, and shared currency symbols.
+
+The **before** column is that same `01b5f678` parser run against every case,
+including the new ones — so the two columns are the same 61 messages through two
+parsers, not two different sets. **after** is the internationalised parser. Both
+were run by the same harness; the numbers in the coverage document come from it.
+
+The **context** column is what a caller told the parser about the reader — a
+region, a locale, or a default currency. It is always optional: the cases marked
+`—` were given nothing at all, and the `*(…)*` note in the **after** column
+lists what the parser therefore had to infer for itself.
+
+## Direction, before and after
+
+| before | after | count |
+| ------ | ----- | ----- |
+| right  | right | 35    |
+| wrong  | right | 26    |
+| right  | wrong | 0     |
+
+**35/61 → 61/61.** On the original 25 alone: **20/25 → 25/25**.
+
+Direction is not the whole story, and the table below is there because it is
+not: four of the 35 the old parser called correctly carried a silently wrong
+**field** — case 61 an amount a thousand times too small, case 59 the balance
+instead of the transaction, case 51 the wrong country's dollar, case 38 the
+wrong day. None of those shows up in a direction score, and all four would have
+reached somebody's ledger looking deliberate.
+
+## The corpus
+
+| #   | case                                         | context     | expected | before                                         | after                                                                 | body                                                                                                                        |
+| --- | -------------------------------------------- | ----------- | -------- | ---------------------------------------------- | --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| 1   | SBI UPI (no currency token)                  | —           | debit    | dropped                                        | debit, INR 150.00, SWIGGY, 2026-09-12 _(currency)_                    | `Dear UPI user A/C X1234 debited by 150.0 on date 12Sep26 trf to SWIGGY Refno 526012345678. If not u? call 1800111109 -SBI` |
+| 2   | HDFC UPI sent                                | —           | debit    | debit, INR 245.00, no merchant, 2026-09-12     | debit, INR 245.00, SWIGGY, 2026-09-12 _(currency+dateOrder)_          | `Sent Rs.245.00 From HDFC Bank A/C x1234 To SWIGGY On 12/09/26 Ref 526012345678 Not You? Call 18002586161`                  |
+| 3   | ICICI acct debit                             | —           | debit    | dropped                                        | debit, INR 500.00, SWIGGY, 2026-09-12 _(currency)_                    | `ICICI Bank Acct XX123 debited for Rs 500.00 on 12-Sep-26; SWIGGY credited. UPI:526012345678. Call 18002662 for dispute.`   |
+| 4   | Axis classic                                 | —           | debit    | debit, INR 1234.00, AMAZON, 2026-09-12         | debit, INR 1234.00, AMAZON, 2026-09-12 _(dateOrder)_                  | `INR 1,234.00 debited from A/c no. XX3456 on 12-09-26 at AMAZON. Avl Bal INR 5,678.90`                                      |
+| 5   | Credit card "used for a transaction of"      | —           | debit    | **credit**, INR 2500.00, AMAZON, 2026-09-12    | debit, INR 2500.00, AMAZON, 2026-09-12                                | `Your ICICI Bank Credit Card XX1234 has been used for a transaction of INR 2,500.00 on 12-Sep-26 at AMAZON.`                |
+| 6   | Debit card spent, ISO-ish date               | —           | debit    | debit, INR 1500.00, AMAZON, no date            | debit, INR 1500.00, AMAZON, 2026-09-12 _(currency)_                   | `Alert: You've spent Rs.1500.00 via Debit Card xx1234 at AMAZON on 2026-09-12:14:23:05.`                                    |
+| 7   | Kotak lakh grouping                          | —           | debit    | debit, INR 123456.78, RENT PAYMENT, 2026-09-12 | debit, INR 123456.78, RENT PAYMENT, 2026-09-12 _(currency+dateOrder)_ | `Rs 1,23,456.78 debited from Kotak A/c XX7890 on 12-09-26 towards RENT PAYMENT. Ref 998877665544`                           |
+| 8   | ATM withdrawal                               | —           | debit    | debit, INR 2000.00, ATM SECTOR 5, 2026-09-12   | debit, INR 2000.00, ATM SECTOR 5, 2026-09-12 _(currency+dateOrder)_   | `Rs.2000 withdrawn from A/c XX1234 at ATM SECTOR 5 on 12-09-26. Avl Bal Rs 12,340.00`                                       |
+| 9   | Paytm wallet                                 | —           | debit    | debit, INR 120.00, SWIGGY, no date             | debit, INR 120.00, SWIGGY, no date _(currency)_                       | `Paid Rs.120 to SWIGGY using Paytm UPI. Txn ID 526012345678`                                                                |
+| 10  | Amazon Pay                                   | —           | debit    | debit, INR 349.00, no merchant, no date        | debit, INR 349.00, no merchant, no date                               | `INR 349 debited from your Amazon Pay balance for order 404-1234567. Ref 7788990011`                                        |
+| 11  | Foreign card spend                           | —           | debit    | debit, USD 42.50, STARBUCKS, 2026-09-12        | debit, USD 42.50, STARBUCKS, 2026-09-12                               | `USD 42.50 spent on your card ending 1234 at STARBUCKS on 12-Sep-26`                                                        |
+| 12  | AED spend                                    | —           | debit    | debit, AED 89.00, CARREFOUR DUBAI, 2026-09-12  | debit, AED 89.00, CARREFOUR DUBAI, 2026-09-12 _(dateOrder)_           | `AED 89.00 debited from Card xx4471 at CARREFOUR DUBAI on 12-09-26`                                                         |
+| 13  | Salary credit                                | —           | credit   | credit, INR 85000.00, **A**, 2026-09-01        | credit, INR 85000.00, no merchant, 2026-09-01 _(dateOrder)_           | `INR 85,000.00 credited to A/c XX1234 on 01-09-26 by NEFT. Avl Bal INR 92,340.00`                                           |
+| 14  | Refund                                       | —           | credit   | dropped                                        | credit, INR 599.00, HDFC, 2026-09-12 _(currency+dateOrder)_           | `Rs.599.00 refunded to your HDFC Card xx1234 by AMAZON on 12-09-26. Ref 5544332211`                                         |
+| 15  | OTP with amount                              | —           | null     | dropped                                        | dropped                                                               | `OTP 445566 for txn of Rs.2,500.00 at AMAZON on HDFC Card xx1234. Do not share.`                                            |
+| 16  | Scheduled autopay                            | —           | null     | dropped                                        | dropped                                                               | `Rs 499.00 will be debited from A/c XX1234 on 15-09-26 towards NETFLIX e-mandate.`                                          |
+| 17  | Balance only                                 | —           | null     | dropped                                        | dropped                                                               | `Avl Bal in A/c XX1234 is Rs 12,340.00 as on 12-09-26.`                                                                     |
+| 18  | Payment due reminder                         | —           | null     | dropped                                        | dropped                                                               | `Your ICICI Credit Card XX1234 payment of Rs 8,450.00 is due on 18-09-26.`                                                  |
+| 19  | Failed txn                                   | —           | null     | dropped                                        | dropped                                                               | `Your transaction of Rs.1,200.00 at AMAZON was declined due to insufficient balance.`                                       |
+| 20  | Marketing                                    | —           | null     | dropped                                        | dropped                                                               | `Get a personal loan of up to Rs 5,00,000 at 10.5% p.a. Apply now!`                                                         |
+| 21  | UPI VPA merchant                             | —           | debit    | debit, INR 75.00, **VPA**, 2026-09-12          | debit, INR 75.00, swiggy, 2026-09-12 _(currency+dateOrder)_           | `Rs.75.00 debited from A/c XX1234 to VPA swiggy@icici on 12-09-26. UPI Ref 526012345678`                                    |
+| 22  | Lowercase bank voice                         | —           | debit    | debit, INR 250.00, no merchant, 2026-09-12     | debit, INR 250.00, bigbasket, 2026-09-12 _(currency+dateOrder)_       | `rs.250 debited from a/c xx1234 at bigbasket on 12-09-26`                                                                   |
+| 23  | No space after Rs                            | —           | debit    | debit, INR 1499.00, MYNTRA, 2026-09-12         | debit, INR 1499.00, MYNTRA, 2026-09-12 _(currency+dateOrder)_         | `Rs1,499.00 spent on HDFC Card xx1234 at MYNTRA on 12-09-26`                                                                |
+| 24  | Amount trailing INR                          | —           | debit    | dropped                                        | debit, INR 350.00, UBER, 2026-09-12 _(dateOrder)_                     | `Your A/c XX1234 is debited with 350.00 INR on 12-09-26 at UBER.`                                                           |
+| 25  | Two amounts, txn then balance                | —           | debit    | debit, INR 450.00, DOMINOS, 2026-09-12         | debit, INR 450.00, DOMINOS, 2026-09-12 _(currency+dateOrder)_         | `Rs.450.00 debited from A/c XX1234 at DOMINOS on 12-09-26. Avl Bal: Rs.9,999.00`                                            |
+| 26  | German decimal comma                         | DE          | debit    | dropped                                        | debit, EUR 1234.56, REWE, 2026-09-12                                  | `Ihr Konto DE12 wurde mit EUR 1.234,56 belastet am 12.09.2026 bei REWE.`                                                    |
+| 27  | German decimal comma, no context             | —           | debit    | dropped                                        | debit, EUR 1234.56, REWE, 2026-09-12 _(dateOrder)_                    | `Ihr Konto wurde mit EUR 1.234,56 belastet am 12.09.2026 bei REWE.`                                                         |
+| 28  | German dot grouping, no decimal part         | DE          | debit    | dropped                                        | debit, EUR 1234.00, REWE, 2026-09-12                                  | `EUR 1.234 belastet Konto 3456 bei REWE am 12.09.2026`                                                                      |
+| 29  | French space grouping                        | FR          | debit    | dropped                                        | debit, EUR 1234.56, CARREFOUR, 2026-09-12                             | `Votre compte 1234 a ete debite de 1 234,56 EUR le 12/09/2026 chez CARREFOUR`                                               |
+| 30  | Swiss apostrophe grouping                    | CH          | debit    | dropped                                        | debit, CHF 1234.50, MIGROS, 2026-09-12                                | `CHF 1'234.50 belastet Konto 4471 bei MIGROS am 12.09.2026`                                                                 |
+| 31  | Spanish card purchase                        | ES          | debit    | dropped                                        | debit, EUR 45.90, MERCADONA, 2026-09-12                               | `Compra de EUR 45,90 en MERCADONA con tarjeta 1234 el 12/09/2026`                                                           |
+| 32  | Portuguese (Brazil)                          | BR          | debit    | dropped                                        | debit, BRL 1234.56, MERCADO LIVRE, 2026-09-12                         | `Compra aprovada: R$ 1.234,56 em MERCADO LIVRE no cartao final 1234 em 12/09/2026`                                          |
+| 33  | Indonesian                                   | ID          | debit    | dropped                                        | debit, IDR 150000.00, TOKOPEDIA, 2026-09-12                           | `Rp 150.000 didebet dari rekening 1234 di TOKOPEDIA pada 12/09/2026`                                                        |
+| 34  | Turkish                                      | TR          | debit    | dropped                                        | debit, TRY 250.75, no merchant, 2026-09-12                            | `Hesabinizdan 250,75 TL harcama yapildi. Kart 1234, 12.09.2026 MIGROS`                                                      |
+| 35  | Kuwaiti dinar, three decimals                | KW          | debit    | dropped                                        | debit, KWD 12.345, LULU, 2026-09-12                                   | `KWD 12.345 debited from Account XX1234 at LULU on 12-09-2026`                                                              |
+| 36  | Kuwaiti dinar, no context                    | —           | debit    | dropped                                        | debit, KWD 12.345, LULU, 2026-09-12 _(decimalSeparator+dateOrder)_    | `KWD 12.345 debited from Account XX1234 at LULU on 12-09-2026`                                                              |
+| 37  | Japanese yen, zero decimals                  | JP          | debit    | dropped                                        | debit, JPY 1234, LAWSON, 2026-09-12                                   | `JPY 1,234 spent on card 1234 at LAWSON on 2026-09-12`                                                                      |
+| 38  | US month-first date                          | US          | debit    | debit, USD 42.50, TARGET, **2026-05-08**       | debit, USD 42.50, TARGET, 2026-08-05                                  | `USD 42.50 spent on card ending 1234 at TARGET on 08/05/2026`                                                               |
+| 39  | Indian day-first, same digits                | IN          | debit    | debit, USD 42.50, TARGET, 2026-05-08           | debit, USD 42.50, TARGET, 2026-05-08                                  | `USD 42.50 spent on card ending 1234 at TARGET on 08/05/2026`                                                               |
+| 40  | Ambiguous date, no context                   | —           | debit    | debit, USD 42.50, TARGET, 2026-05-08           | debit, USD 42.50, TARGET, 2026-05-08 _(dateOrder)_                    | `USD 42.50 spent on card ending 1234 at TARGET on 08/05/2026`                                                               |
+| 41  | ISO date                                     | IE          | debit    | debit, EUR 20.00, IKEA, no date                | debit, EUR 20.00, IKEA, 2026-09-12                                    | `EUR 20.00 debited from account 1234 at IKEA on 2026-09-12`                                                                 |
+| 42  | Named month, month first                     | US          | debit    | debit, USD 42.50, STARBUCKS, no date           | debit, USD 42.50, STARBUCKS, 2026-09-12                               | `USD 42.50 spent at STARBUCKS on Sep 12, 2026 with card 1234`                                                               |
+| 43  | Arabic debit, Arabic-Indic digits            | AE          | debit    | dropped                                        | debit, AED 250.50, كارفور, 2026-09-12                                 | `تم خصم ٢٥٠٫٥٠ د.إ من البطاقة ٤٤٧١ لدى كارفور بتاريخ 12-09-2026`                                                            |
+| 44  | Arabic with a bidi isolate around the amount | AE          | debit    | dropped                                        | debit, AED 250.50, كارفور, no date                                    | `تم خصم ⁦AED 250.50⁩ من الحساب 4471 لدى كارفور`                                                                             |
+| 45  | Hindi Devanagari digits                      | IN          | debit    | dropped                                        | debit, INR 500.00, SWIGGY, 2026-09-12                                 | `आपके खाते XX1234 से ५००.०० रुपये डेबिट किए गए 12-09-2026 को SWIGGY`                                                        |
+| 46  | Thai                                         | TH          | debit    | dropped                                        | debit, THB 1250.00, 7-ELEVEN, 2026-09-12                              | `บัญชี 1234 ถูกหัก THB 1,250.00 ที่ 7-ELEVEN 12/09/2026`                                                                    |
+| 47  | Vietnamese                                   | VN          | debit    | dropped                                        | debit, VND 1250000, HIGHLANDS, 2026-09-12                             | `Tai khoan 1234 ghi no 1.250.000 VND tai HIGHLANDS ngay 12/09/2026`                                                         |
+| 48  | Malay                                        | MY          | debit    | dropped                                        | debit, MYR 125.50, MYDIN, 2026-09-12                                  | `Akaun 1234 didebit RM 125.50 di MYDIN pada 12/09/2026`                                                                     |
+| 49  | Swedish krona                                | SE          | debit    | dropped                                        | debit, SEK 1234.50, ICA, 2026-09-12                                   | `Kortkop 1 234,50 kr hos ICA 12/09/2026 kort 1234`                                                                          |
+| 50  | Dollar with no region                        | —           | debit    | debit, USD 42.50, STARBUCKS, 2026-09-12        | debit, USD 42.50, STARBUCKS, 2026-09-12 _(currency+dateOrder)_        | `$42.50 spent on card ending 1234 at STARBUCKS on 12-09-2026`                                                               |
+| 51  | Canadian dollar by region                    | CA          | debit    | debit, **USD** 42.50, TIM HORTONS, 2026-09-12  | debit, CAD 42.50, TIM HORTONS, 2026-09-12                             | `$42.50 spent on card ending 1234 at TIM HORTONS on 12-09-2026`                                                             |
+| 52  | Bare number, no currency anywhere            | default GBP | debit    | dropped                                        | debit, GBP 150.00, CAFE, 2026-09-12 _(dateOrder)_                     | `Account XX1234 debited by 150.0 at CAFE on 12-09-2026`                                                                     |
+| 53  | Spanish OTP                                  | ES          | null     | dropped                                        | dropped                                                               | `Su codigo de verificacion es 445566 para una compra de EUR 250,00 en ZARA.`                                                |
+| 54  | German scheduled debit                       | DE          | null     | dropped                                        | dropped                                                               | `Ihr Konto wird mit EUR 49,90 belastet am 15.09.2026 fuer NETFLIX.`                                                         |
+| 55  | French declined                              | FR          | null     | dropped                                        | dropped                                                               | `Votre transaction de 45,00 EUR chez FNAC a ete refusee.`                                                                   |
+| 56  | Indonesian balance only                      | ID          | null     | dropped                                        | dropped                                                               | `Saldo rekening 1234 adalah Rp 1.250.000 pada 12/09/2026.`                                                                  |
+| 57  | Turkish due reminder                         | TR          | null     | dropped                                        | dropped                                                               | `Kredi karti 1234 son odeme tarihi 18.09.2026, tutar 1.250,00 TL.`                                                          |
+| 58  | Arabic OTP                                   | AE          | null     | dropped                                        | dropped                                                               | `رمز التحقق 445566 لعملية شراء بقيمة 250.00 د.إ لدى كارفور`                                                                 |
+| 59  | Balance quoted before the transaction        | IN          | debit    | debit, INR **9999.00**, DOMINOS, 2026-09-12    | debit, INR 450.00, DOMINOS, 2026-09-12                                | `Avl Bal Rs 9,999.00. Rs.450.00 debited from A/c XX1234 at DOMINOS on 12-09-26`                                             |
+| 60  | Refund in Spanish                            | ES          | credit   | dropped                                        | credit, EUR 59.90, no merchant, 2026-09-12                            | `Reembolso de EUR 59,90 acreditado a su tarjeta 1234 de ZARA el 12/09/2026`                                                 |
+| 61  | Decimal comma in an English sentence         | DE          | debit    | debit, EUR **1.23**, REWE, 2026-09-12          | debit, EUR 1234.56, REWE, 2026-09-12                                  | `EUR 1.234,56 debited from card 1234 at REWE on 12-09-2026`                                                                 |
+
+Bold marks a field that is **wrong**, as against merely missing.
+
+## Notes on particular cases
+
+**Case 61 is the reason this work happened.** The old parser accepted it,
+scored it 0.9 — comfortably pre-selected — and read €1,234.56 as **€1.23**. The
+amount regex matched `1.23` out of `1.234,56` and stopped, because it took the
+first dot as the decimal point and two digits as the fraction. Nothing about the
+result looks wrong. A person confirming a list of drafts would have to notice
+that one row is a thousandth of what they spent.
+
+**Case 59 replaces the luck in case 25.** Case 25 passed on the old parser
+because Indian banks quote the transaction before the balance and it took the
+first number. Case 59 is the same message with the two swapped, and it is the
+case that fails that way. The parser now skips a number that sits behind a
+balance word rather than relying on the order.
+
+**Cases 35 and 36 are the same message with and without a region.** KWD has
+three minor digits, so `12.345` is twelve dinars and 345 fils — and also,
+equally plausibly, twelve thousand three hundred and forty-five. With a region
+the locale settles it; without one the parser picks the currency's own precision
+and reports `decimalSeparator` as inferred, which drops the confidence below
+pre-selection.
+
+**Cases 38, 39 and 40 are one message read three ways.** `08/05/2026` is the 5th
+of August in Chicago and the 8th of May in Mumbai, and the message says nothing
+either way. Case 40 has no context: the parser answers day-first — the order
+most of the world writes — and says it guessed.
+
+**Case 44 contains invisible characters.** `U+2066` and `U+2069` wrap the amount
+so the digits render left-to-right inside a right-to-left sentence. They will
+not show in a diff or a terminal. The old parser failed on this message not
+because it does not read Arabic but because it does not read Unicode.
+
+**Case 14 still gets the merchant wrong**, reading `HDFC` where `AMAZON` is the
+shop. It is a credit, so it is never proposed as an expense, and telling a bank
+name from a merchant name needs a table this parser does not have.
+
+**Cases 10, 34 and 60 return no merchant.** In 10 the message genuinely names
+only an order number. In 34 the shop is at the very end after a comma with no
+preposition, and in 60 it follows a bare Spanish `de` — a word left out of the
+preposition list on purpose, because it is also an ordinary fragment of English
+and would mint merchants out of the middle of English sentences.
+
+## Reproducing this
+
+Every row comes from `parseSms(body, context)` in
+`packages/core/src/sms/parse.ts`. The behaviours are asserted directly in
+`packages/core/test/sms.test.ts`, which is the version that is kept honest by
+CI; this table is the wider sweep those tests were selected from.

--- a/docs/sms-parser-coverage.md
+++ b/docs/sms-parser-coverage.md
@@ -1,0 +1,322 @@
+# How a bank message reaches Waves, and what the parser does with it
+
+Research, September 2026. Two questions were asked together and they are
+genuinely different, so they are answered separately:
+
+1. **How can a message be read at all?** The access paths, what each one costs,
+   and the two that are quietly closing.
+2. **What does the parser make of the message once it has it?** Measured, not
+   estimated — `parseSms` was run against 61 messages written the way real
+   institutions write them, in fifteen languages.
+
+**Updated September 2026.** The corpus has since grown to 61 messages and the
+parser has been internationalised. Everything below is re-measured; §3 now
+carries both the original numbers and the current ones, and §4 records which of
+the recommendations were acted on.
+
+The short version:
+
+- **The parser handled 20 of 25, and now handles 61 of 61.** The five it used to
+  drop were not exotic: **State Bank of India's UPI alert**, **ICICI's account
+  debit**, **any credit card spend**, **refunds**, and **amounts written
+  `350.00 INR`**. One of the five was worse than a miss — a credit-card purchase
+  was classified as **money coming in**. All five are fixed.
+- **The worst bug was not in the original 25 at all.** `EUR 1.234,56` — the way
+  half of Europe and most of Latin America write an amount — read as **€1.23**,
+  a thousandfold error, accepted at confidence 0.9 and pre-selected. It is
+  corpus case 61, and it is the reason the international pass happened.
+- Several messages that "passed" carried a **wrong merchant** — `VPA`, `A`, or
+  nothing at all where the shop's name was plainly in the text. The most common
+  cause was a single missing `i` flag. Fixed, and the captures now have to pass
+  a plausibility test before they count.
+- **Confidence was measuring the wrong thing.** It counted how many fields were
+  found, not whether they are right, so the worst merchant bug in the set scored
+  **1.0**. It is now based on plausibility, and every field the parser had to
+  guess costs it.
+- **The inbox is a shrinking source.** Banks are migrating alerts to RCS, which
+  `READ_SMS` cannot see at all, and HDFC already stopped sending SMS for small
+  UPI payments. Neither is a reason not to build this; both are reasons the
+  paste and share lanes are not merely the iPhone consolation prize.
+
+---
+
+## 1. How a message can reach the parser
+
+`docs/plan-drafts-and-rules.md` §1.6 covers the permission economics. This is
+the same list re-cut by _what actually arrives_, which is a different question.
+
+| path                                  | what it can see                                  | what it cannot                                                        |
+| ------------------------------------- | ------------------------------------------------ | --------------------------------------------------------------------- |
+| `READ_SMS` (inbox read)               | every SMS in the device store, historic and new  | RCS messages; anything a bank stopped sending; app-only notifications |
+| `RECEIVE_SMS` (live)                  | SMS as it arrives                                | everything above, plus anything sent before install                   |
+| Share sheet                           | the one message the person shares                | everything they do not share                                          |
+| Paste                                 | whatever is selected and copied                  | same                                                                  |
+| Emailed statement (`import/email.ts`) | a whole month, authoritative, reconciled         | anything not on the statement yet                                     |
+| Notification listener                 | every notification, including RCS and app-native | rejected on policy grounds — §1.6                                     |
+
+### 1.1 The two that are closing
+
+**RCS.** In 2026 RCS Business Messaging went from pilot to production in India
+with Jio, Airtel and Vi all supporting it, and banks are among the first movers
+for alerts — verified sender, brand logo, no 160-character limit. **An RCS
+message is not an SMS.** It does not land in the SMS provider that `READ_SMS`
+reads; it lives in the messaging app's own store, and there is no public API for
+a third-party app to read it. Every bank that migrates its alerts is a bank
+whose transactions silently stop appearing. The person will not see an error —
+they will see Waves quietly stop noticing their spending.
+
+**Small UPI payments already stopped.** HDFC Bank stopped sending SMS for UPI
+payments under ₹100 sent and ₹500 received. For an expense-splitting app this is
+exactly the wrong end of the range to lose: the chai, the auto, the ₹80 share of
+something. Other banks are under the same cost pressure.
+
+Neither kills the feature. Both change what it should promise. **"We will catch
+your bank messages" is honest. "We will catch your spending" is not**, and the
+copy should not drift toward the second.
+
+### 1.2 Which messages are even worth reading
+
+India's DLT regime gives a reliable filter that costs nothing. Every commercial
+sender is a registered 6-character header, delivered as `XX-HEADER` where `XX`
+is an operator+circle code the carrier prepends — `AD-HDFCBK` is Airtel Delhi
+plus HDFC Bank's registered `HDFCBK`. Since May 2025 a message-type suffix is
+appended too, which separates transactional from promotional traffic at the
+header level.
+
+Two consequences worth using:
+
+- A **sender allowlist** of known bank headers is a far better first filter than
+  running a regex over every message in the inbox, and it lets the reader touch
+  dramatically fewer messages — which is both faster and a better answer to
+  "why do you need my whole inbox".
+- The **operator prefix must be stripped before matching**, because the same
+  bank arrives as `AD-HDFCBK`, `VM-HDFCBK`, `JD-HDFCBK` depending on the
+  recipient's carrier and circle. Matching the whole string is a bug that will
+  look like "it works on my phone".
+
+`parseSms` used to take `sender` and use it for nothing except display. It now
+strips the operator prefix and, when the header looks like a financial
+institution, adds a little confidence. It is a hint and never a filter: an
+unrecognised header changes nothing, because a bank this list has not heard of
+is still a bank, and nothing in the logic assumes the Indian `XX-HEADER` shape —
+a bare `SANTANDER` or `CHASE` is read as itself.
+
+---
+
+## 2. What the messages actually look like
+
+Four families inside India, and a fifth everywhere else. They are not stylistic
+variations — they need different handling.
+
+**Bank account debit.** `A/c`, a masked tail, a balance trailer.
+`INR 1,234.00 debited from A/c no. XX3456 on 12-09-26 at AMAZON. Avl Bal INR 5,678.90`
+
+**UPI.** The growth area and the least standardised. Often no currency token at
+all, a `Ref`/`RRN`, and the counterparty as either a name or a VPA
+(`swiggy@icici`). SBI's is the canonical hard case:
+`Dear UPI user A/C X1234 debited by 150.0 on date 12Sep26 trf to SWIGGY Refno 526012345678`
+
+**Card.** The word "credit" appears in `Credit Card` on messages that are
+debits — a trap the original parser fell into. Verbs are different too: _spent_,
+_used for a transaction of_, _transaction of_.
+
+**Wallet / PPI.** Paytm, Amazon Pay. Shortest and least consistent; often no
+account tail and no date.
+
+### 2.1 And a fifth family, which is everywhere else
+
+The four above are how an _Indian_ bank writes. Outside India the shape is
+familiar but three things underneath it are not, and all three fail silently
+rather than loudly:
+
+- **The decimal point is a comma.** `EUR 1.234,56` in Germany, Spain, Brazil,
+  Indonesia, Turkey and most of Latin America. Read with English assumptions it
+  is €1.23.
+- **Not every currency has two decimals.** KWD, BHD, OMR, JOD and TND have
+  three; JPY, KRW, VND, CLP and ISK have none.
+- **The date is month-first** in the United States and nowhere Waves currently
+  ships, and `08/05/2026` gives no hint which it is.
+
+There is also a fourth thing that fails loudly and is therefore easier: the
+message may be in Arabic, Thai, Hindi, Vietnamese or German, may write its
+numbers in Devanagari or Arabic-Indic digits, and may wrap its amount in
+invisible bidi controls so it renders correctly inside right-to-left text.
+
+---
+
+## 3. Measured results
+
+`parseSms` was run against 25 messages covering those four families plus the
+negatives it must reject, and later against 61 covering the fifth as well.
+Verbatim bodies are in §6 so this is reproducible.
+
+**Then: 20 of 25.** All six negatives were correctly rejected —
+OTP-with-an-amount, scheduled autopay, balance-only, payment-due, declined, and
+marketing. The rejection side was in good shape and is the side where a mistake
+costs the most, so that mattered.
+
+**Now: 61 of 61**, on a corpus that grew from 25 messages to 61. The same
+`01b5f678` parser scores **35 of 61** on that wider set. All twelve negatives are
+still rejected, in six languages. No case regressed.
+
+The direction score is the headline but not the whole measurement. Of the 35 the
+old parser called correctly, four carried a silently wrong field: case 61 an
+amount a thousand times too small, case 59 the balance instead of the
+transaction, case 51 the wrong country's dollar, case 38 the wrong day. Those
+are invisible in a direction score and visible in somebody's ledger.
+
+### 3.1 The five hard failures (all now fixed)
+
+| #   | case                    | result               | cause                                                                                                            |
+| --- | ----------------------- | -------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| 1   | **SBI UPI**             | dropped              | `AMOUNT` requires a currency token; SBI writes `debited by 150.0`                                                |
+| 2   | **ICICI account debit** | dropped              | message says `debited` _and_ `credited` (of the payee); `debit === credit` bails                                 |
+| 3   | **Credit card spend**   | **booked as income** | `CREDIT_WORDS` matches the word _credit_ inside `Credit Card`; no debit verb matches `used for a transaction of` |
+| 4   | **Refund**              | dropped              | `CREDIT_WORDS` has `refund`; the message says `refunded`                                                         |
+| 5   | **`350.00 INR`**        | dropped              | `AMOUNT` only matches a marker _before_ the number                                                               |
+
+**#3 was the one to fix first.** The others lose a transaction, which the person
+can see and paste again. #3 silently records a ₹2,500 purchase as ₹2,500
+_received_ — a wrong ledger entry that looks deliberate. Everything downstream
+trusts `direction`. It was fixed first, and the rest with it.
+
+### 3.1a The worse failure, which was not in the first 25
+
+`EUR 1.234,56 debited from card 1234 at REWE` — corpus case 61 — was **accepted**
+by the old parser, given `direction: debit`, scored **0.9**, pre-selected, and
+recorded as **€1.23**. `AMOUNT` matched `1.23` out of `1.234,56` and stopped,
+because it read the first dot as the decimal point and took two digits after it.
+
+This is worse than every failure in §3.1 put together. A dropped message is
+visible; the person pastes it again. A thousandfold error in a row that looks
+correctly parsed is not visible at all, and it lands in a shared ledger where
+somebody else is owed the difference.
+
+Two smaller members of the same family: `KWD 12.345` silently truncated to
+`12.340` once the currency was recognised at all (the fraction was capped at two
+digits, and five currencies have three); and `$` resolving to USD everywhere,
+so a Canadian message came back in the wrong currency at full confidence.
+
+### 3.2 The quiet ones — parsed, but wrong (all now fixed)
+
+These all "passed" and would be pre-selected for the person to confirm:
+
+- **`To SWIGGY` yields no merchant.** `MERCHANT` has no `i` flag, so capitalised
+  `To`/`At` never match. HDFC writes `To SWIGGY`. One character fixes it.
+- **Lowercase merchants never match.** The capture requires `[A-Z0-9]` first.
+  `at bigbasket` yields nothing.
+- **`to VPA swiggy@icici` yields the merchant `VPA`** — the literal word,
+  because `to\s+(...)` grabs it before the alternation reaches `VPA`. Scored
+  **confidence 1.0**.
+- **`credited to A/c XX1234` yields the merchant `A`.** The `A` of `A/c`.
+- Amazon Pay and the plain SBI shape yield no merchant at all.
+
+A draft whose merchant reads `VPA` or `A` is worse than one with no merchant:
+the inbox shows a row that looks parsed, and the person has to notice it is
+nonsense.
+
+### 3.3 Confidence is measuring the wrong thing
+
+> `confidence` starts at 0.55 and adds for merchant, reference, date, tail.
+
+It counts _fields found_, never _fields plausible_. So the `VPA` bug scores 1.0
+and is pre-selected, while a perfectly-parsed wallet message with no date and no
+tail scores 0.7. The comment in the source is honest about this — "how much of
+the message we actually understood" — but the number is used as if it meant
+correctness, and `SMS_LOW_CONFIDENCE` gates pre-selection on it.
+
+Minimum fix: a merchant that is a known stop-word (`VPA`, `A`, `A/C`, `UPI`,
+`REF`, a bare number) should score _nothing_, not `+0.2`. That is what it does
+now, and the score also pays for every field the parser had to guess.
+
+### 3.4 Never guess silently — the rule the fix is built on
+
+Three things in a bank message cannot be decided from the message: `08/05/2026`
+is two days, `1.234` is two amounts a thousand apart, and `$` is seven
+currencies. There is no clever reading that resolves them; there is only a
+signal from outside, or a guess.
+
+So `parseSms` takes an optional context — region, locale, default currency, and
+the message's own sender — and for anything the context does not settle it uses
+**one documented fallback and reports it**. `ParsedSms.inferred` lists the fields
+that were decided rather than read (`currency`, `decimalSeparator`, `dateOrder`),
+and each one costs confidence, which is what keeps a guessed row out of the
+pre-selected set. The UI can then point at the field to check rather than
+telling somebody the whole row is doubtful.
+
+The fallbacks, written down so they are arguable:
+
+| ambiguity                            | resolved by                                                  | with nothing at all                                        |
+| ------------------------------------ | ------------------------------------------------------------ | ---------------------------------------------------------- |
+| `08/05/2026`                         | a component over 12; else the region's order                 | day-first, marked `dateOrder`                              |
+| one separator, three digits after it | the currency's exponent — a 2-decimal currency cannot have 3 | grouping, **not** marked: this is a deduction, not a guess |
+| the same, for a 3-decimal currency   | the locale's decimal separator                               | the currency's own precision, marked `decimalSeparator`    |
+| `$`, `kr`, `Rs`, `ريال`              | the region                                                   | the family's most common member, marked `currency`         |
+| no currency token at all             | the caller's default, then the region's currency             | INR — Waves' home market — marked `currency`               |
+
+---
+
+## 4. Recommendations, and what became of them
+
+1. ~~**Stop reading `credit` inside `Credit Card`.**~~ Done. Card phrases are
+   blanked — replaced by spaces of the same length, so every other index into
+   the message still holds — before direction is decided, and the missing debit
+   verbs are in the list.
+2. ~~**Make the currency token optional.**~~ Done. A bare number introduced by a
+   transaction verb is an amount; the currency comes from the caller's default,
+   then the region, then INR, and the last case says it guessed.
+3. ~~**Direction by proximity, not presence.**~~ Done. The verb nearest the
+   amount decides; equidistant still refuses.
+4. ~~**Add the `i` flag to `MERCHANT`, allow lowercase, stop-word the
+   captures.**~~ Done, plus a plausibility test: an implausible capture is
+   skipped and the parser keeps looking rather than returning it.
+5. ~~**Read VPAs properly.**~~ Done — `swiggy@icici` yields `swiggy`.
+   `normaliseMerchantName` was not used: it strips gateway noise for
+   _categorisation_, and a merchant shown to a person should keep the spelling
+   the bank sent.
+6. ~~**Accept a trailing currency.**~~ Done.
+7. **Use the sender** — done as a hint, not as a filter. The recommendation said
+   "let a non-bank header skip the message entirely"; that was not followed. A
+   bank the allowlist has not heard of is still a bank, an allowlist written in
+   India would silently drop every European sender, and a person who pasted a
+   message has already decided it is worth reading. A recognised header raises
+   confidence and nothing lowers it.
+8. ~~**Re-base confidence on plausibility.**~~ Done, per §3.3 and §3.4.
+
+Still open:
+
+- **The sender allowlist as a cheap first filter over a whole inbox** — the
+  performance half of §1.2, distinct from the accuracy half. Nothing in the
+  reader uses it yet.
+- **Telling a bank name from a merchant name** (corpus case 14 reads `HDFC`
+  where the shop is `AMAZON`). That needs a table the parser does not have.
+- **`de`, `a` and `no` as merchant prepositions.** Left out deliberately: each
+  is also an ordinary English fragment and would mint merchants out of the
+  middle of English sentences. It costs a merchant on two Spanish and
+  Portuguese shapes (corpus 34, 60).
+
+## 5. What this research did not do
+
+No real inbox was read — every message here is written to match documented
+formats, not captured from a device. Bank wording changes without notice and
+varies by product within one bank. The corpus is now 61 messages across roughly
+fifteen languages, but it is still a corpus somebody wrote rather than one
+somebody received, and the non-English cases are a bigger leap than the Indian
+ones: those at least match formats that are publicly documented. RCS
+displacement is reported from public sources, not measured. And nothing here has
+been run on a device: these are results from the pure parser, which is the right
+place to test it, but not the same as the feature working.
+
+Two things the parser knows it cannot do. It does not read a language whose
+verbs are not in its list, and that list is written by hand — the failure mode
+is a silent miss, not an error. And it cannot tell a Hindi message from a Hindi
+message _about_ a transaction any better than its Hindi vocabulary allows, which
+is thinner than its English one.
+
+## 6. The corpus
+
+Reproducible — 61 bodies, the five families plus the negatives, with the
+expected direction for each and the result from both the original and the
+current parser. Stored alongside this document as `sms-parser-corpus.md` so a
+fix can be measured against the same set rather than against a new one that
+happens to pass.

--- a/packages/core/src/import/email.ts
+++ b/packages/core/src/import/email.ts
@@ -323,6 +323,10 @@ export function proposeFromEmail(
       accountTail: null,
       reference: null,
       occurredAt,
+      // An email line is read with its own rules, not the SMS parser's, so
+      // nothing here is an inference the SMS module would want to flag. The
+      // field exists on the shared shape; an empty list is the honest value.
+      inferred: [],
       confidence: Math.min(1, Number(confidence.toFixed(2))),
     };
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@
  */
 
 export * from './ids';
+export * from './text/index';
 export * from './time/index';
 export * from './money/index';
 export * from './split/index';

--- a/packages/core/src/sms/locale.ts
+++ b/packages/core/src/sms/locale.ts
@@ -1,0 +1,533 @@
+/**
+ * The things a bank message does not say, and somebody has to decide.
+ *
+ * Three of them are genuinely undecidable from the text alone:
+ *
+ *   - `08/05/2026` is the 8th of May in Mumbai and the 5th of August in
+ *     Chicago, and nothing in the message distinguishes them;
+ *   - `EUR 1.234` is one thousand two hundred and thirty-four euros in Berlin
+ *     and one euro twenty-three in Dublin;
+ *   - `$` is seven different currencies.
+ *
+ * So this module holds the *hints* a caller can supply — the user's country,
+ * their locale, the currency their group counts in — and, for each hint that is
+ * missing, one explicit documented fallback. Every fallback is reported back to
+ * the parser so the answer can say which parts of it were guessed. A parser
+ * that guesses is fine. A parser that guesses silently puts an expense on the
+ * wrong day of a trip, or off by a factor of a thousand, and looks certain
+ * doing it.
+ */
+
+import { currencyForCountry } from '../money/region';
+import { isCurrencyCode, type CurrencyCode } from '../money/currency';
+
+/** Day-month-year, as most of the world writes it, or month-day-year. */
+export type DateOrder = 'dmy' | 'mdy';
+
+/**
+ * What the caller knows that the message does not. Every field is optional and
+ * the parser works with none of them — it just marks more of its answer as
+ * inferred.
+ */
+export interface SmsParseContext {
+  /** ISO-3166 alpha-2, e.g. `IN`, `DE`, `US`. The strongest single hint. */
+  readonly region?: string | null;
+  /** BCP-47, e.g. `de-DE` or `pt`. Its region subtag is used when `region` is absent. */
+  readonly locale?: string | null;
+  /** What to assume when the message names no currency at all. */
+  readonly defaultCurrency?: CurrencyCode | null;
+  /** Overrides the region's date order outright. */
+  readonly dateOrder?: DateOrder | null;
+  /** Overrides the region's decimal separator outright. */
+  readonly decimalSeparator?: '.' | ',' | null;
+  /** Sender id, e.g. `AD-HDFCBK` or `+441234…`. A hint, never a filter. */
+  readonly sender?: string | null;
+}
+
+/** What the parser had to decide for itself. Surfaced so the UI can flag it. */
+export type InferredField = 'currency' | 'decimalSeparator' | 'dateOrder';
+
+/* ------------------------------------------------------------------ *
+ * Region
+ * ------------------------------------------------------------------ */
+
+export function regionOf(context: SmsParseContext): string | null {
+  const direct = (context.region ?? '').trim().toUpperCase();
+  if (/^[A-Z]{2}$/.test(direct)) return direct;
+  const fromLocale = /^[A-Za-z]{2,3}[-_]([A-Za-z]{2})\b/.exec((context.locale ?? '').trim());
+  return fromLocale?.[1] ? fromLocale[1].toUpperCase() : null;
+}
+
+function languageOf(context: SmsParseContext): string | null {
+  const tag = (context.locale ?? '').trim().toLowerCase();
+  const match = /^([a-z]{2,3})(?:[-_]|$)/.exec(tag);
+  return match?.[1] ?? null;
+}
+
+/* ------------------------------------------------------------------ *
+ * Date order
+ * ------------------------------------------------------------------ */
+
+/**
+ * The handful of places that write the month first. Everywhere else — including
+ * every market Waves ships in — writes the day first, which is why that is the
+ * fallback rather than a coin flip.
+ */
+const MONTH_FIRST = new Set(['US', 'PH', 'FM', 'MH', 'PW']);
+
+export function dateOrderFor(context: SmsParseContext): { order: DateOrder; explicit: boolean } {
+  if (context.dateOrder) return { order: context.dateOrder, explicit: true };
+  const region = regionOf(context);
+  if (region) return { order: MONTH_FIRST.has(region) ? 'mdy' : 'dmy', explicit: true };
+  return { order: 'dmy', explicit: false };
+}
+
+/* ------------------------------------------------------------------ *
+ * Decimal separator
+ * ------------------------------------------------------------------ */
+
+/**
+ * Where a comma is the decimal point. Switzerland is deliberately absent: it
+ * writes `1'234.56`, dot-decimal with an apostrophe for grouping, and putting
+ * it in this set would invert every Swiss amount.
+ */
+const COMMA_DECIMAL_REGIONS = new Set([
+  'AL',
+  'AO',
+  'AR',
+  'AT',
+  'AZ',
+  'BA',
+  'BE',
+  'BG',
+  'BO',
+  'BR',
+  'BY',
+  'CL',
+  'CM',
+  'CO',
+  'CR',
+  'CU',
+  'CV',
+  'CZ',
+  'DE',
+  'DK',
+  'DO',
+  'DZ',
+  'EC',
+  'EE',
+  'ES',
+  'FI',
+  'FR',
+  'GR',
+  'GL',
+  'HR',
+  'HU',
+  'ID',
+  'IS',
+  'IT',
+  'LT',
+  'LU',
+  'LV',
+  'MA',
+  'MD',
+  'ME',
+  'MK',
+  'MZ',
+  'NL',
+  'NO',
+  'PL',
+  'PT',
+  'PY',
+  'RO',
+  'RS',
+  'RU',
+  'SE',
+  'SI',
+  'SK',
+  'SN',
+  'TN',
+  'TR',
+  'UA',
+  'UY',
+  'VE',
+  'VN',
+]);
+
+/** Languages that are comma-decimal wherever they are spoken, for a bare `de`/`fr` tag. */
+const COMMA_DECIMAL_LANGUAGES = new Set([
+  'de',
+  'fr',
+  'pt',
+  'it',
+  'nl',
+  'id',
+  'tr',
+  'ru',
+  'pl',
+  'vi',
+  'da',
+  'sv',
+  'nb',
+  'no',
+  'fi',
+  'cs',
+  'el',
+  'ro',
+  'hu',
+  'hr',
+  'sr',
+  'sk',
+  'sl',
+  'bg',
+  'uk',
+  'lv',
+  'lt',
+  'et',
+  'is',
+  'af',
+]);
+
+/**
+ * `null` means "nobody told us", which is different from "we know it is a dot".
+ * The parser treats the two differently: a known separator settles `1,234`
+ * outright, an unknown one falls through to a currency-aware guess that gets
+ * reported as one.
+ */
+export function decimalSeparatorFor(context: SmsParseContext): '.' | ',' | null {
+  if (context.decimalSeparator) return context.decimalSeparator;
+  const region = regionOf(context);
+  if (region) return COMMA_DECIMAL_REGIONS.has(region) ? ',' : '.';
+  const language = languageOf(context);
+  // Spanish is split down the middle — comma in Spain, dot in Mexico — so a
+  // bare `es` says nothing and is left unanswered rather than halved.
+  if (language && language !== 'es' && language !== 'en') {
+    return COMMA_DECIMAL_LANGUAGES.has(language) ? ',' : '.';
+  }
+  return null;
+}
+
+/* ------------------------------------------------------------------ *
+ * Currency
+ * ------------------------------------------------------------------ */
+
+/**
+ * Currencies that share a marker. The symbol says the family; only the reader's
+ * country says which member.
+ */
+const FAMILIES: Readonly<Record<string, { byRegion: Record<string, string>; fallback: string }>> =
+  Object.freeze({
+    dollar: {
+      byRegion: {
+        US: 'USD',
+        CA: 'CAD',
+        AU: 'AUD',
+        NZ: 'NZD',
+        SG: 'SGD',
+        HK: 'HKD',
+        TW: 'TWD',
+        MX: 'MXN',
+        AR: 'ARS',
+        CL: 'CLP',
+        CO: 'COP',
+        BR: 'BRL',
+        FJ: 'FJD',
+        JM: 'JMD',
+      },
+      fallback: 'USD',
+    },
+    rupee: {
+      byRegion: { IN: 'INR', LK: 'LKR', NP: 'NPR', PK: 'PKR', MU: 'MUR', SC: 'SCR' },
+      fallback: 'INR',
+    },
+    pound: {
+      byRegion: { GB: 'GBP', EG: 'EGP', LB: 'LBP', SD: 'SDG', SS: 'SSP', SY: 'SYP' },
+      fallback: 'GBP',
+    },
+    yen: { byRegion: { JP: 'JPY', CN: 'CNY' }, fallback: 'JPY' },
+    krone: { byRegion: { SE: 'SEK', NO: 'NOK', DK: 'DKK', IS: 'ISK', FO: 'DKK' }, fallback: 'SEK' },
+    riyal: { byRegion: { SA: 'SAR', QA: 'QAR', OM: 'OMR', YE: 'YER', IR: 'IRR' }, fallback: 'SAR' },
+    dirham: { byRegion: { AE: 'AED', MA: 'MAD' }, fallback: 'AED' },
+    dinar: {
+      byRegion: {
+        KW: 'KWD',
+        BH: 'BHD',
+        JO: 'JOD',
+        IQ: 'IQD',
+        TN: 'TND',
+        DZ: 'DZD',
+        LY: 'LYD',
+        RS: 'RSD',
+      },
+      fallback: 'KWD',
+    },
+  });
+
+/**
+ * Marker text to an ISO code, or to the name of a family that needs the region
+ * to settle it. Keys are folded: uppercased, with dots and spaces removed.
+ */
+const MARKERS: Readonly<Record<string, string>> = Object.freeze({
+  // Qualified dollars, which are not ambiguous at all.
+  US$: 'USD',
+  CA$: 'CAD',
+  C$: 'CAD',
+  A$: 'AUD',
+  AU$: 'AUD',
+  NZ$: 'NZD',
+  S$: 'SGD',
+  SG$: 'SGD',
+  HK$: 'HKD',
+  NT$: 'TWD',
+  R$: 'BRL',
+  MX$: 'MXN',
+  // Families.
+  $: 'dollar',
+  '₹': 'INR',
+  '₨': 'rupee',
+  RS: 'rupee',
+  '£': 'pound',
+  '¥': 'yen',
+  KR: 'krone',
+  // Unambiguous symbols.
+  '€': 'EUR',
+  '₩': 'KRW',
+  '₫': 'VND',
+  '฿': 'THB',
+  '₦': 'NGN',
+  '₱': 'PHP',
+  '₽': 'RUB',
+  '₪': 'ILS',
+  '₴': 'UAH',
+  '₸': 'KZT',
+  '₺': 'TRY',
+  // Latin abbreviations.
+  RP: 'IDR',
+  RM: 'MYR',
+  DH: 'dirham',
+  DHS: 'dirham',
+  TL: 'TRY',
+  KC: 'CZK',
+  ZL: 'PLN',
+  РУБ: 'RUB',
+  // Arabic abbreviations — the letter pairs Gulf banks actually print.
+  'د.إ': 'AED',
+  'ر.س': 'SAR',
+  'ر.ق': 'QAR',
+  'ر.ع': 'OMR',
+  'د.ك': 'KWD',
+  'د.ب': 'BHD',
+  'د.أ': 'JOD',
+  'د.ا': 'JOD',
+  'د.ت': 'TND',
+  'ج.م': 'EGP',
+  ريال: 'riyal',
+  درهم: 'dirham',
+  دينار: 'dinar',
+  جنيه: 'EGP',
+  // The rupee, spelled out — Hindi and Tamil bank alerts write the word, not
+  // the symbol, and a message in Devanagari digits usually carries one too.
+  रुपये: 'rupee',
+  रुपए: 'rupee',
+  रु: 'rupee',
+  ரூபாய்: 'rupee',
+  ரூ: 'rupee',
+  // CJK and South-East Asia.
+  円: 'JPY',
+  元: 'CNY',
+  บาท: 'THB',
+  Đ: 'VND',
+  VNĐ: 'VND',
+});
+
+/**
+ * The ISO codes the parser will read as a currency marker. Waves' own
+ * `minorUnitExponent` table plus every market `currencyForCountry` names, so
+ * "the currencies Waves supports" and "the currencies the SMS reader knows" are
+ * the same list rather than two lists that drift.
+ */
+const ISO_CODES = [
+  'AED',
+  'ARS',
+  'AUD',
+  'BDT',
+  'BGN',
+  'BHD',
+  'BRL',
+  'CAD',
+  'CHF',
+  'CLP',
+  'CNY',
+  'COP',
+  'CZK',
+  'DKK',
+  'DZD',
+  'EGP',
+  'EUR',
+  'FJD',
+  'GBP',
+  'GHS',
+  'HKD',
+  'HUF',
+  'IDR',
+  'ILS',
+  'INR',
+  'IQD',
+  'ISK',
+  'JMD',
+  'JOD',
+  'JPY',
+  'KES',
+  'KRW',
+  'KWD',
+  'KZT',
+  'LBP',
+  'LKR',
+  'LYD',
+  'MAD',
+  'MUR',
+  'MXN',
+  'MYR',
+  'NGN',
+  'NOK',
+  'NPR',
+  'NZD',
+  'OMR',
+  'PEN',
+  'PHP',
+  'PKR',
+  'PLN',
+  'PYG',
+  'QAR',
+  'RON',
+  'RSD',
+  'RUB',
+  'SAR',
+  'SCR',
+  'SEK',
+  'SGD',
+  'THB',
+  'TND',
+  'TRY',
+  'TWD',
+  'TZS',
+  'UAH',
+  'UGX',
+  'USD',
+  'UYU',
+  'VND',
+  'ZAR',
+] as const;
+
+/** The alternation the amount patterns are built from. Longest forms first. */
+export const CURRENCY_TOKEN_SOURCE = [
+  '(?:US|CA|AU|NZ|SG|HK|NT|MX)\\$',
+  '[RCAS]\\$',
+  `\\b(?:${ISO_CODES.join('|')})\\b`,
+  '\\bRs\\.?',
+  '\\bRp\\.?',
+  '\\bRM\\b',
+  '\\bDhs?\\.?',
+  '\\bTL\\b',
+  // No trailing `\b` on any of these: JavaScript's word boundary is defined
+  // against [A-Za-z0-9_], so there is no boundary after `č`, `ł` or a Cyrillic
+  // letter, and asking for one would make the pattern match nothing at all.
+  '\\bK[čc]\\.?',
+  '\\bz[łl]',
+  '\\bkr\\.?',
+  'руб\\.?',
+  '[₹€£¥₩₫฿₦₱₽₨₪₴₸₺$]',
+  'د\\.[إكبأات]',
+  'ر\\.[سقع]',
+  'ج\\.م',
+  '(?:ريال|درهم|دينار|جنيه)',
+  '(?:रुपये|रुपए|रु|ரூபாய்|ரூ)',
+  '(?:円|元|บาท)',
+  'Đ',
+].join('|');
+
+const foldMarker = (raw: string): string =>
+  raw
+    .replace(/[\s]/g, '')
+    .replace(/\.$/, '')
+    .toUpperCase()
+    // Czech and Polish fold through the same path the message body does.
+    .replace(/Č/g, 'C')
+    .replace(/Ł/g, 'L');
+
+export interface CurrencyReading {
+  readonly currency: CurrencyCode;
+  /** True when nothing in the message or the context actually settled it. */
+  readonly inferred: boolean;
+}
+
+/**
+ * The currency for a marker found beside the amount, or — when the message
+ * named none — the caller's default, the region's currency, and finally INR.
+ *
+ * INR last is not an accident and not neutrality: it is Waves' home market and
+ * the documented last resort. It is always reported as inferred, so a message
+ * from a bank that names no currency never claims to be rupees.
+ */
+export function resolveCurrency(marker: string | null, context: SmsParseContext): CurrencyReading {
+  const region = regionOf(context);
+
+  if (marker) {
+    const folded = foldMarker(marker);
+    const resolved = MARKERS[folded] ?? folded;
+    const family = FAMILIES[resolved];
+    if (family) {
+      const fromRegion = region ? family.byRegion[region] : undefined;
+      if (fromRegion) return { currency: fromRegion, inferred: false };
+      return { currency: family.fallback, inferred: true };
+    }
+    // A marker that resolves to neither a family nor an ISO code is a pattern
+    // that got ahead of this table; fall through rather than hand `money` a
+    // string it will throw on.
+    if (isCurrencyCode(resolved)) return { currency: resolved, inferred: false };
+  }
+
+  if (context.defaultCurrency) return { currency: context.defaultCurrency, inferred: false };
+  const regional = currencyForCountry(region);
+  if (regional) return { currency: regional, inferred: false };
+  return { currency: 'INR', inferred: true };
+}
+
+/* ------------------------------------------------------------------ *
+ * Sender
+ * ------------------------------------------------------------------ */
+
+/**
+ * The registered header inside a sender id, with the carrier's prefix removed.
+ *
+ * India's DLT regime delivers the same bank as `AD-HDFCBK`, `VM-HDFCBK` or
+ * `JD-HDFCBK` depending on the recipient's operator and circle, and since 2025
+ * with a message-type suffix as well. Matching the whole string is a bug that
+ * looks like "it works on my phone". Nothing here assumes the Indian shape
+ * though: a sender with no prefix comes back unchanged, which is what a
+ * European or Gulf short code looks like.
+ */
+export function senderHeader(sender: string | null | undefined): string | null {
+  const raw = (sender ?? '').trim();
+  if (!raw) return null;
+  const withoutOperator = raw.replace(/^[A-Za-z]{2}\d?[-_]/, '');
+  const header = withoutOperator.replace(/[-_][A-Za-z]$/, '').toUpperCase();
+  return header || null;
+}
+
+/**
+ * Whether the sender looks like a financial institution.
+ *
+ * Used only to *raise* confidence, never to drop a message: a bank not on this
+ * list is a bank this list has not heard of yet, and a person who pasted a
+ * message has already decided it is worth reading. The generic shapes at the
+ * end matter more than the names — they are what make this work outside India.
+ */
+export function looksLikeBankSender(sender: string | null | undefined): boolean {
+  const header = senderHeader(sender);
+  if (!header) return false;
+  if (/^\+?\d{6,}$/.test(header)) return false; // a person's phone number
+  return /BANK|BNK|\bBK|CARD|UPI|PAY|CRED|FIN|UBI|SBI|HDFC|ICICI|AXIS|KOTAK|PNB|BOI|CANARA|YES|IDFC|RBL|INDUS|AMEX|CHASE|WELLS|BOFA|BARCL|HSBC|LLOYD|NATWST|SANTAN|REVOLUT|MONZO|WISE|DBS|OCBC|UOB|ENBD|ADCB|FAB|MASHREQ|MAYBANK|CIMB|BCA|MANDIRI|BBVA|CAIXA|ITAU|BRADESCO|NUBANK|SPARKASSE|GARANTI|AKBANK|ZIRAAT|SCB|KBANK|VIETCOM|TECHCOM/i.test(
+    header,
+  );
+}

--- a/packages/core/src/sms/parse.ts
+++ b/packages/core/src/sms/parse.ts
@@ -263,9 +263,20 @@ export interface ExpenseCandidate extends ParsedSms {
 }
 
 export interface ProposeOptions {
-  /** Trip window, inclusive. ISO dates or instants. */
-  readonly from: string;
-  readonly to: string;
+  /**
+   * Trip window, inclusive. ISO dates or instants.
+   *
+   * Both ends are optional, and an absent end means "no bound that way". The
+   * window was mandatory while this only ever ran inside a group, where the
+   * trip's own dates were the obvious fence. The drafts inbox has no trip: a
+   * person pastes the messages they chose, and a window would then silently
+   * drop some of them — the one failure mode a paste flow must not have, since
+   * what went missing is invisible. An unparseable bound is treated as absent
+   * for the same reason: dropping everything because a date field held nonsense
+   * would be worse than proposing too much, which a person can simply untick.
+   */
+  readonly from?: string;
+  readonly to?: string;
   /**
    * Dedupe keys already on the ledger. A candidate matching one of these is
    * dropped — re-scanning the inbox must not re-propose what was confirmed.
@@ -273,16 +284,23 @@ export interface ProposeOptions {
   readonly alreadyImported?: ReadonlySet<string>;
 }
 
+/** A window bound as a number, or ±Infinity when there is no usable bound. */
+function bound(value: string | undefined, edge: (value: string) => string, fallback: number) {
+  if (!value) return fallback;
+  const stamp = Date.parse(edge(value));
+  return Number.isNaN(stamp) ? fallback : stamp;
+}
+
 /**
- * The whole feature, as one pure function: an inbox and a trip window in,
- * candidates out. Nothing is written and nothing is sent anywhere.
+ * The whole feature, as one pure function: an inbox and (optionally) a trip
+ * window in, candidates out. Nothing is written and nothing is sent anywhere.
  */
 export function proposeFromSms(
   messages: readonly SmsMessage[],
-  options: ProposeOptions,
+  options: ProposeOptions = {},
 ): ExpenseCandidate[] {
-  const from = Date.parse(startOfDay(options.from));
-  const to = Date.parse(endOfDay(options.to));
+  const from = bound(options.from, startOfDay, -Infinity);
+  const to = bound(options.to, endOfDay, Infinity);
   const seen = new Set<string>();
   const candidates: ExpenseCandidate[] = [];
 

--- a/packages/core/src/sms/parse.ts
+++ b/packages/core/src/sms/parse.ts
@@ -18,10 +18,55 @@
  *
  * Everything is parsed as digits and assembled into minor units. No float ever
  * exists between the text and the amount (ADR-003).
+ *
+ * ## Never guess silently
+ *
+ * Three things in a bank message are genuinely undecidable from the text:
+ * `08/05/2026` is two different days, `1.234` is two amounts a thousand apart,
+ * and `$` is seven currencies. The rule this file follows everywhere is that
+ * such a thing is either settled by an explicit signal — the caller's region,
+ * locale or default currency, passed in as {@link SmsParseContext} — or it is
+ * decided by one documented fallback *and reported*, in `inferred`, with the
+ * confidence lowered to match. A parser that guesses is fine. A parser that
+ * guesses and then looks certain puts an expense on the wrong day of a trip.
+ *
+ * The context is entirely optional and every path works without it. A caller
+ * that knows the user's country simply gets a better answer, and Waves knows
+ * the user's country.
  */
 
-import { minorUnitExponent, type CurrencyCode } from '../money/currency';
+import { minorUnitExponent, isCurrencyCode, type CurrencyCode } from '../money/currency';
 import { money, type Money } from '../money/money';
+import { normaliseForParsing, foldToken } from '../text/digits';
+import {
+  ACCOUNT_TAIL,
+  BALANCE_ONLY,
+  BALANCE_WORDS,
+  CARD_PHRASES,
+  CREDIT_SOURCE,
+  CREDIT_WORDS,
+  DEBIT_SOURCE,
+  DEBIT_WORDS,
+  MERCHANT_DETERMINERS,
+  MERCHANT_NOISE,
+  MERCHANT_PREPOSITIONS,
+  MERCHANT_STOP_WORDS,
+  MONTHS,
+  NOT_A_TRANSACTION,
+  REFERENCE,
+} from './vocabulary';
+import {
+  CURRENCY_TOKEN_SOURCE,
+  dateOrderFor,
+  decimalSeparatorFor,
+  looksLikeBankSender,
+  resolveCurrency,
+  type InferredField,
+  type SmsParseContext,
+} from './locale';
+
+export type { InferredField, SmsParseContext, DateOrder } from './locale';
+export { senderHeader, looksLikeBankSender } from './locale';
 
 export enum TransactionDirection {
   Debit = 'debit',
@@ -46,6 +91,15 @@ export interface ParsedSms {
    * expense on the wrong day of a trip.
    */
   readonly occurredAt: string | null;
+  /**
+   * Which fields the parser had to decide for itself because the message and
+   * the context between them did not say.
+   *
+   * This is the honest half of the confidence score: a caller can point at the
+   * exact field to check rather than telling somebody the whole row is doubtful
+   * and leaving them to find out which part.
+   */
+  readonly inferred: readonly InferredField[];
   /** 0–1. Below `SMS_LOW_CONFIDENCE` the candidate is shown but not pre-selected. */
   readonly confidence: number;
 }
@@ -53,191 +107,628 @@ export interface ParsedSms {
 /** Below this, a person should look before confirming. */
 export const SMS_LOW_CONFIDENCE = 0.7;
 
+/* ------------------------------------------------------------------ *
+ * Folding
+ * ------------------------------------------------------------------ */
+
 /**
- * Currency markers seen in Indian bank SMS. `Rs` and `INR` are the same thing;
- * a bank abroad will say `USD` or use a symbol.
+ * Letters with no Unicode decomposition, so `normalize('NFD')` cannot strip
+ * them down to a base letter. Each replacement is exactly one character long,
+ * which is the whole constraint: the fold must not change the string's length.
  */
-const CURRENCY_MARKERS: ReadonlyArray<readonly [RegExp, CurrencyCode]> = [
-  [/(?:INR|Rs\.?|₹)/i, 'INR'],
-  // The amount regex matches case-insensitively, so "usd 42" yields an amount;
-  // without `i` here the code fell through every marker and defaulted the
-  // currency to INR, mislabelling the proposed expense.
-  [/(?:USD|\$)/i, 'USD'],
-  [/(?:EUR|€)/i, 'EUR'],
-  [/(?:GBP|£)/i, 'GBP'],
-  [/AED/i, 'AED'],
-  [/SGD/i, 'SGD'],
-  [/THB/i, 'THB'],
-];
+const UNDECOMPOSABLE: Readonly<Record<string, string>> = Object.freeze({
+  ß: 's',
+  Ø: 'O',
+  ø: 'o',
+  Đ: 'D',
+  đ: 'd',
+  Ł: 'L',
+  ł: 'l',
+  ı: 'i',
+  ħ: 'h',
+  Æ: 'A',
+  æ: 'a',
+  Œ: 'O',
+  œ: 'o',
+  Ð: 'D',
+  ð: 'd',
+  Þ: 'T',
+  þ: 't',
+});
+
+const ACCENTED = /[\u00c0-\u024f\u1e00-\u1eff]/g;
 
 /**
- * Words that mean money left the account. Ordered longest-first so that
- * "debited" is not matched by a looser rule before "credited" is considered.
- */
-const DEBIT_WORDS = /\b(debited|debit|spent|paid|withdrawn|purchase|sent|deducted)\b/i;
-const CREDIT_WORDS = /\b(credited|credit|received|refund|reversed|cashback)\b/i;
-
-/**
- * Messages that look like transactions but are not. A one-time password quotes
- * an amount and would otherwise parse cleanly into an expense somebody never
- * made — this is the single most dangerous false positive in the set, because
- * the number is real and the message is from the right sender.
- */
-const NOT_A_TRANSACTION =
-  /\b(OTP|one[- ]time\s*password|will\s+be\s+debited|request(?:ed)?\s+(?:for|to)|is\s+due|due\s+on|reminder|failed|declined|unsuccessful|statement|e-?mandate|auto[- ]?pay\s+scheduled)\b/i;
-
-/**
- * A balance report on its own is not a transaction. The same words appear as a
- * trailer on a real debit alert ("... Avl Bal: Rs 12,340"), so these only
- * disqualify a message that says nothing about money moving.
- */
-const BALANCE_ONLY = /\b(balance\s+is|avl\s*bal|available\s+balance\s+is)\b/i;
-
-/**
- * Amount, as digits: "1,234.56" or "1234" or "1.234,56" is not attempted —
- * Indian and international banks both write "1,23,456.78" or "1,234.56", and
- * both use the dot as the decimal separator.
- */
-const AMOUNT = /(INR|Rs\.?|₹|USD|\$|EUR|€|GBP|£|AED|SGD|THB)\s*([\d,]+(?:\.\d{1,2})?)/i;
-
-/** "to AMAZON", "at STARBUCKS", "towards SWIGGY" — whoever was paid. */
-const MERCHANT =
-  /\b(?:to|at|towards|in\s+favour\s+of|VPA)\s+([A-Z0-9][A-Za-z0-9&.'@_-]*(?:\s+[A-Z0-9][A-Za-z0-9&.'@_-]*){0,3})/;
-
-const ACCOUNT_TAIL = /\b(?:a\/c|acct?|account|card|xx+|\*+)\s*(?:no\.?\s*)?[xX*]*(\d{3,6})\b/;
-const REFERENCE =
-  /\b(?:ref(?:erence)?|txn|transaction|UPI\s*Ref|RRN)\s*(?:no\.?|id)?[:\s]\s*([A-Za-z0-9]{6,})/i;
-
-/** "05-08-26", "05/08/2026", "05-Aug-26". Day first, as Indian banks write it. */
-const DATE_NUMERIC = /\b(\d{1,2})[-/](\d{1,2})[-/](\d{2,4})\b/;
-const DATE_NAMED = /\b(\d{1,2})[-\s]([A-Za-z]{3})[-\s](\d{2,4})\b/;
-const TIME = /\b(\d{1,2}):(\d{2})(?::(\d{2}))?\b/;
-
-const MONTHS: Record<string, number> = {
-  jan: 1,
-  feb: 2,
-  mar: 3,
-  apr: 4,
-  may: 5,
-  jun: 6,
-  jul: 7,
-  aug: 8,
-  sep: 9,
-  oct: 10,
-  nov: 11,
-  dec: 12,
-};
-
-/**
- * "1,23,456.78" → 12345678 minor units, by digits.
+ * `débité` to `debite`, `ağustos` to `agustos`, `số` to `so` — **without
+ * changing the length of the string**.
  *
- * A message quoting more precision than the currency has is truncated, not
- * rounded: banks do not print a third decimal, so seeing one means the parse
- * went wrong somewhere and inventing a rounding rule would hide that.
+ * That constraint is what lets the whole file work: every word list is written
+ * unaccented and matched against the folded text, while merchant names are
+ * sliced out of the *original* text at the indices the folded match reported.
+ * Strip the accents with NFD instead and every index after the first accent in
+ * the message points one character to the left, which is a bug that only shows
+ * up in French.
  */
-function toMinor(text: string, currency: CurrencyCode): bigint {
-  const cleaned = text.replace(/,/g, '');
+function foldLatin(text: string): string {
+  return text.replace(ACCENTED, (character) => {
+    const direct = UNDECOMPOSABLE[character];
+    if (direct) return direct;
+    const base = character.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+    return base.length === 1 ? base : character;
+  });
+}
+
+/** The card phrases blanked out, same length, so every other index still holds. */
+function maskCards(text: string): string {
+  return text.replace(CARD_PHRASES, (match) => ' '.repeat(match.length));
+}
+
+/* ------------------------------------------------------------------ *
+ * Amounts
+ * ------------------------------------------------------------------ */
+
+/**
+ * A written number, in the four shapes the world writes them in.
+ *
+ * Ordered longest-first, because the alternation is tried in order and the
+ * shortest form would otherwise swallow `1,23` out of `1,23,456.78`. Every
+ * group is non-capturing so this can be embedded in larger patterns without
+ * renumbering their groups, and the whole thing ends with a lookahead refusing
+ * a trailing digit: without it `500 123456` reads as `500 123`.
+ *
+ *   1. space, apostrophe or non-breaking space grouping — `1 234,56` (fr, ru),
+ *      `1'234.56` (ch);
+ *   2. comma or dot grouping with the other as the decimal — `1,234.56`,
+ *      `1.234,56`, and India's `1,23,456.78`;
+ *   3. a single separator, which is the ambiguous case — see `readNumber`;
+ *   4. bare digits.
+ */
+const NUMBER_SOURCE =
+  "(?:\\d{1,3}(?:['\u2019 \u00a0\u202f\u2009\u2007]\\d{3})+(?:[.,]\\d{1,4})?" +
+  '|\\d{1,3}(?:[.,]\\d{2,3})+(?:[.,]\\d{1,4})?' +
+  '|\\d+(?:[.,]\\d{1,4})?)(?!\\d)';
+
+const AMOUNT_LEADING = new RegExp(`(${CURRENCY_TOKEN_SOURCE})\\s*(${NUMBER_SOURCE})`, 'gi');
+const AMOUNT_TRAILING = new RegExp(`(${NUMBER_SOURCE})\\s*(${CURRENCY_TOKEN_SOURCE})`, 'gi');
+
+/**
+ * A number with no currency token at all, which is how State Bank of India —
+ * the country's largest bank — writes every UPI alert: `debited by 150.0`.
+ *
+ * Only ever reached when no currency-marked amount was found, and only when a
+ * transaction verb introduces the number, because a bare number in a bank
+ * message is far more often a date, an account tail or a helpline.
+ */
+const AMOUNT_AFTER_VERB = new RegExp(
+  `(?:${DEBIT_SOURCE}|${CREDIT_SOURCE})\\s*(?:by|for|with|of|:|-)?\\s*(${NUMBER_SOURCE})`,
+  'giu',
+);
+const AMOUNT_BEFORE_VERB = new RegExp(
+  `(${NUMBER_SOURCE})\\s*(?:(?:has|have|was|were|is|are)\\s+(?:been\\s+)?)?(?:${DEBIT_SOURCE}|${CREDIT_SOURCE})`,
+  'giu',
+);
+
+interface AmountMatch {
+  /** The digits as written. */
+  readonly token: string;
+  /** The currency marker beside it, when there was one. */
+  readonly marker: string | null;
+  /** Where the digits start, in the collapsed message. */
+  readonly index: number;
+}
+
+/** Ranges in the message where a balance is being reported. */
+function balanceRanges(folded: string): readonly (readonly [number, number])[] {
+  const ranges: [number, number][] = [];
+  BALANCE_WORDS.lastIndex = 0;
+  for (const match of folded.matchAll(BALANCE_WORDS)) {
+    if (match.index === undefined) continue;
+    ranges.push([match.index, match.index + match[0].length]);
+  }
+  return ranges;
+}
+
+/**
+ * A number that is plainly not an amount: part of a date, part of a card tail,
+ * or a reference long enough that no shop charges it.
+ */
+function looksLikeIdentifier(text: string, index: number, token: string): boolean {
+  const before = index > 0 ? text[index - 1] : '';
+  const after = text.slice(index + token.length, index + token.length + 2);
+  if (before && /[\d\-/:xX*]/.test(before)) return true;
+  if (/^[-/:]\d/.test(after)) return true;
+  return !/[.,]/.test(token) && token.replace(/\D/g, '').length >= 9;
+}
+
+function collect(pattern: RegExp, text: string, markerFirst: boolean): AmountMatch[] {
+  const found: AmountMatch[] = [];
+  pattern.lastIndex = 0;
+  for (const match of text.matchAll(pattern)) {
+    if (match.index === undefined) continue;
+    const marker = markerFirst ? (match[1] ?? null) : (match[2] ?? null);
+    const token = markerFirst ? match[2] : match[1];
+    if (!token) continue;
+    const index = match.index + match[0].indexOf(token);
+    if (looksLikeIdentifier(text, index, token)) continue;
+    found.push({ token, marker, index });
+  }
+  return found;
+}
+
+/**
+ * The transaction's amount, out of however many numbers the message quotes.
+ *
+ * Two amounts in one message is the normal case, not the exception — almost
+ * every debit alert carries the running balance as a trailer. The old parser
+ * took the first number and was right by luck, because Indian banks quote the
+ * transaction first. This takes the first number that is *not* sitting behind a
+ * balance word, which is the same answer for those messages and the right one
+ * for a bank that leads with the balance.
+ */
+function findAmount(raw: string, folded: string): AmountMatch | null {
+  let candidates = [...collect(AMOUNT_LEADING, raw, true), ...collect(AMOUNT_TRAILING, raw, false)];
+  if (candidates.length === 0) {
+    candidates = [
+      ...collect(AMOUNT_AFTER_VERB, folded, false),
+      ...collect(AMOUNT_BEFORE_VERB, folded, false),
+    ];
+  }
+  if (candidates.length === 0) return null;
+
+  const byPosition = [...candidates].sort((a, b) => a.index - b.index);
+  const balances = balanceRanges(folded);
+  const isBalance = (candidate: AmountMatch): boolean =>
+    balances.some(([, end]) => end <= candidate.index && candidate.index - end <= 12);
+
+  return byPosition.find((candidate) => !isBalance(candidate)) ?? byPosition[0] ?? null;
+}
+
+interface NumberReading {
+  readonly minor: bigint;
+  /** True when the decimal separator was a coin flip rather than a deduction. */
+  readonly separatorInferred: boolean;
+}
+
+/**
+ * Digits on the page to integer minor units, deciding which separator was the
+ * decimal point and which was grouping.
+ *
+ * The cases in order, and why each one is safe:
+ *
+ *   - **both a dot and a comma appear.** The later one is the decimal point.
+ *     No locale writes it the other way, so `1.234,56` and `1,234.56` are both
+ *     settled outright.
+ *   - **one kind, more than once.** `1.234.567` and India's `1,23,456` can only
+ *     be grouping; nothing has two decimal points.
+ *   - **one separator, fewer than three digits after it.** Grouping is always
+ *     in threes, so this is a decimal point.
+ *   - **one separator, exactly three digits after it.** The genuinely ambiguous
+ *     case — and for almost every currency it is not ambiguous at all, because
+ *     a currency with two minor digits cannot have three. So the currency's own
+ *     exponent settles it, and `EUR 1.234` reads as one thousand two hundred
+ *     and thirty-four rather than as €1.23. Only the three-decimal currencies
+ *     (KWD, BHD, OMR, JOD, TND) are left genuinely open; there the caller's
+ *     locale decides, and with no locale the fallback is reported as inferred.
+ *
+ * More fraction digits than the currency has are truncated rather than rounded,
+ * which is the old rule kept deliberately: inventing a rounding here would hide
+ * a parse that went wrong. A zero-decimal currency therefore never acquires
+ * phantom minor units — `JPY 1,234.00` is ¥1,234, not ¥123,400.
+ */
+function readNumber(
+  token: string,
+  currency: CurrencyCode,
+  context: SmsParseContext,
+): NumberReading | null {
+  // Spaces and apostrophes are only ever grouping — no locale uses either as a
+  // decimal point — so they can go before anything is decided.
+  const cleaned = token.replace(/['\u2019 \u00a0\u202f\u2009\u2007]/g, '');
+  if (!/^\d/.test(cleaned)) return null;
+
   const exponent = minorUnitExponent(currency);
-  const [whole = '0', fraction = ''] = cleaned.split('.');
-  const padded = (fraction + '0'.repeat(exponent)).slice(0, exponent);
-  return BigInt(whole + padded);
-}
+  const lastDot = cleaned.lastIndexOf('.');
+  const lastComma = cleaned.lastIndexOf(',');
+  const dots = (cleaned.match(/\./g) ?? []).length;
+  const commas = (cleaned.match(/,/g) ?? []).length;
 
-function detectCurrency(text: string): CurrencyCode {
-  for (const [pattern, code] of CURRENCY_MARKERS) {
-    if (pattern.test(text)) return code;
-  }
-  return 'INR';
-}
+  let decimalAt = -1;
+  let separatorInferred = false;
 
-function detectDate(text: string): string | null {
-  const time = TIME.exec(text);
-  const clock = time
-    ? `T${(time[1] ?? '0').padStart(2, '0')}:${time[2]}:${(time[3] ?? '00').padStart(2, '0')}.000Z`
-    : 'T00:00:00.000Z';
-
-  const named = DATE_NAMED.exec(text);
-  if (named) {
-    const month = MONTHS[(named[2] ?? '').toLowerCase()];
-    if (month) return `${expandYear(named[3])}-${pad(month)}-${pad(Number(named[1]))}${clock}`;
-  }
-
-  const numeric = DATE_NUMERIC.exec(text);
-  if (numeric) {
-    const day = Number(numeric[1]);
-    const month = Number(numeric[2]);
-    // Always day-first, the Indian convention these alerts are written in. A
-    // US-format message (08/05/2026) is read as 8 August; without the sender's
-    // locale there is nothing here to tell the two apart, so this is a known
-    // limitation rather than a check.
-    if (day >= 1 && day <= 31 && month >= 1 && month <= 12) {
-      return `${expandYear(numeric[3])}-${pad(month)}-${pad(day)}${clock}`;
+  if (dots > 0 && commas > 0) {
+    decimalAt = Math.max(lastDot, lastComma);
+  } else if (dots + commas > 1) {
+    decimalAt = -1;
+  } else if (dots + commas === 1) {
+    const at = dots === 1 ? lastDot : lastComma;
+    const separator = cleaned[at] === '.' ? '.' : ',';
+    const after = cleaned.length - at - 1;
+    const before = at;
+    if (after === 0) {
+      decimalAt = -1;
+    } else if (after !== 3 || before > 3) {
+      decimalAt = at;
+    } else if (exponent !== 3) {
+      // Grouping: a two- or zero-decimal currency cannot carry three of them.
+      decimalAt = -1;
+    } else {
+      const locale = decimalSeparatorFor(context);
+      decimalAt = (locale ?? '.') === separator ? at : -1;
+      separatorInferred = locale === null;
     }
   }
-  return null;
+
+  if (!/^\d+$/.test(cleaned.replace(/[.,]/g, ''))) return null;
+
+  const whole = (decimalAt === -1 ? cleaned : cleaned.slice(0, decimalAt)).replace(/[.,]/g, '');
+  const fraction = decimalAt === -1 ? '' : cleaned.slice(decimalAt + 1).replace(/[.,]/g, '');
+  const padded = (fraction + '0'.repeat(exponent)).slice(0, exponent);
+  return { minor: BigInt((whole || '0') + padded), separatorInferred };
+}
+
+/* ------------------------------------------------------------------ *
+ * Dates
+ * ------------------------------------------------------------------ */
+
+const DATE_ISO = /\b(\d{4})[-/](\d{1,2})[-/](\d{1,2})(?:[T\s:](\d{1,2}):(\d{2})(?::(\d{2}))?)?/;
+// `(?!\d)` on the day is what stops the month-first pattern reading `Okt 2026`
+// as the 20th of October: without it `\d{1,2}` happily takes the `20` out of
+// the year and leaves `26` behind as one.
+// The optional `de`/`di`/`of` is Spanish and Portuguese writing the date out in
+// full — "12 de dezembro de 2026" — which is the ordinary form on a Brazilian
+// card alert, not a flourish.
+const DATE_DAY_FIRST =
+  /(\d{1,2})(?!\d)[-./]?\s*(?:(?:de|di|of)\s+)?(\p{L}{3,12})[-./,]?\s*(?:(?:de|del|di)\s+)?(\d{2,4})\b/gu;
+const DATE_MONTH_FIRST = /(\p{L}{3,12})[-./]?\s*(\d{1,2})(?!\d)(?:st|nd|rd|th)?,?\s*(\d{2,4})\b/gu;
+const DATE_NUMERIC = /\b(\d{1,2})[-/.](\d{1,2})[-/.](\d{2,4})\b/;
+const TIME = /\b(\d{1,2}):(\d{2})(?::(\d{2}))?\b/;
+
+/**
+ * A month name in any of the languages the vocabulary covers, or null.
+ *
+ * Looked up longest key first so French `juin` (6) and `juillet` (7) do not
+ * collapse into a shared `jui`.
+ */
+function monthOf(word: string): number | null {
+  const folded = foldToken(word);
+  return MONTHS[folded] ?? MONTHS[folded.slice(0, 4)] ?? MONTHS[folded.slice(0, 3)] ?? null;
+}
+
+interface DateReading {
+  readonly iso: string;
+  /** True when day-versus-month order was a fallback rather than a deduction. */
+  readonly orderInferred: boolean;
 }
 
 const pad = (value: number): string => String(value).padStart(2, '0');
 const expandYear = (raw: string | undefined): string =>
   !raw ? '1970' : raw.length === 4 ? raw : `20${raw.padStart(2, '0')}`;
 
+const validDay = (day: number, month: number): boolean =>
+  day >= 1 && day <= 31 && month >= 1 && month <= 12;
+
+/**
+ * The first match whose middle word is really a month name.
+ *
+ * Rewinds to one character past the *start* of a rejected match rather than
+ * past its end, which matters more than it looks: `harcama 12 Agustos 2026`
+ * matches the pattern once with `harcama` in the month slot, and skipping past
+ * that whole match would swallow the real date sitting inside it.
+ */
+function scanNamed(
+  pattern: RegExp,
+  text: string,
+  dayGroup: number,
+  monthGroup: number,
+): DateReading | null {
+  pattern.lastIndex = 0;
+  let match = pattern.exec(text);
+  while (match !== null) {
+    const month = monthOf(match[monthGroup] ?? '');
+    const day = Number(match[dayGroup]);
+    if (month !== null && validDay(day, month)) {
+      const end = match.index + match[0].length;
+      return {
+        iso: `${expandYear(match[3])}-${pad(month)}-${pad(day)}${clockOutside(text, match.index, end)}`,
+        orderInferred: false,
+      };
+    }
+    pattern.lastIndex = match.index + 1;
+    match = pattern.exec(text);
+  }
+  return null;
+}
+
+/** The clock in the message, ignoring the span the date itself occupies. */
+function clockOutside(text: string, from: number, to: number): string {
+  const masked = `${text.slice(0, from)}${' '.repeat(to - from)}${text.slice(to)}`;
+  const time = TIME.exec(masked);
+  if (!time) return 'T00:00:00.000Z';
+  return `T${(time[1] ?? '0').padStart(2, '0')}:${time[2]}:${(time[3] ?? '00').padStart(2, '0')}.000Z`;
+}
+
+const clockOf = (hour?: string, minute?: string, second?: string): string =>
+  minute
+    ? `T${(hour ?? '0').padStart(2, '0')}:${minute}:${(second ?? '00').padStart(2, '0')}.000Z`
+    : 'T00:00:00.000Z';
+
+/**
+ * When the bank says it happened.
+ *
+ * ISO first, then a named month in either order, then bare numbers — and the
+ * bare numbers are the hard case. `08/05/2026` is the 8th of May in every
+ * market Waves ships in and the 5th of August in the United States, and the
+ * message itself contains nothing that tells them apart. So: a component over
+ * twelve settles it outright, otherwise the caller's region settles it, and
+ * with neither the fallback is day-first — the order most of the world writes —
+ * reported back as inferred so the confidence drops and the UI can say which
+ * field to check.
+ */
+function detectDate(raw: string, context: SmsParseContext): DateReading | null {
+  const iso = DATE_ISO.exec(raw);
+  if (iso?.[1] && iso[2] && iso[3]) {
+    const month = Number(iso[2]);
+    const day = Number(iso[3]);
+    if (validDay(day, month)) {
+      return {
+        iso: `${iso[1]}-${pad(month)}-${pad(day)}${clockOf(iso[4], iso[5], iso[6])}`,
+        orderInferred: false,
+      };
+    }
+  }
+
+  const dayFirst = scanNamed(DATE_DAY_FIRST, raw, 1, 2);
+  if (dayFirst) return dayFirst;
+
+  const monthFirst = scanNamed(DATE_MONTH_FIRST, raw, 2, 1);
+  if (monthFirst) return monthFirst;
+
+  const numeric = DATE_NUMERIC.exec(raw);
+  if (numeric?.[1] && numeric[2]) {
+    const first = Number(numeric[1]);
+    const second = Number(numeric[2]);
+    const { order, explicit } = dateOrderFor(context);
+
+    let day = order === 'mdy' ? second : first;
+    let month = order === 'mdy' ? first : second;
+    let inferred = !explicit;
+
+    // A component over twelve is not a month, whatever the locale says. That
+    // settles most real messages without any context at all.
+    if (first > 12 && second <= 12) {
+      day = first;
+      month = second;
+      inferred = false;
+    } else if (second > 12 && first <= 12) {
+      day = second;
+      month = first;
+      inferred = false;
+    } else if (first === second) {
+      inferred = false; // 05/05 reads the same either way
+    }
+
+    if (validDay(day, month)) {
+      const end = numeric.index + numeric[0].length;
+      return {
+        iso: `${expandYear(numeric[3])}-${pad(month)}-${pad(day)}${clockOutside(raw, numeric.index, end)}`,
+        orderInferred: inferred,
+      };
+    }
+  }
+
+  return null;
+}
+
+/* ------------------------------------------------------------------ *
+ * Merchant
+ * ------------------------------------------------------------------ */
+
+const PREPOSITION = new RegExp(`(?:${MERCHANT_PREPOSITIONS})\\s*`, 'giu');
+const PAYEE_CREDITED =
+  /([\p{L}\p{N}][\p{L}\p{N}&.'_-]{1,30})\s+(?:credited|creditado|acreditado)\b/iu;
+
+/** A long digit run is a reference, not a shop. */
+const isLongNumber = (token: string): boolean => /^\d{5,}$/.test(token);
+
+/** `12/09/2026` or `12-09-26`: the date that follows the shop's name, not part of it. */
+const isDateToken = (token: string): boolean =>
+  /^\d{1,4}[-/.]\d{1,2}(?:[-/.]\d{2,4})?[.,;:]?$/.test(token);
+
+/**
+ * Whoever was paid, read out of the words after "to", "at", "chez", "bei", "di".
+ *
+ * The old version produced `VPA` and `A` — the literal word before a UPI
+ * address, and the `A` of `A/c` — and scored both at full confidence. A row
+ * reading `A` is worse than a row reading nothing, because it looks parsed and
+ * a person has to notice it is nonsense. So a capture has to survive a
+ * plausibility test before it counts as a merchant at all, and an implausible
+ * one is skipped rather than returned: the parser keeps looking.
+ */
+function readMerchant(tail: string): string | null {
+  // A dot followed by a space ends the sentence; everything after it is the
+  // bank talking. A merchant name can still contain a dot (AMAZON.IN).
+  const sentence = (tail.split(/\.\s|;|\|/)[0] ?? '').trim();
+  const words = sentence.split(/\s+/).slice(0, 6);
+
+  let start = 0;
+  while (start < words.length && MERCHANT_DETERMINERS.has(foldToken(words[start] ?? '')))
+    start += 1;
+
+  const kept: string[] = [];
+  for (const word of words.slice(start)) {
+    const folded = foldToken(word.replace(/[.,;:]+$/, ''));
+    if (!folded) break;
+    if (MERCHANT_NOISE.has(folded) || isLongNumber(folded) || isDateToken(word)) break;
+    kept.push(word);
+    if (kept.length === 4) break;
+  }
+
+  let name = kept
+    .join(' ')
+    .replace(/[.,;:]+$/, '')
+    .trim();
+  // A UPI address or an email is the handle, not the domain: swiggy@icici is
+  // SWIGGY, and showing the bank's name instead would be actively misleading.
+  if (kept.length === 1 && name.includes('@')) name = name.split('@')[0] ?? name;
+
+  return plausibleMerchant(name) ? name : null;
+}
+
+function plausibleMerchant(name: string): boolean {
+  const trimmed = name.trim();
+  if (trimmed.length < 2) return false;
+  if (MERCHANT_STOP_WORDS.has(foldToken(trimmed))) return false;
+  // A bare number, a date, or punctuation: all of these are the message's
+  // furniture rather than a shop.
+  if (/^[\d\s.,:/@#*-]+$/.test(trimmed)) return false;
+  return detectDate(trimmed, {}) === null;
+}
+
+function detectMerchant(
+  raw: string,
+  folded: string,
+  direction: TransactionDirection,
+): string | null {
+  PREPOSITION.lastIndex = 0;
+  for (const match of folded.matchAll(PREPOSITION)) {
+    if (match.index === undefined) continue;
+    const start = match.index + match[0].length;
+    const candidate = readMerchant(raw.slice(start, start + 96));
+    if (candidate) return candidate;
+  }
+
+  // "…debited for Rs 500.00 …; SWIGGY credited." — a transfer alert describes
+  // both sides, and the side that was credited is the shop.
+  if (direction === TransactionDirection.Debit) {
+    const payee = PAYEE_CREDITED.exec(folded);
+    if (payee?.[1] && payee.index !== undefined) {
+      const at = payee.index + payee[0].indexOf(payee[1]);
+      const name = raw.slice(at, at + payee[1].length).replace(/[.,;:]+$/, '');
+      if (plausibleMerchant(name) && !MERCHANT_NOISE.has(foldToken(name))) return name;
+    }
+  }
+
+  return null;
+}
+
+/* ------------------------------------------------------------------ *
+ * Direction
+ * ------------------------------------------------------------------ */
+
+/** Distance from `index` to the nearest match of `pattern`, or null for none. */
+function nearest(pattern: RegExp, text: string, index: number): number | null {
+  pattern.lastIndex = 0;
+  let best: number | null = null;
+  for (const match of text.matchAll(pattern)) {
+    if (match.index === undefined) continue;
+    const start = match.index;
+    const end = start + match[0].length;
+    const distance = index < start ? start - index : index > end ? index - end : 0;
+    if (best === null || distance < best) best = distance;
+  }
+  return best;
+}
+
+/**
+ * Which way the money went, decided by the verb *nearest the amount*.
+ *
+ * The old rule bailed whenever a message contained both a debit and a credit
+ * word, which loses ICICI's entire account-debit format: `debited for Rs 500.00
+ * … ; SWIGGY credited` describes both sides of one transfer and is a perfectly
+ * ordinary debit. Proximity reads it correctly and still refuses the case that
+ * matters — a message where the two are equally close is genuinely unreadable,
+ * and a credit booked as an expense is worse than no candidate at all.
+ */
+function decideDirection(masked: string, amountIndex: number): TransactionDirection | null {
+  const debit = nearest(DEBIT_WORDS, masked, amountIndex);
+  const credit = nearest(CREDIT_WORDS, masked, amountIndex);
+  if (debit === null && credit === null) return null;
+  if (credit === null) return TransactionDirection.Debit;
+  if (debit === null) return TransactionDirection.Credit;
+  if (debit === credit) return null;
+  return debit < credit ? TransactionDirection.Debit : TransactionDirection.Credit;
+}
+
+/* ------------------------------------------------------------------ *
+ * The parse
+ * ------------------------------------------------------------------ */
+
 /**
  * Read one message. Returns null when it is not a transaction at all — which
  * is most of them.
+ *
+ * `context` is optional everywhere. Given the user's region or locale the
+ * parser stops guessing at date order, decimal separators and shared currency
+ * symbols; given nothing it still answers, and says what it guessed.
  */
-export function parseSms(text: string): ParsedSms | null {
-  const body = text.replace(/\s+/g, ' ').trim();
-  if (!body) return null;
+export function parseSms(text: string, context: SmsParseContext = {}): ParsedSms | null {
+  if (!text) return null;
+  // NFKC, bidi marks out, native numerals to ASCII — so an Arabic or Hindi
+  // message reaches the same code path as an English one, and an RTL isolate
+  // around the amount does not hide a number that is plainly there.
+  // A concatenated SMS tops out around 1,600 characters. The cap is not about
+  // correctness, it is about a parser that runs over a whole inbox: the number
+  // patterns backtrack, and nothing should be able to hand this function a
+  // megabyte of digits and have it think about it.
+  const raw = normaliseForParsing(text.slice(0, 2000)).replace(/\s+/g, ' ').trim();
+  if (!raw) return null;
+
+  // Accents folded away, same length, so every index below is valid in both.
+  const folded = foldLatin(raw);
 
   // Checked before anything else: an OTP quotes a real amount from a real bank
   // and is the false positive most likely to be confirmed by accident.
-  if (NOT_A_TRANSACTION.test(body)) return null;
-  if (BALANCE_ONLY.test(body) && !DEBIT_WORDS.test(body) && !CREDIT_WORDS.test(body)) return null;
+  if (NOT_A_TRANSACTION.test(folded)) return null;
+  DEBIT_WORDS.lastIndex = 0;
+  CREDIT_WORDS.lastIndex = 0;
+  const saysMoneyMoved = DEBIT_WORDS.test(folded) || CREDIT_WORDS.test(folded);
+  if (BALANCE_ONLY.test(folded) && !saysMoneyMoved) return null;
 
-  const amountMatch = AMOUNT.exec(body);
-  if (!amountMatch?.[2]) return null;
+  const masked = maskCards(folded);
+  const amountMatch = findAmount(raw, masked);
+  if (!amountMatch) return null;
 
-  // Prefer the marker next to the amount; a body-wide scan can pick a different
-  // currency word than the one actually beside the number.
-  const currency = detectCurrency(amountMatch[1] ?? body);
-  const minor = toMinor(amountMatch[2], currency);
-  if (minor <= 0n) return null;
+  const { currency, inferred: currencyInferred } = resolveCurrency(amountMatch.marker, context);
+  if (!isCurrencyCode(currency)) return null;
+  const number = readNumber(amountMatch.token, currency, context);
+  if (!number || number.minor <= 0n) return null;
 
-  const debit = DEBIT_WORDS.test(body);
-  const credit = CREDIT_WORDS.test(body);
-  // Neither, or both, means we cannot tell which way the money went — and a
-  // credit booked as an expense is worse than no candidate at all.
-  if (debit === credit) return null;
+  const direction = decideDirection(masked, amountMatch.index);
+  if (!direction) return null;
 
-  const merchantMatch = MERCHANT.exec(body);
-  // "at SWIGGY. UPI Ref: …" — a merchant name can contain a dot (AMAZON.IN)
-  // but a dot followed by a space ends the sentence, and everything after it
-  // is the bank talking, not the shop's name.
-  const merchant =
-    merchantMatch?.[1]
-      ?.split(/\.\s/)[0]
-      ?.replace(/[.,;:]+$/, '')
-      .trim() || null;
-  const reference = REFERENCE.exec(body)?.[1] ?? null;
-  const accountTail = ACCOUNT_TAIL.exec(body)?.[1] ?? null;
-  const occurredAt = detectDate(body);
+  const merchant = detectMerchant(raw, masked, direction);
+  const reference = REFERENCE.exec(raw)?.[1] ?? null;
+  const accountTail = ACCOUNT_TAIL.exec(raw)?.[1] ?? null;
+  const date = detectDate(raw, context);
 
-  // Confidence is about how much of the message we actually understood, not
-  // about how plausible the number looks.
+  const inferred: InferredField[] = [];
+  if (currencyInferred) inferred.push('currency');
+  if (number.separatorInferred) inferred.push('decimalSeparator');
+  if (date?.orderInferred) inferred.push('dateOrder');
+
+  // Confidence is about how much of the message we understood *and how much of
+  // that we are entitled to believe*. The old score counted fields found, so a
+  // merchant reading `VPA` scored 1.0 and was pre-selected; a field that failed
+  // its plausibility test now counts for nothing, and every inference above
+  // costs what it is worth.
   let confidence = 0.55;
   if (merchant) confidence += 0.2;
   if (reference) confidence += 0.15;
-  if (occurredAt) confidence += 0.1;
+  if (date) confidence += 0.1;
   if (accountTail) confidence += 0.05;
+  if (looksLikeBankSender(context.sender)) confidence += 0.05;
+  if (currencyInferred) confidence -= 0.1;
+  if (number.separatorInferred) confidence -= 0.15;
+  if (date?.orderInferred) confidence -= 0.1;
 
   return {
-    amount: money(minor, currency),
-    direction: debit ? TransactionDirection.Debit : TransactionDirection.Credit,
+    amount: money(number.minor, currency),
+    direction,
     merchant,
     accountTail,
     reference,
-    occurredAt,
-    confidence: Math.min(1, Number(confidence.toFixed(2))),
+    occurredAt: date?.iso ?? null,
+    inferred,
+    confidence: Math.max(0, Math.min(1, Number(confidence.toFixed(2)))),
   };
 }
 
@@ -246,7 +737,9 @@ export interface SmsMessage {
   readonly body: string;
   /** When it arrived, ISO-8601. Used when the message carries no date itself. */
   readonly receivedAt: string;
-  /** Sender id, e.g. "AD-HDFCBK". Kept only so a person can recognise it. */
+  /** Sender id, e.g. "AD-HDFCBK". Kept so a person can recognise it — and, when
+   * it looks like a bank, as a small nudge to confidence. Never a filter: a
+   * bank the allowlist has not heard of is still a bank. */
   readonly sender?: string;
 }
 
@@ -282,6 +775,12 @@ export interface ProposeOptions {
    * dropped — re-scanning the inbox must not re-propose what was confirmed.
    */
   readonly alreadyImported?: ReadonlySet<string>;
+  /**
+   * What the caller knows that the messages do not: region, locale, the
+   * currency the group counts in. Every message is parsed with it, and each
+   * message's own sender is merged in on top.
+   */
+  readonly context?: SmsParseContext;
 }
 
 /** A window bound as a number, or ±Infinity when there is no usable bound. */
@@ -305,7 +804,7 @@ export function proposeFromSms(
   const candidates: ExpenseCandidate[] = [];
 
   for (const message of messages) {
-    const parsed = parseSms(message.body);
+    const parsed = parseSms(message.body, { ...options.context, sender: message.sender });
     if (!parsed) continue;
     // Money coming in is not an expense. Refunds are real and worth showing one
     // day, but as a reversal of a known expense — not as a negative one.

--- a/packages/core/src/sms/vocabulary.ts
+++ b/packages/core/src/sms/vocabulary.ts
@@ -1,0 +1,745 @@
+/**
+ * What a bank alert says, in the languages banks say it in.
+ *
+ * Split out of `parse.ts` because it is data, not logic: long ordered word
+ * lists that grow every time somebody tries the feature in a new country, and
+ * that nobody should have to read past to understand how the parser works.
+ *
+ * Three rules govern everything here.
+ *
+ * **Terms are written unaccented.** `parse.ts` folds the message to unaccented
+ * Latin *without changing its length*, so every index still points where it
+ * did, and every term below is written the way that fold leaves it: `débité`
+ * becomes `debite`, `ağustos` becomes `agustos`, `số dư` becomes `so du`.
+ * Writing the accented form here would produce a list that looks like French
+ * support and matches nothing.
+ *
+ * **Latin and non-Latin are kept apart.** JavaScript's `\b` is defined against
+ * `[A-Za-z0-9_]`, so there is no word boundary between a space and an Arabic,
+ * Thai or Devanagari letter — `/\bمرفوض\b/` matches nothing, ever, and would
+ * sit in the file looking like Arabic support while providing none. Latin terms
+ * get `\b`; everything else is matched as a plain substring, which is correct
+ * for scripts that do not separate words the way Latin does.
+ *
+ * **A word only earns its place if a false accept is unlikely.** This parser's
+ * worst outcome is proposing an expense nobody made, so a verb that is also an
+ * ordinary word in another language the parser might see is left out rather
+ * than guessed at.
+ */
+
+/** Latin terms joined into one alternation, word-bounded. */
+const latin = (terms: readonly string[]): string => `\\b(?:${terms.join('|')})\\b`;
+
+/** Non-Latin terms joined into one alternation, unbounded — see the note above. */
+const script = (terms: readonly string[]): string => `(?:${terms.join('|')})`;
+
+const either = (latinTerms: readonly string[], scriptTerms: readonly string[]): string =>
+  `(?:${latin(latinTerms)}|${script(scriptTerms)})`;
+
+/* ------------------------------------------------------------------ *
+ * Direction
+ * ------------------------------------------------------------------ */
+
+/**
+ * Money left the account.
+ *
+ * `transaction of` and `used for a transaction of` are here because that is how
+ * every card issuer writes a purchase; bare `transaction` is not, because
+ * "transaction declined" and "your transaction reference" are both common and
+ * neither is a debit.
+ */
+const DEBIT_LATIN = [
+  // English
+  'used for a transaction of',
+  'transaction of',
+  'txn of',
+  'debited',
+  'debit',
+  'spent',
+  'paid',
+  'purchased',
+  'purchase',
+  'withdrawn',
+  'withdrawal',
+  'sent',
+  'deducted',
+  'charged',
+  // Spanish
+  'cargo',
+  'cargado',
+  'cargada',
+  'compra',
+  'retiro',
+  'debitado',
+  'debitada',
+  'pagado',
+  'gastado',
+  // Portuguese
+  'saque',
+  'pago',
+  'cobrado',
+  // French
+  'debite',
+  'debitee',
+  'retrait',
+  'preleve',
+  'prelevement',
+  'achat',
+  'paye',
+  // German
+  'belastet',
+  'abbuchung',
+  'abgebucht',
+  'lastschrift',
+  'bezahlt',
+  'abgehoben',
+  // Italian / Dutch
+  'addebitato',
+  'addebito',
+  'afgeschreven',
+  'betaald',
+  'opname',
+  // Indonesian / Malay
+  'didebet',
+  'didebit',
+  'didebitkan',
+  'dipotong',
+  'belanja',
+  'pembelian',
+  // Turkish
+  'harcama',
+  'cekildi',
+  'odendi',
+  // Danish, Swedish, Norwegian — the markets the `kr` marker belongs to
+  'kortkop',
+  'kortkjop',
+  'debiteret',
+  'debiterats',
+  'dragits',
+  'trukket',
+  'uttag',
+  'hevet',
+  'betalt',
+  // Vietnamese, as the fold leaves it
+  'ghi no',
+  'thanh toan',
+  'tru tien',
+  // Russian, transliterated
+  'spisano',
+  'oplata',
+] as const;
+
+const DEBIT_SCRIPT = [
+  // Hindi
+  'डेबिट',
+  'निकाले',
+  'भुगतान',
+  'खर्च',
+  // Tamil
+  'பற்று',
+  'செலவு',
+  'செலுத்த',
+  // Arabic — خصم deducted, سحب withdrawn, شراء purchase, دفع paid
+  'خصم',
+  'مدين',
+  'سحب',
+  'شراء',
+  'دفع',
+  // Thai
+  'ถูกหัก',
+  'หักเงิน',
+  'ชำระเงิน',
+  'ใช้จ่าย',
+  // Russian
+  'списано',
+  'оплата',
+  'покупка',
+] as const;
+
+/** Money arrived. Deliberately includes `refunded`, which the old list missed. */
+const CREDIT_LATIN = [
+  // English
+  'credited',
+  'credit',
+  'received',
+  'refunded',
+  'refund',
+  'reversed',
+  'reversal',
+  'cashback',
+  'deposited',
+  // Spanish / Portuguese
+  'abonado',
+  'abono',
+  'acreditado',
+  'creditado',
+  'reembolsado',
+  'reembolso',
+  'deposito',
+  'recibido',
+  'devolucion',
+  'estorno',
+  // French
+  'credite',
+  'creditee',
+  'rembourse',
+  'remboursement',
+  // German / Dutch / Italian
+  'gutgeschrieben',
+  'gutschrift',
+  'erstattet',
+  'erstattung',
+  'bijgeschreven',
+  'ontvangen',
+  'accreditato',
+  'accredito',
+  'rimborso',
+  // Indonesian / Malay / Turkish
+  'dikreditkan',
+  'dikredit',
+  'diterima',
+  'iade',
+  'yatirildi',
+  // Danish, Swedish, Norwegian
+  'insatt',
+  'indsat',
+  'innsatt',
+  'tilbakebetalt',
+  'aterbetalning',
+  // Vietnamese / Russian, as the fold leaves them
+  'ghi co',
+  'hoan tien',
+  'zachislenie',
+] as const;
+
+const CREDIT_SCRIPT = [
+  'क्रेडिट',
+  'जमा',
+  'वापसी',
+  'வரவு',
+  'திரும்ப',
+  'إيداع',
+  'دائن',
+  'استرداد',
+  'أضيف',
+  'เข้าบัญชี',
+  'คืนเงิน',
+  'зачислено',
+  'возврат',
+] as const;
+
+/** The alternations on their own, so larger patterns can embed them. */
+export const DEBIT_SOURCE = either(DEBIT_LATIN, DEBIT_SCRIPT);
+export const CREDIT_SOURCE = either(CREDIT_LATIN, CREDIT_SCRIPT);
+
+export const DEBIT_WORDS = new RegExp(DEBIT_SOURCE, 'giu');
+export const CREDIT_WORDS = new RegExp(CREDIT_SOURCE, 'giu');
+
+/**
+ * "Credit Card" is not a credit, and reading it as one is the single failure in
+ * this parser that writes a wrong ledger entry rather than losing a right one.
+ * These phrases are blanked — replaced by spaces of the same length, so every
+ * other index into the message still points where it did — before direction is
+ * decided. `debit card` goes with it for the mirror-image reason.
+ */
+export const CARD_PHRASES = new RegExp(
+  [
+    '\\b(?:credit|debit)\\s*/?\\s*(?:credit|debit)?\\s*cards?\\b',
+    '\\btarjeta\\s+de\\s+(?:credito|debito)\\b',
+    '\\bcartao\\s+de\\s+(?:credito|debito)\\b',
+    '\\bcarte\\s+de\\s+(?:credit|debit)\\b',
+    '\\b(?:kredit|debit)\\s*-?\\s*karte\\b',
+    '\\bkartu\\s+(?:kredit|debit)\\b',
+    '\\bkredi\\s+kart\\w*\\b',
+    '\\bcarta\\s+di\\s+credito\\b',
+    '\\bthe\\s+(?:tin\\s+dung|ghi\\s+no)\\b',
+    'بطاقة\\s+(?:الائتمان|ائتمانية|الخصم)',
+    'क्रेडिट\\s*कार्ड',
+    'डेबिट\\s*कार्ड',
+    'கிரெடிட்\\s*கார்டு',
+    'டெபிட்\\s*கார்டு',
+    'บัตรเครดิต',
+    'บัตรเดบิต',
+  ].join('|'),
+  'giu',
+);
+
+/* ------------------------------------------------------------------ *
+ * Refusals
+ * ------------------------------------------------------------------ */
+
+/**
+ * Messages shaped like a transaction that are not one.
+ *
+ * A one-time password is the dangerous member of this set: right sender, right
+ * amount, right merchant, and a person tapping through confirms a purchase they
+ * were in the middle of *not* making. Every language added to the debit list
+ * above has to be added here too, or internationalising the parser means
+ * internationalising its worst false positive.
+ */
+export const NOT_A_TRANSACTION = new RegExp(
+  [
+    latin([
+      // English
+      'OTP',
+      'one[- ]time\\s*password',
+      'one[- ]time\\s*code',
+      'verification\\s+code',
+      'security\\s+code',
+      'will\\s+be\\s+debited',
+      'will\\s+be\\s+charged',
+      'will\\s+be\\s+deducted',
+      '(?:has|have)\\s+requested',
+      'request(?:ed)?\\s+(?:for|to)',
+      'is\\s+due',
+      'due\\s+on',
+      'due\\s+by',
+      'payment\\s+due',
+      'minimum\\s+due',
+      'reminder',
+      'failed',
+      'declined',
+      'unsuccessful',
+      'statement',
+      'e-?mandate',
+      'auto[- ]?pay\\s+scheduled',
+      'scheduled\\s+for',
+      // Spanish
+      'codigo\\s+(?:de\\s+)?(?:verificacion|seguridad)',
+      'clave\\s+temporal',
+      'rechazad[ao]',
+      'fallid[ao]',
+      'sera\\s+(?:cargado|debitado)',
+      'se\\s+debitara',
+      'vence\\s+el',
+      'fecha\\s+de\\s+vencimiento',
+      // Portuguese
+      'codigo\\s+de\\s+verificacao',
+      'recusad[ao]',
+      'negad[ao]',
+      'sera\\s+(?:debitado|cobrado)',
+      'vencimento',
+      // French
+      'code\\s+de\\s+(?:verification|securite)',
+      'refusees?',
+      'refusee',
+      'echec',
+      'sera\\s+(?:debite|preleve)',
+      'echeance',
+      // German
+      'einmalkennwort',
+      'einmalpasswort',
+      'bestatigungscode',
+      'abgelehnt',
+      'fehlgeschlagen',
+      // German puts the amount between the auxiliary and the participle —
+      // "wird mit EUR 49,90 belastet" — so the two cannot be required to be
+      // adjacent the way English's "will be debited" can.
+      'wird\\s+[^.]{0,48}?\\s*(?:belastet|abgebucht)',
+      'fallig\\s+am',
+      // Indonesian / Malay
+      'kode\\s+otp',
+      'kod\\s+otp',
+      'kode\\s+verifikasi',
+      'ditolak',
+      'gagal',
+      'jatuh\\s+tempo',
+      'akan\\s+didebet',
+      // Turkish
+      'dogrulama\\s+kodu',
+      'tek\\s+kullanimlik',
+      'reddedildi',
+      'basarisiz',
+      'son\\s+odeme',
+      // Vietnamese / Russian, as the fold leaves them
+      'ma\\s+otp',
+      'ma\\s+xac\\s+thuc',
+      'that\\s+bai',
+      'tu\\s+choi',
+      'den\\s+han',
+      'kod\\s+podtverzhdeniya',
+    ]),
+    script([
+      // Hindi
+      'ओटीपी',
+      'सत्यापन\\s*कोड',
+      'अस्वीकृत',
+      'विफल',
+      'देय\\s*तिथि',
+      'किया\\s*जाएगा',
+      // Tamil
+      'ஒருமுறை\\s*கடவுச்சொல்',
+      'நிராகரிக்கப்பட்டது',
+      'தோல்வி',
+      // Arabic
+      'رمز\\s*التحقق',
+      'كلمة\\s*المرور\\s*لمرة',
+      'مرفوض',
+      'فشل',
+      'مستحق',
+      'سيتم\\s*خصم',
+      'تاريخ\\s*الاستحقاق',
+      // Thai
+      'รหัสยืนยัน',
+      'ปฏิเสธ',
+      'ไม่สำเร็จ',
+      'ครบกำหนด',
+      // Russian
+      'код\\s*подтверждения',
+      'отклонен',
+      'отказано',
+    ]),
+  ].join('|'),
+  'iu',
+);
+
+/**
+ * Balance words. A running balance is a trailer on real debit alerts, so these
+ * only disqualify a message that says nothing about money moving — and they
+ * separately mark an amount as "this number is a balance, not a transaction",
+ * which is how the parser stops picking the wrong one of two amounts.
+ */
+export const BALANCE_WORDS = new RegExp(
+  [
+    latin([
+      'avl\\s*bal\\w*',
+      'avbl\\s*bal\\w*',
+      'avail(?:able)?\\s*bal(?:ance)?',
+      'balance',
+      'bal',
+      'saldo',
+      'solde',
+      'kontostand',
+      'guthaben',
+      'bakiye',
+      'baki',
+      'so\\s*du',
+      'ostatok',
+      'limit',
+    ]),
+    script(['الرصيد', 'शेष', 'बैलेंस', 'இருப்பு', 'ยอดคงเหลือ', 'остаток', 'баланс']),
+  ].join('|'),
+  'giu',
+);
+
+/** The subset that, alone, makes a message a balance report rather than a debit. */
+export const BALANCE_ONLY = new RegExp(
+  [
+    latin([
+      'balance\\s+is',
+      'avl\\s*bal\\w*',
+      'avbl\\s*bal\\w*',
+      'available\\s+balance\\s+is',
+      'saldo\\s+(?:es|e|disponivel|disponible|adalah)',
+      'solde\\s+disponible',
+      'ihr\\s+kontostand',
+      'so\\s*du\\s*kha\\s*dung',
+    ]),
+    script(['الرصيد\\s*المتاح', 'शेष\\s*राशि', 'ยอดคงเหลือ']),
+  ].join('|'),
+  'iu',
+);
+
+/* ------------------------------------------------------------------ *
+ * Fields
+ * ------------------------------------------------------------------ */
+
+/**
+ * The masked tail of an account or card.
+ *
+ * Written out rather than built with `latin()` for two reasons, both of which
+ * were bugs the first time round: `xx+` must not carry a *trailing* word
+ * boundary, because `xx1234` has none between the x and the 1; and the Arabic,
+ * Thai and Devanagari words must not carry a *leading* one, because `البطاقة`
+ * begins with letters `\b` does not recognise, so the pattern would have
+ * matched nothing in exactly the scripts it was added for.
+ */
+export const ACCOUNT_TAIL = new RegExp(
+  '(?:' +
+    '\\b(?:a\\/c|acct?|account|akaun|card|kart\\w*|conta|cuenta|compte|konto|rekening|hesab\\w*|xx+)' +
+    '|\\*+' +
+    '|บัญชี|حساب|بطاقة|खाता|கணக்கு' +
+    ')\\s*(?:no\\.?\\s*|nr\\.?\\s*|num\\.?\\s*)?[xX*·.]*(\\d{3,6})\\b',
+  'iu',
+);
+
+export const REFERENCE = new RegExp(
+  '(?:' +
+    latin([
+      'ref\\s*no',
+      'refno',
+      'ref(?:erence)?',
+      'txn(?:\\s*id)?',
+      'transaction(?:\\s*id)?',
+      'trn',
+      'rrn',
+      'utr',
+      'auth(?:\\s*code)?',
+      'referencia',
+      'referenz',
+      'belegnr',
+      'referensi',
+      'ma\\s*giao\\s*dich',
+    ]) +
+    '|' +
+    script(['مرجع', 'رقم\\s*العملية', 'संदर्भ', 'குறிப்பு', 'หมายเลขอ้างอิง']) +
+    ')\\s*(?:no\\.?|nr\\.?|id)?[:\\s]\\s*([A-Za-z0-9]{6,})',
+  'iu',
+);
+
+/**
+ * The words that introduce whoever was paid.
+ *
+ * Short function words from other languages are a real hazard here — Spanish
+ * `a`, French `à` and Portuguese `no` are all common English fragments too, and
+ * each one would mint a merchant out of the middle of an English sentence. They
+ * are left out on purpose; what survives is the set that is either unambiguous
+ * or long enough not to collide.
+ */
+export const MERCHANT_PREPOSITIONS = [
+  latin([
+    'to',
+    'at',
+    'towards?',
+    'in\\s+fav(?:ou)?r\\s+of',
+    'en', // es
+    'em',
+    'para', // pt
+    'chez', // fr
+    'bei', // de
+    'presso', // it
+    'bij', // nl
+    'di',
+    'ke',
+    'kepada',
+    'pada', // id / ms
+    'tai', // vi
+    'hos', // da / sv / nb
+  ]),
+  script(['ที่', 'لدى', 'إلى', 'في', 'को', 'இல்']),
+].join('|');
+
+/**
+ * Tokens that are the bank talking, not the shop's name. A captured phrase is
+ * cut at the first of these, which is what turns "SWIGGY Refno 526012345678"
+ * into "SWIGGY".
+ */
+export const MERCHANT_NOISE: ReadonlySet<string> = new Set([
+  // Every preposition is its own terminator: "TOKOPEDIA pada 12/09/2026" is a
+  // shop followed by a date, not a four-word shop.
+  'on',
+  'at',
+  'to',
+  'by',
+  'from',
+  'in',
+  'en',
+  'em',
+  'para',
+  'chez',
+  'bei',
+  'presso',
+  'bij',
+  'di',
+  'ke',
+  'kepada',
+  'pada',
+  'tai',
+  'hos',
+  'khoan',
+  'ngay',
+  'towards',
+  'toward',
+  'is',
+  'was',
+  'has',
+  // "with a card ending…" in the languages that say it after the shop's name.
+  'con',
+  'com',
+  'mit',
+  'met',
+  'avec',
+  'tarjeta',
+  'cartao',
+  'carte',
+  'karte',
+  'kart',
+  'kartu',
+  'no',
+  'na',
+  'بتاريخ',
+  'ref',
+  'refno',
+  'reference',
+  'referencia',
+  'referenz',
+  'upi',
+  'imps',
+  'neft',
+  'rtgs',
+  'txn',
+  'trn',
+  'rrn',
+  'utr',
+  'id',
+  'info',
+  'avl',
+  'avbl',
+  'bal',
+  'balance',
+  'saldo',
+  'solde',
+  'not',
+  'call',
+  'dt',
+  'date',
+  'using',
+  'via',
+  'card',
+  'a/c',
+  'ac',
+  'acct',
+  'account',
+  'conta',
+  'cuenta',
+  'compte',
+  'konto',
+  'rekening',
+  'am',
+  'um',
+  'auf',
+  'op',
+]);
+
+/** Tokens skipped when they *start* a capture: "to your HDFC Card" is not "your". */
+export const MERCHANT_DETERMINERS: ReadonlySet<string> = new Set([
+  'your',
+  'the',
+  'my',
+  'a',
+  'an',
+  'su',
+  'sua',
+  'seu',
+  'votre',
+  'ihr',
+  'ihre',
+  'uw',
+  'anda',
+  'vpa',
+  'upi',
+]);
+
+/**
+ * A capture that is one of these is not a merchant, whatever the grammar says.
+ * `VPA` and `A` are the two the old parser actually produced, and a row reading
+ * "A" is worse than a row reading nothing: it looks parsed.
+ */
+export const MERCHANT_STOP_WORDS: ReadonlySet<string> = new Set([
+  'vpa',
+  'upi',
+  'a',
+  'ac',
+  'a/c',
+  'acct',
+  'account',
+  'card',
+  'ref',
+  'refno',
+  'reference',
+  'txn',
+  'trn',
+  'transaction',
+  'transaksi',
+  'payment',
+  'purchase',
+  'merchant',
+  'bank',
+  'pos',
+  'atm',
+  'na',
+  'n/a',
+  'nil',
+  'null',
+  'cuenta',
+  'conta',
+  'compte',
+  'konto',
+  'rekening',
+  'saldo',
+  'solde',
+  'balance',
+  'bal',
+]);
+
+/* ------------------------------------------------------------------ *
+ * Months
+ * ------------------------------------------------------------------ */
+
+/**
+ * Month names, folded to unaccented lowercase, across the languages the app
+ * ships in and the ones its markets bank in. Looked up longest key first, which
+ * is how French `juin` (6) and `juillet` (7) stay apart when both start `jui`.
+ */
+export const MONTHS: Readonly<Record<string, number>> = Object.freeze({
+  // English
+  jan: 1,
+  feb: 2,
+  mar: 3,
+  apr: 4,
+  may: 5,
+  jun: 6,
+  jul: 7,
+  aug: 8,
+  sep: 9,
+  oct: 10,
+  nov: 11,
+  dec: 12,
+  // Spanish
+  ene: 1,
+  abr: 4,
+  ago: 8,
+  dic: 12,
+  // Portuguese
+  fev: 2,
+  mai: 5,
+  set: 9,
+  out: 10,
+  dez: 12,
+  // French — four-letter keys so juin and juillet do not collide
+  janv: 1,
+  fevr: 2,
+  mars: 3,
+  avr: 4,
+  juin: 6,
+  juil: 7,
+  aout: 8,
+  sept: 9,
+  // German
+  mrz: 3,
+  okt: 10,
+  // Italian
+  gen: 1,
+  mag: 5,
+  giu: 6,
+  lug: 7,
+  ott: 10,
+  // Dutch
+  mrt: 3,
+  maa: 3,
+  mei: 5,
+  // Indonesian / Malay
+  agu: 8,
+  ags: 8,
+  des: 12,
+  // Turkish
+  oca: 1,
+  sub: 2,
+  nis: 4,
+  haz: 6,
+  tem: 7,
+  eyl: 9,
+  eki: 10,
+  kas: 11,
+  ara: 12,
+});

--- a/packages/core/src/text/digits.ts
+++ b/packages/core/src/text/digits.ts
@@ -1,0 +1,98 @@
+/**
+ * Turning text somebody actually typed — or a bank actually sent — into
+ * something a digit-based parser can read.
+ *
+ * This lives in core rather than beside any one reader because the voice
+ * parser, the receipt reader and the SMS importer all hit the same problems,
+ * and three copies of a numeral table is three places for a locale to go
+ * missing. There is no locale data here beyond Unicode's own: nothing below
+ * decides what a number *means*, only which codepoints are digits.
+ */
+
+/**
+ * The digit blocks this app's locales and their neighbours actually type or
+ * speak: Devanagari (hi), Tamil (ta), Arabic-Indic and Eastern Arabic
+ * (ar, fa, ur), the other Indic scripts, Thai and Burmese.
+ *
+ * Each block is ten consecutive codepoints starting at the zero, which is a
+ * property of the Unicode standard rather than a coincidence, so a single
+ * subtraction converts any of them.
+ */
+const NATIVE_DIGIT_BLOCKS: readonly number[] = [
+  0x0660, // Arabic-Indic
+  0x06f0, // Extended Arabic-Indic (Persian, Urdu)
+  0x0966, // Devanagari
+  0x09e6, // Bengali
+  0x0be6, // Tamil
+  0x0c66, // Telugu
+  0x0ce6, // Kannada
+  0x0d66, // Malayalam
+  0x0e50, // Thai
+  0x1040, // Burmese
+];
+
+const NATIVE_DIGITS =
+  /[\u0660-\u0669\u06f0-\u06f9\u0966-\u096f\u09e6-\u09ef\u0be6-\u0bef\u0c66-\u0c6f\u0ce6-\u0cef\u0d66-\u0d6f\u0e50-\u0e59\u1040-\u1049]/g;
+
+/** Native numerals to ASCII, so Hindi, Tamil and Arabic amounts all read as numbers. */
+export function normaliseDigits(text: string): string {
+  return text.replace(NATIVE_DIGITS, (character) => {
+    const code = character.codePointAt(0) ?? 0;
+    for (const base of NATIVE_DIGIT_BLOCKS) {
+      if (code >= base && code <= base + 9) return String(code - base);
+    }
+    return character;
+  });
+}
+
+/**
+ * Bidirectional formatting controls, which carry no meaning for a parser but
+ * sit *inside* words and numbers in Arabic, Hebrew and Urdu text.
+ *
+ * An Arabic bank alert routinely wraps its amount in an isolate so the digits
+ * render left-to-right inside a right-to-left sentence. Those marks are
+ * invisible, and a regex that does not expect them simply fails to match a
+ * number that is plainly there — the failure looks like "the parser does not
+ * speak Arabic" when it is really "the parser does not speak Unicode".
+ */
+const BIDI_CONTROLS = /[\u200e\u200f\u061c\u202a-\u202e\u2066-\u2069]/g;
+
+export function stripBidiControls(text: string): string {
+  return text.replace(BIDI_CONTROLS, '');
+}
+
+/**
+ * Arabic's own separators to the ASCII ones. U+066B is the decimal separator
+ * and U+066C the thousands separator — the mirror image of the Latin habit, and
+ * reading them the wrong way round is a factor-of-a-thousand mistake rather
+ * than a cosmetic one.
+ */
+export function normaliseArabicSeparators(text: string): string {
+  return text.replace(/\u066b/g, '.').replace(/\u066c/g, ',');
+}
+
+/**
+ * Everything above, in the order it has to happen: compatibility folding first
+ * (so presentation forms and fullwidth digits become their ordinary shapes),
+ * then the invisible marks, then the numerals, then the separators.
+ *
+ * NFKC is deliberate. It is the normalisation that treats a presentation form
+ * and its plain equivalent as the same character, which is exactly what a
+ * parser reading somebody else's message wants; NFC would leave a fullwidth
+ * digit unreadable.
+ */
+export function normaliseForParsing(text: string): string {
+  return normaliseArabicSeparators(normaliseDigits(stripBidiControls(text.normalize('NFKC'))));
+}
+
+/**
+ * A word reduced to the letters and digits that identify it, with diacritics
+ * removed — "août" and "aout", "ağu" and "agu", read the same. Used for looking
+ * a token up in a table, never for display.
+ */
+export function foldToken(token: string): string {
+  return token
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+}

--- a/packages/core/src/text/index.ts
+++ b/packages/core/src/text/index.ts
@@ -1,0 +1,1 @@
+export * from './digits';

--- a/packages/core/test/sms.test.ts
+++ b/packages/core/test/sms.test.ts
@@ -249,6 +249,43 @@ describe('what a person is asked to look at', () => {
   });
 });
 
+describe('a drafts list has no trip to bound by', () => {
+  const old = sms('Rs.400 debited at CAFE on 05-01-24', '2024-01-05T09:00:00.000Z');
+  const recent = sms('Rs.900 debited at SWIGGY on 02-03-26');
+
+  it('proposes everything when no window is given at all', () => {
+    // The paste flow has no trip: the person already chose which messages to
+    // hand over, and a window would drop some of them invisibly.
+    const proposed = proposeFromSms([old, recent]);
+    expect(proposed.map((item) => item.amount.minor)).toEqual([40000n, 90000n]);
+  });
+
+  it('takes one bound on its own', () => {
+    expect(proposeFromSms([old, recent], { from: '2026-01-01' })).toHaveLength(1);
+    expect(proposeFromSms([old, recent], { to: '2025-01-01' })).toHaveLength(1);
+  });
+
+  it('treats an unparseable bound as no bound, rather than dropping everything', () => {
+    // A half-typed date in a field must not silently empty the list.
+    expect(proposeFromSms([old, recent], { from: '2026-0', to: '' })).toHaveLength(2);
+  });
+
+  it('still dedupes and still refuses credits with no window', () => {
+    const proposed = proposeFromSms([
+      recent,
+      { ...recent },
+      sms('Rs.2,000 credited to a/c XX4471 from RAVI on 02-03-26'),
+    ]);
+    expect(proposed).toHaveLength(1);
+  });
+
+  it('honours alreadyImported with no window', () => {
+    const first = proposeFromSms([recent]);
+    const key = first[0]!.dedupeKey;
+    expect(proposeFromSms([recent], { alreadyImported: new Set([key]) })).toHaveLength(0);
+  });
+});
+
 describe('no float ever exists between the text and the amount (ADR-003)', () => {
   it('parses amounts that a float would round wrong', () => {
     for (const [text, minor] of [

--- a/packages/core/test/sms.test.ts
+++ b/packages/core/test/sms.test.ts
@@ -11,7 +11,13 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { SMS_LOW_CONFIDENCE, parseSms, proposeFromSms, type SmsMessage } from '../src/index.js';
+import {
+  SMS_LOW_CONFIDENCE,
+  parseSms,
+  proposeFromSms,
+  senderHeader,
+  type SmsMessage,
+} from '../src/index.js';
 
 const sms = (body: string, receivedAt = '2026-03-02T10:00:00.000Z'): SmsMessage => ({
   body,
@@ -297,5 +303,547 @@ describe('no float ever exists between the text and the amount (ADR-003)', () =>
     ] as const) {
       expect(parseSms(text)?.amount.minor).toBe(minor);
     }
+  });
+});
+
+/* ================================================================== *
+ * The five messages the coverage study measured as failures.
+ * ================================================================== */
+
+describe('the formats that used to be dropped', () => {
+  it('reads SBI, which quotes no currency at all', () => {
+    // India's largest bank writes "debited by 150.0" with no Rs, no INR and no
+    // symbol. Requiring a currency token lost every one of its UPI alerts.
+    const parsed = parseSms(
+      'Dear UPI user A/C X1234 debited by 150.0 on date 12Sep26 trf to SWIGGY Refno 526012345678',
+      { region: 'IN' },
+    );
+    expect(parsed?.direction).toBe('debit');
+    expect(parsed?.amount.minor).toBe(15000n);
+    expect(parsed?.amount.currency).toBe('INR');
+    expect(parsed?.merchant).toBe('SWIGGY');
+    expect(parsed?.occurredAt?.slice(0, 10)).toBe('2026-09-12');
+  });
+
+  it('reads ICICI, which names both sides of the transfer', () => {
+    // "debited … ; SWIGGY credited" is one ordinary debit described from both
+    // ends. Bailing whenever both words appear lost the whole format; the verb
+    // nearest the amount is the one that means something.
+    const parsed = parseSms(
+      'ICICI Bank Acct XX123 debited for Rs 500.00 on 12-Sep-26; SWIGGY credited. UPI:526012345678',
+      { region: 'IN' },
+    );
+    expect(parsed?.direction).toBe('debit');
+    expect(parsed?.amount.minor).toBe(50000n);
+    expect(parsed?.merchant).toBe('SWIGGY');
+  });
+
+  it('does not read the word "credit" inside "Credit Card" as money coming in', () => {
+    // The only failure in the set that wrote a wrong ledger entry: a ₹2,500
+    // purchase booked as ₹2,500 received, looking entirely deliberate.
+    const parsed = parseSms(
+      'Your ICICI Bank Credit Card XX1234 has been used for a transaction of INR 2,500.00 on 12-Sep-26 at AMAZON.',
+    );
+    expect(parsed?.direction).toBe('debit');
+    expect(parsed?.amount.minor).toBe(250000n);
+    expect(parsed?.merchant).toBe('AMAZON');
+  });
+
+  it('reads a refund, whichever way the bank conjugates it', () => {
+    for (const text of [
+      'Rs.599.00 refunded to your HDFC Card xx1234 by AMAZON on 12-09-26',
+      'Rs.599.00 refund credited to your HDFC Card xx1234 on 12-09-26',
+    ]) {
+      expect(parseSms(text)?.direction).toBe('credit');
+    }
+  });
+
+  it('reads a currency written after the number', () => {
+    const parsed = parseSms('Your A/c XX1234 is debited with 350.00 INR on 12-09-26 at UBER.');
+    expect(parsed?.amount.minor).toBe(35000n);
+    expect(parsed?.amount.currency).toBe('INR');
+    expect(parsed?.merchant).toBe('UBER');
+  });
+});
+
+describe('who was actually paid', () => {
+  it('reads a capitalised preposition', () => {
+    // HDFC writes "To SWIGGY". A missing `i` flag meant it never matched.
+    expect(
+      parseSms('Sent Rs.245.00 From HDFC Bank A/C x1234 To SWIGGY On 12/09/26')?.merchant,
+    ).toBe('SWIGGY');
+  });
+
+  it('reads a lowercase merchant', () => {
+    expect(parseSms('rs.250 debited from a/c xx1234 at bigbasket on 12-09-26')?.merchant).toBe(
+      'bigbasket',
+    );
+  });
+
+  it('reads the handle out of a UPI address, not the word VPA', () => {
+    const parsed = parseSms('Rs.75.00 debited from A/c XX1234 to VPA swiggy@icici on 12-09-26');
+    expect(parsed?.merchant).toBe('swiggy');
+  });
+
+  it('never returns the "A" of "A/c" as a shop', () => {
+    // A row reading "A" is worse than a row reading nothing: it looks parsed,
+    // and somebody has to notice it is nonsense.
+    const parsed = parseSms('INR 85,000.00 credited to A/c XX1234 on 01-09-26 by NEFT');
+    expect(parsed?.merchant).toBeNull();
+  });
+
+  it('stops the name at the bank’s own words', () => {
+    expect(parseSms('Paid Rs.120 to SWIGGY using Paytm UPI. Txn ID 526012345678')?.merchant).toBe(
+      'SWIGGY',
+    );
+    expect(
+      parseSms('Rp 150.000 didebet dari rekening 1234 di TOKOPEDIA pada 12/09/2026', {
+        region: 'ID',
+      })?.merchant,
+    ).toBe('TOKOPEDIA');
+  });
+
+  it('does not score an implausible merchant, so it cannot be pre-selected on one', () => {
+    // The old score counted fields found, so the VPA bug scored 1.0.
+    const withName = parseSms('Rs.500 debited at CAFE on 02-03-26', { region: 'IN' });
+    const withNonsense = parseSms('Rs.500 debited to A/c XX1234 on 02-03-26', { region: 'IN' });
+    expect(withNonsense?.merchant).toBeNull();
+    expect(withNonsense!.confidence).toBeLessThan(withName!.confidence);
+  });
+});
+
+/* ================================================================== *
+ * Hazard A — the decimal comma. A silent 1000x error.
+ * ================================================================== */
+
+describe('a comma can be the decimal point', () => {
+  it('reads 1.234,56 as one thousand two hundred, not as one twenty-three', () => {
+    // Half of Europe and most of Latin America write it this way. Read as an
+    // English number it is €1.23 — a thousandfold error that looks valid.
+    for (const region of ['DE', 'ES', 'BR', 'ID', 'TR', undefined]) {
+      expect(parseSms('EUR 1.234,56 belastet Konto 3456', { region })?.amount.minor).toBe(123456n);
+    }
+  });
+
+  it('reads 1,234.56 the English way in the same breath', () => {
+    expect(parseSms('EUR 1,234.56 debited at IKEA', { region: 'IE' })?.amount.minor).toBe(123456n);
+  });
+
+  it('reads a lone dot with three digits after it as grouping, not as decimals', () => {
+    // "EUR 1.234" cannot be €1.234: the euro has two minor digits. The
+    // currency's own exponent settles this without needing a locale at all.
+    expect(parseSms('EUR 1.234 belastet Konto 3456', { region: 'DE' })?.amount.minor).toBe(123400n);
+    expect(parseSms('EUR 1.234 belastet Konto 3456')?.amount.minor).toBe(123400n);
+    expect(parseSms('EUR 1.234 belastet Konto 3456')?.inferred).not.toContain('decimalSeparator');
+  });
+
+  it('reads a space or a non-breaking space as grouping', () => {
+    const nbsp = String.fromCharCode(0x00a0);
+    expect(
+      parseSms('Votre compte 1234 a ete debite de 1 234,56 EUR le 12/09/2026', { region: 'FR' })
+        ?.amount.minor,
+    ).toBe(123456n);
+    expect(
+      parseSms(`Votre compte 1234 a ete debite de 1${nbsp}234,56 EUR le 12/09/2026`, {
+        region: 'FR',
+      })?.amount.minor,
+    ).toBe(123456n);
+  });
+
+  it('reads the Swiss apostrophe as grouping', () => {
+    expect(
+      parseSms("CHF 1'234.50 belastet Konto 4471 bei MIGROS", { region: 'CH' })?.amount.minor,
+    ).toBe(123450n);
+  });
+
+  it('reads Arabic’s own separators', () => {
+    // U+066B is the decimal separator and U+066C the thousands separator — the
+    // mirror image of the Latin habit.
+    const decimal = String.fromCharCode(0x066b);
+    expect(
+      parseSms(`AED 250${decimal}50 debited from Card 4471`, { region: 'AE' })?.amount.minor,
+    ).toBe(25050n);
+  });
+
+  it('still reads India’s two-digit grouping', () => {
+    expect(parseSms('Rs 1,23,456.78 debited at HOTEL TAJ')?.amount.minor).toBe(12345678n);
+  });
+});
+
+/* ================================================================== *
+ * Hazard B — the currency's exponent.
+ * ================================================================== */
+
+describe('a currency decides how many decimals it has', () => {
+  it('keeps all three digits of a Kuwaiti dinar', () => {
+    // KWD, BHD, OMR, JOD and TND have three minor digits. Capping the fraction
+    // at two silently turned 12.345 into 12.340.
+    const parsed = parseSms('KWD 12.345 debited from Account XX1234 at LULU', { region: 'KW' });
+    expect(parsed?.amount.minor).toBe(12345n);
+    expect(parsed?.inferred).not.toContain('decimalSeparator');
+  });
+
+  it('says so when three decimals could equally have been grouping', () => {
+    // With no locale, "KWD 12.345" is genuinely either twelve dinars and a bit
+    // or twelve thousand. It is answered, and it says it guessed.
+    const parsed = parseSms('KWD 12.345 debited from Account XX1234 at LULU');
+    expect(parsed?.amount.minor).toBe(12345n);
+    expect(parsed?.inferred).toContain('decimalSeparator');
+    expect(parsed!.confidence).toBeLessThan(
+      parseSms('KWD 12.345 debited from Account XX1234 at LULU', { region: 'KW' })!.confidence,
+    );
+  });
+
+  it('never gives a zero-decimal currency phantom minor units', () => {
+    expect(parseSms('JPY 1,234 spent on card 1234 at LAWSON')?.amount.minor).toBe(1234n);
+    expect(parseSms('JPY 1,234.00 spent on card 1234 at LAWSON')?.amount.minor).toBe(1234n);
+    expect(parseSms('KRW 50,000 spent at OLIVE YOUNG')?.amount.minor).toBe(50000n);
+  });
+});
+
+/* ================================================================== *
+ * Hazard C — day-first or month-first.
+ * ================================================================== */
+
+describe('08/05/2026 is two different days', () => {
+  const body = 'USD 42.50 spent on card ending 1234 at TARGET on 08/05/2026';
+
+  it('is the 5th of August in the United States', () => {
+    expect(parseSms(body, { region: 'US' })?.occurredAt?.slice(0, 10)).toBe('2026-08-05');
+  });
+
+  it('is the 8th of May in India', () => {
+    expect(parseSms(body, { region: 'IN' })?.occurredAt?.slice(0, 10)).toBe('2026-05-08');
+  });
+
+  it('falls back to day-first when nobody said, and says that it did', () => {
+    const parsed = parseSms(body);
+    expect(parsed?.occurredAt?.slice(0, 10)).toBe('2026-05-08');
+    expect(parsed?.inferred).toContain('dateOrder');
+    expect(parsed!.confidence).toBeLessThan(parseSms(body, { region: 'IN' })!.confidence);
+  });
+
+  it('does not guess when a component is over twelve', () => {
+    const parsed = parseSms('Rs.400 debited at CAFE on 28/02/26');
+    expect(parsed?.occurredAt?.slice(0, 10)).toBe('2026-02-28');
+    expect(parsed?.inferred).not.toContain('dateOrder');
+  });
+
+  it('takes an explicit order over the region', () => {
+    expect(parseSms(body, { region: 'IN', dateOrder: 'mdy' })?.occurredAt?.slice(0, 10)).toBe(
+      '2026-08-05',
+    );
+  });
+
+  it('reads an ISO date, which used to match nothing at all', () => {
+    expect(parseSms('EUR 20.00 debited from account 1234 at IKEA on 2026-09-12')?.occurredAt).toBe(
+      '2026-09-12T00:00:00.000Z',
+    );
+    expect(
+      parseSms("You've spent Rs.1500.00 via Debit Card xx1234 at AMAZON on 2026-09-12:14:23:05.")
+        ?.occurredAt,
+    ).toBe('2026-09-12T14:23:05.000Z');
+  });
+
+  it('reads a month name in either order', () => {
+    expect(parseSms('USD 42.50 spent at STARBUCKS on Sep 12, 2026')?.occurredAt?.slice(0, 10)).toBe(
+      '2026-09-12',
+    );
+    expect(parseSms('USD 42.50 spent at STARBUCKS on 12-Sep-2026')?.occurredAt?.slice(0, 10)).toBe(
+      '2026-09-12',
+    );
+    expect(parseSms('Rs 500 debited at CAFE on date 12Sep26')?.occurredAt?.slice(0, 10)).toBe(
+      '2026-09-12',
+    );
+  });
+
+  it('reads a month name in another language', () => {
+    for (const [text, day] of [
+      ['EUR 20,00 belastet Konto 1234 bei IKEA am 12. Okt 2026', '2026-10-12'],
+      ['EUR 20,00 debitado da conta 1234 em 12 de dezembro de 2026', '2026-12-12'],
+      ['EUR 20,00 debite du compte 1234 le 12 juillet 2026', '2026-07-12'],
+      ['EUR 20,00 debite du compte 1234 le 12 juin 2026', '2026-06-12'],
+      ['TRY 20,00 harcama 12 Agustos 2026 kart 1234', '2026-08-12'],
+    ] as const) {
+      expect(parseSms(text, { region: 'DE' })?.occurredAt?.slice(0, 10)).toBe(day);
+    }
+  });
+});
+
+/* ================================================================== *
+ * Hazard D — the language the bank is writing in.
+ * ================================================================== */
+
+describe('banks do not all write in English', () => {
+  it('reads a debit in the languages Waves ships in and the ones it banks in', () => {
+    for (const [text, context] of [
+      ['Ihr Konto DE12 wurde mit EUR 1.234,56 belastet am 12.09.2026 bei REWE.', { region: 'DE' }],
+      ['Compra de EUR 45,90 en MERCADONA con tarjeta 1234 el 12/09/2026', { region: 'ES' }],
+      ['Compra aprovada: R$ 1.234,56 em MERCADO LIVRE em 12/09/2026', { region: 'BR' }],
+      ['Votre compte 1234 a ete debite de 45,00 EUR le 12/09/2026 chez FNAC', { region: 'FR' }],
+      ['Rp 150.000 didebet dari rekening 1234 di TOKOPEDIA pada 12/09/2026', { region: 'ID' }],
+      ['Hesabinizdan 250,75 TL harcama yapildi. Kart 1234, 12.09.2026', { region: 'TR' }],
+      ['Akaun 1234 didebit RM 125.50 di MYDIN pada 12/09/2026', { region: 'MY' }],
+      ['Tai khoan 1234 ghi no 1.250.000 VND tai HIGHLANDS ngay 12/09/2026', { region: 'VN' }],
+      ['Kortkop 1 234,50 kr hos ICA 12/09/2026 kort 1234', { region: 'SE' }],
+    ] as const) {
+      expect(parseSms(text, context), text).not.toBeNull();
+      expect(parseSms(text, context)?.direction, text).toBe('debit');
+    }
+  });
+
+  it('reads Thai, which separates nothing with spaces', () => {
+    const parsed = parseSms('บัญชี 1234 ถูกหัก THB 1,250.00 ที่ 7-ELEVEN 12/09/2026', {
+      region: 'TH',
+    });
+    expect(parsed?.direction).toBe('debit');
+    expect(parsed?.amount.minor).toBe(125000n);
+    expect(parsed?.merchant).toBe('7-ELEVEN');
+  });
+
+  it('refuses the same six kinds of message in those languages too', () => {
+    // A false accept is worse than a false reject, and internationalising the
+    // debit verbs without internationalising these would internationalise the
+    // parser's worst false positive rather than its usefulness.
+    for (const [text, context] of [
+      [
+        'Su codigo de verificacion es 445566 para una compra de EUR 250,00 en ZARA.',
+        { region: 'ES' },
+      ],
+      ['Ihr Konto wird mit EUR 49,90 belastet am 15.09.2026 fuer NETFLIX.', { region: 'DE' }],
+      ['Votre transaction de 45,00 EUR chez FNAC a ete refusee.', { region: 'FR' }],
+      ['Saldo rekening 1234 adalah Rp 1.250.000 pada 12/09/2026.', { region: 'ID' }],
+      ['Kredi karti 1234 son odeme tarihi 18.09.2026, tutar 1.250,00 TL.', { region: 'TR' }],
+      ['Sua compra de R$ 250,00 foi recusada por saldo insuficiente.', { region: 'BR' }],
+    ] as const) {
+      expect(parseSms(text, context), text).toBeNull();
+    }
+  });
+});
+
+describe('right-to-left text', () => {
+  const isolateStart = String.fromCharCode(0x2066);
+  const isolateEnd = String.fromCharCode(0x2069);
+
+  it('reads an Arabic debit', () => {
+    const parsed = parseSms('تم خصم 250.50 د.إ من البطاقة 4471 لدى كارفور 12-09-2026', {
+      region: 'AE',
+    });
+    expect(parsed?.direction).toBe('debit');
+    expect(parsed?.amount.currency).toBe('AED');
+    expect(parsed?.amount.minor).toBe(25050n);
+    expect(parsed?.accountTail).toBe('4471');
+  });
+
+  it('is not defeated by an invisible bidi isolate around the amount', () => {
+    // An Arabic alert wraps its amount so the digits render left-to-right
+    // inside a right-to-left sentence. The marks are invisible; a parser that
+    // does not strip them simply fails to see a number that is plainly there.
+    const wrapped = `تم خصم ${isolateStart}AED 250.50${isolateEnd} من الحساب 4471`;
+    expect(parseSms(wrapped, { region: 'AE' })?.amount.minor).toBe(25050n);
+  });
+
+  it('refuses an Arabic one-time password', () => {
+    expect(parseSms('رمز التحقق 445566 لعملية شراء بقيمة 250.00 د.إ', { region: 'AE' })).toBeNull();
+  });
+});
+
+/* ================================================================== *
+ * Hazard E — numerals that are not 0-9.
+ * ================================================================== */
+
+describe('numerals that are not ASCII', () => {
+  it('reads Devanagari digits', () => {
+    const parsed = parseSms('आपके खाते XX1234 से ५००.०० रुपये डेबिट किए गए 12-09-2026', {
+      region: 'IN',
+    });
+    expect(parsed?.direction).toBe('debit');
+    expect(parsed?.amount.currency).toBe('INR');
+    expect(parsed?.amount.minor).toBe(50000n);
+  });
+
+  it('reads Arabic-Indic digits', () => {
+    const parsed = parseSms('تم خصم ٢٥٠.٥٠ د.إ من البطاقة ٤٤٧١', { region: 'AE' });
+    expect(parsed?.amount.minor).toBe(25050n);
+    expect(parsed?.accountTail).toBe('4471');
+  });
+});
+
+/* ================================================================== *
+ * Hazard F — currency coverage, and the symbols that are shared.
+ * ================================================================== */
+
+describe('a symbol is not a currency', () => {
+  const body = '$42.50 spent on card ending 1234 at STARBUCKS on 12-09-2026';
+
+  it('reads the dollar of the country it was told about', () => {
+    expect(parseSms(body, { region: 'CA' })?.amount.currency).toBe('CAD');
+    expect(parseSms(body, { region: 'AU' })?.amount.currency).toBe('AUD');
+    expect(parseSms(body, { region: 'SG' })?.amount.currency).toBe('SGD');
+    expect(parseSms(body, { region: 'CA' })?.inferred).not.toContain('currency');
+  });
+
+  it('falls back to the dollar most people mean, and says it guessed', () => {
+    const parsed = parseSms(body);
+    expect(parsed?.amount.currency).toBe('USD');
+    expect(parsed?.inferred).toContain('currency');
+  });
+
+  it('reads a qualified symbol without needing a region at all', () => {
+    expect(parseSms('R$ 1.234,56 debitado do cartao 1234')?.amount.currency).toBe('BRL');
+    expect(parseSms('S$ 42.50 spent on card 1234 at NTUC')?.amount.currency).toBe('SGD');
+  });
+
+  it('reads the Nordic krone by country', () => {
+    expect(
+      parseSms('Kortkop 1 234,50 kr hos ICA kort 1234', { region: 'SE' })?.amount.currency,
+    ).toBe('SEK');
+    expect(
+      parseSms('Kortkop 1 234,50 kr hos REMA kort 1234', { region: 'NO' })?.amount.currency,
+    ).toBe('NOK');
+  });
+
+  it('reads both the symbol and the code for the currencies Waves supports', () => {
+    for (const [text, code] of [
+      ['₹ 500 debited at CAFE', 'INR'],
+      ['INR 500 debited at CAFE', 'INR'],
+      ['€ 20,00 belastet bei IKEA', 'EUR'],
+      ['£ 20.00 debited at TESCO', 'GBP'],
+      ['AED 89.00 debited at CARREFOUR', 'AED'],
+      ['MYR 125.50 debited at MYDIN', 'MYR'],
+      ['RM 125.50 didebit di MYDIN', 'MYR'],
+      ['Rp 150.000 didebet di TOKOPEDIA', 'IDR'],
+      ['THB 1,250.00 debited at 7-ELEVEN', 'THB'],
+      ['฿ 1,250.00 debited at 7-ELEVEN', 'THB'],
+      ['VND 1.250.000 debited at HIGHLANDS', 'VND'],
+      ['ZAR 250.00 debited at WOOLWORTHS', 'ZAR'],
+      ['CHF 20.00 belastet bei MIGROS', 'CHF'],
+      ['TRY 250,75 harcama MIGROS', 'TRY'],
+      ['LKR 500 debited at KEELLS', 'LKR'],
+    ] as const) {
+      expect(parseSms(text, { region: undefined })?.amount.currency, text).toBe(code);
+    }
+  });
+
+  it('takes a caller’s default when the message names nothing', () => {
+    const parsed = parseSms('Account XX1234 debited by 150.0 at CAFE on 12-09-2026', {
+      defaultCurrency: 'GBP',
+    });
+    expect(parsed?.amount.currency).toBe('GBP');
+    expect(parsed?.amount.minor).toBe(15000n);
+    expect(parsed?.inferred).not.toContain('currency');
+  });
+
+  it('takes the region’s currency before falling back to rupees', () => {
+    expect(
+      parseSms('Account XX1234 debited by 150.0 at CAFE', { region: 'DE' })?.amount.currency,
+    ).toBe('EUR');
+    const nothing = parseSms('Account XX1234 debited by 150.0 at CAFE');
+    expect(nothing?.amount.currency).toBe('INR');
+    expect(nothing?.inferred).toContain('currency');
+  });
+});
+
+/* ================================================================== *
+ * Hazard G — the sender.
+ * ================================================================== */
+
+describe('the sender is a hint, never a filter', () => {
+  it('strips the operator prefix, which differs by carrier and circle', () => {
+    expect(senderHeader('AD-HDFCBK')).toBe('HDFCBK');
+    expect(senderHeader('VM-HDFCBK')).toBe('HDFCBK');
+    expect(senderHeader('JD-HDFCBK-S')).toBe('HDFCBK');
+    // Nothing here assumes the Indian shape: a bare short code is itself.
+    expect(senderHeader('SANTANDER')).toBe('SANTANDER');
+    expect(senderHeader('')).toBeNull();
+  });
+
+  it('raises confidence when the sender looks like a bank', () => {
+    const body = 'Rs.500 debited at CAFE on 02-03-26';
+    const known = parseSms(body, { region: 'IN', sender: 'AD-HDFCBK' });
+    const unknown = parseSms(body, { region: 'IN', sender: '+919876543210' });
+    expect(known!.confidence).toBeGreaterThan(unknown!.confidence);
+  });
+
+  it('never drops a message because the sender is not recognised', () => {
+    // A bank the list has not heard of is still a bank, and a person who pasted
+    // a message has already decided it is worth reading.
+    for (const sender of ['ZZ-NEVERHEARDOF', '+441234567890', undefined]) {
+      expect(parseSms('EUR 20.00 debited at IKEA on 12-09-2026', { sender })).not.toBeNull();
+    }
+  });
+});
+
+/* ================================================================== *
+ * Two amounts, and which one is the transaction.
+ * ================================================================== */
+
+describe('a message that quotes a balance as well', () => {
+  it('takes the transaction even when the balance comes first', () => {
+    // The old parser took the first number and was right by luck, because
+    // Indian banks quote the transaction first.
+    const parsed = parseSms(
+      'Avl Bal Rs 9,999.00. Rs.450.00 debited from A/c XX1234 at DOMINOS on 12-09-26',
+      { region: 'IN' },
+    );
+    expect(parsed?.amount.minor).toBe(45000n);
+    expect(parsed?.merchant).toBe('DOMINOS');
+  });
+
+  it('still takes the transaction when the balance trails', () => {
+    expect(
+      parseSms('Rs.450.00 debited from A/c XX1234 at DOMINOS on 12-09-26. Avl Bal: Rs.9,999.00')
+        ?.amount.minor,
+    ).toBe(45000n);
+  });
+});
+
+/* ================================================================== *
+ * The rule the whole file is written around.
+ * ================================================================== */
+
+describe('never guess silently', () => {
+  it('reports nothing as inferred when every signal was present', () => {
+    const parsed = parseSms(
+      'INR 1,234.00 debited from A/c no. XX3456 on 2026-09-12 at AMAZON. Ref: 412703998812',
+      { region: 'IN' },
+    );
+    expect(parsed?.inferred).toEqual([]);
+    expect(parsed?.confidence).toBeGreaterThanOrEqual(SMS_LOW_CONFIDENCE);
+  });
+
+  it('names each field it had to decide for itself', () => {
+    const parsed = parseSms('$ 1.234 debited at CAFE on 08/05/26');
+    expect(parsed?.inferred).toContain('currency');
+    expect(parsed?.inferred).toContain('dateOrder');
+  });
+
+  it('lowers confidence far enough that a guessed row is not pre-selected', () => {
+    const proposed = proposeFromSms([
+      { body: 'KWD 12.345 debited on 08/05/26', receivedAt: '2026-05-08T10:00:00.000Z' },
+    ]);
+    expect(proposed[0]?.preselect).toBe(false);
+    expect(proposed[0]?.inferred).toContain('decimalSeparator');
+  });
+
+  it('passes the caller’s context to every message, and the sender on top', () => {
+    const proposed = proposeFromSms(
+      [
+        {
+          body: '$42.50 spent on card ending 1234 at TARGET on 08/05/2026',
+          receivedAt: '2026-08-05T10:00:00.000Z',
+          sender: 'CHASE',
+        },
+      ],
+      { context: { region: 'US' } },
+    );
+    expect(proposed[0]?.amount.currency).toBe('USD');
+    expect(proposed[0]?.at.slice(0, 10)).toBe('2026-08-05');
+    expect(proposed[0]?.inferred).toEqual([]);
+    expect(proposed[0]?.preselect).toBe(true);
+  });
+
+  it('refuses a pathological body rather than thinking about it', () => {
+    expect(parseSms(`Rs ${'1'.repeat(5000)} debited at CAFE`)).not.toBeUndefined();
   });
 });


### PR DESCRIPTION
Phases 0, 1 and 4 of `docs/plan-drafts-and-rules.md`. Nothing from the rules
engine, no multi-select, no "waiting to send", no statement paste, no share
target — those are other PRs.

## What a person sees

**Before.** The Review tab held drafts that arrived one of three ways: typed on
the capture screen, scanned off a bill, or spoken. A bank message was not one of
them, and the ~45 translated `smsImport.*` strings in `i18n/index.ts` were
referenced by nothing.

**After.** The Review tab's header gains one glyph — "Add from a message" — and
its empty state a second, quieter button beside "Save an expense". Both open a
new screen. Everything the screen produces lands in the same list, as the same
rows, with the same ⋯ and the same "Add to". There is no filter, no second tab
and no new row shape: that is phase 2's business, and the point of this one is
that it needed none of it.

## How the paste flow reads

`captures/paste`, one scroll region:

1. A card says what to do and — only on a build that cannot read the inbox —
   why Waves cannot do it for you (`whyNotAutomatic`, kept verbatim).
2. A paste box, with a **Paste** button and a live count of blocks. Messages are
   separated by blank lines, because a single SMS wraps.
3. `proposeFromSms` runs on every keystroke, on the phone. Refunds, OTPs,
   reminders and balance alerts are dropped by the parser, which is what makes
   its refusals safe.
4. **FOUND** / *"Add these to Review?"* — an eyebrow over a question, Copilot
   Money's grammar. Under it, plainly: how many blocks did not look like a
   payment, and how many of the ones found are already waiting in Review. The
   Mercury lesson: a list that quietly shows four rows for six messages reads as
   broken.
5. Date-grouped rows (Cleo): day heading, tick, shop on the left, amount on the
   right. The second line carries only what would make you hesitate — which bank
   said it, which card, and whether the *day* came from the message or only from
   when it arrived. A message half understood is not pre-ticked and wears a
   "Check this" badge saying so.
6. **Add {n} drafts** writes them. Each id is derived from the message, so a
   second paste of the same statement writes nothing — the database decides
   that, not this screen's memory of it.

It is a `FlashList` with the group-ledger settings (`drawDistance` 1500,
`extraData`, clearance), the intro and paste box riding as the header, because a
month of statements is a hundred rows.

## The two gates on the Android reader

**Build-time, and this one is the compliance requirement.**
`plugins/withSmsReader.js` adds `android.permission.READ_SMS` only when
`WAVES_SMS_READER=1` is set at prebuild. With the switch off it registers no mod
at all and returns the config object it was handed — there is no code path that
could add the permission, not merely one that chooses not to.

Verified three ways, and the numbers are in the report on the task:
`npx expo config --type introspect` with the plugin removed from `app.json`
entirely, and with it present but the switch off, produce **byte-identical**
Android mod results (6913 = 6913). With `WAVES_SMS_READER=1` the introspected
manifest gains exactly one entry, `android.permission.READ_SMS`, and nothing
else changes (5184 → 5237 bytes of manifest, 53 bytes = the one entry).
`test/smsReaderPlugin.test.ts` pins the same property by reference equality, and
that the switch is on for exactly one spelling — `'true'`, `'yes'`, `'on'` and
`' 1'` are all off.

**Runtime.** `lib/smsFeature.ts` makes the dormant `sms_inbox_read` flag real,
through `lib/flags.tsx` — the repo's one flag mechanism, not a second. It asks
for the `treatment` arm rather than mere enrolment: the flag's arms are
`{control, treatment}`, and "enrolled at all" would hand a restricted permission
to the control group.

## The disclosure

`captures/messages`, before Android's dialog ever appears — an illustration, a
headline, three icon bullets (what is read · where it happens · what is kept),
the window chips, and the line that names what comes next: *"On the next screen
Android asks whether Waves may read your messages. You can say no — pasting them
still works."* Primary **Allow**, quiet **Not now**. The gates are re-checked on
this screen too, so a deep link or a stale back stack cannot reach the system
prompt.

## Where the raw-text rule lives

`lib/smsDrafts.ts`. A **pasted** message keeps its body as `rawText`, exactly as
a scanned receipt's OCR does — the person handed it over. A **read** message
never does: `planSmsDrafts` ignores the body map for anything in `readKeys`, so
a caller that passes bodies for the whole list still cannot leak one. A message
that was both read and pasted counts as read; the stricter rule wins.

`test/smsDrafts.test.ts` pins it, and does so by searching the whole serialised
draft for the message text rather than asserting on the one field it is supposed
to be in — so a future field that started carrying the body fails too. Nothing
on this path reports anything to Sentry, Clarity or any analytics: not the body,
not the merchant, not a count.

## Also

- `proposeFromSms` gains an optional window. It required a trip's `from`/`to`,
  which a global drafts list does not have; an unparseable bound now reads as no
  bound, because a half-typed date must not silently empty the list.
- `lib/smsReader.ts` and its 27 tests are restored from `92ac9306^` — the lazy
  require and non-throwing availability check are unchanged, which is the rule
  this repo has been bitten by.
- `react-native-get-sms-android` stays in `package.json`, as asked.

## Gates

`pnpm format` clean · `pnpm lint` clean (one pre-existing warning in
`group/[id]/settings.tsx`, untouched) · mobile typecheck clean · mobile 1538
tests pass · core 998 · edge 307 · web 53 · api-client 12 · admin 40.
`packages/db` tests and typecheck were skipped: no local Postgres on 54330 and
no `DIRECT_URL` here. `packages/db` is untouched — there is no migration in this
PR.

https://claude.ai/code/session_015jhzmZz5fkjnZZ14YxHGfS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a bank-message capture flow for pasted SMS text, with parsed expense candidates and selectable drafts.
  * Added Android SMS inbox importing with date-range selection, permission disclosure, and clear handling for unreadable or empty results.
  * Added stable duplicate detection so previously imported messages are not added again.
  * Added entry points from the Captures screen and support for English, Tamil, Hindi, and Arabic.
  * Added internationalized SMS parsing for multiple currencies, date formats, scripts, and languages.

* **Bug Fixes**
  * SMS parsing now works correctly when no date range is provided.
  * Imported inbox message bodies are excluded from saved capture data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->