### PR TITLE
Research: what the SMS parser actually reads, measured against 25 real message shapes

### DIFF
--- a/docs/sms-parser-corpus.md
+++ b/docs/sms-parser-corpus.md
@@ -1,0 +1,49 @@
+# The SMS corpus these results were measured against
+
+25 bodies written to match documented institution formats — **not captured from
+any real device or inbox**. Kept so that a parser change can be measured against
+the same set rather than against a new one that happens to pass. See
+[sms-parser-coverage.md](sms-parser-coverage.md) for the results.
+
+`null` means the parser must reject it. Those six matter most: a wrong rejection
+loses a transaction the person can paste again, but a wrong acceptance writes a
+ledger entry nobody made.
+
+Result column records behaviour as measured on `packages/core/src/sms/parse.ts`
+at commit `01b5f678`, September 2026.
+
+| #   | case                                    | expected | result               | body                                                                                                                        |
+| --- | --------------------------------------- | -------- | -------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| 1   | SBI UPI (no currency token)             | debit    | **dropped**          | `Dear UPI user A/C X1234 debited by 150.0 on date 12Sep26 trf to SWIGGY Refno 526012345678. If not u? call 1800111109 -SBI` |
+| 2   | HDFC UPI sent                           | debit    | ok, no merchant      | `Sent Rs.245.00 From HDFC Bank A/C x1234 To SWIGGY On 12/09/26 Ref 526012345678 Not You? Call 18002586161`                  |
+| 3   | ICICI acct debit                        | debit    | **dropped**          | `ICICI Bank Acct XX123 debited for Rs 500.00 on 12-Sep-26; SWIGGY credited. UPI:526012345678. Call 18002662 for dispute.`   |
+| 4   | Axis classic                            | debit    | ok                   | `INR 1,234.00 debited from A/c no. XX3456 on 12-09-26 at AMAZON. Avl Bal INR 5,678.90`                                      |
+| 5   | Credit card "used for a transaction of" | debit    | **booked as credit** | `Your ICICI Bank Credit Card XX1234 has been used for a transaction of INR 2,500.00 on 12-Sep-26 at AMAZON.`                |
+| 6   | Debit card spent, ISO-ish date          | debit    | ok, no date          | `Alert: You've spent Rs.1500.00 via Debit Card xx1234 at AMAZON on 2026-09-12:14:23:05.`                                    |
+| 7   | Kotak lakh grouping                     | debit    | ok                   | `Rs 1,23,456.78 debited from Kotak A/c XX7890 on 12-09-26 towards RENT PAYMENT. Ref 998877665544`                           |
+| 8   | ATM withdrawal                          | debit    | ok                   | `Rs.2000 withdrawn from A/c XX1234 at ATM SECTOR 5 on 12-09-26. Avl Bal Rs 12,340.00`                                       |
+| 9   | Paytm wallet                            | debit    | ok                   | `Paid Rs.120 to SWIGGY using Paytm UPI. Txn ID 526012345678`                                                                |
+| 10  | Amazon Pay                              | debit    | ok, no merchant      | `INR 349 debited from your Amazon Pay balance for order 404-1234567. Ref 7788990011`                                        |
+| 11  | Foreign card spend                      | debit    | ok                   | `USD 42.50 spent on your card ending 1234 at STARBUCKS on 12-Sep-26`                                                        |
+| 12  | AED spend                               | debit    | ok                   | `AED 89.00 debited from Card xx4471 at CARREFOUR DUBAI on 12-09-26`                                                         |
+| 13  | Salary credit                           | credit   | ok, merchant `A`     | `INR 85,000.00 credited to A/c XX1234 on 01-09-26 by NEFT. Avl Bal INR 92,340.00`                                           |
+| 14  | Refund                                  | credit   | **dropped**          | `Rs.599.00 refunded to your HDFC Card xx1234 by AMAZON on 12-09-26. Ref 5544332211`                                         |
+| 15  | OTP with amount                         | null     | ok                   | `OTP 445566 for txn of Rs.2,500.00 at AMAZON on HDFC Card xx1234. Do not share.`                                            |
+| 16  | Scheduled autopay                       | null     | ok                   | `Rs 499.00 will be debited from A/c XX1234 on 15-09-26 towards NETFLIX e-mandate.`                                          |
+| 17  | Balance only                            | null     | ok                   | `Avl Bal in A/c XX1234 is Rs 12,340.00 as on 12-09-26.`                                                                     |
+| 18  | Payment due reminder                    | null     | ok                   | `Your ICICI Credit Card XX1234 payment of Rs 8,450.00 is due on 18-09-26.`                                                  |
+| 19  | Failed txn                              | null     | ok                   | `Your transaction of Rs.1,200.00 at AMAZON was declined due to insufficient balance.`                                       |
+| 20  | Marketing                               | null     | ok                   | `Get a personal loan of up to Rs 5,00,000 at 10.5% p.a. Apply now!`                                                         |
+| 21  | UPI VPA merchant                        | debit    | ok, merchant `VPA`   | `Rs.75.00 debited from A/c XX1234 to VPA swiggy@icici on 12-09-26. UPI Ref 526012345678`                                    |
+| 22  | Lowercase bank voice                    | debit    | ok, no merchant      | `rs.250 debited from a/c xx1234 at bigbasket on 12-09-26`                                                                   |
+| 23  | No space after Rs                       | debit    | ok                   | `Rs1,499.00 spent on HDFC Card xx1234 at MYNTRA on 12-09-26`                                                                |
+| 24  | Amount trailing INR                     | debit    | **dropped**          | `Your A/c XX1234 is debited with 350.00 INR on 12-09-26 at UBER.`                                                           |
+| 25  | Two amounts, txn then balance           | debit    | ok                   | `Rs.450.00 debited from A/c XX1234 at DOMINOS on 12-09-26. Avl Bal: Rs.9,999.00`                                            |
+
+**Score: 20/25 on direction, of which 6 more carry a wrong or missing
+merchant.** All six negatives (15–20) were correctly rejected.
+
+Case 25 is worth keeping for the reason it passes: the message quotes two
+amounts, and the parser takes the first. That is right here, because the
+transaction is quoted before the balance — but it is positional luck, not a
+rule, and a bank that leads with the balance would break it.

--- a/docs/sms-parser-coverage.md
+++ b/docs/sms-parser-coverage.md
@@ -1,0 +1,213 @@
+# How a bank message reaches Waves, and what the parser does with it
+
+Research, September 2026. Two questions were asked together and they are
+genuinely different, so they are answered separately:
+
+1. **How can a message be read at all?** The access paths, what each one costs,
+   and the two that are quietly closing.
+2. **What does the parser make of the message once it has it?** Measured, not
+   estimated — `parseSms` was run against 25 messages written the way real
+   institutions write them.
+
+The short version:
+
+- **The parser handles 20 of 25.** The five it does not are not exotic. They are
+  **State Bank of India's UPI alert**, **ICICI's account debit**, **any credit
+  card spend**, **refunds**, and **amounts written `350.00 INR`**. One of the
+  five is worse than a miss: a credit-card purchase is currently classified as
+  **money coming in**.
+- Several messages that "pass" carry a **wrong merchant** — `VPA`, `A`, or
+  nothing at all where the shop's name is plainly in the text. The most common
+  cause is a single missing `i` flag.
+- **Confidence is measuring the wrong thing.** It counts how many fields were
+  found, not whether they are right, so the worst merchant bug in the set scores
+  **1.0**.
+- **The inbox is a shrinking source.** Banks are migrating alerts to RCS, which
+  `READ_SMS` cannot see at all, and HDFC already stopped sending SMS for small
+  UPI payments. Neither is a reason not to build this; both are reasons the
+  paste and share lanes are not merely the iPhone consolation prize.
+
+---
+
+## 1. How a message can reach the parser
+
+`docs/plan-drafts-and-rules.md` §1.6 covers the permission economics. This is
+the same list re-cut by _what actually arrives_, which is a different question.
+
+| path                                  | what it can see                                  | what it cannot                                                        |
+| ------------------------------------- | ------------------------------------------------ | --------------------------------------------------------------------- |
+| `READ_SMS` (inbox read)               | every SMS in the device store, historic and new  | RCS messages; anything a bank stopped sending; app-only notifications |
+| `RECEIVE_SMS` (live)                  | SMS as it arrives                                | everything above, plus anything sent before install                   |
+| Share sheet                           | the one message the person shares                | everything they do not share                                          |
+| Paste                                 | whatever is selected and copied                  | same                                                                  |
+| Emailed statement (`import/email.ts`) | a whole month, authoritative, reconciled         | anything not on the statement yet                                     |
+| Notification listener                 | every notification, including RCS and app-native | rejected on policy grounds — §1.6                                     |
+
+### 1.1 The two that are closing
+
+**RCS.** In 2026 RCS Business Messaging went from pilot to production in India
+with Jio, Airtel and Vi all supporting it, and banks are among the first movers
+for alerts — verified sender, brand logo, no 160-character limit. **An RCS
+message is not an SMS.** It does not land in the SMS provider that `READ_SMS`
+reads; it lives in the messaging app's own store, and there is no public API for
+a third-party app to read it. Every bank that migrates its alerts is a bank
+whose transactions silently stop appearing. The person will not see an error —
+they will see Waves quietly stop noticing their spending.
+
+**Small UPI payments already stopped.** HDFC Bank stopped sending SMS for UPI
+payments under ₹100 sent and ₹500 received. For an expense-splitting app this is
+exactly the wrong end of the range to lose: the chai, the auto, the ₹80 share of
+something. Other banks are under the same cost pressure.
+
+Neither kills the feature. Both change what it should promise. **"We will catch
+your bank messages" is honest. "We will catch your spending" is not**, and the
+copy should not drift toward the second.
+
+### 1.2 Which messages are even worth reading
+
+India's DLT regime gives a reliable filter that costs nothing. Every commercial
+sender is a registered 6-character header, delivered as `XX-HEADER` where `XX`
+is an operator+circle code the carrier prepends — `AD-HDFCBK` is Airtel Delhi
+plus HDFC Bank's registered `HDFCBK`. Since May 2025 a message-type suffix is
+appended too, which separates transactional from promotional traffic at the
+header level.
+
+Two consequences worth using:
+
+- A **sender allowlist** of known bank headers is a far better first filter than
+  running a regex over every message in the inbox, and it lets the reader touch
+  dramatically fewer messages — which is both faster and a better answer to
+  "why do you need my whole inbox".
+- The **operator prefix must be stripped before matching**, because the same
+  bank arrives as `AD-HDFCBK`, `VM-HDFCBK`, `JD-HDFCBK` depending on the
+  recipient's carrier and circle. Matching the whole string is a bug that will
+  look like "it works on my phone".
+
+`parseSms` currently takes `sender` but does not use it for anything except
+display. That is a free accuracy win left on the floor.
+
+---
+
+## 2. What the messages actually look like
+
+Four families, and they are not stylistic variations — they need different
+handling.
+
+**Bank account debit.** `A/c`, a masked tail, a balance trailer.
+`INR 1,234.00 debited from A/c no. XX3456 on 12-09-26 at AMAZON. Avl Bal INR 5,678.90`
+
+**UPI.** The growth area and the least standardised. Often no currency token at
+all, a `Ref`/`RRN`, and the counterparty as either a name or a VPA
+(`swiggy@icici`). SBI's is the canonical hard case:
+`Dear UPI user A/C X1234 debited by 150.0 on date 12Sep26 trf to SWIGGY Refno 526012345678`
+
+**Card.** The word "credit" appears in `Credit Card` on messages that are
+debits — a trap the current parser falls into. Verbs are different too: _spent_,
+_used for a transaction of_, _transaction of_.
+
+**Wallet / PPI.** Paytm, Amazon Pay. Shortest and least consistent; often no
+account tail and no date.
+
+---
+
+## 3. Measured results
+
+`parseSms` was run against 25 messages covering those four families plus the
+negatives it must reject. Verbatim bodies are in §6 so this is reproducible.
+
+**20 of 25 behaved as expected.** All six negatives were correctly rejected —
+OTP-with-an-amount, scheduled autopay, balance-only, payment-due, declined, and
+marketing. The rejection side is in good shape and is the side where a mistake
+costs the most, so that matters.
+
+### 3.1 The five hard failures
+
+| #   | case                    | result               | cause                                                                                                            |
+| --- | ----------------------- | -------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| 1   | **SBI UPI**             | dropped              | `AMOUNT` requires a currency token; SBI writes `debited by 150.0`                                                |
+| 2   | **ICICI account debit** | dropped              | message says `debited` _and_ `credited` (of the payee); `debit === credit` bails                                 |
+| 3   | **Credit card spend**   | **booked as income** | `CREDIT_WORDS` matches the word _credit_ inside `Credit Card`; no debit verb matches `used for a transaction of` |
+| 4   | **Refund**              | dropped              | `CREDIT_WORDS` has `refund`; the message says `refunded`                                                         |
+| 5   | **`350.00 INR`**        | dropped              | `AMOUNT` only matches a marker _before_ the number                                                               |
+
+**#3 is the one to fix first.** The others lose a transaction, which the person
+can see and paste again. #3 silently records a ₹2,500 purchase as ₹2,500
+_received_ — a wrong ledger entry that looks deliberate. Everything downstream
+trusts `direction`.
+
+### 3.2 The quiet ones — parsed, but wrong
+
+These all "passed" and would be pre-selected for the person to confirm:
+
+- **`To SWIGGY` yields no merchant.** `MERCHANT` has no `i` flag, so capitalised
+  `To`/`At` never match. HDFC writes `To SWIGGY`. One character fixes it.
+- **Lowercase merchants never match.** The capture requires `[A-Z0-9]` first.
+  `at bigbasket` yields nothing.
+- **`to VPA swiggy@icici` yields the merchant `VPA`** — the literal word,
+  because `to\s+(...)` grabs it before the alternation reaches `VPA`. Scored
+  **confidence 1.0**.
+- **`credited to A/c XX1234` yields the merchant `A`.** The `A` of `A/c`.
+- Amazon Pay and the plain SBI shape yield no merchant at all.
+
+A draft whose merchant reads `VPA` or `A` is worse than one with no merchant:
+the inbox shows a row that looks parsed, and the person has to notice it is
+nonsense.
+
+### 3.3 Confidence is measuring the wrong thing
+
+> `confidence` starts at 0.55 and adds for merchant, reference, date, tail.
+
+It counts _fields found_, never _fields plausible_. So the `VPA` bug scores 1.0
+and is pre-selected, while a perfectly-parsed wallet message with no date and no
+tail scores 0.7. The comment in the source is honest about this — "how much of
+the message we actually understood" — but the number is used as if it meant
+correctness, and `SMS_LOW_CONFIDENCE` gates pre-selection on it.
+
+Minimum fix: a merchant that is a known stop-word (`VPA`, `A`, `A/C`, `UPI`,
+`REF`, a bare number) should score _nothing_, not `+0.2`.
+
+---
+
+## 4. Recommendations, in order
+
+1. **Stop reading `credit` inside `Credit Card`.** Strip card phrases before the
+   direction test, and add the missing debit verbs (`used for a transaction of`,
+   `transaction of`, `txn of`). Fixes the only failure that writes a wrong
+   ledger entry.
+2. **Make the currency token optional.** When a debit verb and an account
+   pattern are present, a bare `150.0` is an amount. Default to the account's
+   currency, not to a body-wide guess. Recovers SBI — the largest bank in India.
+3. **Direction by proximity, not presence.** Take the verb nearest the amount
+   rather than bailing when both appear. Recovers ICICI, which is simply
+   describing both sides of a transfer.
+4. **Add the `i` flag to `MERCHANT`, allow lowercase, and stop-word the
+   captures.** The cheapest quality win in the document.
+5. **Read VPAs properly.** `swiggy@icici` should yield `swiggy` — and
+   `normaliseMerchantName` in `category/merchant.ts` already exists to tidy it.
+6. **Accept a trailing currency** (`350.00 INR`).
+7. **Use the sender.** Strip the `XX-` operator prefix, match a bank allowlist,
+   and let a known bank header raise confidence and a non-bank header skip the
+   message entirely.
+8. **Re-base confidence on plausibility**, per §3.3.
+
+1–4 are small, self-contained changes to a pure function with an existing test
+suite. They are worth doing before anybody tests the feature on a real inbox,
+because the first impression of this feature is entirely a function of its hit
+rate.
+
+## 5. What this research did not do
+
+No real inbox was read — every message here is written to match documented
+formats, not captured from a device. Bank wording changes without notice and
+varies by product within one bank. The corpus is India-heavy, with two foreign
+cases (USD, AED) and none from a European or US bank. RCS displacement is
+reported from public sources, not measured. And nothing here has been run on a
+device: these are results from the pure parser, which is the right place to
+test it, but not the same as the feature working.
+
+## 6. The corpus
+
+Reproducible — 25 bodies, the four families plus the negatives, with the
+expected direction for each. Stored alongside this document as
+`sms-parser-corpus.md` so a fix can be measured against the same set rather than
+against a new one that happens to pass.


### PR DESCRIPTION
Answers two questions that were asked together but are different: **how a message can reach the parser**, and **what the parser makes of it**. The second was measured, not estimated — `parseSms` run against 25 bodies written the way real institutions write them. The corpus is committed so a fix is measured against the same set rather than a new one that happens to pass.

## 20 of 25

The five failures are the largest banks in India, not edge cases:

| case | result | cause |
| --- | --- | --- |
| **SBI UPI** | dropped | `AMOUNT` needs a currency token; SBI writes `debited by 150.0` |
| **ICICI account debit** | dropped | says `debited` *and* `credited` (of the payee); `debit === credit` bails |
| **Credit card spend** | **booked as income** | `CREDIT_WORDS` matches *credit* inside `Credit Card`; no debit verb matches `used for a transaction of` |
| **Refund** | dropped | `CREDIT_WORDS` has `refund`, message says `refunded` |
| **`350.00 INR`** | dropped | `AMOUNT` only matches a marker before the number |

**The credit-card one is the only one that writes something wrong.** The others lose a transaction the person can paste again; this one records a ₹2,500 purchase as ₹2,500 *received*, and everything downstream trusts `direction`.

## Six more parse but lie about the merchant

`MERCHANT` has no `i` flag, so HDFC's `To SWIGGY` never matches. The capture requires an uppercase first character, so `at bigbasket` never matches. `to VPA swiggy@icici` yields the literal word `VPA`. `credited to A/c` yields `A`.

Those last two score **confidence 1.0** — because confidence counts fields *found*, never fields *plausible*, and `SMS_LOW_CONFIDENCE` gates pre-selection on it. A row reading `VPA` that is pre-ticked is worse than a row with no merchant at all.

## The rejection side is fine

All six negatives refused, including an OTP quoting a real amount from the right sender — the false positive that would cost the most.

## Two findings about the source, not the parser

**RCS.** Banks are migrating alerts to RCS in India (Jio, Airtel and Vi all in production in 2026). `READ_SMS` cannot see an RCS message — different store, no third-party read API. Every bank that migrates is a bank whose transactions quietly stop appearing, with no error the person can see.

**Small UPI already stopped.** HDFC no longer sends SMS for UPI under ₹100 sent / ₹500 received — the chai and the auto, which is the wrong end of the range for a splitting app.

Neither kills the feature. Both mean the paste and statement lanes are not merely the iPhone consolation prize, and that the copy should promise to catch *bank messages*, not to catch *spending*.

## Unused accuracy win

`parseSms` takes a `sender` and does nothing with it. India's DLT regime makes every commercial sender a registered 6-character header (`AD-HDFCBK` = Airtel Delhi + `HDFCBK`), so a bank allowlist is a better first filter than a regex over the whole inbox — and a better answer to "why do you need my inbox". Strip the operator prefix first: the same bank arrives as `AD-`, `VM-` or `JD-` by carrier and circle.

## Scope

Docs only, no parser change. Recommendations are ordered; the first four are small self-contained changes to a pure function with an existing suite, and worth doing before anyone tests against a real inbox — first impressions of this feature are entirely its hit rate.

Limits are stated in §5: no real inbox was read, the corpus is India-heavy, and RCS displacement is from public reporting rather than measurement.

https://claude.ai/code/session_015jhzmZz5fkjnZZ14YxHGfS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a measurement corpus covering 25 synthetic bank SMS messages, expected classifications, parser results, and scoring.
  * Added coverage documentation describing supported message channels, message families, parser outcomes, and known extraction and confidence-scoring issues.
  * Documented reproducibility details, measurement limitations, rejection behavior, and prioritized areas for improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->