### PR TITLE
The paste screen says what it means, and lets you check it

### DIFF
--- a/apps/mobile/src/app/captures/paste.tsx
+++ b/apps/mobile/src/app/captures/paste.tsx
@@ -14,6 +14,22 @@
  * Everything downstream of that button — the found list, the ticking, the
  * writing — is this screen, unchanged.
  *
+ * WHO THIS IS FOR. Somebody who has never used an expense app, and may never
+ * have deliberately copied text on a phone before. Everything on the screen is
+ * measured against that: no codes, no jargon, no rule about blank lines to get
+ * wrong, and never a guess dressed up as a fact.
+ *
+ * - The sender is a telecom routing header (`JM-ICICIT-S`), so it is turned
+ *   into "ICICI Bank" by `lib/smsPlain.ts` — and when that table does not know
+ *   the id, the line is simply not there. A code on screen is worse than a
+ *   blank.
+ * - A merchant that is plainly not a name — a phone number, a bare "VPA" —
+ *   does not become the title. "Payment from Axis Bank" is less specific and
+ *   entirely true, which is the trade this screen always makes.
+ * - A row the parser was unsure of says *what* it was unsure of, in a sentence,
+ *   and every pasted row can be opened to read the message it was made from.
+ *   "Check this" with nothing to check against is not a warning, it is a worry.
+ *
  * WHERE THINGS GO. Each ticked payment becomes a `captures` row: an expense
  * with no group yet, which is what the Review tab has held since A34. Not a
  * second inbox (#565 undid that once already), not an expense in a group —
@@ -24,10 +40,12 @@
  * account tail, a balance and sometimes a one-time password. The text of a
  * pasted message rides along as `rawText` the way a scanned receipt's OCR does
  * — a person put it there themselves. The text of a *read* message never does;
- * `lib/smsDrafts.ts` is where that is decided, and a test pins it. And nothing
- * on this screen reports anything at all: no Sentry event, no Clarity event,
- * not even a count. A paste that parses badly is said to the person in front of
- * it, and to nobody else.
+ * `lib/smsDrafts.ts` is where that is decided, and a test pins it. The same
+ * function decides what may be *shown*, so the message a person can open on a
+ * row is exactly the message that will be kept, and a read one is neither. And
+ * nothing on this screen reports anything at all: no Sentry event, no Clarity
+ * event, not even a count. A paste that parses badly is said to the person in
+ * front of it, and to nobody else.
  *
  * WHY IT IS A FLASHLIST. A month of statements is a hundred rows, and this is
  * the screen the plan points the backfill at. The paste box and the intro ride
@@ -42,7 +60,12 @@ import * as Clipboard from 'expo-clipboard';
 import { useFocusEffect } from 'expo-router';
 import { Pressable, TextInput, View } from 'react-native';
 
-import { proposeFromSms, type ExpenseCandidate, type SmsMessage } from '@waves/core';
+import {
+  proposeFromSms,
+  SMS_LOW_CONFIDENCE,
+  type ExpenseCandidate,
+  type SmsMessage,
+} from '@waves/core';
 import {
   Badge,
   Button,
@@ -55,7 +78,6 @@ import {
   MoneyText,
   Row,
   Screen,
-  SectionHeader,
   Text,
   useTheme,
 } from '@waves/ui';
@@ -71,95 +93,230 @@ import { router } from '@/lib/navigation';
 import { smsCaptureId } from '@/lib/smsCaptureId';
 import {
   bodiesByKey,
+  bodyForDisplay,
   planSmsDrafts,
   splitMessages,
   unreadableCount,
   type SmsDraftProvenance,
 } from '@/lib/smsDrafts';
 import { useSmsInboxReader } from '@/lib/smsFeature';
+import { bankFromSender, bankFromText, merchantName } from '@/lib/smsPlain';
 import { takeReadMessages } from '@/lib/smsReadBridge';
 
-/** A day heading, or one payment under it. */
+/**
+ * A day heading, or one payment under it.
+ *
+ * The body rides on the item rather than being looked up in the renderer, so
+ * the rule about which bodies may be seen is applied once, where the list is
+ * built, instead of at every recycle.
+ */
 type FoundItem =
   | { kind: 'day'; key: string; at: string }
-  | { kind: 'candidate'; key: string; candidate: ExpenseCandidate };
+  | { kind: 'candidate'; key: string; candidate: ExpenseCandidate; body: string | null };
+
+/** A comfortable target for a thumb that is not aiming carefully. */
+const ROW_MIN_HEIGHT = 60;
 
 /**
- * One found payment: a tick, the shop, the amount.
+ * What to call this payment, and who said so.
  *
- * The date is not on the row — the day heading above it already carries that,
- * which is the point of grouping. What the row's second line carries instead is
- * everything that would make a person hesitate: which bank said it, which card
- * it was, and — the one that matters most on a trip — whether the day came from
- * the message or was only the day it arrived.
+ * Never the raw sender and never a merchant that is obviously not a merchant —
+ * both judgements live in `lib/smsPlain.ts` and are pinned by its test. The
+ * order of the fallbacks is the order of decreasing specificity and constant
+ * truthfulness: the shop if we have one, otherwise the bank, otherwise the
+ * plainest thing that is still certainly true.
+ */
+function describe(
+  candidate: ExpenseCandidate,
+  body: string | null,
+  t: UiStrings,
+): { title: string; from: string | null } {
+  const bank = bankFromSender(candidate.sender) ?? bankFromText(body);
+  const shop = merchantName(candidate.merchant);
+  if (shop) return { title: shop, from: bank };
+  if (bank) return { title: t.smsImport.paymentFromBank.replace('{bank}', bank), from: null };
+  return { title: t.smsImport.aPayment, from: null };
+}
+
+/**
+ * Why a row is not already ticked, in words.
+ *
+ * `preselect` is false for exactly two reasons and this says which: a message
+ * that named no day, and a message the parser only half understood. A flag
+ * without a reason asks a person to check something they cannot see.
+ */
+function doubts(candidate: ExpenseCandidate, t: UiStrings): string[] {
+  const reasons: string[] = [];
+  if (candidate.dateInferred) reasons.push(t.smsImport.dateNotInMessage);
+  if (candidate.confidence < SMS_LOW_CONFIDENCE) reasons.push(t.smsImport.hardToRead);
+  return reasons;
+}
+
+/**
+ * One found payment: a tick, who it was, the amount — and, underneath, the
+ * message it was made from.
+ *
+ * The date is not on the row; the day heading above it carries that, which is
+ * the point of grouping. The second line carries who the bank says it was and
+ * which card, in words rather than in the bank's own shorthand.
+ *
+ * The whole row toggles the tick, so the target is the row and not the little
+ * box. "Read the message" is a separate, smaller target underneath precisely so
+ * that reaching for it cannot tick anything by accident.
  */
 function FoundRow({
   candidate,
+  body,
   picked,
+  open,
   locale,
   t,
   onToggle,
+  onOpen,
 }: {
   candidate: ExpenseCandidate;
+  body: string | null;
   picked: boolean;
+  open: boolean;
   locale: string;
   t: UiStrings;
   onToggle: () => void;
+  onOpen: () => void;
 }): React.JSX.Element {
   const theme = useTheme();
-  const title = candidate.merchant ?? t.smsImport.cardPayment;
+  const { title, from } = describe(candidate, body, t);
   const parts: string[] = [];
-  if (candidate.sender) parts.push(candidate.sender);
-  if (candidate.accountTail) parts.push(`⋯${candidate.accountTail}`);
-  if (candidate.dateInferred) parts.push(t.smsImport.dateNotInMessage);
+  if (from) parts.push(from);
+  if (candidate.accountTail)
+    parts.push(t.smsImport.cardEnding.replace('{tail}', candidate.accountTail));
   const subtitle = parts.join(' · ');
+  const reasons = doubts(candidate, t);
 
   return (
-    <Pressable
-      accessibilityRole="checkbox"
-      accessibilityState={{ checked: picked }}
-      accessibilityLabel={`${title}, ${picked ? t.smsImport.selected : t.smsImport.notSelected}`}
-      onPress={onToggle}
-      style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}
-    >
-      <Row
+    <View>
+      <Pressable
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: picked }}
+        accessibilityLabel={`${title}, ${picked ? t.smsImport.selected : t.smsImport.notSelected}`}
+        onPress={onToggle}
+        style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}
+      >
+        <Row
+          style={{
+            gap: theme.spacing.md,
+            alignItems: 'center',
+            paddingVertical: theme.spacing.md,
+            minHeight: ROW_MIN_HEIGHT,
+          }}
+        >
+          {/* Never colour alone: the tick is a different glyph, not just a
+              different shade, and the a11y state says it a third way (#191). */}
+          <Ionicons
+            name={picked ? 'checkbox' : 'square-outline'}
+            size={iconSize.jumbo}
+            color={picked ? theme.color.brand : theme.color.textFaint}
+          />
+          <View style={{ flex: 1, minWidth: 0, gap: 2 }}>
+            <Text variant="subheading" numberOfLines={2}>
+              {title}
+            </Text>
+            {subtitle ? (
+              <Text variant="caption" tone="muted" numberOfLines={1}>
+                {subtitle}
+              </Text>
+            ) : null}
+            {/* An icon as well as the words, so the uncertainty is not carried
+                by colour (#191) — and the words themselves, so "check this"
+                names something a person can actually go and check. */}
+            {reasons.map((reason) => (
+              <Row key={reason} gap={theme.spacing.xs} style={{ alignItems: 'flex-start' }}>
+                <Ionicons
+                  name="alert-circle-outline"
+                  size={iconSize.sm}
+                  color={theme.color.warning}
+                  style={{ marginTop: 2 }}
+                />
+                <Text variant="caption" tone="muted" style={{ flex: 1 }}>
+                  {reason}
+                </Text>
+              </Row>
+            ))}
+          </View>
+          <View style={{ alignItems: 'flex-end', gap: theme.spacing.xs }}>
+            <MoneyText
+              amount={candidate.amount.minor}
+              currency={candidate.amount.currency}
+              locale={locale}
+              variant="subheading"
+            />
+            {/* A row "select all" swept in is still marked, so nobody is
+                carried past a doubt without seeing it. */}
+            {candidate.preselect ? null : <Badge label={t.smsImport.checkThis} />}
+          </View>
+        </Row>
+      </Pressable>
+
+      {/* Only ever a pasted message. `bodyForDisplay` is the same function that
+          decides what may be stored, so what can be read here is exactly what
+          will be kept — and a message read out of the inbox is neither. */}
+      {body ? (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityState={{ expanded: open }}
+          onPress={onOpen}
+          hitSlop={8}
+          style={({ pressed }) => ({
+            alignSelf: 'flex-start',
+            paddingVertical: theme.spacing.sm,
+            opacity: pressed ? 0.7 : 1,
+          })}
+        >
+          <Row gap={theme.spacing.xs}>
+            <Ionicons
+              name={open ? 'chevron-up' : 'chevron-down'}
+              size={iconSize.sm}
+              color={theme.color.brand}
+            />
+            <Text variant="caption" tone="brand">
+              {open ? t.smsImport.hideMessage : t.smsImport.showMessage}
+            </Text>
+          </Row>
+        </Pressable>
+      ) : null}
+      {open && body ? (
+        <Card flat style={{ padding: theme.spacing.lg, marginBottom: theme.spacing.md }}>
+          <Text variant="caption" tone="muted" selectable>
+            {body}
+          </Text>
+        </Card>
+      ) : null}
+    </View>
+  );
+}
+
+/** One line of the three-step path in, for somebody who has never done this. */
+function Step({ index, text }: { index: number; text: string }): React.JSX.Element {
+  const theme = useTheme();
+  return (
+    <Row gap={theme.spacing.md} style={{ alignItems: 'flex-start' }}>
+      <View
         style={{
-          gap: theme.spacing.md,
+          width: 22,
+          height: 22,
+          borderRadius: theme.radius.pill,
+          backgroundColor: theme.color.brandSoft,
           alignItems: 'center',
-          paddingVertical: theme.spacing.sm,
-          minHeight: 52,
+          justifyContent: 'center',
         }}
       >
-        {/* Never colour alone: the tick is a different glyph, not just a
-            different shade, and the a11y state says it a third way (#191). */}
-        <Ionicons
-          name={picked ? 'checkbox' : 'square-outline'}
-          size={iconSize.xxl}
-          color={picked ? theme.color.brand : theme.color.textFaint}
-        />
-        <View style={{ flex: 1, minWidth: 0, gap: 2 }}>
-          <Text variant="subheading" numberOfLines={1}>
-            {title}
-          </Text>
-          {subtitle ? (
-            <Text variant="micro" tone="muted" numberOfLines={1}>
-              {subtitle}
-            </Text>
-          ) : null}
-        </View>
-        <View style={{ alignItems: 'flex-end', gap: 2 }}>
-          <MoneyText
-            amount={candidate.amount.minor}
-            currency={candidate.amount.currency}
-            locale={locale}
-            variant="subheading"
-          />
-          {/* A message we only half understood is not pre-ticked, and says so
-              rather than simply sitting there unticked for no visible reason. */}
-          {candidate.preselect ? null : <Badge label={t.smsImport.checkThis} />}
-        </View>
-      </Row>
-    </Pressable>
+        <Text variant="micro" tone="brand">
+          {String(index)}
+        </Text>
+      </View>
+      <Text variant="caption" style={{ flex: 1 }}>
+        {text}
+      </Text>
+    </Row>
   );
 }
 
@@ -185,6 +342,8 @@ export default function PasteMessagesScreen(): React.JSX.Element {
   // Explicit ticks, over the parser's own pre-selection. Absent means "whatever
   // `preselect` said", so a person who ticks nothing still gets the sensible set.
   const [ticks, setTicks] = useState<Record<string, boolean>>({});
+  // Which rows have their message open. Per row, and forgotten on leaving.
+  const [opened, setOpened] = useState<Record<string, boolean>>({});
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [added, setAdded] = useState<number | null>(null);
@@ -272,6 +431,8 @@ export default function PasteMessagesScreen(): React.JSX.Element {
     return keys;
   }, [fresh, ticks]);
 
+  const allChosen = fresh.length > 0 && chosen.size === fresh.length;
+
   const feed = useMemo((): FoundItem[] => {
     const items: FoundItem[] = [];
     let day = '';
@@ -281,19 +442,56 @@ export default function PasteMessagesScreen(): React.JSX.Element {
         day = candidateDay;
         items.push({ kind: 'day', key: `day-${candidateDay}`, at: candidate.at });
       }
-      items.push({ kind: 'candidate', key: candidate.dedupeKey, candidate });
+      items.push({
+        kind: 'candidate',
+        key: candidate.dedupeKey,
+        candidate,
+        body: bodyForDisplay(candidate.dedupeKey, bodies, readKeys),
+      });
     }
     return items;
-  }, [fresh]);
+  }, [bodies, fresh, readKeys]);
 
   const toggle = useCallback((key: string, next: boolean): void => {
     setTicks((current) => ({ ...current, [key]: next }));
   }, []);
 
+  const openMessage = useCallback((key: string): void => {
+    setOpened((current) => ({ ...current, [key]: !current[key] }));
+  }, []);
+
+  /**
+   * One control, two states — the Wallet pattern.
+   *
+   * "Select all" takes the uncertain rows too. Somebody who asks for all of
+   * them has asked for all of them, and quietly holding two back would be the
+   * screen overruling a person who said what they wanted. What it must not do
+   * is sweep them in *invisibly*, so the "Check this" mark and the sentence
+   * under each one stay exactly as they were: still selectable, still
+   * questioned, and one tap away from being put back.
+   */
+  const toggleAll = useCallback((): void => {
+    const next: Record<string, boolean> = {};
+    for (const item of fresh) next[item.dedupeKey] = !allChosen;
+    setTicks((current) => ({ ...current, ...next }));
+  }, [allChosen, fresh]);
+
+  /** Typing or pasting again puts the screen back to work, so "done" clears. */
+  const edit = useCallback((text: string): void => {
+    setBlob(text);
+    setAdded(null);
+    setError(null);
+  }, []);
+
   const paste = useCallback(async (): Promise<void> => {
     const text = await Clipboard.getStringAsync();
     if (!text.trim()) return;
+    // Joined with a blank line, which is the separator this screen no longer
+    // asks anybody to know about: `splitMessages` finds the boundaries itself,
+    // and the Paste button puts the clearest one in for free.
     setBlob((current) => (current ? `${current}\n\n${text}` : text));
+    setAdded(null);
+    setError(null);
   }, []);
 
   /**
@@ -334,6 +532,7 @@ export default function PasteMessagesScreen(): React.JSX.Element {
       setAdded(placed);
       setBlob('');
       setTicks({});
+      setOpened({});
       setReadMessages([]);
     } catch (caught) {
       setAdded(placed > 0 ? placed : null);
@@ -353,26 +552,38 @@ export default function PasteMessagesScreen(): React.JSX.Element {
     t.captures.couldNotSave,
   ]);
 
+  // Nothing handed over and nothing done yet: the one moment the three steps
+  // are worth the room. They go away the instant there is anything to look at.
+  const firstRun = blob.length === 0 && readMessages.length === 0 && added === null;
+  const done = added !== null && error === null && fresh.length === 0;
+
   const header = (
     <View style={{ gap: theme.spacing.lg, paddingBottom: theme.spacing.md }}>
       <Row style={{ paddingTop: theme.spacing.md, alignItems: 'center' }}>
         <IconButton label={t.common.close} onPress={() => router.back()}>
           <Ionicons name="close" size={iconSize.xl} color={theme.color.text} />
         </IconButton>
-        <Text variant="subheading" style={{ marginLeft: theme.spacing.md, flex: 1 }}>
+        {/* `marginStart`, not `marginLeft`: the title sits beside the close
+            button on both sides of the world. */}
+        <Text variant="heading" style={{ marginStart: theme.spacing.md, flex: 1 }}>
           {t.smsImport.title}
         </Text>
       </Row>
 
-      <Card style={{ gap: theme.spacing.sm }}>
-        <Text variant="caption" tone="muted">
-          {t.smsImport.howToDrafts}
-        </Text>
+      <Card style={{ gap: theme.spacing.md }}>
+        <Text variant="body">{t.smsImport.howToDrafts}</Text>
+        {firstRun ? (
+          <View style={{ gap: theme.spacing.sm }}>
+            <Step index={1} text={t.smsImport.howToSteps.open} />
+            <Step index={2} text={t.smsImport.howToSteps.copy} />
+            <Step index={3} text={t.smsImport.howToSteps.comeBack} />
+          </View>
+        ) : null}
         {/* Why there is no switch for this. Said only where it is true: a build
             that can read the inbox has the button below instead, and the
             sentence would contradict it. */}
         {readerOffered ? null : (
-          <Text variant="micro" tone="muted">
+          <Text variant="caption" tone="muted">
             {t.smsImport.whyNotAutomatic}
           </Text>
         )}
@@ -388,11 +599,11 @@ export default function PasteMessagesScreen(): React.JSX.Element {
               <Ionicons name="chatbubbles-outline" size={iconSize.md} color={theme.color.brand} />
             }
           />
-          <Text variant="micro" tone="muted">
+          <Text variant="caption" tone="muted">
             {t.smsImport.readOnAndroid}
           </Text>
           {readMessages.length > 0 ? (
-            <Text variant="micro" tone="muted">
+            <Text variant="caption" tone="muted">
               {plural(locale, readMessages.length, t.smsImport.readCount)}
             </Text>
           ) : null}
@@ -400,11 +611,10 @@ export default function PasteMessagesScreen(): React.JSX.Element {
       ) : null}
 
       <View style={{ gap: theme.spacing.sm }}>
-        <SectionHeader title={t.smsImport.messagesSection} />
         <Card style={{ gap: theme.spacing.sm }}>
           <TextInput
             value={blob}
-            onChangeText={setBlob}
+            onChangeText={edit}
             multiline
             autoCapitalize="none"
             accessibilityLabel={t.smsImport.pasteLabel}
@@ -412,20 +622,34 @@ export default function PasteMessagesScreen(): React.JSX.Element {
             placeholderTextColor={theme.color.textFaint}
             style={{
               minHeight: 140,
-              fontSize: 15,
+              fontSize: 16,
               color: theme.color.text,
               textAlignVertical: 'top',
             }}
           />
           <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
-            <Text variant="micro" tone="muted">
+            <Text variant="caption" tone="muted">
               {pastedBlocks.length === 0
                 ? t.smsImport.nothingPasted
                 : plural(locale, pastedBlocks.length, t.smsImport.messageCount)}
             </Text>
-            <Button label={t.smsImport.paste} variant="ghost" onPress={() => void paste()} />
+            {/* The only control while the box is empty, so it leads rather than
+                sits in the corner as a ghost. */}
+            <Button
+              label={t.smsImport.paste}
+              variant={blob.length === 0 ? 'secondary' : 'ghost'}
+              onPress={() => void paste()}
+            />
           </Row>
         </Card>
+        {/* The blank-line rule, demoted. `splitMessages` finds the boundaries
+            on its own now, so this is a hint offered once something has
+            actually gone unread — never an instruction to get wrong up front. */}
+        {notPayments > 0 ? (
+          <Text variant="micro" tone="muted">
+            {t.smsImport.runTogether}
+          </Text>
+        ) : null}
       </View>
 
       {/* Only over a list that has something in it. With nothing found, the
@@ -433,21 +657,34 @@ export default function PasteMessagesScreen(): React.JSX.Element {
           them twice. */}
       {fresh.length > 0 ? (
         <View style={{ gap: theme.spacing.xs }}>
-          {/* An eyebrow over a question, not a noun over a list: the list has
-              one thing to ask and the button below is the answer. */}
-          <Text variant="micro" tone="muted" style={{ textTransform: 'uppercase' }}>
-            {t.smsImport.foundSection}
+          {/* The count is the headline and the control sits beside it — one
+              button with two labels rather than two buttons (Wallet). The
+              count is live, and the button at the foot says the same number
+              back as the thing it is about to do. */}
+          <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+            <Text variant="title" style={{ flex: 1 }}>
+              {chosen.size === 0
+                ? t.smsImport.nothingSelected
+                : plural(locale, chosen.size, t.smsImport.chosenCount)}
+            </Text>
+            <Button
+              label={allChosen ? t.smsImport.unselectAll : t.smsImport.selectAll}
+              variant="ghost"
+              onPress={toggleAll}
+            />
+          </Row>
+          <Text variant="caption" tone="muted">
+            {plural(locale, fresh.length, t.smsImport.foundCount)}
           </Text>
-          <Text variant="heading">{t.smsImport.foundQuestion}</Text>
           {/* Everything the parser could not use, said plainly. A screen that
               quietly shows four rows for six messages reads as broken. */}
           {notPayments > 0 ? (
-            <Text variant="micro" tone="muted">
+            <Text variant="caption" tone="muted">
               {plural(locale, notPayments, t.smsImport.someNotParsed)}
             </Text>
           ) : null}
           {alreadyCount > 0 ? (
-            <Text variant="micro" tone="muted">
+            <Text variant="caption" tone="muted">
               {plural(locale, alreadyCount, t.smsImport.alreadyAdded)}
             </Text>
           ) : null}
@@ -462,17 +699,23 @@ export default function PasteMessagesScreen(): React.JSX.Element {
       {added !== null ? (
         <Callout tone="positive">{plural(locale, added, t.smsImport.addedDraftCount)}</Callout>
       ) : null}
-      <Button
-        label={
-          saving
-            ? t.smsImport.adding
-            : chosen.size === 0
-              ? t.smsImport.nothingSelected
-              : plural(locale, chosen.size, t.smsImport.addDraftCount)
-        }
-        onPress={() => void add()}
-        disabled={chosen.size === 0 || saving}
-      />
+      {/* Where they went, and a way to go there. A screen that says "added" and
+          leaves a person on the same page has told them half of it. */}
+      {done ? (
+        <Button label={t.smsImport.openReview} onPress={() => router.replace('/captures')} />
+      ) : (
+        <Button
+          label={
+            saving
+              ? t.smsImport.adding
+              : chosen.size === 0
+                ? t.smsImport.nothingSelected
+                : plural(locale, chosen.size, t.smsImport.addDraftCount)
+          }
+          onPress={() => void add()}
+          disabled={chosen.size === 0 || saving}
+        />
+      )}
     </View>
   );
 
@@ -498,17 +741,24 @@ export default function PasteMessagesScreen(): React.JSX.Element {
         <View>
           <FoundRow
             candidate={item.candidate}
+            body={item.body}
             picked={picked}
+            open={opened[item.candidate.dedupeKey] ?? false}
             locale={locale}
             t={t}
             onToggle={() => toggle(item.candidate.dedupeKey, !picked)}
+            onOpen={() => openMessage(item.candidate.dedupeKey)}
           />
           <Divider />
         </View>
       );
     },
-    [chosen, locale, t, theme.spacing.md, theme.spacing.xs, toggle],
+    [chosen, locale, openMessage, opened, t, theme.spacing.md, theme.spacing.xs, toggle],
   );
+
+  // One object so a tick *or* an opened message re-renders a row FlashList
+  // would otherwise recycle unchanged.
+  const listState = useMemo(() => ({ chosen, opened }), [chosen, opened]);
 
   return (
     <Screen edges={['top']}>
@@ -520,7 +770,7 @@ export default function PasteMessagesScreen(): React.JSX.Element {
         // The group-ledger settings: `extraData` because a tick changes a row
         // that FlashList would otherwise recycle unchanged, and the drop
         // distance so a pasted month scrolls without blanking.
-        extraData={chosen}
+        extraData={listState}
         drawDistance={1500}
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
@@ -532,8 +782,9 @@ export default function PasteMessagesScreen(): React.JSX.Element {
         ListFooterComponent={footer}
         ListEmptyComponent={
           // Nothing handed over yet is not an empty result; it is a screen
-          // waiting to be used, and the paste box above already says so.
-          pastedBlocks.length === 0 && readMessages.length === 0 ? null : (
+          // waiting to be used, and the paste box above already says so. Nor is
+          // a finished run: the footer is already saying where those went.
+          (pastedBlocks.length === 0 && readMessages.length === 0) || done ? null : (
             <EmptyState
               title={t.smsImport.nothingToImport}
               // Why there is nothing, in the honest order: because you have

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -2530,7 +2530,6 @@ export interface UiStrings {
     title: string;
     howTo: string;
     whyNotAutomatic: string;
-    messagesSection: string;
     pasteLabel: string;
     pastePlaceholder: string;
     nothingPasted: string;
@@ -2544,11 +2543,9 @@ export interface UiStrings {
     last30: string;
     datePlaceholder: string;
     dateFieldLabel: string;
-    foundSection: string;
     nothingToImport: string;
     nothingLikeAPayment: string;
     allAnotherCurrency: string;
-    cardPayment: string;
     selected: string;
     notSelected: string;
     checkThis: string;
@@ -2585,8 +2582,42 @@ export interface UiStrings {
      * so the older sentence's "this trip" would be a lie on it.
      */
     howToDrafts: string;
-    /** The found list's own title — a question, because the answer is one tap. */
-    foundQuestion: string;
+    /**
+     * The way in for somebody who has never copied text on a phone. Three short
+     * lines, shown only until something has been pasted, and never again.
+     */
+    howToSteps: {
+      open: string;
+      copy: string;
+      comeBack: string;
+    };
+    /**
+     * The live headline over the list. `nothingSelected` above is the word for
+     * none of them — the same phrase the button at the foot wears, deliberately.
+     */
+    chosenCount: PluralForms;
+    /** How many payments were found in what was handed over. */
+    foundCount: PluralForms;
+    /** One control, two labels (Apple Wallet). Never two buttons. */
+    selectAll: string;
+    unselectAll: string;
+    /**
+     * Titles for a payment whose merchant is missing or is plainly not a name.
+     * Less specific than a shop and entirely true, which is the trade.
+     */
+    paymentFromBank: string;
+    aPayment: string;
+    /** "card ending 4471" — the account tail in words rather than as "⋯4471". */
+    cardEnding: string;
+    /** The second reason a row is not pre-ticked; the first is `dateNotInMessage`. */
+    hardToRead: string;
+    /** Opening a row to read the message it was made from. */
+    showMessage: string;
+    hideMessage: string;
+    /** The blank-line rule, demoted to a hint and said only when it may help. */
+    runTogether: string;
+    /** Where the payments went, offered as somewhere to go. */
+    openReview: string;
     /** Said plainly rather than hidden: how many pasted blocks were not a payment. */
     someNotParsed: PluralForms;
     /** How many of the payments found are already waiting in Review. */
@@ -5156,14 +5187,13 @@ const en: UiStrings = {
     wavesVersionOut: 'Waves {latest} is out',
   },
   smsImport: {
-    title: 'Import from messages',
+    title: 'Add from bank messages',
     howTo:
       'Open your messages app, select the bank messages from this trip, copy them, and paste them here. Waves reads them on this phone — nothing is sent anywhere until you confirm an expense.',
     whyNotAutomatic:
-      'Waves cannot read your inbox by itself. iPhones give no app that access, and on Android it is reserved for whichever app you use as your messages app.',
-    messagesSection: 'The messages',
+      'Waves cannot read your messages on its own, so you copy across the ones you want.',
     pasteLabel: 'Paste bank messages',
-    pastePlaceholder: 'Paste here.\n\nLeave a blank line between messages.',
+    pastePlaceholder: 'Paste your bank messages here',
     nothingPasted: 'Nothing pasted yet',
     messageCount: { one: '{n} message', other: '{n} messages' },
     paste: 'Paste',
@@ -5176,12 +5206,10 @@ const en: UiStrings = {
     last30: 'Last 30 days',
     datePlaceholder: 'YYYY-MM-DD',
     dateFieldLabel: '{label} date, year month day',
-    foundSection: 'What was found',
-    nothingToImport: 'Nothing to import',
+    nothingToImport: 'No payments in that',
     nothingLikeAPayment:
-      'None of those messages looked like a payment inside these dates. Reminders, one-time passwords and money coming in are all left out on purpose.',
+      'None of that looked like a payment. Reminders, one-time passwords and money coming in are all left out on purpose.',
     allAnotherCurrency: 'Every payment found was in another currency.',
-    cardPayment: 'Card payment',
     selected: 'selected',
     notSelected: 'not selected',
     checkThis: 'Check this',
@@ -5199,7 +5227,7 @@ const en: UiStrings = {
         '{n} expenses added. They are saved on this phone and will sync when there is a connection.',
     },
     adding: 'Adding…',
-    nothingSelected: 'Nothing selected',
+    nothingSelected: 'Nothing chosen yet',
     addCount: { one: 'Add {n} expense', other: 'Add {n} expenses' },
     readMessages: 'Read my messages',
     reading: 'Reading…',
@@ -5224,10 +5252,29 @@ const en: UiStrings = {
       allow: 'Allow',
       notNow: 'Not now',
     },
-    dateNotInMessage: 'date not in the message',
+    dateNotInMessage: 'The message did not say which day this was.',
     howToDrafts:
-      'Open your messages app, pick the bank messages you want, copy them, and paste them here. Waves reads them on this phone and turns each payment into a draft you can file into a group later.',
-    foundQuestion: 'Add these to Review?',
+      'Copy a payment message from your messages app and paste it here. Waves reads it on this phone and puts the payment in Review for you.',
+    howToSteps: {
+      open: 'Open your messages app.',
+      copy: 'Press and hold a bank message, then tap Copy.',
+      comeBack: 'Come back here and tap Paste.',
+    },
+    chosenCount: { one: '{n} chosen', other: '{n} chosen' },
+    foundCount: {
+      one: 'We found {n} payment in what you pasted.',
+      other: 'We found {n} payments in what you pasted.',
+    },
+    selectAll: 'Select all',
+    unselectAll: 'Unselect all',
+    paymentFromBank: 'Payment from {bank}',
+    aPayment: 'Payment from your bank',
+    cardEnding: 'card ending {tail}',
+    hardToRead: 'Some of this message was hard to read.',
+    showMessage: 'Read the message',
+    hideMessage: 'Hide the message',
+    runTogether: 'If two messages ran together, leave a blank line between them.',
+    openReview: 'Open Review',
     someNotParsed: {
       one: '{n} of those did not look like a payment, so it was left out.',
       other: '{n} of those did not look like payments, so they were left out.',
@@ -5236,11 +5283,11 @@ const en: UiStrings = {
       one: '{n} is already waiting in Review.',
       other: '{n} are already waiting in Review.',
     },
-    addDraftCount: { one: 'Add {n} draft', other: 'Add {n} drafts' },
+    addDraftCount: { one: 'Add {n} to Review', other: 'Add {n} to Review' },
     addedDraftCount: {
-      one: '{n} draft is waiting in Review. It is saved on this phone and will sync when there is a connection.',
+      one: '{n} payment is waiting in Review. It is saved on this phone and will sync when there is a connection.',
       other:
-        '{n} drafts are waiting in Review. They are saved on this phone and will sync when there is a connection.',
+        '{n} payments are waiting in Review. They are saved on this phone and will sync when there is a connection.',
     },
     readWindowNote:
       'Waves only looks at this stretch of your inbox. Everything older stays untouched.',
@@ -7888,14 +7935,13 @@ const ta: UiStrings = {
     wavesVersionOut: 'Waves {latest} வெளியாகிவிட்டது',
   },
   smsImport: {
-    title: 'செய்திகளிலிருந்து இறக்குமதி',
+    title: 'வங்கிச் செய்திகளிலிருந்து சேர்',
     howTo:
       'உங்கள் செய்தி செயலியைத் திறந்து, இந்தப் பயணத்தின் வங்கிச் செய்திகளைத் தேர்ந்தெடுத்து, நகலெடுத்து இங்கே ஒட்டுங்கள். Waves அவற்றை இந்த ஃபோனிலேயே படிக்கும் — நீங்கள் ஒரு செலவை உறுதி செய்யும் வரை எதுவும் எங்கும் அனுப்பப்படாது.',
     whyNotAutomatic:
-      'Waves-ஆல் உங்கள் இன்பாக்ஸைத் தானாகப் படிக்க முடியாது. iPhone எந்தச் செயலிக்கும் அந்த அனுமதியைத் தராது; Android இல் அது உங்கள் செய்தி செயலிக்கு மட்டுமே உரியது.',
-    messagesSection: 'செய்திகள்',
+      'Waves-ஆல் உங்கள் செய்திகளைத் தானாகப் படிக்க முடியாது, எனவே வேண்டியவற்றை நீங்களே நகலெடுத்துத் தாருங்கள்.',
     pasteLabel: 'வங்கிச் செய்திகளை ஒட்டு',
-    pastePlaceholder: 'இங்கே ஒட்டவும்.\n\nசெய்திகளுக்கு இடையே ஒரு காலி வரி விடவும்.',
+    pastePlaceholder: 'உங்கள் வங்கிச் செய்திகளை இங்கே ஒட்டுங்கள்',
     nothingPasted: 'இன்னும் எதுவும் ஒட்டப்படவில்லை',
     messageCount: { one: '{n} செய்தி', other: '{n} செய்திகள்' },
     paste: 'ஒட்டு',
@@ -7908,12 +7954,10 @@ const ta: UiStrings = {
     last30: 'கடந்த 30 நாட்கள்',
     datePlaceholder: 'YYYY-MM-DD',
     dateFieldLabel: '{label} தேதி, ஆண்டு மாதம் நாள்',
-    foundSection: 'கிடைத்தவை',
-    nothingToImport: 'இறக்குமதி செய்ய எதுவும் இல்லை',
+    nothingToImport: 'அதில் கொடுப்பனவுகள் எதுவும் இல்லை',
     nothingLikeAPayment:
-      'அந்தச் செய்திகளில் எதுவும் இந்தத் தேதிகளுக்குள் ஒரு கொடுப்பனவாகத் தெரியவில்லை. நினைவூட்டல்கள், ஒருமுறைக் கடவுச்சொற்கள், வரும் பணம் — இவை வேண்டுமென்றே விடப்படுகின்றன.',
+      'அதில் எதுவும் ஒரு கொடுப்பனவாகத் தெரியவில்லை. நினைவூட்டல்கள், ஒருமுறைக் கடவுச்சொற்கள், வரும் பணம் — இவை வேண்டுமென்றே விடப்படுகின்றன.',
     allAnotherCurrency: 'கிடைத்த ஒவ்வொரு கொடுப்பனவும் வேறு நாணயத்தில் இருந்தது.',
-    cardPayment: 'அட்டைக் கொடுப்பனவு',
     selected: 'தேர்ந்தெடுக்கப்பட்டது',
     notSelected: 'தேர்ந்தெடுக்கப்படவில்லை',
     checkThis: 'இதைச் சரிபார்',
@@ -7931,7 +7975,7 @@ const ta: UiStrings = {
         '{n} செலவுகள் சேர்க்கப்பட்டன. அவை இந்த ஃபோனில் சேமிக்கப்பட்டுள்ளன, இணைப்பு கிடைத்ததும் ஒத்திசைக்கும்.',
     },
     adding: 'சேர்க்கிறது…',
-    nothingSelected: 'எதுவும் தேர்ந்தெடுக்கப்படவில்லை',
+    nothingSelected: 'இன்னும் எதுவும் தேர்ந்தெடுக்கப்படவில்லை',
     addCount: { one: '{n} செலவைச் சேர்', other: '{n} செலவுகளைச் சேர்' },
     readMessages: 'என் செய்திகளைப் படி',
     reading: 'படிக்கிறது…',
@@ -7957,10 +8001,33 @@ const ta: UiStrings = {
       allow: 'அனுமதி',
       notNow: 'இப்போது வேண்டாம்',
     },
-    dateNotInMessage: 'செய்தியில் தேதி இல்லை',
+    dateNotInMessage: 'இது எந்த நாள் என்று செய்தி சொல்லவில்லை.',
     howToDrafts:
-      'உங்கள் செய்தி செயலியைத் திறந்து, வேண்டிய வங்கிச் செய்திகளைத் தேர்ந்தெடுத்து, நகலெடுத்து இங்கே ஒட்டுங்கள். Waves அவற்றை இந்த ஃபோனிலேயே படித்து, ஒவ்வொரு கொடுப்பனவையும் பிறகு ஒரு குழுவில் சேர்க்கக்கூடிய வரைவாக மாற்றும்.',
-    foundQuestion: 'இவற்றை மறுபார்வையில் சேர்க்கவா?',
+      'உங்கள் செய்தி செயலியிலிருந்து ஒரு கொடுப்பனவுச் செய்தியை நகலெடுத்து இங்கே ஒட்டுங்கள். Waves அதை இந்த ஃபோனிலேயே படித்து, அந்தக் கொடுப்பனவை மறுபார்வையில் வைக்கும்.',
+    howToSteps: {
+      open: 'உங்கள் செய்தி செயலியைத் திறங்கள்.',
+      copy: 'ஒரு வங்கிச் செய்தியை அழுத்திப் பிடித்து, நகலெடு என்பதைத் தட்டுங்கள்.',
+      comeBack: 'இங்கே திரும்பி வந்து ஒட்டு என்பதைத் தட்டுங்கள்.',
+    },
+    chosenCount: {
+      one: '{n} தேர்ந்தெடுக்கப்பட்டது',
+      other: '{n} தேர்ந்தெடுக்கப்பட்டவை',
+    },
+    foundCount: {
+      one: 'நீங்கள் ஒட்டியதில் {n} கொடுப்பனவு கிடைத்தது.',
+      other: 'நீங்கள் ஒட்டியதில் {n} கொடுப்பனவுகள் கிடைத்தன.',
+    },
+    selectAll: 'எல்லாவற்றையும் தேர்ந்தெடு',
+    unselectAll: 'தேர்வை நீக்கு',
+    paymentFromBank: '{bank} மூலம் கொடுப்பனவு',
+    aPayment: 'உங்கள் வங்கியிலிருந்து ஒரு கொடுப்பனவு',
+    cardEnding: '{tail} இல் முடியும் அட்டை',
+    hardToRead: 'இந்தச் செய்தியின் சில பகுதிகளைப் படிப்பது கடினமாக இருந்தது.',
+    showMessage: 'செய்தியைப் படி',
+    hideMessage: 'செய்தியை மறை',
+    runTogether:
+      'இரண்டு செய்திகள் ஒன்றாகச் சேர்ந்துவிட்டால், அவற்றுக்கு இடையே ஒரு காலி வரி விடுங்கள்.',
+    openReview: 'மறுபார்வையைத் திற',
     someNotParsed: {
       one: 'அவற்றில் {n} கொடுப்பனவாகத் தெரியவில்லை, அது விடப்பட்டது.',
       other: 'அவற்றில் {n} கொடுப்பனவாகத் தெரியவில்லை, அவை விடப்பட்டன.',
@@ -7969,11 +8036,14 @@ const ta: UiStrings = {
       one: '{n} ஏற்கனவே மறுபார்வையில் காத்திருக்கிறது.',
       other: '{n} ஏற்கனவே மறுபார்வையில் காத்திருக்கின்றன.',
     },
-    addDraftCount: { one: '{n} வரைவைச் சேர்', other: '{n} வரைவுகளைச் சேர்' },
+    addDraftCount: {
+      one: '{n} ஐ மறுபார்வையில் சேர்',
+      other: '{n} ஐ மறுபார்வையில் சேர்',
+    },
     addedDraftCount: {
-      one: '{n} வரைவு மறுபார்வையில் காத்திருக்கிறது. அது இந்த ஃபோனில் சேமிக்கப்பட்டுள்ளது, இணைப்பு கிடைத்ததும் ஒத்திசைக்கும்.',
+      one: '{n} கொடுப்பனவு மறுபார்வையில் காத்திருக்கிறது. அது இந்த ஃபோனில் சேமிக்கப்பட்டுள்ளது, இணைப்பு கிடைத்ததும் ஒத்திசைக்கும்.',
       other:
-        '{n} வரைவுகள் மறுபார்வையில் காத்திருக்கின்றன. அவை இந்த ஃபோனில் சேமிக்கப்பட்டுள்ளன, இணைப்பு கிடைத்ததும் ஒத்திசைக்கும்.',
+        '{n} கொடுப்பனவுகள் மறுபார்வையில் காத்திருக்கின்றன. அவை இந்த ஃபோனில் சேமிக்கப்பட்டுள்ளன, இணைப்பு கிடைத்ததும் ஒத்திசைக்கும்.',
     },
     readWindowNote:
       'உங்கள் இன்பாக்ஸில் இந்தப் பகுதியை மட்டுமே Waves பார்க்கும். அதற்கு முந்தையவை தொடப்படாது.',
@@ -10574,14 +10644,13 @@ const hi: UiStrings = {
     wavesVersionOut: 'Waves {latest} आ गया है',
   },
   smsImport: {
-    title: 'संदेशों से आयात',
+    title: 'बैंक संदेशों से जोड़ें',
     howTo:
       'अपना मैसेज ऐप खोलें, इस यात्रा के बैंक संदेश चुनें, कॉपी करें और यहाँ पेस्ट करें। Waves उन्हें इसी फ़ोन पर पढ़ता है — जब तक आप कोई खर्च पक्का नहीं करते, कुछ भी कहीं नहीं भेजा जाता।',
     whyNotAutomatic:
-      'Waves आपका इनबॉक्स खुद नहीं पढ़ सकता। iPhone किसी भी ऐप को यह पहुँच नहीं देता, और Android पर यह सिर्फ़ उसी ऐप के लिए है जिसे आप मैसेज ऐप की तरह इस्तेमाल करते हैं।',
-    messagesSection: 'संदेश',
+      'Waves आपके संदेश खुद नहीं पढ़ सकता, इसलिए जो चाहिए वे आप ही कॉपी करके लाते हैं।',
     pasteLabel: 'बैंक संदेश पेस्ट करें',
-    pastePlaceholder: 'यहाँ पेस्ट करें।\n\nसंदेशों के बीच एक खाली पंक्ति छोड़ें।',
+    pastePlaceholder: 'अपने बैंक संदेश यहाँ पेस्ट करें',
     nothingPasted: 'अभी कुछ पेस्ट नहीं किया',
     messageCount: { one: '{n} संदेश', other: '{n} संदेश' },
     paste: 'पेस्ट',
@@ -10593,12 +10662,10 @@ const hi: UiStrings = {
     last30: 'पिछले 30 दिन',
     datePlaceholder: 'YYYY-MM-DD',
     dateFieldLabel: '{label} तारीख़, साल महीना दिन',
-    foundSection: 'क्या मिला',
-    nothingToImport: 'आयात करने को कुछ नहीं',
+    nothingToImport: 'उसमें कोई भुगतान नहीं',
     nothingLikeAPayment:
-      'इन तारीखों के भीतर उन संदेशों में से कोई भुगतान जैसा नहीं लगा। याद दिलाने वाले संदेश, वन-टाइम पासवर्ड और आने वाला पैसा जान-बूझकर छोड़े जाते हैं।',
+      'उसमें से कुछ भी भुगतान जैसा नहीं लगा। याद दिलाने वाले संदेश, वन-टाइम पासवर्ड और आने वाला पैसा जान-बूझकर छोड़े जाते हैं।',
     allAnotherCurrency: 'जो भी भुगतान मिला वह दूसरी मुद्रा में था।',
-    cardPayment: 'कार्ड भुगतान',
     selected: 'चुना गया',
     notSelected: 'नहीं चुना',
     checkThis: 'इसे जाँचें',
@@ -10615,7 +10682,7 @@ const hi: UiStrings = {
       other: '{n} खर्च जुड़े। ये इसी फ़ोन पर सेव हैं और कनेक्शन मिलते ही सिंक हो जाएँगे।',
     },
     adding: 'जोड़ रहे हैं…',
-    nothingSelected: 'कुछ नहीं चुना',
+    nothingSelected: 'अभी कुछ नहीं चुना',
     addCount: { one: '{n} खर्च जोड़ें', other: '{n} खर्च जोड़ें' },
     readMessages: 'मेरे संदेश पढ़ें',
     reading: 'पढ़ रहे हैं…',
@@ -10640,10 +10707,29 @@ const hi: UiStrings = {
       allow: 'अनुमति दें',
       notNow: 'अभी नहीं',
     },
-    dateNotInMessage: 'संदेश में तारीख नहीं थी',
+    dateNotInMessage: 'संदेश में यह नहीं लिखा कि यह किस दिन हुआ।',
     howToDrafts:
-      'अपना मैसेज ऐप खोलें, जो बैंक संदेश चाहिए उन्हें चुनें, कॉपी करें और यहाँ पेस्ट करें। Waves उन्हें इसी फ़ोन पर पढ़ता है और हर भुगतान को एक ड्राफ़्ट बना देता है, जिसे बाद में किसी समूह में डाला जा सकता है।',
-    foundQuestion: 'इन्हें समीक्षा में जोड़ें?',
+      'अपने मैसेज ऐप से कोई भुगतान वाला संदेश कॉपी करके यहाँ पेस्ट करें। Waves उसे इसी फ़ोन पर पढ़ता है और वह भुगतान आपके लिए समीक्षा में रख देता है।',
+    howToSteps: {
+      open: 'अपना मैसेज ऐप खोलें।',
+      copy: 'किसी बैंक संदेश को दबाकर रखें, फिर कॉपी दबाएँ।',
+      comeBack: 'यहाँ वापस आकर पेस्ट दबाएँ।',
+    },
+    chosenCount: { one: '{n} चुना', other: '{n} चुने' },
+    foundCount: {
+      one: 'आपने जो पेस्ट किया उसमें {n} भुगतान मिला।',
+      other: 'आपने जो पेस्ट किया उसमें {n} भुगतान मिले।',
+    },
+    selectAll: 'सब चुनें',
+    unselectAll: 'चुनाव हटाएँ',
+    paymentFromBank: '{bank} से भुगतान',
+    aPayment: 'आपके बैंक से एक भुगतान',
+    cardEnding: '{tail} पर ख़त्म होने वाला कार्ड',
+    hardToRead: 'इस संदेश का कुछ हिस्सा पढ़ना मुश्किल था।',
+    showMessage: 'संदेश पढ़ें',
+    hideMessage: 'संदेश छिपाएँ',
+    runTogether: 'अगर दो संदेश आपस में जुड़ गए हों, तो उनके बीच एक खाली पंक्ति छोड़ दें।',
+    openReview: 'समीक्षा खोलें',
     someNotParsed: {
       one: 'उनमें से {n} भुगतान जैसा नहीं लगा, इसलिए छोड़ दिया गया।',
       other: 'उनमें से {n} भुगतान जैसे नहीं लगे, इसलिए छोड़ दिए गए।',
@@ -10652,11 +10738,11 @@ const hi: UiStrings = {
       one: '{n} पहले से समीक्षा में इंतज़ार कर रहा है।',
       other: '{n} पहले से समीक्षा में इंतज़ार कर रहे हैं।',
     },
-    addDraftCount: { one: '{n} ड्राफ़्ट जोड़ें', other: '{n} ड्राफ़्ट जोड़ें' },
+    addDraftCount: { one: '{n} को समीक्षा में जोड़ें', other: '{n} को समीक्षा में जोड़ें' },
     addedDraftCount: {
-      one: '{n} ड्राफ़्ट समीक्षा में इंतज़ार कर रहा है। यह इसी फ़ोन पर सेव है और कनेक्शन मिलते ही सिंक हो जाएगा।',
+      one: '{n} भुगतान समीक्षा में इंतज़ार कर रहा है। यह इसी फ़ोन पर सेव है और कनेक्शन मिलते ही सिंक हो जाएगा।',
       other:
-        '{n} ड्राफ़्ट समीक्षा में इंतज़ार कर रहे हैं। ये इसी फ़ोन पर सेव हैं और कनेक्शन मिलते ही सिंक हो जाएँगे।',
+        '{n} भुगतान समीक्षा में इंतज़ार कर रहे हैं। ये इसी फ़ोन पर सेव हैं और कनेक्शन मिलते ही सिंक हो जाएँगे।',
     },
     readWindowNote:
       'Waves आपके इनबॉक्स का सिर्फ़ इतना हिस्सा देखता है। इससे पुराना सब कुछ अछूता रहता है।',
@@ -13431,14 +13517,12 @@ const ar: UiStrings = {
     wavesVersionOut: 'صدر Waves {latest}',
   },
   smsImport: {
-    title: 'استيراد من الرسائل',
+    title: 'الإضافة من رسائل البنك',
     howTo:
       'افتح تطبيق الرسائل، واختر رسائل البنك الخاصة بهذه الرحلة، وانسخها والصقها هنا. يقرأها Waves على هذا الهاتف — ولا يُرسل أي شيء إلى أي مكان حتى تؤكّد مصروفًا.',
-    whyNotAutomatic:
-      'لا يستطيع Waves قراءة صندوق رسائلك من تلقاء نفسه. لا يمنح iPhone هذه الصلاحية لأي تطبيق، وفي أندرويد تقتصر على التطبيق الذي تستخدمه للرسائل.',
-    messagesSection: 'الرسائل',
+    whyNotAutomatic: 'لا يستطيع Waves قراءة رسائلك من تلقاء نفسه، لذلك تنسخ أنت ما تريده منها.',
     pasteLabel: 'ألصق رسائل البنك',
-    pastePlaceholder: 'ألصق هنا.\n\nاترك سطرًا فارغًا بين كل رسالة وأخرى.',
+    pastePlaceholder: 'ألصق رسائل بنكك هنا',
     nothingPasted: 'لم يُلصق شيء بعد',
     messageCount: {
       zero: 'لا رسائل',
@@ -13458,12 +13542,10 @@ const ar: UiStrings = {
     last30: 'آخر 30 يومًا',
     datePlaceholder: 'YYYY-MM-DD',
     dateFieldLabel: 'تاريخ {label}، سنة شهر يوم',
-    foundSection: 'ما وُجد',
-    nothingToImport: 'لا شيء للاستيراد',
+    nothingToImport: 'لا مدفوعات في ذلك',
     nothingLikeAPayment:
-      'لم تبدُ أي من تلك الرسائل دفعةً داخل هذه التواريخ. التذكيرات وكلمات المرور لمرة واحدة والأموال الواردة كلها مستبعدة عن قصد.',
+      'لم يبدُ أي من ذلك دفعةً. التذكيرات وكلمات المرور لمرة واحدة والأموال الواردة كلها مستبعدة عن قصد.',
     allAnotherCurrency: 'كل دفعة وُجدت كانت بعملة أخرى.',
-    cardPayment: 'دفعة بالبطاقة',
     selected: 'محدَّد',
     notSelected: 'غير محدَّد',
     checkThis: 'تحقّق من هذا',
@@ -13488,7 +13570,7 @@ const ar: UiStrings = {
       other: 'أُضيف {n} مصروف. إنها محفوظة على هذا الهاتف وستُزامَن عند توفّر اتصال.',
     },
     adding: 'جارٍ الإضافة…',
-    nothingSelected: 'لم يُحدَّد شيء',
+    nothingSelected: 'لم يُختَر شيء بعد',
     addCount: {
       zero: 'لا شيء لإضافته',
       one: 'أضف مصروفًا واحدًا',
@@ -13523,10 +13605,40 @@ const ar: UiStrings = {
       allow: 'السماح',
       notNow: 'ليس الآن',
     },
-    dateNotInMessage: 'التاريخ غير مذكور في الرسالة',
+    dateNotInMessage: 'لم تذكر الرسالة في أي يوم كان هذا.',
     howToDrafts:
-      'افتح تطبيق الرسائل، واختر رسائل البنك التي تريدها، وانسخها والصقها هنا. يقرأها Waves على هذا الهاتف ويحوّل كل دفعة إلى مسوّدة يمكنك إضافتها إلى مجموعة لاحقًا.',
-    foundQuestion: 'أتضيف هذه إلى المراجعة؟',
+      'انسخ رسالة دفع من تطبيق الرسائل وألصقها هنا. يقرأها Waves على هذا الهاتف ويضع الدفعة في المراجعة نيابةً عنك.',
+    howToSteps: {
+      open: 'افتح تطبيق الرسائل.',
+      copy: 'اضغط مطوّلًا على رسالة من البنك ثم اختر نسخ.',
+      comeBack: 'عُد إلى هنا واضغط لصق.',
+    },
+    chosenCount: {
+      zero: 'لم يُختَر شيء',
+      one: 'واحدة مختارة',
+      two: 'اثنتان مختارتان',
+      few: '{n} مختارة',
+      many: '{n} مختارة',
+      other: '{n} مختارة',
+    },
+    foundCount: {
+      zero: 'لم نجد أي دفعة فيما ألصقته.',
+      one: 'وجدنا دفعة واحدة فيما ألصقته.',
+      two: 'وجدنا دفعتين فيما ألصقته.',
+      few: 'وجدنا {n} دفعات فيما ألصقته.',
+      many: 'وجدنا {n} دفعة فيما ألصقته.',
+      other: 'وجدنا {n} دفعة فيما ألصقته.',
+    },
+    selectAll: 'تحديد الكل',
+    unselectAll: 'إلغاء تحديد الكل',
+    paymentFromBank: 'دفعة من {bank}',
+    aPayment: 'دفعة من بنكك',
+    cardEnding: 'بطاقة تنتهي بـ {tail}',
+    hardToRead: 'كان جزء من هذه الرسالة صعب القراءة.',
+    showMessage: 'اقرأ الرسالة',
+    hideMessage: 'أخفِ الرسالة',
+    runTogether: 'إذا التصقت رسالتان معًا، اترك سطرًا فارغًا بينهما.',
+    openReview: 'افتح المراجعة',
     someNotParsed: {
       zero: 'لم يُستبعد شيء.',
       one: 'واحدة منها لم تبدُ دفعة، فاستُبعدت.',
@@ -13545,19 +13657,19 @@ const ar: UiStrings = {
     },
     addDraftCount: {
       zero: 'لا شيء لإضافته',
-      one: 'أضف مسوّدة واحدة',
-      two: 'أضف مسوّدتين',
-      few: 'أضف {n} مسوّدات',
-      many: 'أضف {n} مسوّدة',
-      other: 'أضف {n} مسوّدة',
+      one: 'أضف واحدة إلى المراجعة',
+      two: 'أضف اثنتين إلى المراجعة',
+      few: 'أضف {n} إلى المراجعة',
+      many: 'أضف {n} إلى المراجعة',
+      other: 'أضف {n} إلى المراجعة',
     },
     addedDraftCount: {
-      zero: 'لم تُضف أي مسوّدة.',
-      one: 'مسوّدة واحدة تنتظر في المراجعة. إنها محفوظة على هذا الهاتف وستُزامَن عند توفّر اتصال.',
-      two: 'مسوّدتان تنتظران في المراجعة. إنهما محفوظتان على هذا الهاتف وستُزامَنان عند توفّر اتصال.',
-      few: '{n} مسوّدات تنتظر في المراجعة. إنها محفوظة على هذا الهاتف وستُزامَن عند توفّر اتصال.',
-      many: '{n} مسوّدة تنتظر في المراجعة. إنها محفوظة على هذا الهاتف وستُزامَن عند توفّر اتصال.',
-      other: '{n} مسوّدة تنتظر في المراجعة. إنها محفوظة على هذا الهاتف وستُزامَن عند توفّر اتصال.',
+      zero: 'لم تُضف أي دفعة.',
+      one: 'دفعة واحدة تنتظر في المراجعة. إنها محفوظة على هذا الهاتف وستُزامَن عند توفّر اتصال.',
+      two: 'دفعتان تنتظران في المراجعة. إنهما محفوظتان على هذا الهاتف وستُزامَنان عند توفّر اتصال.',
+      few: '{n} دفعات تنتظر في المراجعة. إنها محفوظة على هذا الهاتف وستُزامَن عند توفّر اتصال.',
+      many: '{n} دفعة تنتظر في المراجعة. إنها محفوظة على هذا الهاتف وستُزامَن عند توفّر اتصال.',
+      other: '{n} دفعة تنتظر في المراجعة. إنها محفوظة على هذا الهاتف وستُزامَن عند توفّر اتصال.',
     },
     readWindowNote: 'لا ينظر Waves إلا في هذا الجزء من صندوق رسائلك، ويبقى كل ما هو أقدم دون مساس.',
     disclosure: {

--- a/apps/mobile/src/lib/smsDrafts.ts
+++ b/apps/mobile/src/lib/smsDrafts.ts
@@ -39,6 +39,8 @@ import {
   type SmsMessage,
 } from '@waves/core';
 
+import { merchantName } from './smsPlain';
+
 /** Where a draft's message came from. The two are not treated alike. */
 export type SmsDraftChannel = 'paste' | 'inbox';
 
@@ -100,19 +102,92 @@ export interface PlanSmsDraftsInput {
 }
 
 /**
- * Messages are separated by a blank line.
+ * A line that looks like the first line of a *new* message.
  *
- * A single SMS wraps over several lines of its own, so splitting on every
- * newline would cut most of them in half — and half a message parses to either
- * nothing or, worse, a smaller amount. The count is shown before anything is
- * parsed so a bad paste is visible rather than silently producing two
- * candidates from six messages.
+ * Two shapes, both put there by the messages app rather than by the bank: a DLT
+ * sender header (`JM-ICICIT-S`, with or without the punctuation after it) and a
+ * date stamp of the kind a copy-several-messages action stamps each one with.
+ */
+const STARTS_A_MESSAGE =
+  /^(?:[A-Z]{2}-[A-Z][A-Z0-9]{2,9}(?:-[A-Z])?\b|\d{1,2}[/-]\d{1,2}[/-]\d{2,4}\b|\d{1,2}:\d{2}\s*(?:[AaPp][Mm])?\s*[-–—]\s)/;
+
+/** Split before every line that announces a new message. */
+function splitAtStarts(block: string): string[] {
+  const lines = block.split('\n');
+  const parts: string[] = [];
+  let current: string[] = [];
+  const flush = (): void => {
+    const joined = current.join('\n').trim();
+    if (joined) parts.push(joined);
+    current = [];
+  };
+  for (const line of lines) {
+    if (STARTS_A_MESSAGE.test(line.trim()) && current.some((held) => held.trim())) flush();
+    current.push(line);
+  }
+  flush();
+  return parts;
+}
+
+/** How many of these pieces the parser can read as a transaction at all. */
+function readableCount(parts: readonly string[]): number {
+  let readable = 0;
+  for (const part of parts) {
+    if (parseSms(part)) readable += 1;
+  }
+  return readable;
+}
+
+/**
+ * One pasted block, cut up only if cutting it up demonstrably reads better.
+ *
+ * The blank line between messages used to be a rule a person had to know, which
+ * is exactly the sort of rule somebody gets wrong and then feels stupid about.
+ * It is now a hint: three ways of cutting the block are tried — leave it whole,
+ * cut at the lines that announce a new message, cut at every line — and the one
+ * that yields the most *readable* messages wins.
+ *
+ * Ties go to the coarser split, deliberately. A single SMS wraps over several
+ * lines, and half a message parses either to nothing or, worse, to a smaller
+ * amount; so this can only ever find more messages than leaving the block
+ * alone, never fewer. That one-way property is what makes it safe to do without
+ * asking.
+ */
+function bestSplit(block: string): string[] {
+  let best = [block];
+  let bestScore = readableCount(best);
+
+  for (const attempt of [splitAtStarts(block), block.split('\n')]) {
+    const parts = attempt.map((part) => part.trim()).filter((part) => part.length > 0);
+    if (parts.length < 2) continue;
+    const score = readableCount(parts);
+    if (score > bestScore) {
+      best = parts;
+      bestScore = score;
+    }
+  }
+
+  return best;
+}
+
+/**
+ * A paste, as messages.
+ *
+ * A blank line is still the clearest separator and the one the Paste button
+ * writes for you, but nothing here depends on a person knowing that — see
+ * {@link bestSplit}. The count is shown before anything is parsed so a paste
+ * that came out wrong is visible rather than silently producing two candidates
+ * from six messages.
  */
 export function splitMessages(blob: string): string[] {
-  return blob
+  const blocks = blob
     .split(/\n\s*\n+/)
     .map((part) => part.trim())
     .filter((part) => part.length > 0);
+
+  const messages: string[] = [];
+  for (const block of blocks) messages.push(...bestSplit(block));
+  return messages;
 }
 
 /**
@@ -158,6 +233,25 @@ export function bodiesByKey(messages: readonly SmsMessage[]): Map<string, string
   return bodies;
 }
 
+/**
+ * The body a person may be shown for one candidate, or null.
+ *
+ * The same rule as {@link planSmsDrafts}'s `rawText`, in one function so that
+ * "what you can read on the screen" and "what gets written down" cannot drift
+ * apart: a read message's body is neither stored nor displayed, because the one
+ * copy of it lives in the phone's own Messages app and that is enough. A pasted
+ * message's body is both, because the person put it there and will want to
+ * check it against the row this screen made of it.
+ */
+export function bodyForDisplay(
+  key: string,
+  bodies: ReadonlyMap<string, string> | undefined,
+  readKeys: ReadonlySet<string> | undefined,
+): string | null {
+  if (readKeys?.has(key)) return null;
+  return bodies?.get(key) ?? null;
+}
+
 /** The ticked candidates, as drafts. Order is the candidates' own. */
 export function planSmsDrafts(input: PlanSmsDraftsInput): SmsDraft[] {
   const drafts: SmsDraft[] = [];
@@ -168,14 +262,18 @@ export function planSmsDrafts(input: PlanSmsDraftsInput): SmsDraft[] {
     // matter what the caller passed in `bodies`.
     const read = input.readKeys?.has(candidate.dedupeKey) ?? false;
     const channel: SmsDraftChannel = read ? 'inbox' : 'paste';
-    const rawText = read ? null : (input.bodies?.get(candidate.dedupeKey) ?? null);
+    const rawText = bodyForDisplay(candidate.dedupeKey, input.bodies, input.readKeys);
 
     // The merchant is the description, the way it is for every other capture.
     // With no merchant the draft has no name — the amount and the day are what
     // the message gave us, and inventing "Card payment" as *stored* text would
     // put a word into the ledger the bank never said. The screen shows that
     // wording; the row keeps the truth.
-    const description = candidate.merchant?.trim() ?? '';
+    //
+    // `merchantName` is the same guard the row's title uses, so a payment shown
+    // as "Payment from Axis Bank" cannot arrive in Review named "9215676766".
+    // A person ticks what they read.
+    const description = merchantName(candidate.merchant) ?? '';
 
     drafts.push({
       dedupeKey: candidate.dedupeKey,

--- a/apps/mobile/src/lib/smsPlain.ts
+++ b/apps/mobile/src/lib/smsPlain.ts
@@ -1,0 +1,213 @@
+/**
+ * Plain words for what a bank message says.
+ *
+ * A bank SMS is written for a machine as much as for a person: the sender is a
+ * telecom routing header, the "merchant" is whatever the parser could pull out
+ * of a sentence, and neither is safe to print at a grandmother. This module is
+ * the one place that decides what a person is allowed to *see*, and its whole
+ * rule is: **when we do not know, we say nothing.** A code on the screen is
+ * worse than a blank, because a blank is honestly empty and a code looks like
+ * information the reader is failing to understand.
+ *
+ * Nothing here parses money, dates or direction — that is
+ * `packages/core/src/sms/parse.ts`, and this deliberately does not reach into
+ * it. These are pure string judgements, so `test/smsPlain.test.ts` can pin
+ * every one of them without a device.
+ *
+ * WHY IT LIVES IN THE APP AND NOT IN CORE. A candidate is a fact; a name is a
+ * presentation choice, and the table below is a list of Indian banks that will
+ * grow every time somebody's bank is missing. Core should not have to be
+ * released for that.
+ */
+
+/**
+ * India's DLT sender format is `XX-HEADER` or `XX-HEADER-S`.
+ *
+ * `XX` is an operator-and-circle code the carrier prepends (JM, AX, VM, AD, BP,
+ * …) — it says which network carried the message and nothing about who sent it.
+ * `HEADER` is the sender id the bank registered. The trailing single letter is
+ * the message category: `-S` service, `-T` transactional, `-P` promotional,
+ * `-G` government. So `JM-ICICIT-S` carries exactly one useful token, `ICICIT`,
+ * and the other two are routing.
+ */
+const OPERATOR_PREFIX = /^[A-Z]{2}-/;
+const CATEGORY_SUFFIX = /-[A-Z]$/;
+
+/**
+ * Registered sender ids, longest-first where one is a prefix of another.
+ *
+ * Matched on the *start* of the stripped id, because banks register several
+ * headers off one stem (ICICIB, ICICIT, ICICIN) and a new one appearing is not
+ * a reason to show a code. Anything not on this list is unknown, and unknown
+ * shows nothing at all.
+ */
+const SENDER_NAMES: readonly (readonly [RegExp, string])[] = [
+  [/^HDFC/, 'HDFC Bank'],
+  [/^ICICI/, 'ICICI Bank'],
+  [/^AXIS/, 'Axis Bank'],
+  [/^(?:SBI|ATMSBI|SBICRD|SBIINB|SBIUPI)/, 'State Bank of India'],
+  [/^KOTAK/, 'Kotak Mahindra Bank'],
+  [/^INDUS/, 'IndusInd Bank'],
+  [/^YES(?:BNK|BK|BANK)?/, 'Yes Bank'],
+  [/^PNB/, 'Punjab National Bank'],
+  [/^(?:BOB|BARB)/, 'Bank of Baroda'],
+  [/^(?:CANBNK|CANARA|CNRB)/, 'Canara Bank'],
+  [/^(?:UNIONB|UBIN|UNIONBK)/, 'Union Bank of India'],
+  [/^IDFC/, 'IDFC First Bank'],
+  [/^IDBI/, 'IDBI Bank'],
+  [/^RBL/, 'RBL Bank'],
+  [/^(?:FEDBNK|FEDERAL|FDRL)/, 'Federal Bank'],
+  [/^(?:INDBNK|INDIANB|IDIB)/, 'Indian Bank'],
+  [/^(?:CENTBK|CBIN|CENTBNK)/, 'Central Bank of India'],
+  [/^(?:AUBANK|AUFINB)/, 'AU Small Finance Bank'],
+  [/^BANDHAN/, 'Bandhan Bank'],
+  [/^(?:CITI|CITIBK)/, 'Citibank'],
+  [/^HSBC/, 'HSBC'],
+  [/^(?:SCBANK|SCBIND|STANC|SCBL)/, 'Standard Chartered'],
+  [/^AMEX/, 'American Express'],
+  [/^DBSBNK/, 'DBS Bank'],
+  [/^PAYTM/, 'Paytm'],
+  [/^PHONEPE/, 'PhonePe'],
+  [/^(?:GPAY|GOOGLEPAY)/, 'Google Pay'],
+  [/^(?:AMZN|AMAZONPAY)/, 'Amazon Pay'],
+  [/^SLICE/, 'slice'],
+  [/^JUPITER/, 'Jupiter'],
+  [/^(?:ONECRD|ONECARD)/, 'OneCard'],
+];
+
+/**
+ * The bank's own name as it is written in the body of its messages.
+ *
+ * A pasted message carries no sender — the clipboard does not hold one — so the
+ * only place left to look is the text, and a bank alert almost always names
+ * itself in it ("ICICI Bank Acct XX123 debited…"). Word-bounded so that a shop
+ * called "Citi Bakery" is not read as Citibank.
+ */
+const NAMES_IN_TEXT: readonly (readonly [RegExp, string])[] = [
+  [/\bHDFC\b/i, 'HDFC Bank'],
+  [/\bICICI\b/i, 'ICICI Bank'],
+  [/\bAXIS\s*BANK\b/i, 'Axis Bank'],
+  [/\b(?:SBI|State\s+Bank\s+of\s+India)\b/i, 'State Bank of India'],
+  [/\bKOTAK\b/i, 'Kotak Mahindra Bank'],
+  [/\bINDUSIND\b/i, 'IndusInd Bank'],
+  [/\bYES\s*BANK\b/i, 'Yes Bank'],
+  [/\b(?:PNB|Punjab\s+National)\b/i, 'Punjab National Bank'],
+  [/\bBank\s+of\s+Baroda\b/i, 'Bank of Baroda'],
+  [/\bCANARA\b/i, 'Canara Bank'],
+  [/\bUNION\s+BANK\b/i, 'Union Bank of India'],
+  [/\bIDFC\b/i, 'IDFC First Bank'],
+  [/\bIDBI\b/i, 'IDBI Bank'],
+  [/\bRBL\b/i, 'RBL Bank'],
+  [/\bFEDERAL\s+BANK\b/i, 'Federal Bank'],
+  [/\bINDIAN\s+BANK\b/i, 'Indian Bank'],
+  [/\bCENTRAL\s+BANK\s+OF\s+INDIA\b/i, 'Central Bank of India'],
+  [/\bAU\s+SMALL\s+FINANCE\b/i, 'AU Small Finance Bank'],
+  [/\bBANDHAN\s+BANK\b/i, 'Bandhan Bank'],
+  [/\bCITI\s*BANK\b/i, 'Citibank'],
+  [/\bHSBC\b/i, 'HSBC'],
+  [/\bSTANDARD\s+CHARTERED\b/i, 'Standard Chartered'],
+  [/\bAMERICAN\s+EXPRESS\b/i, 'American Express'],
+  [/\bDBS\s+BANK\b/i, 'DBS Bank'],
+  [/\bPAYTM\b/i, 'Paytm'],
+  [/\bPHONEPE\b/i, 'PhonePe'],
+];
+
+/**
+ * `JM-ICICIT-S` → `ICICI Bank`. An id nobody recognises → `null`.
+ *
+ * Null rather than the raw string on purpose. `AX-AIRDUE-S` is a phone bill
+ * reminder routed through the same machinery as a bank alert; printing its
+ * header would put a telecom code under a payment and teach a person that this
+ * screen speaks in codes.
+ */
+export function bankFromSender(sender: string | null | undefined): string | null {
+  if (!sender) return null;
+  const id = sender.trim().toUpperCase().replace(OPERATOR_PREFIX, '').replace(CATEGORY_SUFFIX, '');
+  // A numeric sender is somebody's phone, not a registered bank header.
+  if (!/^[A-Z]/.test(id)) return null;
+  for (const [pattern, name] of SENDER_NAMES) {
+    if (pattern.test(id)) return name;
+  }
+  return null;
+}
+
+/** The bank named in the message itself, for a paste that carries no sender. */
+export function bankFromText(body: string | null | undefined): string | null {
+  if (!body) return null;
+  for (const [pattern, name] of NAMES_IN_TEXT) {
+    if (pattern.test(body)) return name;
+  }
+  return null;
+}
+
+/**
+ * Words the parser sometimes hands back as a "merchant" that are not a name.
+ *
+ * Every one of these is a fragment of bank grammar — the word before the thing
+ * it was looking for — and showing it as the title of a payment says "you paid
+ * VPA", which is nonsense a person cannot act on.
+ */
+const NOT_A_NAME = new Set([
+  'A',
+  'AC',
+  'ACCT',
+  'ACCOUNT',
+  'AN',
+  'ATM',
+  'BANK',
+  'CARD',
+  'CREDIT',
+  'CREDITED',
+  'DEBIT',
+  'DEBITED',
+  'IMPS',
+  'INFO',
+  'INR',
+  'NA',
+  'NEFT',
+  'OTP',
+  'PAYMENT',
+  'POS',
+  'REF',
+  'RRN',
+  'RS',
+  'RTGS',
+  'THE',
+  'TXN',
+  'UPI',
+  'VPA',
+  'YOUR',
+]);
+
+/**
+ * The merchant, if it is plausibly the name of somebody who was paid.
+ *
+ * This is a *display* guard, not a parser fix: `packages/core/src/sms/parse.ts`
+ * owns the extraction and is being sharpened separately. What it cannot do is
+ * promise never to be wrong, and a title is the one place on this screen where
+ * being wrong is indistinguishable from being right — "9215676766" printed
+ * where a shop's name goes reads as a shop called 9215676766.
+ *
+ * Rejected, and why:
+ * - nothing but digits and punctuation — an account number or a phone number;
+ * - a run of six or more digits at the front — "919951860002 Axis Bank", which
+ *   is a phone number with the bank's name stuck to it;
+ * - no letters at all;
+ * - a single bank-grammar word (see {@link NOT_A_NAME});
+ * - the bank's own name, which is who *sent* the message, not who was paid.
+ *
+ * The last of those asks for the word "bank" as well as a match, so that a
+ * wallet somebody really did pay ("PAYTM") survives and "Axis Bank" does not.
+ */
+export function merchantName(raw: string | null | undefined): string | null {
+  const name = raw?.trim();
+  if (!name) return null;
+  if (name.length < 2) return null;
+  if (!/\p{L}/u.test(name)) return null;
+  if (/^[+\d][\d\s().-]*$/.test(name)) return null;
+  if (/^\d{6,}/.test(name)) return null;
+  if (NOT_A_NAME.has(name.toUpperCase().replace(/[^A-Z]/g, ''))) return null;
+  // "Axis Bank" is who sent the message, not who was paid.
+  if (/\bbank\b/i.test(name) && bankFromText(name) !== null) return null;
+  return name;
+}

--- a/apps/mobile/test/smsDrafts.test.ts
+++ b/apps/mobile/test/smsDrafts.test.ts
@@ -200,12 +200,18 @@ describe('what a draft is made of', () => {
     // A person ticks a row that reads "Payment from your bank". It must not
     // arrive in Review called 9215676766 — the same guard decides both, so
     // what was read and what was kept cannot drift apart.
-    const junk = proposeFromSms([sms('Rs.300 debited on 02-03-26 to 9215676766')]);
+    //
+    // The junk merchant is handed in directly rather than coaxed out of the
+    // parser. Both layers now refuse a bare number, and an earlier version of
+    // this test asserted the *parser* still produced one as its setup — so
+    // tightening the parser broke a test about the app-layer guard, which was
+    // never what it was measuring. Two defences, tested where each one lives.
+    const [real] = proposeFromSms([sms('Rs.300 debited on 02-03-26 to SWIGGY')]);
+    const junk = { ...real!, merchant: '9215676766' };
     const [draft] = planSmsDrafts({
-      candidates: junk,
-      chosen: new Set(junk.map((item) => item.dedupeKey)),
+      candidates: [junk],
+      chosen: new Set([junk.dedupeKey]),
     });
-    expect(junk[0]?.merchant).toBe('9215676766');
     expect(draft?.description).toBe('');
     expect(draft?.category).toBeNull();
   });

--- a/apps/mobile/test/smsDrafts.test.ts
+++ b/apps/mobile/test/smsDrafts.test.ts
@@ -13,7 +13,13 @@ import { describe, expect, it } from 'vitest';
 
 import { proposeFromSms, type SmsMessage } from '@waves/core';
 
-import { bodiesByKey, planSmsDrafts, splitMessages, unreadableCount } from '@/lib/smsDrafts';
+import {
+  bodiesByKey,
+  bodyForDisplay,
+  planSmsDrafts,
+  splitMessages,
+  unreadableCount,
+} from '@/lib/smsDrafts';
 
 const SWIGGY = 'Rs.1,250.00 debited from a/c XX4471 on 02-03-26 at SWIGGY. UPI Ref: 412703998812';
 const CAFE = 'Rs.240 debited at BLUE TOKAI on 03-03-26. Ref: 998877665544';
@@ -47,6 +53,26 @@ describe('splitting a paste into messages', () => {
   it('gives nothing for nothing', () => {
     expect(splitMessages('')).toEqual([]);
     expect(splitMessages('   \n  \n ')).toEqual([]);
+  });
+
+  // The blank line used to be a rule a person had to know. It is now a hint:
+  // cutting a block up only wins when the finer cut reads *better*, so this can
+  // find messages the old splitter ran together and can never lose one.
+  it('separates two messages a person pasted with no blank line', () => {
+    expect(splitMessages(`${SWIGGY}\n${CAFE}`)).toEqual([SWIGGY, CAFE]);
+  });
+
+  it('cuts at the sender header a messages app stamps on each one', () => {
+    const lump = `JM-ICICIT-S\n${SWIGGY}\nAX-AXISBK-S\n${CAFE}`;
+    expect(splitMessages(lump)).toEqual([`JM-ICICIT-S\n${SWIGGY}`, `AX-AXISBK-S\n${CAFE}`]);
+  });
+
+  it('leaves a message that wraps over several lines whole', () => {
+    // The safety property: a tie goes to the coarser cut, so half a message —
+    // which parses to nothing, or worse to a smaller amount — is never made.
+    const wrapped =
+      'Rs.1,250.00 debited from a/c XX4471\non 02-03-26 at SWIGGY.\nUPI Ref: 412703998812';
+    expect(splitMessages(wrapped)).toEqual([wrapped]);
   });
 });
 
@@ -152,8 +178,9 @@ describe('what a draft is made of', () => {
   });
 
   it('leaves a message with no shop unnamed rather than inventing a word', () => {
-    // The screen shows "Card payment"; the row keeps the truth, because a
-    // description is a thing a person typed or a bank said.
+    // The screen says "Payment from HDFC Bank", which is true of the message;
+    // the row keeps the truth, because a description is a thing a person typed
+    // or a bank said.
     const bare = proposeFromSms([sms('Rs.500 debited on 02-03-26')]);
     const [draft] = planSmsDrafts({
       candidates: bare,
@@ -167,6 +194,41 @@ describe('what a draft is made of', () => {
     const one = planSmsDrafts({ candidates, chosen: new Set([candidates[0]!.dedupeKey]) });
     expect(one).toHaveLength(1);
     expect(planSmsDrafts({ candidates, chosen: new Set() })).toEqual([]);
+  });
+
+  it('does not file a phone number as the name of a shop', () => {
+    // A person ticks a row that reads "Payment from your bank". It must not
+    // arrive in Review called 9215676766 — the same guard decides both, so
+    // what was read and what was kept cannot drift apart.
+    const junk = proposeFromSms([sms('Rs.300 debited on 02-03-26 to 9215676766')]);
+    const [draft] = planSmsDrafts({
+      candidates: junk,
+      chosen: new Set(junk.map((item) => item.dedupeKey)),
+    });
+    expect(junk[0]?.merchant).toBe('9215676766');
+    expect(draft?.description).toBe('');
+    expect(draft?.category).toBeNull();
+  });
+});
+
+describe('the message a person may read is the message that will be kept', () => {
+  const messages = [sms(SWIGGY)];
+  const key = proposeFromSms(messages)[0]!.dedupeKey;
+  const bodies = bodiesByKey(messages);
+
+  it('hands back a pasted body', () => {
+    expect(bodyForDisplay(key, bodies, new Set())).toBe(SWIGGY);
+  });
+
+  it('hands back nothing for a message read out of the inbox', () => {
+    // Not merely "is not stored" — not shown either, and by the same function,
+    // so the disclosure's promise cannot be undone by a screen.
+    expect(bodyForDisplay(key, bodies, new Set([key]))).toBeNull();
+  });
+
+  it('hands back nothing when there is no body to hand back', () => {
+    expect(bodyForDisplay('amt:INR:1:2026-03-02:?', bodies, undefined)).toBeNull();
+    expect(bodyForDisplay(key, undefined, undefined)).toBeNull();
   });
 });
 

--- a/apps/mobile/test/smsPlain.test.ts
+++ b/apps/mobile/test/smsPlain.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Plain words for what a bank message says.
+ *
+ * Every case here came off a real screenshot of the paste screen: rows headed
+ * `919951860002 Axis Bank` and `9215676766`, subtitled `JM-ICICIT-S` and
+ * `AX-AIRDUE-S`. The rule these pin is the same one in both directions — when
+ * this module does not know, it says nothing, because a code shown to a person
+ * is worse than a blank.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { bankFromSender, bankFromText, merchantName } from '@/lib/smsPlain';
+
+describe('a sender header becomes a bank', () => {
+  it('strips the operator prefix and the message-type suffix', () => {
+    expect(bankFromSender('JM-ICICIT-S')).toBe('ICICI Bank');
+    expect(bankFromSender('AX-AXISBK-S')).toBe('Axis Bank');
+    expect(bankFromSender('AD-HDFCBK')).toBe('HDFC Bank');
+    expect(bankFromSender('VM-SBIINB-T')).toBe('State Bank of India');
+  });
+
+  it('takes a header with no operator prefix at all', () => {
+    expect(bankFromSender('HDFCBK')).toBe('HDFC Bank');
+    expect(bankFromSender('kotakb')).toBe('Kotak Mahindra Bank');
+  });
+
+  it('says nothing for a sender it does not recognise', () => {
+    // A phone bill reminder rides the same rails as a bank alert. Printing
+    // "AIRDUE" under a payment would teach a person that this screen speaks in
+    // codes, which is exactly the habit being unlearned here.
+    expect(bankFromSender('AX-AIRDUE-S')).toBeNull();
+    expect(bankFromSender('VK-SOMEONE')).toBeNull();
+  });
+
+  it('says nothing for a number, which is somebody phoning, not a bank', () => {
+    expect(bankFromSender('919951860002')).toBeNull();
+    expect(bankFromSender('9215676766')).toBeNull();
+  });
+
+  it('says nothing for nothing', () => {
+    expect(bankFromSender(null)).toBeNull();
+    expect(bankFromSender('')).toBeNull();
+  });
+});
+
+describe('a pasted message names its own bank', () => {
+  it('finds the bank in the text, where a paste has no sender to give', () => {
+    expect(bankFromText('ICICI Bank Acct XX123 debited for Rs 450')).toBe('ICICI Bank');
+    expect(bankFromText('Rs.1,250 debited from your Axis Bank card')).toBe('Axis Bank');
+  });
+
+  it('does not read a shop as a bank', () => {
+    expect(bankFromText('Rs.200 paid at CITI BAKERY')).toBeNull();
+    expect(bankFromText('Rs.90 paid at CAFE')).toBeNull();
+  });
+});
+
+describe('a merchant is only shown when it is plausibly a name', () => {
+  it('keeps a name', () => {
+    expect(merchantName('SWIGGY')).toBe('SWIGGY');
+    expect(merchantName('Blue Tokai Coffee')).toBe('Blue Tokai Coffee');
+    expect(merchantName(' AMAZON.IN ')).toBe('AMAZON.IN');
+  });
+
+  it('keeps a wallet somebody really did pay', () => {
+    expect(merchantName('PAYTM')).toBe('PAYTM');
+  });
+
+  it('refuses a phone number', () => {
+    expect(merchantName('9215676766')).toBeNull();
+    expect(merchantName('+91 99518 60002')).toBeNull();
+  });
+
+  it('refuses a number with a bank stuck to it', () => {
+    expect(merchantName('919951860002 Axis Bank')).toBeNull();
+  });
+
+  it('refuses a fragment of bank grammar', () => {
+    for (const junk of ['VPA', 'A', 'UPI', 'REF', 'a/c', 'Your']) {
+      expect(merchantName(junk)).toBeNull();
+    }
+  });
+
+  it('refuses the bank that sent the message, which is not who was paid', () => {
+    expect(merchantName('Axis Bank')).toBeNull();
+    expect(merchantName('HDFC Bank')).toBeNull();
+  });
+
+  it('keeps a real place whose name happens to contain a bank word', () => {
+    expect(merchantName('Bank Street Cafe')).toBe('Bank Street Cafe');
+  });
+
+  it('says nothing for nothing', () => {
+    expect(merchantName(null)).toBeNull();
+    expect(merchantName('   ')).toBeNull();
+    expect(merchantName('...')).toBeNull();
+  });
+});


### PR DESCRIPTION
Redesigns `captures/paste` for the person it is actually for — the stated bar was "a very young child or a grandma". Every defect below came off a live run on a real phone with real bank messages, not from reading the code.

**Base is `feat/sms-import` (PR #796), not `main`.** Merge that first.

## Before → after

| | Before | After |
|---|---|---|
| Subtitle | `JM-ICICIT-S · ⋯4471` | `ICICI Bank · card ending 4471` |
| Unknown sender | `AX-AIRDUE-S` | *(nothing)* |
| Junk title | `9215676766`, `919951860002 Axis Bank` | `Payment from Axis Bank` |
| No merchant | `Card payment` (a guess, stated as fact) | `Payment from your bank` |
| Uncertainty | a bare "Check this" badge | the badge **and** the reason: "The message did not say which day this was." |
| The message itself | nowhere on the screen | "Read the message" opens it under the row |
| Select all | did not exist | one control, two labels, beside a live count |
| Separator | "Leave a blank line between messages" as the placeholder | the splitter finds boundaries itself; the hint appears only if something went unread |
| Header | "The messages" | *(gone — the box and its placeholder say it)* |
| Title | "Import from messages" | "Add from bank messages" |
| First run | nothing | three short lines: open Messages · hold and copy · come back and Paste |
| After adding | "6 drafts are waiting in Review" | the same, plus an **Open Review** button |
| Row height | `minHeight: 52`, 11pt secondary text | `minHeight: 60`, 13pt secondary text, whole row still the target |

## How a sender header becomes a bank name

New `apps/mobile/src/lib/smsPlain.ts`. India's DLT format is `XX-HEADER` or `XX-HEADER-S`: `XX` is the operator-and-circle code the carrier prepends, the middle is the id the bank registered, the trailing letter is the message category (`-S` service, `-T` transactional). So `JM-ICICIT-S` carries one useful token, `ICICIT`, matched on its stem against a table of registered ids.

**An unknown id shows nothing at all.** `AX-AIRDUE-S` is a phone-bill reminder riding the same rails as a bank alert; printing `AIRDUE` under a payment would teach a person that this screen speaks in codes. A blank is honestly empty; a code looks like information the reader is failing to understand.

A *pasted* message carries no sender — the clipboard does not hold one — so the bank is read out of the message text instead (`bankFromText`), word-bounded so `CITI BAKERY` is not Citibank. The read path already has a real sender. Both paths therefore get a name.

The table lives in the app, not in `@waves/core`: a candidate is a fact, a name is a presentation choice, and this list grows every time somebody's bank is missing.

## Degrading gracefully around the parser

`packages/core/src/sms/parse.ts` and `packages/core/test/sms.test.ts` are **untouched** — another agent owns them. `merchantName` is a display guard, not a parser fix. It refuses:

- a bare number or phone number (`9215676766`, `+91 99518 60002`);
- a leading run of six or more digits (`919951860002 Axis Bank`);
- a single fragment of bank grammar — `VPA`, `UPI`, `REF`, `A`, `a/c`, `Your`;
- the bank that *sent* the message, which is not who was paid (`Axis Bank`) — and only when the word "bank" is in it, so a wallet somebody really did pay (`PAYTM`) survives and `Bank Street Cafe` survives.

The title then falls back to `Payment from {bank}`, or `Payment from your bank`. Both are less specific than a shop and entirely true, which is the trade this screen always makes.

**`planSmsDrafts` applies the same guard**, so a row read as "Payment from your bank" cannot land in Review named `9215676766`. A person ticks what they read. When the parser fix lands upstream this guard becomes a no-op, which is the right shape for it.

## Where the original message is now, and how `raw_text` survives

`bodyForDisplay(key, bodies, readKeys)` in `smsDrafts.ts` is now the **single function** deciding both what may be shown on a row and what is written as `rawText`. `planSmsDrafts` calls it instead of reaching into `bodies` itself.

- **Pasted** → both shown and stored. A person handed it over, and it is the thing they will want to check the row against.
- **Read from the inbox** → neither shown nor stored. The one copy lives in the phone's own Messages app, which is enough.
- **Both** → counted as read, the stricter rule, as before.

So the rule got *stronger*, not weaker: it used to govern storage only and a screen could have shown a read body by reaching into the map. Now it cannot, because there is one function and no second path. `test/smsDrafts.test.ts` pins all three cases, and the existing test that greps the whole serialised draft for the message text still passes untouched.

## What "select all" does about low-confidence rows

**It selects them too, and leaves them marked.** Somebody who asks for all of them has asked for all of them; quietly holding two back would be the screen overruling a person who said what they wanted, and they would never learn why the count did not match. What it must *not* do is sweep them in invisibly — so the "Check this" badge is driven by `candidate.preselect`, never by selection, and stays exactly where it was, with the sentence saying which doubt it is, one tap from being put back.

One control, two labels (`Select all` → `Unselect all`), never two controls. The count beside it is live and the button at the foot already says the same number back as the thing it will do ("Add 6 to Review"), which was already right and is kept.

## A blank line is no longer a rule

`splitMessages` tries three cuts of each pasted block — leave it whole, cut where a line announces a new message (a DLT header, a date stamp), cut at every line — and keeps whichever yields the most **parseable** messages. **Ties go to the coarser cut.** That one-way property is what makes it safe to do without asking: it can only ever find more messages than before, never fewer, so half a message — which parses to nothing, or worse to a smaller amount — is never made. The Paste button still joins with a blank line, so the common path was already fine.

The instruction is gone from the placeholder. It reappears as one quiet micro line only when something actually went unread.

## Plain-language pass

Every string on the screen, read aloud. Changed in **en/ta/hi/ar**, each anchored on that locale's own translated string. Four keys that were jargon or dead were removed from the interface and all four tables: `cardPayment`, `messagesSection`, `foundSection`, `foundQuestion`.

- "Import from messages" → "Add from bank messages"
- "The messages" → *(cut)*
- "Paste here. / Leave a blank line between messages." → "Paste your bank messages here"
- "Nothing to import" → "No payments in that"
- "Nothing selected" → "Nothing chosen yet"
- "Add 6 drafts" → "Add 6 to Review"
- "6 drafts are waiting in Review" → "6 payments are waiting in Review"
- "date not in the message" → "The message did not say which day this was."
- new: "Some of this message was hard to read.", "card ending 4471", "Read the message" / "Hide the message", "Select all" / "Unselect all", "6 chosen", "We found 9 payments in what you pasted.", "Open Review", and the three first-run lines.

Arabic gets all six plural forms wherever a count appears.

## Kept exactly as it was

Credits are still filtered in `smsDrafts.ts` (untouched). The tick is still a different glyph with `accessibilityRole="checkbox"` and real state (#191) — and the new uncertainty lines carry an alert icon as well as their colour for the same reason. The FlashList and its group-ledger settings stay (`drawDistance: 1500`, `extraData` now one object so a tick *or* an opened message re-renders a recycled row). `dedupeKey`/`smsCaptureId` idempotency, the already-in-Review count, the per-draft write loop, the guest guard, and "nothing here reports anything to Sentry or Clarity" are all unchanged.

## Deliberately not changed

- `packages/core/src/sms/parse.ts` and its test — another agent's.
- The Android reader path (`captures/messages.tsx`, the disclosure, the two gates). Its strings were re-sized to match the screen and nothing else.
- The share-sheet route in as a first-run path. The brief said "later", and one more entry point is one more decision today.
- The date-window UI, `whoPaid*`, `otherCurrencyNote` and the other strings left over from the per-group import this screen replaced. Dead before this PR, dead after; cleaning them is not this change.

## Gates

`pnpm format` clean · mobile lint clean (one pre-existing warning in `group/[id]/settings.tsx`) · mobile typecheck clean · mobile tests 1560 passed (117 files) · core tests 998 passed (63 files) · `scripts/check-filenames.sh` clean.

Not run on a device.

https://claude.ai/code/session_015jhzmZz5fkjnZZ14YxHGfS
