### PR TITLE
The bank-message parser reads the rest of the world, and says what it guessed

### DIFF
--- a/apps/mobile/src/lib/voiceExpense.ts
+++ b/apps/mobile/src/lib/voiceExpense.ts
@@ -14,7 +14,13 @@
  * and the group are cheap and certain here, and everyone gets them.
  */
 
-import { CATEGORIES, isCurrencyCode, minorUnitScale, type CategoryId } from '@waves/core';
+import {
+  CATEGORIES,
+  isCurrencyCode,
+  minorUnitScale,
+  normaliseDigits,
+  type CategoryId,
+} from '@waves/core';
 
 /** Above this, a voice parse is more likely corrupted or misheard than safe to book. */
 export const MAX_VOICE_AMOUNT_MAJOR = 1_000_000_000;
@@ -1131,20 +1137,14 @@ export function detectBalanceQuery(transcript: string): VoiceBalanceQuery | null
 
 /**
  * Native numerals to ASCII, so "५०० रुपये" and "௫" and "٥" all read as numbers.
- * Devanagari, Tamil, Arabic-Indic and Eastern-Arabic (Persian/Urdu) digits are
- * the ones this app's four locales and their neighbours actually type or speak.
+ *
+ * The table moved to `@waves/core` when the SMS parser needed the same one: the
+ * bank messages this app reads are written in the same scripts its users speak
+ * in, and two copies of a numeral table is two places for a script to go
+ * missing. Re-exported under the name this module has always used so nothing
+ * that imports it from here has to move.
  */
-const NATIVE_DIGIT_BLOCKS: readonly number[] = [0x0966, 0x0be6, 0x0660, 0x06f0];
-
-export function normalizeDigits(text: string): string {
-  return text.replace(/[०-९௦-௯٠-٩۰-۹]/g, (ch) => {
-    const code = ch.codePointAt(0) ?? 0;
-    for (const base of NATIVE_DIGIT_BLOCKS) {
-      if (code >= base && code <= base + 9) return String(code - base);
-    }
-    return ch;
-  });
-}
+export const normalizeDigits = normaliseDigits;
 
 function normalizeCurrencyPrefixes(text: string): string {
   return text.replace(/\b(rp|idr)\.?\s*(?=\d)/gi, '$1 ');

--- a/docs/sms-parser-corpus.md
+++ b/docs/sms-parser-corpus.md
@@ -1,49 +1,161 @@
 # The SMS corpus these results were measured against
 
-25 bodies written to match documented institution formats — **not captured from
+61 bodies written to match documented institution formats — **not captured from
 any real device or inbox**. Kept so that a parser change can be measured against
 the same set rather than against a new one that happens to pass. See
 [sms-parser-coverage.md](sms-parser-coverage.md) for the results.
 
-`null` means the parser must reject it. Those six matter most: a wrong rejection
-loses a transaction the person can paste again, but a wrong acceptance writes a
-ledger entry nobody made.
+`null` in the **expected** column means the parser must reject it. Those twelve
+matter most: a wrong rejection loses a transaction the person can paste again,
+but a wrong acceptance writes a ledger entry nobody made.
 
-Result column records behaviour as measured on `packages/core/src/sms/parse.ts`
-at commit `01b5f678`, September 2026.
+**1–25** are the original India-first set, measured on
+`packages/core/src/sms/parse.ts` at commit `01b5f678`, September 2026. Their
+numbering has not changed. **26–61** were added when the parser was
+internationalised, and cover the hazards that only appear outside one country:
+the decimal comma, three- and zero-decimal currencies, month-first dates,
+non-Latin numerals, right-to-left text, and shared currency symbols.
 
-| #   | case                                    | expected | result               | body                                                                                                                        |
-| --- | --------------------------------------- | -------- | -------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| 1   | SBI UPI (no currency token)             | debit    | **dropped**          | `Dear UPI user A/C X1234 debited by 150.0 on date 12Sep26 trf to SWIGGY Refno 526012345678. If not u? call 1800111109 -SBI` |
-| 2   | HDFC UPI sent                           | debit    | ok, no merchant      | `Sent Rs.245.00 From HDFC Bank A/C x1234 To SWIGGY On 12/09/26 Ref 526012345678 Not You? Call 18002586161`                  |
-| 3   | ICICI acct debit                        | debit    | **dropped**          | `ICICI Bank Acct XX123 debited for Rs 500.00 on 12-Sep-26; SWIGGY credited. UPI:526012345678. Call 18002662 for dispute.`   |
-| 4   | Axis classic                            | debit    | ok                   | `INR 1,234.00 debited from A/c no. XX3456 on 12-09-26 at AMAZON. Avl Bal INR 5,678.90`                                      |
-| 5   | Credit card "used for a transaction of" | debit    | **booked as credit** | `Your ICICI Bank Credit Card XX1234 has been used for a transaction of INR 2,500.00 on 12-Sep-26 at AMAZON.`                |
-| 6   | Debit card spent, ISO-ish date          | debit    | ok, no date          | `Alert: You've spent Rs.1500.00 via Debit Card xx1234 at AMAZON on 2026-09-12:14:23:05.`                                    |
-| 7   | Kotak lakh grouping                     | debit    | ok                   | `Rs 1,23,456.78 debited from Kotak A/c XX7890 on 12-09-26 towards RENT PAYMENT. Ref 998877665544`                           |
-| 8   | ATM withdrawal                          | debit    | ok                   | `Rs.2000 withdrawn from A/c XX1234 at ATM SECTOR 5 on 12-09-26. Avl Bal Rs 12,340.00`                                       |
-| 9   | Paytm wallet                            | debit    | ok                   | `Paid Rs.120 to SWIGGY using Paytm UPI. Txn ID 526012345678`                                                                |
-| 10  | Amazon Pay                              | debit    | ok, no merchant      | `INR 349 debited from your Amazon Pay balance for order 404-1234567. Ref 7788990011`                                        |
-| 11  | Foreign card spend                      | debit    | ok                   | `USD 42.50 spent on your card ending 1234 at STARBUCKS on 12-Sep-26`                                                        |
-| 12  | AED spend                               | debit    | ok                   | `AED 89.00 debited from Card xx4471 at CARREFOUR DUBAI on 12-09-26`                                                         |
-| 13  | Salary credit                           | credit   | ok, merchant `A`     | `INR 85,000.00 credited to A/c XX1234 on 01-09-26 by NEFT. Avl Bal INR 92,340.00`                                           |
-| 14  | Refund                                  | credit   | **dropped**          | `Rs.599.00 refunded to your HDFC Card xx1234 by AMAZON on 12-09-26. Ref 5544332211`                                         |
-| 15  | OTP with amount                         | null     | ok                   | `OTP 445566 for txn of Rs.2,500.00 at AMAZON on HDFC Card xx1234. Do not share.`                                            |
-| 16  | Scheduled autopay                       | null     | ok                   | `Rs 499.00 will be debited from A/c XX1234 on 15-09-26 towards NETFLIX e-mandate.`                                          |
-| 17  | Balance only                            | null     | ok                   | `Avl Bal in A/c XX1234 is Rs 12,340.00 as on 12-09-26.`                                                                     |
-| 18  | Payment due reminder                    | null     | ok                   | `Your ICICI Credit Card XX1234 payment of Rs 8,450.00 is due on 18-09-26.`                                                  |
-| 19  | Failed txn                              | null     | ok                   | `Your transaction of Rs.1,200.00 at AMAZON was declined due to insufficient balance.`                                       |
-| 20  | Marketing                               | null     | ok                   | `Get a personal loan of up to Rs 5,00,000 at 10.5% p.a. Apply now!`                                                         |
-| 21  | UPI VPA merchant                        | debit    | ok, merchant `VPA`   | `Rs.75.00 debited from A/c XX1234 to VPA swiggy@icici on 12-09-26. UPI Ref 526012345678`                                    |
-| 22  | Lowercase bank voice                    | debit    | ok, no merchant      | `rs.250 debited from a/c xx1234 at bigbasket on 12-09-26`                                                                   |
-| 23  | No space after Rs                       | debit    | ok                   | `Rs1,499.00 spent on HDFC Card xx1234 at MYNTRA on 12-09-26`                                                                |
-| 24  | Amount trailing INR                     | debit    | **dropped**          | `Your A/c XX1234 is debited with 350.00 INR on 12-09-26 at UBER.`                                                           |
-| 25  | Two amounts, txn then balance           | debit    | ok                   | `Rs.450.00 debited from A/c XX1234 at DOMINOS on 12-09-26. Avl Bal: Rs.9,999.00`                                            |
+The **before** column is that same `01b5f678` parser run against every case,
+including the new ones — so the two columns are the same 61 messages through two
+parsers, not two different sets. **after** is the internationalised parser. Both
+were run by the same harness; the numbers in the coverage document come from it.
 
-**Score: 20/25 on direction, of which 6 more carry a wrong or missing
-merchant.** All six negatives (15–20) were correctly rejected.
+The **context** column is what a caller told the parser about the reader — a
+region, a locale, or a default currency. It is always optional: the cases marked
+`—` were given nothing at all, and the `*(…)*` note in the **after** column
+lists what the parser therefore had to infer for itself.
 
-Case 25 is worth keeping for the reason it passes: the message quotes two
-amounts, and the parser takes the first. That is right here, because the
-transaction is quoted before the balance — but it is positional luck, not a
-rule, and a bank that leads with the balance would break it.
+## Direction, before and after
+
+| before | after | count |
+| ------ | ----- | ----- |
+| right  | right | 35    |
+| wrong  | right | 26    |
+| right  | wrong | 0     |
+
+**35/61 → 61/61.** On the original 25 alone: **20/25 → 25/25**.
+
+Direction is not the whole story, and the table below is there because it is
+not: four of the 35 the old parser called correctly carried a silently wrong
+**field** — case 61 an amount a thousand times too small, case 59 the balance
+instead of the transaction, case 51 the wrong country's dollar, case 38 the
+wrong day. None of those shows up in a direction score, and all four would have
+reached somebody's ledger looking deliberate.
+
+## The corpus
+
+| #   | case                                         | context     | expected | before                                         | after                                                                 | body                                                                                                                        |
+| --- | -------------------------------------------- | ----------- | -------- | ---------------------------------------------- | --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| 1   | SBI UPI (no currency token)                  | —           | debit    | dropped                                        | debit, INR 150.00, SWIGGY, 2026-09-12 _(currency)_                    | `Dear UPI user A/C X1234 debited by 150.0 on date 12Sep26 trf to SWIGGY Refno 526012345678. If not u? call 1800111109 -SBI` |
+| 2   | HDFC UPI sent                                | —           | debit    | debit, INR 245.00, no merchant, 2026-09-12     | debit, INR 245.00, SWIGGY, 2026-09-12 _(currency+dateOrder)_          | `Sent Rs.245.00 From HDFC Bank A/C x1234 To SWIGGY On 12/09/26 Ref 526012345678 Not You? Call 18002586161`                  |
+| 3   | ICICI acct debit                             | —           | debit    | dropped                                        | debit, INR 500.00, SWIGGY, 2026-09-12 _(currency)_                    | `ICICI Bank Acct XX123 debited for Rs 500.00 on 12-Sep-26; SWIGGY credited. UPI:526012345678. Call 18002662 for dispute.`   |
+| 4   | Axis classic                                 | —           | debit    | debit, INR 1234.00, AMAZON, 2026-09-12         | debit, INR 1234.00, AMAZON, 2026-09-12 _(dateOrder)_                  | `INR 1,234.00 debited from A/c no. XX3456 on 12-09-26 at AMAZON. Avl Bal INR 5,678.90`                                      |
+| 5   | Credit card "used for a transaction of"      | —           | debit    | **credit**, INR 2500.00, AMAZON, 2026-09-12    | debit, INR 2500.00, AMAZON, 2026-09-12                                | `Your ICICI Bank Credit Card XX1234 has been used for a transaction of INR 2,500.00 on 12-Sep-26 at AMAZON.`                |
+| 6   | Debit card spent, ISO-ish date               | —           | debit    | debit, INR 1500.00, AMAZON, no date            | debit, INR 1500.00, AMAZON, 2026-09-12 _(currency)_                   | `Alert: You've spent Rs.1500.00 via Debit Card xx1234 at AMAZON on 2026-09-12:14:23:05.`                                    |
+| 7   | Kotak lakh grouping                          | —           | debit    | debit, INR 123456.78, RENT PAYMENT, 2026-09-12 | debit, INR 123456.78, RENT PAYMENT, 2026-09-12 _(currency+dateOrder)_ | `Rs 1,23,456.78 debited from Kotak A/c XX7890 on 12-09-26 towards RENT PAYMENT. Ref 998877665544`                           |
+| 8   | ATM withdrawal                               | —           | debit    | debit, INR 2000.00, ATM SECTOR 5, 2026-09-12   | debit, INR 2000.00, ATM SECTOR 5, 2026-09-12 _(currency+dateOrder)_   | `Rs.2000 withdrawn from A/c XX1234 at ATM SECTOR 5 on 12-09-26. Avl Bal Rs 12,340.00`                                       |
+| 9   | Paytm wallet                                 | —           | debit    | debit, INR 120.00, SWIGGY, no date             | debit, INR 120.00, SWIGGY, no date _(currency)_                       | `Paid Rs.120 to SWIGGY using Paytm UPI. Txn ID 526012345678`                                                                |
+| 10  | Amazon Pay                                   | —           | debit    | debit, INR 349.00, no merchant, no date        | debit, INR 349.00, no merchant, no date                               | `INR 349 debited from your Amazon Pay balance for order 404-1234567. Ref 7788990011`                                        |
+| 11  | Foreign card spend                           | —           | debit    | debit, USD 42.50, STARBUCKS, 2026-09-12        | debit, USD 42.50, STARBUCKS, 2026-09-12                               | `USD 42.50 spent on your card ending 1234 at STARBUCKS on 12-Sep-26`                                                        |
+| 12  | AED spend                                    | —           | debit    | debit, AED 89.00, CARREFOUR DUBAI, 2026-09-12  | debit, AED 89.00, CARREFOUR DUBAI, 2026-09-12 _(dateOrder)_           | `AED 89.00 debited from Card xx4471 at CARREFOUR DUBAI on 12-09-26`                                                         |
+| 13  | Salary credit                                | —           | credit   | credit, INR 85000.00, **A**, 2026-09-01        | credit, INR 85000.00, no merchant, 2026-09-01 _(dateOrder)_           | `INR 85,000.00 credited to A/c XX1234 on 01-09-26 by NEFT. Avl Bal INR 92,340.00`                                           |
+| 14  | Refund                                       | —           | credit   | dropped                                        | credit, INR 599.00, HDFC, 2026-09-12 _(currency+dateOrder)_           | `Rs.599.00 refunded to your HDFC Card xx1234 by AMAZON on 12-09-26. Ref 5544332211`                                         |
+| 15  | OTP with amount                              | —           | null     | dropped                                        | dropped                                                               | `OTP 445566 for txn of Rs.2,500.00 at AMAZON on HDFC Card xx1234. Do not share.`                                            |
+| 16  | Scheduled autopay                            | —           | null     | dropped                                        | dropped                                                               | `Rs 499.00 will be debited from A/c XX1234 on 15-09-26 towards NETFLIX e-mandate.`                                          |
+| 17  | Balance only                                 | —           | null     | dropped                                        | dropped                                                               | `Avl Bal in A/c XX1234 is Rs 12,340.00 as on 12-09-26.`                                                                     |
+| 18  | Payment due reminder                         | —           | null     | dropped                                        | dropped                                                               | `Your ICICI Credit Card XX1234 payment of Rs 8,450.00 is due on 18-09-26.`                                                  |
+| 19  | Failed txn                                   | —           | null     | dropped                                        | dropped                                                               | `Your transaction of Rs.1,200.00 at AMAZON was declined due to insufficient balance.`                                       |
+| 20  | Marketing                                    | —           | null     | dropped                                        | dropped                                                               | `Get a personal loan of up to Rs 5,00,000 at 10.5% p.a. Apply now!`                                                         |
+| 21  | UPI VPA merchant                             | —           | debit    | debit, INR 75.00, **VPA**, 2026-09-12          | debit, INR 75.00, swiggy, 2026-09-12 _(currency+dateOrder)_           | `Rs.75.00 debited from A/c XX1234 to VPA swiggy@icici on 12-09-26. UPI Ref 526012345678`                                    |
+| 22  | Lowercase bank voice                         | —           | debit    | debit, INR 250.00, no merchant, 2026-09-12     | debit, INR 250.00, bigbasket, 2026-09-12 _(currency+dateOrder)_       | `rs.250 debited from a/c xx1234 at bigbasket on 12-09-26`                                                                   |
+| 23  | No space after Rs                            | —           | debit    | debit, INR 1499.00, MYNTRA, 2026-09-12         | debit, INR 1499.00, MYNTRA, 2026-09-12 _(currency+dateOrder)_         | `Rs1,499.00 spent on HDFC Card xx1234 at MYNTRA on 12-09-26`                                                                |
+| 24  | Amount trailing INR                          | —           | debit    | dropped                                        | debit, INR 350.00, UBER, 2026-09-12 _(dateOrder)_                     | `Your A/c XX1234 is debited with 350.00 INR on 12-09-26 at UBER.`                                                           |
+| 25  | Two amounts, txn then balance                | —           | debit    | debit, INR 450.00, DOMINOS, 2026-09-12         | debit, INR 450.00, DOMINOS, 2026-09-12 _(currency+dateOrder)_         | `Rs.450.00 debited from A/c XX1234 at DOMINOS on 12-09-26. Avl Bal: Rs.9,999.00`                                            |
+| 26  | German decimal comma                         | DE          | debit    | dropped                                        | debit, EUR 1234.56, REWE, 2026-09-12                                  | `Ihr Konto DE12 wurde mit EUR 1.234,56 belastet am 12.09.2026 bei REWE.`                                                    |
+| 27  | German decimal comma, no context             | —           | debit    | dropped                                        | debit, EUR 1234.56, REWE, 2026-09-12 _(dateOrder)_                    | `Ihr Konto wurde mit EUR 1.234,56 belastet am 12.09.2026 bei REWE.`                                                         |
+| 28  | German dot grouping, no decimal part         | DE          | debit    | dropped                                        | debit, EUR 1234.00, REWE, 2026-09-12                                  | `EUR 1.234 belastet Konto 3456 bei REWE am 12.09.2026`                                                                      |
+| 29  | French space grouping                        | FR          | debit    | dropped                                        | debit, EUR 1234.56, CARREFOUR, 2026-09-12                             | `Votre compte 1234 a ete debite de 1 234,56 EUR le 12/09/2026 chez CARREFOUR`                                               |
+| 30  | Swiss apostrophe grouping                    | CH          | debit    | dropped                                        | debit, CHF 1234.50, MIGROS, 2026-09-12                                | `CHF 1'234.50 belastet Konto 4471 bei MIGROS am 12.09.2026`                                                                 |
+| 31  | Spanish card purchase                        | ES          | debit    | dropped                                        | debit, EUR 45.90, MERCADONA, 2026-09-12                               | `Compra de EUR 45,90 en MERCADONA con tarjeta 1234 el 12/09/2026`                                                           |
+| 32  | Portuguese (Brazil)                          | BR          | debit    | dropped                                        | debit, BRL 1234.56, MERCADO LIVRE, 2026-09-12                         | `Compra aprovada: R$ 1.234,56 em MERCADO LIVRE no cartao final 1234 em 12/09/2026`                                          |
+| 33  | Indonesian                                   | ID          | debit    | dropped                                        | debit, IDR 150000.00, TOKOPEDIA, 2026-09-12                           | `Rp 150.000 didebet dari rekening 1234 di TOKOPEDIA pada 12/09/2026`                                                        |
+| 34  | Turkish                                      | TR          | debit    | dropped                                        | debit, TRY 250.75, no merchant, 2026-09-12                            | `Hesabinizdan 250,75 TL harcama yapildi. Kart 1234, 12.09.2026 MIGROS`                                                      |
+| 35  | Kuwaiti dinar, three decimals                | KW          | debit    | dropped                                        | debit, KWD 12.345, LULU, 2026-09-12                                   | `KWD 12.345 debited from Account XX1234 at LULU on 12-09-2026`                                                              |
+| 36  | Kuwaiti dinar, no context                    | —           | debit    | dropped                                        | debit, KWD 12.345, LULU, 2026-09-12 _(decimalSeparator+dateOrder)_    | `KWD 12.345 debited from Account XX1234 at LULU on 12-09-2026`                                                              |
+| 37  | Japanese yen, zero decimals                  | JP          | debit    | dropped                                        | debit, JPY 1234, LAWSON, 2026-09-12                                   | `JPY 1,234 spent on card 1234 at LAWSON on 2026-09-12`                                                                      |
+| 38  | US month-first date                          | US          | debit    | debit, USD 42.50, TARGET, **2026-05-08**       | debit, USD 42.50, TARGET, 2026-08-05                                  | `USD 42.50 spent on card ending 1234 at TARGET on 08/05/2026`                                                               |
+| 39  | Indian day-first, same digits                | IN          | debit    | debit, USD 42.50, TARGET, 2026-05-08           | debit, USD 42.50, TARGET, 2026-05-08                                  | `USD 42.50 spent on card ending 1234 at TARGET on 08/05/2026`                                                               |
+| 40  | Ambiguous date, no context                   | —           | debit    | debit, USD 42.50, TARGET, 2026-05-08           | debit, USD 42.50, TARGET, 2026-05-08 _(dateOrder)_                    | `USD 42.50 spent on card ending 1234 at TARGET on 08/05/2026`                                                               |
+| 41  | ISO date                                     | IE          | debit    | debit, EUR 20.00, IKEA, no date                | debit, EUR 20.00, IKEA, 2026-09-12                                    | `EUR 20.00 debited from account 1234 at IKEA on 2026-09-12`                                                                 |
+| 42  | Named month, month first                     | US          | debit    | debit, USD 42.50, STARBUCKS, no date           | debit, USD 42.50, STARBUCKS, 2026-09-12                               | `USD 42.50 spent at STARBUCKS on Sep 12, 2026 with card 1234`                                                               |
+| 43  | Arabic debit, Arabic-Indic digits            | AE          | debit    | dropped                                        | debit, AED 250.50, كارفور, 2026-09-12                                 | `تم خصم ٢٥٠٫٥٠ د.إ من البطاقة ٤٤٧١ لدى كارفور بتاريخ 12-09-2026`                                                            |
+| 44  | Arabic with a bidi isolate around the amount | AE          | debit    | dropped                                        | debit, AED 250.50, كارفور, no date                                    | `تم خصم ⁦AED 250.50⁩ من الحساب 4471 لدى كارفور`                                                                             |
+| 45  | Hindi Devanagari digits                      | IN          | debit    | dropped                                        | debit, INR 500.00, SWIGGY, 2026-09-12                                 | `आपके खाते XX1234 से ५००.०० रुपये डेबिट किए गए 12-09-2026 को SWIGGY`                                                        |
+| 46  | Thai                                         | TH          | debit    | dropped                                        | debit, THB 1250.00, 7-ELEVEN, 2026-09-12                              | `บัญชี 1234 ถูกหัก THB 1,250.00 ที่ 7-ELEVEN 12/09/2026`                                                                    |
+| 47  | Vietnamese                                   | VN          | debit    | dropped                                        | debit, VND 1250000, HIGHLANDS, 2026-09-12                             | `Tai khoan 1234 ghi no 1.250.000 VND tai HIGHLANDS ngay 12/09/2026`                                                         |
+| 48  | Malay                                        | MY          | debit    | dropped                                        | debit, MYR 125.50, MYDIN, 2026-09-12                                  | `Akaun 1234 didebit RM 125.50 di MYDIN pada 12/09/2026`                                                                     |
+| 49  | Swedish krona                                | SE          | debit    | dropped                                        | debit, SEK 1234.50, ICA, 2026-09-12                                   | `Kortkop 1 234,50 kr hos ICA 12/09/2026 kort 1234`                                                                          |
+| 50  | Dollar with no region                        | —           | debit    | debit, USD 42.50, STARBUCKS, 2026-09-12        | debit, USD 42.50, STARBUCKS, 2026-09-12 _(currency+dateOrder)_        | `$42.50 spent on card ending 1234 at STARBUCKS on 12-09-2026`                                                               |
+| 51  | Canadian dollar by region                    | CA          | debit    | debit, **USD** 42.50, TIM HORTONS, 2026-09-12  | debit, CAD 42.50, TIM HORTONS, 2026-09-12                             | `$42.50 spent on card ending 1234 at TIM HORTONS on 12-09-2026`                                                             |
+| 52  | Bare number, no currency anywhere            | default GBP | debit    | dropped                                        | debit, GBP 150.00, CAFE, 2026-09-12 _(dateOrder)_                     | `Account XX1234 debited by 150.0 at CAFE on 12-09-2026`                                                                     |
+| 53  | Spanish OTP                                  | ES          | null     | dropped                                        | dropped                                                               | `Su codigo de verificacion es 445566 para una compra de EUR 250,00 en ZARA.`                                                |
+| 54  | German scheduled debit                       | DE          | null     | dropped                                        | dropped                                                               | `Ihr Konto wird mit EUR 49,90 belastet am 15.09.2026 fuer NETFLIX.`                                                         |
+| 55  | French declined                              | FR          | null     | dropped                                        | dropped                                                               | `Votre transaction de 45,00 EUR chez FNAC a ete refusee.`                                                                   |
+| 56  | Indonesian balance only                      | ID          | null     | dropped                                        | dropped                                                               | `Saldo rekening 1234 adalah Rp 1.250.000 pada 12/09/2026.`                                                                  |
+| 57  | Turkish due reminder                         | TR          | null     | dropped                                        | dropped                                                               | `Kredi karti 1234 son odeme tarihi 18.09.2026, tutar 1.250,00 TL.`                                                          |
+| 58  | Arabic OTP                                   | AE          | null     | dropped                                        | dropped                                                               | `رمز التحقق 445566 لعملية شراء بقيمة 250.00 د.إ لدى كارفور`                                                                 |
+| 59  | Balance quoted before the transaction        | IN          | debit    | debit, INR **9999.00**, DOMINOS, 2026-09-12    | debit, INR 450.00, DOMINOS, 2026-09-12                                | `Avl Bal Rs 9,999.00. Rs.450.00 debited from A/c XX1234 at DOMINOS on 12-09-26`                                             |
+| 60  | Refund in Spanish                            | ES          | credit   | dropped                                        | credit, EUR 59.90, no merchant, 2026-09-12                            | `Reembolso de EUR 59,90 acreditado a su tarjeta 1234 de ZARA el 12/09/2026`                                                 |
+| 61  | Decimal comma in an English sentence         | DE          | debit    | debit, EUR **1.23**, REWE, 2026-09-12          | debit, EUR 1234.56, REWE, 2026-09-12                                  | `EUR 1.234,56 debited from card 1234 at REWE on 12-09-2026`                                                                 |
+
+Bold marks a field that is **wrong**, as against merely missing.
+
+## Notes on particular cases
+
+**Case 61 is the reason this work happened.** The old parser accepted it,
+scored it 0.9 — comfortably pre-selected — and read €1,234.56 as **€1.23**. The
+amount regex matched `1.23` out of `1.234,56` and stopped, because it took the
+first dot as the decimal point and two digits as the fraction. Nothing about the
+result looks wrong. A person confirming a list of drafts would have to notice
+that one row is a thousandth of what they spent.
+
+**Case 59 replaces the luck in case 25.** Case 25 passed on the old parser
+because Indian banks quote the transaction before the balance and it took the
+first number. Case 59 is the same message with the two swapped, and it is the
+case that fails that way. The parser now skips a number that sits behind a
+balance word rather than relying on the order.
+
+**Cases 35 and 36 are the same message with and without a region.** KWD has
+three minor digits, so `12.345` is twelve dinars and 345 fils — and also,
+equally plausibly, twelve thousand three hundred and forty-five. With a region
+the locale settles it; without one the parser picks the currency's own precision
+and reports `decimalSeparator` as inferred, which drops the confidence below
+pre-selection.
+
+**Cases 38, 39 and 40 are one message read three ways.** `08/05/2026` is the 5th
+of August in Chicago and the 8th of May in Mumbai, and the message says nothing
+either way. Case 40 has no context: the parser answers day-first — the order
+most of the world writes — and says it guessed.
+
+**Case 44 contains invisible characters.** `U+2066` and `U+2069` wrap the amount
+so the digits render left-to-right inside a right-to-left sentence. They will
+not show in a diff or a terminal. The old parser failed on this message not
+because it does not read Arabic but because it does not read Unicode.
+
+**Case 14 still gets the merchant wrong**, reading `HDFC` where `AMAZON` is the
+shop. It is a credit, so it is never proposed as an expense, and telling a bank
+name from a merchant name needs a table this parser does not have.
+
+**Cases 10, 34 and 60 return no merchant.** In 10 the message genuinely names
+only an order number. In 34 the shop is at the very end after a comma with no
+preposition, and in 60 it follows a bare Spanish `de` — a word left out of the
+preposition list on purpose, because it is also an ordinary fragment of English
+and would mint merchants out of the middle of English sentences.
+
+## Reproducing this
+
+Every row comes from `parseSms(body, context)` in
+`packages/core/src/sms/parse.ts`. The behaviours are asserted directly in
+`packages/core/test/sms.test.ts`, which is the version that is kept honest by
+CI; this table is the wider sweep those tests were selected from.

--- a/docs/sms-parser-corpus.md
+++ b/docs/sms-parser-corpus.md
@@ -1,0 +1,49 @@
+# The SMS corpus these results were measured against
+
+25 bodies written to match documented institution formats — **not captured from
+any real device or inbox**. Kept so that a parser change can be measured against
+the same set rather than against a new one that happens to pass. See
+[sms-parser-coverage.md](sms-parser-coverage.md) for the results.
+
+`null` means the parser must reject it. Those six matter most: a wrong rejection
+loses a transaction the person can paste again, but a wrong acceptance writes a
+ledger entry nobody made.
+
+Result column records behaviour as measured on `packages/core/src/sms/parse.ts`
+at commit `01b5f678`, September 2026.
+
+| #   | case                                    | expected | result               | body                                                                                                                        |
+| --- | --------------------------------------- | -------- | -------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| 1   | SBI UPI (no currency token)             | debit    | **dropped**          | `Dear UPI user A/C X1234 debited by 150.0 on date 12Sep26 trf to SWIGGY Refno 526012345678. If not u? call 1800111109 -SBI` |
+| 2   | HDFC UPI sent                           | debit    | ok, no merchant      | `Sent Rs.245.00 From HDFC Bank A/C x1234 To SWIGGY On 12/09/26 Ref 526012345678 Not You? Call 18002586161`                  |
+| 3   | ICICI acct debit                        | debit    | **dropped**          | `ICICI Bank Acct XX123 debited for Rs 500.00 on 12-Sep-26; SWIGGY credited. UPI:526012345678. Call 18002662 for dispute.`   |
+| 4   | Axis classic                            | debit    | ok                   | `INR 1,234.00 debited from A/c no. XX3456 on 12-09-26 at AMAZON. Avl Bal INR 5,678.90`                                      |
+| 5   | Credit card "used for a transaction of" | debit    | **booked as credit** | `Your ICICI Bank Credit Card XX1234 has been used for a transaction of INR 2,500.00 on 12-Sep-26 at AMAZON.`                |
+| 6   | Debit card spent, ISO-ish date          | debit    | ok, no date          | `Alert: You've spent Rs.1500.00 via Debit Card xx1234 at AMAZON on 2026-09-12:14:23:05.`                                    |
+| 7   | Kotak lakh grouping                     | debit    | ok                   | `Rs 1,23,456.78 debited from Kotak A/c XX7890 on 12-09-26 towards RENT PAYMENT. Ref 998877665544`                           |
+| 8   | ATM withdrawal                          | debit    | ok                   | `Rs.2000 withdrawn from A/c XX1234 at ATM SECTOR 5 on 12-09-26. Avl Bal Rs 12,340.00`                                       |
+| 9   | Paytm wallet                            | debit    | ok                   | `Paid Rs.120 to SWIGGY using Paytm UPI. Txn ID 526012345678`                                                                |
+| 10  | Amazon Pay                              | debit    | ok, no merchant      | `INR 349 debited from your Amazon Pay balance for order 404-1234567. Ref 7788990011`                                        |
+| 11  | Foreign card spend                      | debit    | ok                   | `USD 42.50 spent on your card ending 1234 at STARBUCKS on 12-Sep-26`                                                        |
+| 12  | AED spend                               | debit    | ok                   | `AED 89.00 debited from Card xx4471 at CARREFOUR DUBAI on 12-09-26`                                                         |
+| 13  | Salary credit                           | credit   | ok, merchant `A`     | `INR 85,000.00 credited to A/c XX1234 on 01-09-26 by NEFT. Avl Bal INR 92,340.00`                                           |
+| 14  | Refund                                  | credit   | **dropped**          | `Rs.599.00 refunded to your HDFC Card xx1234 by AMAZON on 12-09-26. Ref 5544332211`                                         |
+| 15  | OTP with amount                         | null     | ok                   | `OTP 445566 for txn of Rs.2,500.00 at AMAZON on HDFC Card xx1234. Do not share.`                                            |
+| 16  | Scheduled autopay                       | null     | ok                   | `Rs 499.00 will be debited from A/c XX1234 on 15-09-26 towards NETFLIX e-mandate.`                                          |
+| 17  | Balance only                            | null     | ok                   | `Avl Bal in A/c XX1234 is Rs 12,340.00 as on 12-09-26.`                                                                     |
+| 18  | Payment due reminder                    | null     | ok                   | `Your ICICI Credit Card XX1234 payment of Rs 8,450.00 is due on 18-09-26.`                                                  |
+| 19  | Failed txn                              | null     | ok                   | `Your transaction of Rs.1,200.00 at AMAZON was declined due to insufficient balance.`                                       |
+| 20  | Marketing                               | null     | ok                   | `Get a personal loan of up to Rs 5,00,000 at 10.5% p.a. Apply now!`                                                         |
+| 21  | UPI VPA merchant                        | debit    | ok, merchant `VPA`   | `Rs.75.00 debited from A/c XX1234 to VPA swiggy@icici on 12-09-26. UPI Ref 526012345678`                                    |
+| 22  | Lowercase bank voice                    | debit    | ok, no merchant      | `rs.250 debited from a/c xx1234 at bigbasket on 12-09-26`                                                                   |
+| 23  | No space after Rs                       | debit    | ok                   | `Rs1,499.00 spent on HDFC Card xx1234 at MYNTRA on 12-09-26`                                                                |
+| 24  | Amount trailing INR                     | debit    | **dropped**          | `Your A/c XX1234 is debited with 350.00 INR on 12-09-26 at UBER.`                                                           |
+| 25  | Two amounts, txn then balance           | debit    | ok                   | `Rs.450.00 debited from A/c XX1234 at DOMINOS on 12-09-26. Avl Bal: Rs.9,999.00`                                            |
+
+**Score: 20/25 on direction, of which 6 more carry a wrong or missing
+merchant.** All six negatives (15–20) were correctly rejected.
+
+Case 25 is worth keeping for the reason it passes: the message quotes two
+amounts, and the parser takes the first. That is right here, because the
+transaction is quoted before the balance — but it is positional luck, not a
+rule, and a bank that leads with the balance would break it.

--- a/docs/sms-parser-coverage.md
+++ b/docs/sms-parser-coverage.md
@@ -1,0 +1,213 @@
+# How a bank message reaches Waves, and what the parser does with it
+
+Research, September 2026. Two questions were asked together and they are
+genuinely different, so they are answered separately:
+
+1. **How can a message be read at all?** The access paths, what each one costs,
+   and the two that are quietly closing.
+2. **What does the parser make of the message once it has it?** Measured, not
+   estimated — `parseSms` was run against 25 messages written the way real
+   institutions write them.
+
+The short version:
+
+- **The parser handles 20 of 25.** The five it does not are not exotic. They are
+  **State Bank of India's UPI alert**, **ICICI's account debit**, **any credit
+  card spend**, **refunds**, and **amounts written `350.00 INR`**. One of the
+  five is worse than a miss: a credit-card purchase is currently classified as
+  **money coming in**.
+- Several messages that "pass" carry a **wrong merchant** — `VPA`, `A`, or
+  nothing at all where the shop's name is plainly in the text. The most common
+  cause is a single missing `i` flag.
+- **Confidence is measuring the wrong thing.** It counts how many fields were
+  found, not whether they are right, so the worst merchant bug in the set scores
+  **1.0**.
+- **The inbox is a shrinking source.** Banks are migrating alerts to RCS, which
+  `READ_SMS` cannot see at all, and HDFC already stopped sending SMS for small
+  UPI payments. Neither is a reason not to build this; both are reasons the
+  paste and share lanes are not merely the iPhone consolation prize.
+
+---
+
+## 1. How a message can reach the parser
+
+`docs/plan-drafts-and-rules.md` §1.6 covers the permission economics. This is
+the same list re-cut by _what actually arrives_, which is a different question.
+
+| path                                  | what it can see                                  | what it cannot                                                        |
+| ------------------------------------- | ------------------------------------------------ | --------------------------------------------------------------------- |
+| `READ_SMS` (inbox read)               | every SMS in the device store, historic and new  | RCS messages; anything a bank stopped sending; app-only notifications |
+| `RECEIVE_SMS` (live)                  | SMS as it arrives                                | everything above, plus anything sent before install                   |
+| Share sheet                           | the one message the person shares                | everything they do not share                                          |
+| Paste                                 | whatever is selected and copied                  | same                                                                  |
+| Emailed statement (`import/email.ts`) | a whole month, authoritative, reconciled         | anything not on the statement yet                                     |
+| Notification listener                 | every notification, including RCS and app-native | rejected on policy grounds — §1.6                                     |
+
+### 1.1 The two that are closing
+
+**RCS.** In 2026 RCS Business Messaging went from pilot to production in India
+with Jio, Airtel and Vi all supporting it, and banks are among the first movers
+for alerts — verified sender, brand logo, no 160-character limit. **An RCS
+message is not an SMS.** It does not land in the SMS provider that `READ_SMS`
+reads; it lives in the messaging app's own store, and there is no public API for
+a third-party app to read it. Every bank that migrates its alerts is a bank
+whose transactions silently stop appearing. The person will not see an error —
+they will see Waves quietly stop noticing their spending.
+
+**Small UPI payments already stopped.** HDFC Bank stopped sending SMS for UPI
+payments under ₹100 sent and ₹500 received. For an expense-splitting app this is
+exactly the wrong end of the range to lose: the chai, the auto, the ₹80 share of
+something. Other banks are under the same cost pressure.
+
+Neither kills the feature. Both change what it should promise. **"We will catch
+your bank messages" is honest. "We will catch your spending" is not**, and the
+copy should not drift toward the second.
+
+### 1.2 Which messages are even worth reading
+
+India's DLT regime gives a reliable filter that costs nothing. Every commercial
+sender is a registered 6-character header, delivered as `XX-HEADER` where `XX`
+is an operator+circle code the carrier prepends — `AD-HDFCBK` is Airtel Delhi
+plus HDFC Bank's registered `HDFCBK`. Since May 2025 a message-type suffix is
+appended too, which separates transactional from promotional traffic at the
+header level.
+
+Two consequences worth using:
+
+- A **sender allowlist** of known bank headers is a far better first filter than
+  running a regex over every message in the inbox, and it lets the reader touch
+  dramatically fewer messages — which is both faster and a better answer to
+  "why do you need my whole inbox".
+- The **operator prefix must be stripped before matching**, because the same
+  bank arrives as `AD-HDFCBK`, `VM-HDFCBK`, `JD-HDFCBK` depending on the
+  recipient's carrier and circle. Matching the whole string is a bug that will
+  look like "it works on my phone".
+
+`parseSms` currently takes `sender` but does not use it for anything except
+display. That is a free accuracy win left on the floor.
+
+---
+
+## 2. What the messages actually look like
+
+Four families, and they are not stylistic variations — they need different
+handling.
+
+**Bank account debit.** `A/c`, a masked tail, a balance trailer.
+`INR 1,234.00 debited from A/c no. XX3456 on 12-09-26 at AMAZON. Avl Bal INR 5,678.90`
+
+**UPI.** The growth area and the least standardised. Often no currency token at
+all, a `Ref`/`RRN`, and the counterparty as either a name or a VPA
+(`swiggy@icici`). SBI's is the canonical hard case:
+`Dear UPI user A/C X1234 debited by 150.0 on date 12Sep26 trf to SWIGGY Refno 526012345678`
+
+**Card.** The word "credit" appears in `Credit Card` on messages that are
+debits — a trap the current parser falls into. Verbs are different too: _spent_,
+_used for a transaction of_, _transaction of_.
+
+**Wallet / PPI.** Paytm, Amazon Pay. Shortest and least consistent; often no
+account tail and no date.
+
+---
+
+## 3. Measured results
+
+`parseSms` was run against 25 messages covering those four families plus the
+negatives it must reject. Verbatim bodies are in §6 so this is reproducible.
+
+**20 of 25 behaved as expected.** All six negatives were correctly rejected —
+OTP-with-an-amount, scheduled autopay, balance-only, payment-due, declined, and
+marketing. The rejection side is in good shape and is the side where a mistake
+costs the most, so that matters.
+
+### 3.1 The five hard failures
+
+| #   | case                    | result               | cause                                                                                                            |
+| --- | ----------------------- | -------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| 1   | **SBI UPI**             | dropped              | `AMOUNT` requires a currency token; SBI writes `debited by 150.0`                                                |
+| 2   | **ICICI account debit** | dropped              | message says `debited` _and_ `credited` (of the payee); `debit === credit` bails                                 |
+| 3   | **Credit card spend**   | **booked as income** | `CREDIT_WORDS` matches the word _credit_ inside `Credit Card`; no debit verb matches `used for a transaction of` |
+| 4   | **Refund**              | dropped              | `CREDIT_WORDS` has `refund`; the message says `refunded`                                                         |
+| 5   | **`350.00 INR`**        | dropped              | `AMOUNT` only matches a marker _before_ the number                                                               |
+
+**#3 is the one to fix first.** The others lose a transaction, which the person
+can see and paste again. #3 silently records a ₹2,500 purchase as ₹2,500
+_received_ — a wrong ledger entry that looks deliberate. Everything downstream
+trusts `direction`.
+
+### 3.2 The quiet ones — parsed, but wrong
+
+These all "passed" and would be pre-selected for the person to confirm:
+
+- **`To SWIGGY` yields no merchant.** `MERCHANT` has no `i` flag, so capitalised
+  `To`/`At` never match. HDFC writes `To SWIGGY`. One character fixes it.
+- **Lowercase merchants never match.** The capture requires `[A-Z0-9]` first.
+  `at bigbasket` yields nothing.
+- **`to VPA swiggy@icici` yields the merchant `VPA`** — the literal word,
+  because `to\s+(...)` grabs it before the alternation reaches `VPA`. Scored
+  **confidence 1.0**.
+- **`credited to A/c XX1234` yields the merchant `A`.** The `A` of `A/c`.
+- Amazon Pay and the plain SBI shape yield no merchant at all.
+
+A draft whose merchant reads `VPA` or `A` is worse than one with no merchant:
+the inbox shows a row that looks parsed, and the person has to notice it is
+nonsense.
+
+### 3.3 Confidence is measuring the wrong thing
+
+> `confidence` starts at 0.55 and adds for merchant, reference, date, tail.
+
+It counts _fields found_, never _fields plausible_. So the `VPA` bug scores 1.0
+and is pre-selected, while a perfectly-parsed wallet message with no date and no
+tail scores 0.7. The comment in the source is honest about this — "how much of
+the message we actually understood" — but the number is used as if it meant
+correctness, and `SMS_LOW_CONFIDENCE` gates pre-selection on it.
+
+Minimum fix: a merchant that is a known stop-word (`VPA`, `A`, `A/C`, `UPI`,
+`REF`, a bare number) should score _nothing_, not `+0.2`.
+
+---
+
+## 4. Recommendations, in order
+
+1. **Stop reading `credit` inside `Credit Card`.** Strip card phrases before the
+   direction test, and add the missing debit verbs (`used for a transaction of`,
+   `transaction of`, `txn of`). Fixes the only failure that writes a wrong
+   ledger entry.
+2. **Make the currency token optional.** When a debit verb and an account
+   pattern are present, a bare `150.0` is an amount. Default to the account's
+   currency, not to a body-wide guess. Recovers SBI — the largest bank in India.
+3. **Direction by proximity, not presence.** Take the verb nearest the amount
+   rather than bailing when both appear. Recovers ICICI, which is simply
+   describing both sides of a transfer.
+4. **Add the `i` flag to `MERCHANT`, allow lowercase, and stop-word the
+   captures.** The cheapest quality win in the document.
+5. **Read VPAs properly.** `swiggy@icici` should yield `swiggy` — and
+   `normaliseMerchantName` in `category/merchant.ts` already exists to tidy it.
+6. **Accept a trailing currency** (`350.00 INR`).
+7. **Use the sender.** Strip the `XX-` operator prefix, match a bank allowlist,
+   and let a known bank header raise confidence and a non-bank header skip the
+   message entirely.
+8. **Re-base confidence on plausibility**, per §3.3.
+
+1–4 are small, self-contained changes to a pure function with an existing test
+suite. They are worth doing before anybody tests the feature on a real inbox,
+because the first impression of this feature is entirely a function of its hit
+rate.
+
+## 5. What this research did not do
+
+No real inbox was read — every message here is written to match documented
+formats, not captured from a device. Bank wording changes without notice and
+varies by product within one bank. The corpus is India-heavy, with two foreign
+cases (USD, AED) and none from a European or US bank. RCS displacement is
+reported from public sources, not measured. And nothing here has been run on a
+device: these are results from the pure parser, which is the right place to
+test it, but not the same as the feature working.
+
+## 6. The corpus
+
+Reproducible — 25 bodies, the four families plus the negatives, with the
+expected direction for each. Stored alongside this document as
+`sms-parser-corpus.md` so a fix can be measured against the same set rather than
+against a new one that happens to pass.

--- a/docs/sms-parser-coverage.md
+++ b/docs/sms-parser-coverage.md
@@ -6,22 +6,33 @@ genuinely different, so they are answered separately:
 1. **How can a message be read at all?** The access paths, what each one costs,
    and the two that are quietly closing.
 2. **What does the parser make of the message once it has it?** Measured, not
-   estimated — `parseSms` was run against 25 messages written the way real
-   institutions write them.
+   estimated — `parseSms` was run against 61 messages written the way real
+   institutions write them, in fifteen languages.
+
+**Updated September 2026.** The corpus has since grown to 61 messages and the
+parser has been internationalised. Everything below is re-measured; §3 now
+carries both the original numbers and the current ones, and §4 records which of
+the recommendations were acted on.
 
 The short version:
 
-- **The parser handles 20 of 25.** The five it does not are not exotic. They are
-  **State Bank of India's UPI alert**, **ICICI's account debit**, **any credit
-  card spend**, **refunds**, and **amounts written `350.00 INR`**. One of the
-  five is worse than a miss: a credit-card purchase is currently classified as
-  **money coming in**.
-- Several messages that "pass" carry a **wrong merchant** — `VPA`, `A`, or
-  nothing at all where the shop's name is plainly in the text. The most common
-  cause is a single missing `i` flag.
-- **Confidence is measuring the wrong thing.** It counts how many fields were
-  found, not whether they are right, so the worst merchant bug in the set scores
-  **1.0**.
+- **The parser handled 20 of 25, and now handles 61 of 61.** The five it used to
+  drop were not exotic: **State Bank of India's UPI alert**, **ICICI's account
+  debit**, **any credit card spend**, **refunds**, and **amounts written
+  `350.00 INR`**. One of the five was worse than a miss — a credit-card purchase
+  was classified as **money coming in**. All five are fixed.
+- **The worst bug was not in the original 25 at all.** `EUR 1.234,56` — the way
+  half of Europe and most of Latin America write an amount — read as **€1.23**,
+  a thousandfold error, accepted at confidence 0.9 and pre-selected. It is
+  corpus case 61, and it is the reason the international pass happened.
+- Several messages that "passed" carried a **wrong merchant** — `VPA`, `A`, or
+  nothing at all where the shop's name was plainly in the text. The most common
+  cause was a single missing `i` flag. Fixed, and the captures now have to pass
+  a plausibility test before they count.
+- **Confidence was measuring the wrong thing.** It counted how many fields were
+  found, not whether they are right, so the worst merchant bug in the set scored
+  **1.0**. It is now based on plausibility, and every field the parser had to
+  guess costs it.
 - **The inbox is a shrinking source.** Banks are migrating alerts to RCS, which
   `READ_SMS` cannot see at all, and HDFC already stopped sending SMS for small
   UPI payments. Neither is a reason not to build this; both are reasons the
@@ -83,15 +94,19 @@ Two consequences worth using:
   recipient's carrier and circle. Matching the whole string is a bug that will
   look like "it works on my phone".
 
-`parseSms` currently takes `sender` but does not use it for anything except
-display. That is a free accuracy win left on the floor.
+`parseSms` used to take `sender` and use it for nothing except display. It now
+strips the operator prefix and, when the header looks like a financial
+institution, adds a little confidence. It is a hint and never a filter: an
+unrecognised header changes nothing, because a bank this list has not heard of
+is still a bank, and nothing in the logic assumes the Indian `XX-HEADER` shape —
+a bare `SANTANDER` or `CHASE` is read as itself.
 
 ---
 
 ## 2. What the messages actually look like
 
-Four families, and they are not stylistic variations — they need different
-handling.
+Four families inside India, and a fifth everywhere else. They are not stylistic
+variations — they need different handling.
 
 **Bank account debit.** `A/c`, a masked tail, a balance trailer.
 `INR 1,234.00 debited from A/c no. XX3456 on 12-09-26 at AMAZON. Avl Bal INR 5,678.90`
@@ -102,25 +117,55 @@ all, a `Ref`/`RRN`, and the counterparty as either a name or a VPA
 `Dear UPI user A/C X1234 debited by 150.0 on date 12Sep26 trf to SWIGGY Refno 526012345678`
 
 **Card.** The word "credit" appears in `Credit Card` on messages that are
-debits — a trap the current parser falls into. Verbs are different too: _spent_,
+debits — a trap the original parser fell into. Verbs are different too: _spent_,
 _used for a transaction of_, _transaction of_.
 
 **Wallet / PPI.** Paytm, Amazon Pay. Shortest and least consistent; often no
 account tail and no date.
+
+### 2.1 And a fifth family, which is everywhere else
+
+The four above are how an _Indian_ bank writes. Outside India the shape is
+familiar but three things underneath it are not, and all three fail silently
+rather than loudly:
+
+- **The decimal point is a comma.** `EUR 1.234,56` in Germany, Spain, Brazil,
+  Indonesia, Turkey and most of Latin America. Read with English assumptions it
+  is €1.23.
+- **Not every currency has two decimals.** KWD, BHD, OMR, JOD and TND have
+  three; JPY, KRW, VND, CLP and ISK have none.
+- **The date is month-first** in the United States and nowhere Waves currently
+  ships, and `08/05/2026` gives no hint which it is.
+
+There is also a fourth thing that fails loudly and is therefore easier: the
+message may be in Arabic, Thai, Hindi, Vietnamese or German, may write its
+numbers in Devanagari or Arabic-Indic digits, and may wrap its amount in
+invisible bidi controls so it renders correctly inside right-to-left text.
 
 ---
 
 ## 3. Measured results
 
 `parseSms` was run against 25 messages covering those four families plus the
-negatives it must reject. Verbatim bodies are in §6 so this is reproducible.
+negatives it must reject, and later against 61 covering the fifth as well.
+Verbatim bodies are in §6 so this is reproducible.
 
-**20 of 25 behaved as expected.** All six negatives were correctly rejected —
+**Then: 20 of 25.** All six negatives were correctly rejected —
 OTP-with-an-amount, scheduled autopay, balance-only, payment-due, declined, and
-marketing. The rejection side is in good shape and is the side where a mistake
-costs the most, so that matters.
+marketing. The rejection side was in good shape and is the side where a mistake
+costs the most, so that mattered.
 
-### 3.1 The five hard failures
+**Now: 61 of 61**, on a corpus that grew from 25 messages to 61. The same
+`01b5f678` parser scores **35 of 61** on that wider set. All twelve negatives are
+still rejected, in six languages. No case regressed.
+
+The direction score is the headline but not the whole measurement. Of the 35 the
+old parser called correctly, four carried a silently wrong field: case 61 an
+amount a thousand times too small, case 59 the balance instead of the
+transaction, case 51 the wrong country's dollar, case 38 the wrong day. Those
+are invisible in a direction score and visible in somebody's ledger.
+
+### 3.1 The five hard failures (all now fixed)
 
 | #   | case                    | result               | cause                                                                                                            |
 | --- | ----------------------- | -------------------- | ---------------------------------------------------------------------------------------------------------------- |
@@ -130,12 +175,29 @@ costs the most, so that matters.
 | 4   | **Refund**              | dropped              | `CREDIT_WORDS` has `refund`; the message says `refunded`                                                         |
 | 5   | **`350.00 INR`**        | dropped              | `AMOUNT` only matches a marker _before_ the number                                                               |
 
-**#3 is the one to fix first.** The others lose a transaction, which the person
+**#3 was the one to fix first.** The others lose a transaction, which the person
 can see and paste again. #3 silently records a ₹2,500 purchase as ₹2,500
 _received_ — a wrong ledger entry that looks deliberate. Everything downstream
-trusts `direction`.
+trusts `direction`. It was fixed first, and the rest with it.
 
-### 3.2 The quiet ones — parsed, but wrong
+### 3.1a The worse failure, which was not in the first 25
+
+`EUR 1.234,56 debited from card 1234 at REWE` — corpus case 61 — was **accepted**
+by the old parser, given `direction: debit`, scored **0.9**, pre-selected, and
+recorded as **€1.23**. `AMOUNT` matched `1.23` out of `1.234,56` and stopped,
+because it read the first dot as the decimal point and took two digits after it.
+
+This is worse than every failure in §3.1 put together. A dropped message is
+visible; the person pastes it again. A thousandfold error in a row that looks
+correctly parsed is not visible at all, and it lands in a shared ledger where
+somebody else is owed the difference.
+
+Two smaller members of the same family: `KWD 12.345` silently truncated to
+`12.340` once the currency was recognised at all (the fraction was capped at two
+digits, and five currencies have three); and `$` resolving to USD everywhere,
+so a Canadian message came back in the wrong currency at full confidence.
+
+### 3.2 The quiet ones — parsed, but wrong (all now fixed)
 
 These all "passed" and would be pre-selected for the person to confirm:
 
@@ -164,50 +226,97 @@ the message we actually understood" — but the number is used as if it meant
 correctness, and `SMS_LOW_CONFIDENCE` gates pre-selection on it.
 
 Minimum fix: a merchant that is a known stop-word (`VPA`, `A`, `A/C`, `UPI`,
-`REF`, a bare number) should score _nothing_, not `+0.2`.
+`REF`, a bare number) should score _nothing_, not `+0.2`. That is what it does
+now, and the score also pays for every field the parser had to guess.
+
+### 3.4 Never guess silently — the rule the fix is built on
+
+Three things in a bank message cannot be decided from the message: `08/05/2026`
+is two days, `1.234` is two amounts a thousand apart, and `$` is seven
+currencies. There is no clever reading that resolves them; there is only a
+signal from outside, or a guess.
+
+So `parseSms` takes an optional context — region, locale, default currency, and
+the message's own sender — and for anything the context does not settle it uses
+**one documented fallback and reports it**. `ParsedSms.inferred` lists the fields
+that were decided rather than read (`currency`, `decimalSeparator`, `dateOrder`),
+and each one costs confidence, which is what keeps a guessed row out of the
+pre-selected set. The UI can then point at the field to check rather than
+telling somebody the whole row is doubtful.
+
+The fallbacks, written down so they are arguable:
+
+| ambiguity                            | resolved by                                                  | with nothing at all                                        |
+| ------------------------------------ | ------------------------------------------------------------ | ---------------------------------------------------------- |
+| `08/05/2026`                         | a component over 12; else the region's order                 | day-first, marked `dateOrder`                              |
+| one separator, three digits after it | the currency's exponent — a 2-decimal currency cannot have 3 | grouping, **not** marked: this is a deduction, not a guess |
+| the same, for a 3-decimal currency   | the locale's decimal separator                               | the currency's own precision, marked `decimalSeparator`    |
+| `$`, `kr`, `Rs`, `ريال`              | the region                                                   | the family's most common member, marked `currency`         |
+| no currency token at all             | the caller's default, then the region's currency             | INR — Waves' home market — marked `currency`               |
 
 ---
 
-## 4. Recommendations, in order
+## 4. Recommendations, and what became of them
 
-1. **Stop reading `credit` inside `Credit Card`.** Strip card phrases before the
-   direction test, and add the missing debit verbs (`used for a transaction of`,
-   `transaction of`, `txn of`). Fixes the only failure that writes a wrong
-   ledger entry.
-2. **Make the currency token optional.** When a debit verb and an account
-   pattern are present, a bare `150.0` is an amount. Default to the account's
-   currency, not to a body-wide guess. Recovers SBI — the largest bank in India.
-3. **Direction by proximity, not presence.** Take the verb nearest the amount
-   rather than bailing when both appear. Recovers ICICI, which is simply
-   describing both sides of a transfer.
-4. **Add the `i` flag to `MERCHANT`, allow lowercase, and stop-word the
-   captures.** The cheapest quality win in the document.
-5. **Read VPAs properly.** `swiggy@icici` should yield `swiggy` — and
-   `normaliseMerchantName` in `category/merchant.ts` already exists to tidy it.
-6. **Accept a trailing currency** (`350.00 INR`).
-7. **Use the sender.** Strip the `XX-` operator prefix, match a bank allowlist,
-   and let a known bank header raise confidence and a non-bank header skip the
-   message entirely.
-8. **Re-base confidence on plausibility**, per §3.3.
+1. ~~**Stop reading `credit` inside `Credit Card`.**~~ Done. Card phrases are
+   blanked — replaced by spaces of the same length, so every other index into
+   the message still holds — before direction is decided, and the missing debit
+   verbs are in the list.
+2. ~~**Make the currency token optional.**~~ Done. A bare number introduced by a
+   transaction verb is an amount; the currency comes from the caller's default,
+   then the region, then INR, and the last case says it guessed.
+3. ~~**Direction by proximity, not presence.**~~ Done. The verb nearest the
+   amount decides; equidistant still refuses.
+4. ~~**Add the `i` flag to `MERCHANT`, allow lowercase, stop-word the
+   captures.**~~ Done, plus a plausibility test: an implausible capture is
+   skipped and the parser keeps looking rather than returning it.
+5. ~~**Read VPAs properly.**~~ Done — `swiggy@icici` yields `swiggy`.
+   `normaliseMerchantName` was not used: it strips gateway noise for
+   _categorisation_, and a merchant shown to a person should keep the spelling
+   the bank sent.
+6. ~~**Accept a trailing currency.**~~ Done.
+7. **Use the sender** — done as a hint, not as a filter. The recommendation said
+   "let a non-bank header skip the message entirely"; that was not followed. A
+   bank the allowlist has not heard of is still a bank, an allowlist written in
+   India would silently drop every European sender, and a person who pasted a
+   message has already decided it is worth reading. A recognised header raises
+   confidence and nothing lowers it.
+8. ~~**Re-base confidence on plausibility.**~~ Done, per §3.3 and §3.4.
 
-1–4 are small, self-contained changes to a pure function with an existing test
-suite. They are worth doing before anybody tests the feature on a real inbox,
-because the first impression of this feature is entirely a function of its hit
-rate.
+Still open:
+
+- **The sender allowlist as a cheap first filter over a whole inbox** — the
+  performance half of §1.2, distinct from the accuracy half. Nothing in the
+  reader uses it yet.
+- **Telling a bank name from a merchant name** (corpus case 14 reads `HDFC`
+  where the shop is `AMAZON`). That needs a table the parser does not have.
+- **`de`, `a` and `no` as merchant prepositions.** Left out deliberately: each
+  is also an ordinary English fragment and would mint merchants out of the
+  middle of English sentences. It costs a merchant on two Spanish and
+  Portuguese shapes (corpus 34, 60).
 
 ## 5. What this research did not do
 
 No real inbox was read — every message here is written to match documented
 formats, not captured from a device. Bank wording changes without notice and
-varies by product within one bank. The corpus is India-heavy, with two foreign
-cases (USD, AED) and none from a European or US bank. RCS displacement is
-reported from public sources, not measured. And nothing here has been run on a
-device: these are results from the pure parser, which is the right place to
-test it, but not the same as the feature working.
+varies by product within one bank. The corpus is now 61 messages across roughly
+fifteen languages, but it is still a corpus somebody wrote rather than one
+somebody received, and the non-English cases are a bigger leap than the Indian
+ones: those at least match formats that are publicly documented. RCS
+displacement is reported from public sources, not measured. And nothing here has
+been run on a device: these are results from the pure parser, which is the right
+place to test it, but not the same as the feature working.
+
+Two things the parser knows it cannot do. It does not read a language whose
+verbs are not in its list, and that list is written by hand — the failure mode
+is a silent miss, not an error. And it cannot tell a Hindi message from a Hindi
+message _about_ a transaction any better than its Hindi vocabulary allows, which
+is thinner than its English one.
 
 ## 6. The corpus
 
-Reproducible — 25 bodies, the four families plus the negatives, with the
-expected direction for each. Stored alongside this document as
-`sms-parser-corpus.md` so a fix can be measured against the same set rather than
-against a new one that happens to pass.
+Reproducible — 61 bodies, the five families plus the negatives, with the
+expected direction for each and the result from both the original and the
+current parser. Stored alongside this document as `sms-parser-corpus.md` so a
+fix can be measured against the same set rather than against a new one that
+happens to pass.

--- a/packages/core/src/import/email.ts
+++ b/packages/core/src/import/email.ts
@@ -323,6 +323,10 @@ export function proposeFromEmail(
       accountTail: null,
       reference: null,
       occurredAt,
+      // An email line is read with its own rules, not the SMS parser's, so
+      // nothing here is an inference the SMS module would want to flag. The
+      // field exists on the shared shape; an empty list is the honest value.
+      inferred: [],
       confidence: Math.min(1, Number(confidence.toFixed(2))),
     };
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@
  */
 
 export * from './ids';
+export * from './text/index';
 export * from './time/index';
 export * from './money/index';
 export * from './split/index';

--- a/packages/core/src/sms/locale.ts
+++ b/packages/core/src/sms/locale.ts
@@ -1,0 +1,533 @@
+/**
+ * The things a bank message does not say, and somebody has to decide.
+ *
+ * Three of them are genuinely undecidable from the text alone:
+ *
+ *   - `08/05/2026` is the 8th of May in Mumbai and the 5th of August in
+ *     Chicago, and nothing in the message distinguishes them;
+ *   - `EUR 1.234` is one thousand two hundred and thirty-four euros in Berlin
+ *     and one euro twenty-three in Dublin;
+ *   - `$` is seven different currencies.
+ *
+ * So this module holds the *hints* a caller can supply — the user's country,
+ * their locale, the currency their group counts in — and, for each hint that is
+ * missing, one explicit documented fallback. Every fallback is reported back to
+ * the parser so the answer can say which parts of it were guessed. A parser
+ * that guesses is fine. A parser that guesses silently puts an expense on the
+ * wrong day of a trip, or off by a factor of a thousand, and looks certain
+ * doing it.
+ */
+
+import { currencyForCountry } from '../money/region';
+import { isCurrencyCode, type CurrencyCode } from '../money/currency';
+
+/** Day-month-year, as most of the world writes it, or month-day-year. */
+export type DateOrder = 'dmy' | 'mdy';
+
+/**
+ * What the caller knows that the message does not. Every field is optional and
+ * the parser works with none of them — it just marks more of its answer as
+ * inferred.
+ */
+export interface SmsParseContext {
+  /** ISO-3166 alpha-2, e.g. `IN`, `DE`, `US`. The strongest single hint. */
+  readonly region?: string | null;
+  /** BCP-47, e.g. `de-DE` or `pt`. Its region subtag is used when `region` is absent. */
+  readonly locale?: string | null;
+  /** What to assume when the message names no currency at all. */
+  readonly defaultCurrency?: CurrencyCode | null;
+  /** Overrides the region's date order outright. */
+  readonly dateOrder?: DateOrder | null;
+  /** Overrides the region's decimal separator outright. */
+  readonly decimalSeparator?: '.' | ',' | null;
+  /** Sender id, e.g. `AD-HDFCBK` or `+441234…`. A hint, never a filter. */
+  readonly sender?: string | null;
+}
+
+/** What the parser had to decide for itself. Surfaced so the UI can flag it. */
+export type InferredField = 'currency' | 'decimalSeparator' | 'dateOrder';
+
+/* ------------------------------------------------------------------ *
+ * Region
+ * ------------------------------------------------------------------ */
+
+export function regionOf(context: SmsParseContext): string | null {
+  const direct = (context.region ?? '').trim().toUpperCase();
+  if (/^[A-Z]{2}$/.test(direct)) return direct;
+  const fromLocale = /^[A-Za-z]{2,3}[-_]([A-Za-z]{2})\b/.exec((context.locale ?? '').trim());
+  return fromLocale?.[1] ? fromLocale[1].toUpperCase() : null;
+}
+
+function languageOf(context: SmsParseContext): string | null {
+  const tag = (context.locale ?? '').trim().toLowerCase();
+  const match = /^([a-z]{2,3})(?:[-_]|$)/.exec(tag);
+  return match?.[1] ?? null;
+}
+
+/* ------------------------------------------------------------------ *
+ * Date order
+ * ------------------------------------------------------------------ */
+
+/**
+ * The handful of places that write the month first. Everywhere else — including
+ * every market Waves ships in — writes the day first, which is why that is the
+ * fallback rather than a coin flip.
+ */
+const MONTH_FIRST = new Set(['US', 'PH', 'FM', 'MH', 'PW']);
+
+export function dateOrderFor(context: SmsParseContext): { order: DateOrder; explicit: boolean } {
+  if (context.dateOrder) return { order: context.dateOrder, explicit: true };
+  const region = regionOf(context);
+  if (region) return { order: MONTH_FIRST.has(region) ? 'mdy' : 'dmy', explicit: true };
+  return { order: 'dmy', explicit: false };
+}
+
+/* ------------------------------------------------------------------ *
+ * Decimal separator
+ * ------------------------------------------------------------------ */
+
+/**
+ * Where a comma is the decimal point. Switzerland is deliberately absent: it
+ * writes `1'234.56`, dot-decimal with an apostrophe for grouping, and putting
+ * it in this set would invert every Swiss amount.
+ */
+const COMMA_DECIMAL_REGIONS = new Set([
+  'AL',
+  'AO',
+  'AR',
+  'AT',
+  'AZ',
+  'BA',
+  'BE',
+  'BG',
+  'BO',
+  'BR',
+  'BY',
+  'CL',
+  'CM',
+  'CO',
+  'CR',
+  'CU',
+  'CV',
+  'CZ',
+  'DE',
+  'DK',
+  'DO',
+  'DZ',
+  'EC',
+  'EE',
+  'ES',
+  'FI',
+  'FR',
+  'GR',
+  'GL',
+  'HR',
+  'HU',
+  'ID',
+  'IS',
+  'IT',
+  'LT',
+  'LU',
+  'LV',
+  'MA',
+  'MD',
+  'ME',
+  'MK',
+  'MZ',
+  'NL',
+  'NO',
+  'PL',
+  'PT',
+  'PY',
+  'RO',
+  'RS',
+  'RU',
+  'SE',
+  'SI',
+  'SK',
+  'SN',
+  'TN',
+  'TR',
+  'UA',
+  'UY',
+  'VE',
+  'VN',
+]);
+
+/** Languages that are comma-decimal wherever they are spoken, for a bare `de`/`fr` tag. */
+const COMMA_DECIMAL_LANGUAGES = new Set([
+  'de',
+  'fr',
+  'pt',
+  'it',
+  'nl',
+  'id',
+  'tr',
+  'ru',
+  'pl',
+  'vi',
+  'da',
+  'sv',
+  'nb',
+  'no',
+  'fi',
+  'cs',
+  'el',
+  'ro',
+  'hu',
+  'hr',
+  'sr',
+  'sk',
+  'sl',
+  'bg',
+  'uk',
+  'lv',
+  'lt',
+  'et',
+  'is',
+  'af',
+]);
+
+/**
+ * `null` means "nobody told us", which is different from "we know it is a dot".
+ * The parser treats the two differently: a known separator settles `1,234`
+ * outright, an unknown one falls through to a currency-aware guess that gets
+ * reported as one.
+ */
+export function decimalSeparatorFor(context: SmsParseContext): '.' | ',' | null {
+  if (context.decimalSeparator) return context.decimalSeparator;
+  const region = regionOf(context);
+  if (region) return COMMA_DECIMAL_REGIONS.has(region) ? ',' : '.';
+  const language = languageOf(context);
+  // Spanish is split down the middle — comma in Spain, dot in Mexico — so a
+  // bare `es` says nothing and is left unanswered rather than halved.
+  if (language && language !== 'es' && language !== 'en') {
+    return COMMA_DECIMAL_LANGUAGES.has(language) ? ',' : '.';
+  }
+  return null;
+}
+
+/* ------------------------------------------------------------------ *
+ * Currency
+ * ------------------------------------------------------------------ */
+
+/**
+ * Currencies that share a marker. The symbol says the family; only the reader's
+ * country says which member.
+ */
+const FAMILIES: Readonly<Record<string, { byRegion: Record<string, string>; fallback: string }>> =
+  Object.freeze({
+    dollar: {
+      byRegion: {
+        US: 'USD',
+        CA: 'CAD',
+        AU: 'AUD',
+        NZ: 'NZD',
+        SG: 'SGD',
+        HK: 'HKD',
+        TW: 'TWD',
+        MX: 'MXN',
+        AR: 'ARS',
+        CL: 'CLP',
+        CO: 'COP',
+        BR: 'BRL',
+        FJ: 'FJD',
+        JM: 'JMD',
+      },
+      fallback: 'USD',
+    },
+    rupee: {
+      byRegion: { IN: 'INR', LK: 'LKR', NP: 'NPR', PK: 'PKR', MU: 'MUR', SC: 'SCR' },
+      fallback: 'INR',
+    },
+    pound: {
+      byRegion: { GB: 'GBP', EG: 'EGP', LB: 'LBP', SD: 'SDG', SS: 'SSP', SY: 'SYP' },
+      fallback: 'GBP',
+    },
+    yen: { byRegion: { JP: 'JPY', CN: 'CNY' }, fallback: 'JPY' },
+    krone: { byRegion: { SE: 'SEK', NO: 'NOK', DK: 'DKK', IS: 'ISK', FO: 'DKK' }, fallback: 'SEK' },
+    riyal: { byRegion: { SA: 'SAR', QA: 'QAR', OM: 'OMR', YE: 'YER', IR: 'IRR' }, fallback: 'SAR' },
+    dirham: { byRegion: { AE: 'AED', MA: 'MAD' }, fallback: 'AED' },
+    dinar: {
+      byRegion: {
+        KW: 'KWD',
+        BH: 'BHD',
+        JO: 'JOD',
+        IQ: 'IQD',
+        TN: 'TND',
+        DZ: 'DZD',
+        LY: 'LYD',
+        RS: 'RSD',
+      },
+      fallback: 'KWD',
+    },
+  });
+
+/**
+ * Marker text to an ISO code, or to the name of a family that needs the region
+ * to settle it. Keys are folded: uppercased, with dots and spaces removed.
+ */
+const MARKERS: Readonly<Record<string, string>> = Object.freeze({
+  // Qualified dollars, which are not ambiguous at all.
+  US$: 'USD',
+  CA$: 'CAD',
+  C$: 'CAD',
+  A$: 'AUD',
+  AU$: 'AUD',
+  NZ$: 'NZD',
+  S$: 'SGD',
+  SG$: 'SGD',
+  HK$: 'HKD',
+  NT$: 'TWD',
+  R$: 'BRL',
+  MX$: 'MXN',
+  // Families.
+  $: 'dollar',
+  '₹': 'INR',
+  '₨': 'rupee',
+  RS: 'rupee',
+  '£': 'pound',
+  '¥': 'yen',
+  KR: 'krone',
+  // Unambiguous symbols.
+  '€': 'EUR',
+  '₩': 'KRW',
+  '₫': 'VND',
+  '฿': 'THB',
+  '₦': 'NGN',
+  '₱': 'PHP',
+  '₽': 'RUB',
+  '₪': 'ILS',
+  '₴': 'UAH',
+  '₸': 'KZT',
+  '₺': 'TRY',
+  // Latin abbreviations.
+  RP: 'IDR',
+  RM: 'MYR',
+  DH: 'dirham',
+  DHS: 'dirham',
+  TL: 'TRY',
+  KC: 'CZK',
+  ZL: 'PLN',
+  РУБ: 'RUB',
+  // Arabic abbreviations — the letter pairs Gulf banks actually print.
+  'د.إ': 'AED',
+  'ر.س': 'SAR',
+  'ر.ق': 'QAR',
+  'ر.ع': 'OMR',
+  'د.ك': 'KWD',
+  'د.ب': 'BHD',
+  'د.أ': 'JOD',
+  'د.ا': 'JOD',
+  'د.ت': 'TND',
+  'ج.م': 'EGP',
+  ريال: 'riyal',
+  درهم: 'dirham',
+  دينار: 'dinar',
+  جنيه: 'EGP',
+  // The rupee, spelled out — Hindi and Tamil bank alerts write the word, not
+  // the symbol, and a message in Devanagari digits usually carries one too.
+  रुपये: 'rupee',
+  रुपए: 'rupee',
+  रु: 'rupee',
+  ரூபாய்: 'rupee',
+  ரூ: 'rupee',
+  // CJK and South-East Asia.
+  円: 'JPY',
+  元: 'CNY',
+  บาท: 'THB',
+  Đ: 'VND',
+  VNĐ: 'VND',
+});
+
+/**
+ * The ISO codes the parser will read as a currency marker. Waves' own
+ * `minorUnitExponent` table plus every market `currencyForCountry` names, so
+ * "the currencies Waves supports" and "the currencies the SMS reader knows" are
+ * the same list rather than two lists that drift.
+ */
+const ISO_CODES = [
+  'AED',
+  'ARS',
+  'AUD',
+  'BDT',
+  'BGN',
+  'BHD',
+  'BRL',
+  'CAD',
+  'CHF',
+  'CLP',
+  'CNY',
+  'COP',
+  'CZK',
+  'DKK',
+  'DZD',
+  'EGP',
+  'EUR',
+  'FJD',
+  'GBP',
+  'GHS',
+  'HKD',
+  'HUF',
+  'IDR',
+  'ILS',
+  'INR',
+  'IQD',
+  'ISK',
+  'JMD',
+  'JOD',
+  'JPY',
+  'KES',
+  'KRW',
+  'KWD',
+  'KZT',
+  'LBP',
+  'LKR',
+  'LYD',
+  'MAD',
+  'MUR',
+  'MXN',
+  'MYR',
+  'NGN',
+  'NOK',
+  'NPR',
+  'NZD',
+  'OMR',
+  'PEN',
+  'PHP',
+  'PKR',
+  'PLN',
+  'PYG',
+  'QAR',
+  'RON',
+  'RSD',
+  'RUB',
+  'SAR',
+  'SCR',
+  'SEK',
+  'SGD',
+  'THB',
+  'TND',
+  'TRY',
+  'TWD',
+  'TZS',
+  'UAH',
+  'UGX',
+  'USD',
+  'UYU',
+  'VND',
+  'ZAR',
+] as const;
+
+/** The alternation the amount patterns are built from. Longest forms first. */
+export const CURRENCY_TOKEN_SOURCE = [
+  '(?:US|CA|AU|NZ|SG|HK|NT|MX)\\$',
+  '[RCAS]\\$',
+  `\\b(?:${ISO_CODES.join('|')})\\b`,
+  '\\bRs\\.?',
+  '\\bRp\\.?',
+  '\\bRM\\b',
+  '\\bDhs?\\.?',
+  '\\bTL\\b',
+  // No trailing `\b` on any of these: JavaScript's word boundary is defined
+  // against [A-Za-z0-9_], so there is no boundary after `č`, `ł` or a Cyrillic
+  // letter, and asking for one would make the pattern match nothing at all.
+  '\\bK[čc]\\.?',
+  '\\bz[łl]',
+  '\\bkr\\.?',
+  'руб\\.?',
+  '[₹€£¥₩₫฿₦₱₽₨₪₴₸₺$]',
+  'د\\.[إكبأات]',
+  'ر\\.[سقع]',
+  'ج\\.م',
+  '(?:ريال|درهم|دينار|جنيه)',
+  '(?:रुपये|रुपए|रु|ரூபாய்|ரூ)',
+  '(?:円|元|บาท)',
+  'Đ',
+].join('|');
+
+const foldMarker = (raw: string): string =>
+  raw
+    .replace(/[\s]/g, '')
+    .replace(/\.$/, '')
+    .toUpperCase()
+    // Czech and Polish fold through the same path the message body does.
+    .replace(/Č/g, 'C')
+    .replace(/Ł/g, 'L');
+
+export interface CurrencyReading {
+  readonly currency: CurrencyCode;
+  /** True when nothing in the message or the context actually settled it. */
+  readonly inferred: boolean;
+}
+
+/**
+ * The currency for a marker found beside the amount, or — when the message
+ * named none — the caller's default, the region's currency, and finally INR.
+ *
+ * INR last is not an accident and not neutrality: it is Waves' home market and
+ * the documented last resort. It is always reported as inferred, so a message
+ * from a bank that names no currency never claims to be rupees.
+ */
+export function resolveCurrency(marker: string | null, context: SmsParseContext): CurrencyReading {
+  const region = regionOf(context);
+
+  if (marker) {
+    const folded = foldMarker(marker);
+    const resolved = MARKERS[folded] ?? folded;
+    const family = FAMILIES[resolved];
+    if (family) {
+      const fromRegion = region ? family.byRegion[region] : undefined;
+      if (fromRegion) return { currency: fromRegion, inferred: false };
+      return { currency: family.fallback, inferred: true };
+    }
+    // A marker that resolves to neither a family nor an ISO code is a pattern
+    // that got ahead of this table; fall through rather than hand `money` a
+    // string it will throw on.
+    if (isCurrencyCode(resolved)) return { currency: resolved, inferred: false };
+  }
+
+  if (context.defaultCurrency) return { currency: context.defaultCurrency, inferred: false };
+  const regional = currencyForCountry(region);
+  if (regional) return { currency: regional, inferred: false };
+  return { currency: 'INR', inferred: true };
+}
+
+/* ------------------------------------------------------------------ *
+ * Sender
+ * ------------------------------------------------------------------ */
+
+/**
+ * The registered header inside a sender id, with the carrier's prefix removed.
+ *
+ * India's DLT regime delivers the same bank as `AD-HDFCBK`, `VM-HDFCBK` or
+ * `JD-HDFCBK` depending on the recipient's operator and circle, and since 2025
+ * with a message-type suffix as well. Matching the whole string is a bug that
+ * looks like "it works on my phone". Nothing here assumes the Indian shape
+ * though: a sender with no prefix comes back unchanged, which is what a
+ * European or Gulf short code looks like.
+ */
+export function senderHeader(sender: string | null | undefined): string | null {
+  const raw = (sender ?? '').trim();
+  if (!raw) return null;
+  const withoutOperator = raw.replace(/^[A-Za-z]{2}\d?[-_]/, '');
+  const header = withoutOperator.replace(/[-_][A-Za-z]$/, '').toUpperCase();
+  return header || null;
+}
+
+/**
+ * Whether the sender looks like a financial institution.
+ *
+ * Used only to *raise* confidence, never to drop a message: a bank not on this
+ * list is a bank this list has not heard of yet, and a person who pasted a
+ * message has already decided it is worth reading. The generic shapes at the
+ * end matter more than the names — they are what make this work outside India.
+ */
+export function looksLikeBankSender(sender: string | null | undefined): boolean {
+  const header = senderHeader(sender);
+  if (!header) return false;
+  if (/^\+?\d{6,}$/.test(header)) return false; // a person's phone number
+  return /BANK|BNK|\bBK|CARD|UPI|PAY|CRED|FIN|UBI|SBI|HDFC|ICICI|AXIS|KOTAK|PNB|BOI|CANARA|YES|IDFC|RBL|INDUS|AMEX|CHASE|WELLS|BOFA|BARCL|HSBC|LLOYD|NATWST|SANTAN|REVOLUT|MONZO|WISE|DBS|OCBC|UOB|ENBD|ADCB|FAB|MASHREQ|MAYBANK|CIMB|BCA|MANDIRI|BBVA|CAIXA|ITAU|BRADESCO|NUBANK|SPARKASSE|GARANTI|AKBANK|ZIRAAT|SCB|KBANK|VIETCOM|TECHCOM/i.test(
+    header,
+  );
+}

--- a/packages/core/src/sms/parse.ts
+++ b/packages/core/src/sms/parse.ts
@@ -18,10 +18,55 @@
  *
  * Everything is parsed as digits and assembled into minor units. No float ever
  * exists between the text and the amount (ADR-003).
+ *
+ * ## Never guess silently
+ *
+ * Three things in a bank message are genuinely undecidable from the text:
+ * `08/05/2026` is two different days, `1.234` is two amounts a thousand apart,
+ * and `$` is seven currencies. The rule this file follows everywhere is that
+ * such a thing is either settled by an explicit signal — the caller's region,
+ * locale or default currency, passed in as {@link SmsParseContext} — or it is
+ * decided by one documented fallback *and reported*, in `inferred`, with the
+ * confidence lowered to match. A parser that guesses is fine. A parser that
+ * guesses and then looks certain puts an expense on the wrong day of a trip.
+ *
+ * The context is entirely optional and every path works without it. A caller
+ * that knows the user's country simply gets a better answer, and Waves knows
+ * the user's country.
  */
 
-import { minorUnitExponent, type CurrencyCode } from '../money/currency';
+import { minorUnitExponent, isCurrencyCode, type CurrencyCode } from '../money/currency';
 import { money, type Money } from '../money/money';
+import { normaliseForParsing, foldToken } from '../text/digits';
+import {
+  ACCOUNT_TAIL,
+  BALANCE_ONLY,
+  BALANCE_WORDS,
+  CARD_PHRASES,
+  CREDIT_SOURCE,
+  CREDIT_WORDS,
+  DEBIT_SOURCE,
+  DEBIT_WORDS,
+  MERCHANT_DETERMINERS,
+  MERCHANT_NOISE,
+  MERCHANT_PREPOSITIONS,
+  MERCHANT_STOP_WORDS,
+  MONTHS,
+  NOT_A_TRANSACTION,
+  REFERENCE,
+} from './vocabulary';
+import {
+  CURRENCY_TOKEN_SOURCE,
+  dateOrderFor,
+  decimalSeparatorFor,
+  looksLikeBankSender,
+  resolveCurrency,
+  type InferredField,
+  type SmsParseContext,
+} from './locale';
+
+export type { InferredField, SmsParseContext, DateOrder } from './locale';
+export { senderHeader, looksLikeBankSender } from './locale';
 
 export enum TransactionDirection {
   Debit = 'debit',
@@ -46,6 +91,15 @@ export interface ParsedSms {
    * expense on the wrong day of a trip.
    */
   readonly occurredAt: string | null;
+  /**
+   * Which fields the parser had to decide for itself because the message and
+   * the context between them did not say.
+   *
+   * This is the honest half of the confidence score: a caller can point at the
+   * exact field to check rather than telling somebody the whole row is doubtful
+   * and leaving them to find out which part.
+   */
+  readonly inferred: readonly InferredField[];
   /** 0–1. Below `SMS_LOW_CONFIDENCE` the candidate is shown but not pre-selected. */
   readonly confidence: number;
 }
@@ -53,191 +107,628 @@ export interface ParsedSms {
 /** Below this, a person should look before confirming. */
 export const SMS_LOW_CONFIDENCE = 0.7;
 
+/* ------------------------------------------------------------------ *
+ * Folding
+ * ------------------------------------------------------------------ */
+
 /**
- * Currency markers seen in Indian bank SMS. `Rs` and `INR` are the same thing;
- * a bank abroad will say `USD` or use a symbol.
+ * Letters with no Unicode decomposition, so `normalize('NFD')` cannot strip
+ * them down to a base letter. Each replacement is exactly one character long,
+ * which is the whole constraint: the fold must not change the string's length.
  */
-const CURRENCY_MARKERS: ReadonlyArray<readonly [RegExp, CurrencyCode]> = [
-  [/(?:INR|Rs\.?|₹)/i, 'INR'],
-  // The amount regex matches case-insensitively, so "usd 42" yields an amount;
-  // without `i` here the code fell through every marker and defaulted the
-  // currency to INR, mislabelling the proposed expense.
-  [/(?:USD|\$)/i, 'USD'],
-  [/(?:EUR|€)/i, 'EUR'],
-  [/(?:GBP|£)/i, 'GBP'],
-  [/AED/i, 'AED'],
-  [/SGD/i, 'SGD'],
-  [/THB/i, 'THB'],
-];
+const UNDECOMPOSABLE: Readonly<Record<string, string>> = Object.freeze({
+  ß: 's',
+  Ø: 'O',
+  ø: 'o',
+  Đ: 'D',
+  đ: 'd',
+  Ł: 'L',
+  ł: 'l',
+  ı: 'i',
+  ħ: 'h',
+  Æ: 'A',
+  æ: 'a',
+  Œ: 'O',
+  œ: 'o',
+  Ð: 'D',
+  ð: 'd',
+  Þ: 'T',
+  þ: 't',
+});
+
+const ACCENTED = /[\u00c0-\u024f\u1e00-\u1eff]/g;
 
 /**
- * Words that mean money left the account. Ordered longest-first so that
- * "debited" is not matched by a looser rule before "credited" is considered.
- */
-const DEBIT_WORDS = /\b(debited|debit|spent|paid|withdrawn|purchase|sent|deducted)\b/i;
-const CREDIT_WORDS = /\b(credited|credit|received|refund|reversed|cashback)\b/i;
-
-/**
- * Messages that look like transactions but are not. A one-time password quotes
- * an amount and would otherwise parse cleanly into an expense somebody never
- * made — this is the single most dangerous false positive in the set, because
- * the number is real and the message is from the right sender.
- */
-const NOT_A_TRANSACTION =
-  /\b(OTP|one[- ]time\s*password|will\s+be\s+debited|request(?:ed)?\s+(?:for|to)|is\s+due|due\s+on|reminder|failed|declined|unsuccessful|statement|e-?mandate|auto[- ]?pay\s+scheduled)\b/i;
-
-/**
- * A balance report on its own is not a transaction. The same words appear as a
- * trailer on a real debit alert ("... Avl Bal: Rs 12,340"), so these only
- * disqualify a message that says nothing about money moving.
- */
-const BALANCE_ONLY = /\b(balance\s+is|avl\s*bal|available\s+balance\s+is)\b/i;
-
-/**
- * Amount, as digits: "1,234.56" or "1234" or "1.234,56" is not attempted —
- * Indian and international banks both write "1,23,456.78" or "1,234.56", and
- * both use the dot as the decimal separator.
- */
-const AMOUNT = /(INR|Rs\.?|₹|USD|\$|EUR|€|GBP|£|AED|SGD|THB)\s*([\d,]+(?:\.\d{1,2})?)/i;
-
-/** "to AMAZON", "at STARBUCKS", "towards SWIGGY" — whoever was paid. */
-const MERCHANT =
-  /\b(?:to|at|towards|in\s+favour\s+of|VPA)\s+([A-Z0-9][A-Za-z0-9&.'@_-]*(?:\s+[A-Z0-9][A-Za-z0-9&.'@_-]*){0,3})/;
-
-const ACCOUNT_TAIL = /\b(?:a\/c|acct?|account|card|xx+|\*+)\s*(?:no\.?\s*)?[xX*]*(\d{3,6})\b/;
-const REFERENCE =
-  /\b(?:ref(?:erence)?|txn|transaction|UPI\s*Ref|RRN)\s*(?:no\.?|id)?[:\s]\s*([A-Za-z0-9]{6,})/i;
-
-/** "05-08-26", "05/08/2026", "05-Aug-26". Day first, as Indian banks write it. */
-const DATE_NUMERIC = /\b(\d{1,2})[-/](\d{1,2})[-/](\d{2,4})\b/;
-const DATE_NAMED = /\b(\d{1,2})[-\s]([A-Za-z]{3})[-\s](\d{2,4})\b/;
-const TIME = /\b(\d{1,2}):(\d{2})(?::(\d{2}))?\b/;
-
-const MONTHS: Record<string, number> = {
-  jan: 1,
-  feb: 2,
-  mar: 3,
-  apr: 4,
-  may: 5,
-  jun: 6,
-  jul: 7,
-  aug: 8,
-  sep: 9,
-  oct: 10,
-  nov: 11,
-  dec: 12,
-};
-
-/**
- * "1,23,456.78" → 12345678 minor units, by digits.
+ * `débité` to `debite`, `ağustos` to `agustos`, `số` to `so` — **without
+ * changing the length of the string**.
  *
- * A message quoting more precision than the currency has is truncated, not
- * rounded: banks do not print a third decimal, so seeing one means the parse
- * went wrong somewhere and inventing a rounding rule would hide that.
+ * That constraint is what lets the whole file work: every word list is written
+ * unaccented and matched against the folded text, while merchant names are
+ * sliced out of the *original* text at the indices the folded match reported.
+ * Strip the accents with NFD instead and every index after the first accent in
+ * the message points one character to the left, which is a bug that only shows
+ * up in French.
  */
-function toMinor(text: string, currency: CurrencyCode): bigint {
-  const cleaned = text.replace(/,/g, '');
+function foldLatin(text: string): string {
+  return text.replace(ACCENTED, (character) => {
+    const direct = UNDECOMPOSABLE[character];
+    if (direct) return direct;
+    const base = character.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+    return base.length === 1 ? base : character;
+  });
+}
+
+/** The card phrases blanked out, same length, so every other index still holds. */
+function maskCards(text: string): string {
+  return text.replace(CARD_PHRASES, (match) => ' '.repeat(match.length));
+}
+
+/* ------------------------------------------------------------------ *
+ * Amounts
+ * ------------------------------------------------------------------ */
+
+/**
+ * A written number, in the four shapes the world writes them in.
+ *
+ * Ordered longest-first, because the alternation is tried in order and the
+ * shortest form would otherwise swallow `1,23` out of `1,23,456.78`. Every
+ * group is non-capturing so this can be embedded in larger patterns without
+ * renumbering their groups, and the whole thing ends with a lookahead refusing
+ * a trailing digit: without it `500 123456` reads as `500 123`.
+ *
+ *   1. space, apostrophe or non-breaking space grouping — `1 234,56` (fr, ru),
+ *      `1'234.56` (ch);
+ *   2. comma or dot grouping with the other as the decimal — `1,234.56`,
+ *      `1.234,56`, and India's `1,23,456.78`;
+ *   3. a single separator, which is the ambiguous case — see `readNumber`;
+ *   4. bare digits.
+ */
+const NUMBER_SOURCE =
+  "(?:\\d{1,3}(?:['\u2019 \u00a0\u202f\u2009\u2007]\\d{3})+(?:[.,]\\d{1,4})?" +
+  '|\\d{1,3}(?:[.,]\\d{2,3})+(?:[.,]\\d{1,4})?' +
+  '|\\d+(?:[.,]\\d{1,4})?)(?!\\d)';
+
+const AMOUNT_LEADING = new RegExp(`(${CURRENCY_TOKEN_SOURCE})\\s*(${NUMBER_SOURCE})`, 'gi');
+const AMOUNT_TRAILING = new RegExp(`(${NUMBER_SOURCE})\\s*(${CURRENCY_TOKEN_SOURCE})`, 'gi');
+
+/**
+ * A number with no currency token at all, which is how State Bank of India —
+ * the country's largest bank — writes every UPI alert: `debited by 150.0`.
+ *
+ * Only ever reached when no currency-marked amount was found, and only when a
+ * transaction verb introduces the number, because a bare number in a bank
+ * message is far more often a date, an account tail or a helpline.
+ */
+const AMOUNT_AFTER_VERB = new RegExp(
+  `(?:${DEBIT_SOURCE}|${CREDIT_SOURCE})\\s*(?:by|for|with|of|:|-)?\\s*(${NUMBER_SOURCE})`,
+  'giu',
+);
+const AMOUNT_BEFORE_VERB = new RegExp(
+  `(${NUMBER_SOURCE})\\s*(?:(?:has|have|was|were|is|are)\\s+(?:been\\s+)?)?(?:${DEBIT_SOURCE}|${CREDIT_SOURCE})`,
+  'giu',
+);
+
+interface AmountMatch {
+  /** The digits as written. */
+  readonly token: string;
+  /** The currency marker beside it, when there was one. */
+  readonly marker: string | null;
+  /** Where the digits start, in the collapsed message. */
+  readonly index: number;
+}
+
+/** Ranges in the message where a balance is being reported. */
+function balanceRanges(folded: string): readonly (readonly [number, number])[] {
+  const ranges: [number, number][] = [];
+  BALANCE_WORDS.lastIndex = 0;
+  for (const match of folded.matchAll(BALANCE_WORDS)) {
+    if (match.index === undefined) continue;
+    ranges.push([match.index, match.index + match[0].length]);
+  }
+  return ranges;
+}
+
+/**
+ * A number that is plainly not an amount: part of a date, part of a card tail,
+ * or a reference long enough that no shop charges it.
+ */
+function looksLikeIdentifier(text: string, index: number, token: string): boolean {
+  const before = index > 0 ? text[index - 1] : '';
+  const after = text.slice(index + token.length, index + token.length + 2);
+  if (before && /[\d\-/:xX*]/.test(before)) return true;
+  if (/^[-/:]\d/.test(after)) return true;
+  return !/[.,]/.test(token) && token.replace(/\D/g, '').length >= 9;
+}
+
+function collect(pattern: RegExp, text: string, markerFirst: boolean): AmountMatch[] {
+  const found: AmountMatch[] = [];
+  pattern.lastIndex = 0;
+  for (const match of text.matchAll(pattern)) {
+    if (match.index === undefined) continue;
+    const marker = markerFirst ? (match[1] ?? null) : (match[2] ?? null);
+    const token = markerFirst ? match[2] : match[1];
+    if (!token) continue;
+    const index = match.index + match[0].indexOf(token);
+    if (looksLikeIdentifier(text, index, token)) continue;
+    found.push({ token, marker, index });
+  }
+  return found;
+}
+
+/**
+ * The transaction's amount, out of however many numbers the message quotes.
+ *
+ * Two amounts in one message is the normal case, not the exception — almost
+ * every debit alert carries the running balance as a trailer. The old parser
+ * took the first number and was right by luck, because Indian banks quote the
+ * transaction first. This takes the first number that is *not* sitting behind a
+ * balance word, which is the same answer for those messages and the right one
+ * for a bank that leads with the balance.
+ */
+function findAmount(raw: string, folded: string): AmountMatch | null {
+  let candidates = [...collect(AMOUNT_LEADING, raw, true), ...collect(AMOUNT_TRAILING, raw, false)];
+  if (candidates.length === 0) {
+    candidates = [
+      ...collect(AMOUNT_AFTER_VERB, folded, false),
+      ...collect(AMOUNT_BEFORE_VERB, folded, false),
+    ];
+  }
+  if (candidates.length === 0) return null;
+
+  const byPosition = [...candidates].sort((a, b) => a.index - b.index);
+  const balances = balanceRanges(folded);
+  const isBalance = (candidate: AmountMatch): boolean =>
+    balances.some(([, end]) => end <= candidate.index && candidate.index - end <= 12);
+
+  return byPosition.find((candidate) => !isBalance(candidate)) ?? byPosition[0] ?? null;
+}
+
+interface NumberReading {
+  readonly minor: bigint;
+  /** True when the decimal separator was a coin flip rather than a deduction. */
+  readonly separatorInferred: boolean;
+}
+
+/**
+ * Digits on the page to integer minor units, deciding which separator was the
+ * decimal point and which was grouping.
+ *
+ * The cases in order, and why each one is safe:
+ *
+ *   - **both a dot and a comma appear.** The later one is the decimal point.
+ *     No locale writes it the other way, so `1.234,56` and `1,234.56` are both
+ *     settled outright.
+ *   - **one kind, more than once.** `1.234.567` and India's `1,23,456` can only
+ *     be grouping; nothing has two decimal points.
+ *   - **one separator, fewer than three digits after it.** Grouping is always
+ *     in threes, so this is a decimal point.
+ *   - **one separator, exactly three digits after it.** The genuinely ambiguous
+ *     case — and for almost every currency it is not ambiguous at all, because
+ *     a currency with two minor digits cannot have three. So the currency's own
+ *     exponent settles it, and `EUR 1.234` reads as one thousand two hundred
+ *     and thirty-four rather than as €1.23. Only the three-decimal currencies
+ *     (KWD, BHD, OMR, JOD, TND) are left genuinely open; there the caller's
+ *     locale decides, and with no locale the fallback is reported as inferred.
+ *
+ * More fraction digits than the currency has are truncated rather than rounded,
+ * which is the old rule kept deliberately: inventing a rounding here would hide
+ * a parse that went wrong. A zero-decimal currency therefore never acquires
+ * phantom minor units — `JPY 1,234.00` is ¥1,234, not ¥123,400.
+ */
+function readNumber(
+  token: string,
+  currency: CurrencyCode,
+  context: SmsParseContext,
+): NumberReading | null {
+  // Spaces and apostrophes are only ever grouping — no locale uses either as a
+  // decimal point — so they can go before anything is decided.
+  const cleaned = token.replace(/['\u2019 \u00a0\u202f\u2009\u2007]/g, '');
+  if (!/^\d/.test(cleaned)) return null;
+
   const exponent = minorUnitExponent(currency);
-  const [whole = '0', fraction = ''] = cleaned.split('.');
-  const padded = (fraction + '0'.repeat(exponent)).slice(0, exponent);
-  return BigInt(whole + padded);
-}
+  const lastDot = cleaned.lastIndexOf('.');
+  const lastComma = cleaned.lastIndexOf(',');
+  const dots = (cleaned.match(/\./g) ?? []).length;
+  const commas = (cleaned.match(/,/g) ?? []).length;
 
-function detectCurrency(text: string): CurrencyCode {
-  for (const [pattern, code] of CURRENCY_MARKERS) {
-    if (pattern.test(text)) return code;
-  }
-  return 'INR';
-}
+  let decimalAt = -1;
+  let separatorInferred = false;
 
-function detectDate(text: string): string | null {
-  const time = TIME.exec(text);
-  const clock = time
-    ? `T${(time[1] ?? '0').padStart(2, '0')}:${time[2]}:${(time[3] ?? '00').padStart(2, '0')}.000Z`
-    : 'T00:00:00.000Z';
-
-  const named = DATE_NAMED.exec(text);
-  if (named) {
-    const month = MONTHS[(named[2] ?? '').toLowerCase()];
-    if (month) return `${expandYear(named[3])}-${pad(month)}-${pad(Number(named[1]))}${clock}`;
-  }
-
-  const numeric = DATE_NUMERIC.exec(text);
-  if (numeric) {
-    const day = Number(numeric[1]);
-    const month = Number(numeric[2]);
-    // Always day-first, the Indian convention these alerts are written in. A
-    // US-format message (08/05/2026) is read as 8 August; without the sender's
-    // locale there is nothing here to tell the two apart, so this is a known
-    // limitation rather than a check.
-    if (day >= 1 && day <= 31 && month >= 1 && month <= 12) {
-      return `${expandYear(numeric[3])}-${pad(month)}-${pad(day)}${clock}`;
+  if (dots > 0 && commas > 0) {
+    decimalAt = Math.max(lastDot, lastComma);
+  } else if (dots + commas > 1) {
+    decimalAt = -1;
+  } else if (dots + commas === 1) {
+    const at = dots === 1 ? lastDot : lastComma;
+    const separator = cleaned[at] === '.' ? '.' : ',';
+    const after = cleaned.length - at - 1;
+    const before = at;
+    if (after === 0) {
+      decimalAt = -1;
+    } else if (after !== 3 || before > 3) {
+      decimalAt = at;
+    } else if (exponent !== 3) {
+      // Grouping: a two- or zero-decimal currency cannot carry three of them.
+      decimalAt = -1;
+    } else {
+      const locale = decimalSeparatorFor(context);
+      decimalAt = (locale ?? '.') === separator ? at : -1;
+      separatorInferred = locale === null;
     }
   }
-  return null;
+
+  if (!/^\d+$/.test(cleaned.replace(/[.,]/g, ''))) return null;
+
+  const whole = (decimalAt === -1 ? cleaned : cleaned.slice(0, decimalAt)).replace(/[.,]/g, '');
+  const fraction = decimalAt === -1 ? '' : cleaned.slice(decimalAt + 1).replace(/[.,]/g, '');
+  const padded = (fraction + '0'.repeat(exponent)).slice(0, exponent);
+  return { minor: BigInt((whole || '0') + padded), separatorInferred };
+}
+
+/* ------------------------------------------------------------------ *
+ * Dates
+ * ------------------------------------------------------------------ */
+
+const DATE_ISO = /\b(\d{4})[-/](\d{1,2})[-/](\d{1,2})(?:[T\s:](\d{1,2}):(\d{2})(?::(\d{2}))?)?/;
+// `(?!\d)` on the day is what stops the month-first pattern reading `Okt 2026`
+// as the 20th of October: without it `\d{1,2}` happily takes the `20` out of
+// the year and leaves `26` behind as one.
+// The optional `de`/`di`/`of` is Spanish and Portuguese writing the date out in
+// full — "12 de dezembro de 2026" — which is the ordinary form on a Brazilian
+// card alert, not a flourish.
+const DATE_DAY_FIRST =
+  /(\d{1,2})(?!\d)[-./]?\s*(?:(?:de|di|of)\s+)?(\p{L}{3,12})[-./,]?\s*(?:(?:de|del|di)\s+)?(\d{2,4})\b/gu;
+const DATE_MONTH_FIRST = /(\p{L}{3,12})[-./]?\s*(\d{1,2})(?!\d)(?:st|nd|rd|th)?,?\s*(\d{2,4})\b/gu;
+const DATE_NUMERIC = /\b(\d{1,2})[-/.](\d{1,2})[-/.](\d{2,4})\b/;
+const TIME = /\b(\d{1,2}):(\d{2})(?::(\d{2}))?\b/;
+
+/**
+ * A month name in any of the languages the vocabulary covers, or null.
+ *
+ * Looked up longest key first so French `juin` (6) and `juillet` (7) do not
+ * collapse into a shared `jui`.
+ */
+function monthOf(word: string): number | null {
+  const folded = foldToken(word);
+  return MONTHS[folded] ?? MONTHS[folded.slice(0, 4)] ?? MONTHS[folded.slice(0, 3)] ?? null;
+}
+
+interface DateReading {
+  readonly iso: string;
+  /** True when day-versus-month order was a fallback rather than a deduction. */
+  readonly orderInferred: boolean;
 }
 
 const pad = (value: number): string => String(value).padStart(2, '0');
 const expandYear = (raw: string | undefined): string =>
   !raw ? '1970' : raw.length === 4 ? raw : `20${raw.padStart(2, '0')}`;
 
+const validDay = (day: number, month: number): boolean =>
+  day >= 1 && day <= 31 && month >= 1 && month <= 12;
+
+/**
+ * The first match whose middle word is really a month name.
+ *
+ * Rewinds to one character past the *start* of a rejected match rather than
+ * past its end, which matters more than it looks: `harcama 12 Agustos 2026`
+ * matches the pattern once with `harcama` in the month slot, and skipping past
+ * that whole match would swallow the real date sitting inside it.
+ */
+function scanNamed(
+  pattern: RegExp,
+  text: string,
+  dayGroup: number,
+  monthGroup: number,
+): DateReading | null {
+  pattern.lastIndex = 0;
+  let match = pattern.exec(text);
+  while (match !== null) {
+    const month = monthOf(match[monthGroup] ?? '');
+    const day = Number(match[dayGroup]);
+    if (month !== null && validDay(day, month)) {
+      const end = match.index + match[0].length;
+      return {
+        iso: `${expandYear(match[3])}-${pad(month)}-${pad(day)}${clockOutside(text, match.index, end)}`,
+        orderInferred: false,
+      };
+    }
+    pattern.lastIndex = match.index + 1;
+    match = pattern.exec(text);
+  }
+  return null;
+}
+
+/** The clock in the message, ignoring the span the date itself occupies. */
+function clockOutside(text: string, from: number, to: number): string {
+  const masked = `${text.slice(0, from)}${' '.repeat(to - from)}${text.slice(to)}`;
+  const time = TIME.exec(masked);
+  if (!time) return 'T00:00:00.000Z';
+  return `T${(time[1] ?? '0').padStart(2, '0')}:${time[2]}:${(time[3] ?? '00').padStart(2, '0')}.000Z`;
+}
+
+const clockOf = (hour?: string, minute?: string, second?: string): string =>
+  minute
+    ? `T${(hour ?? '0').padStart(2, '0')}:${minute}:${(second ?? '00').padStart(2, '0')}.000Z`
+    : 'T00:00:00.000Z';
+
+/**
+ * When the bank says it happened.
+ *
+ * ISO first, then a named month in either order, then bare numbers — and the
+ * bare numbers are the hard case. `08/05/2026` is the 8th of May in every
+ * market Waves ships in and the 5th of August in the United States, and the
+ * message itself contains nothing that tells them apart. So: a component over
+ * twelve settles it outright, otherwise the caller's region settles it, and
+ * with neither the fallback is day-first — the order most of the world writes —
+ * reported back as inferred so the confidence drops and the UI can say which
+ * field to check.
+ */
+function detectDate(raw: string, context: SmsParseContext): DateReading | null {
+  const iso = DATE_ISO.exec(raw);
+  if (iso?.[1] && iso[2] && iso[3]) {
+    const month = Number(iso[2]);
+    const day = Number(iso[3]);
+    if (validDay(day, month)) {
+      return {
+        iso: `${iso[1]}-${pad(month)}-${pad(day)}${clockOf(iso[4], iso[5], iso[6])}`,
+        orderInferred: false,
+      };
+    }
+  }
+
+  const dayFirst = scanNamed(DATE_DAY_FIRST, raw, 1, 2);
+  if (dayFirst) return dayFirst;
+
+  const monthFirst = scanNamed(DATE_MONTH_FIRST, raw, 2, 1);
+  if (monthFirst) return monthFirst;
+
+  const numeric = DATE_NUMERIC.exec(raw);
+  if (numeric?.[1] && numeric[2]) {
+    const first = Number(numeric[1]);
+    const second = Number(numeric[2]);
+    const { order, explicit } = dateOrderFor(context);
+
+    let day = order === 'mdy' ? second : first;
+    let month = order === 'mdy' ? first : second;
+    let inferred = !explicit;
+
+    // A component over twelve is not a month, whatever the locale says. That
+    // settles most real messages without any context at all.
+    if (first > 12 && second <= 12) {
+      day = first;
+      month = second;
+      inferred = false;
+    } else if (second > 12 && first <= 12) {
+      day = second;
+      month = first;
+      inferred = false;
+    } else if (first === second) {
+      inferred = false; // 05/05 reads the same either way
+    }
+
+    if (validDay(day, month)) {
+      const end = numeric.index + numeric[0].length;
+      return {
+        iso: `${expandYear(numeric[3])}-${pad(month)}-${pad(day)}${clockOutside(raw, numeric.index, end)}`,
+        orderInferred: inferred,
+      };
+    }
+  }
+
+  return null;
+}
+
+/* ------------------------------------------------------------------ *
+ * Merchant
+ * ------------------------------------------------------------------ */
+
+const PREPOSITION = new RegExp(`(?:${MERCHANT_PREPOSITIONS})\\s*`, 'giu');
+const PAYEE_CREDITED =
+  /([\p{L}\p{N}][\p{L}\p{N}&.'_-]{1,30})\s+(?:credited|creditado|acreditado)\b/iu;
+
+/** A long digit run is a reference, not a shop. */
+const isLongNumber = (token: string): boolean => /^\d{5,}$/.test(token);
+
+/** `12/09/2026` or `12-09-26`: the date that follows the shop's name, not part of it. */
+const isDateToken = (token: string): boolean =>
+  /^\d{1,4}[-/.]\d{1,2}(?:[-/.]\d{2,4})?[.,;:]?$/.test(token);
+
+/**
+ * Whoever was paid, read out of the words after "to", "at", "chez", "bei", "di".
+ *
+ * The old version produced `VPA` and `A` — the literal word before a UPI
+ * address, and the `A` of `A/c` — and scored both at full confidence. A row
+ * reading `A` is worse than a row reading nothing, because it looks parsed and
+ * a person has to notice it is nonsense. So a capture has to survive a
+ * plausibility test before it counts as a merchant at all, and an implausible
+ * one is skipped rather than returned: the parser keeps looking.
+ */
+function readMerchant(tail: string): string | null {
+  // A dot followed by a space ends the sentence; everything after it is the
+  // bank talking. A merchant name can still contain a dot (AMAZON.IN).
+  const sentence = (tail.split(/\.\s|;|\|/)[0] ?? '').trim();
+  const words = sentence.split(/\s+/).slice(0, 6);
+
+  let start = 0;
+  while (start < words.length && MERCHANT_DETERMINERS.has(foldToken(words[start] ?? '')))
+    start += 1;
+
+  const kept: string[] = [];
+  for (const word of words.slice(start)) {
+    const folded = foldToken(word.replace(/[.,;:]+$/, ''));
+    if (!folded) break;
+    if (MERCHANT_NOISE.has(folded) || isLongNumber(folded) || isDateToken(word)) break;
+    kept.push(word);
+    if (kept.length === 4) break;
+  }
+
+  let name = kept
+    .join(' ')
+    .replace(/[.,;:]+$/, '')
+    .trim();
+  // A UPI address or an email is the handle, not the domain: swiggy@icici is
+  // SWIGGY, and showing the bank's name instead would be actively misleading.
+  if (kept.length === 1 && name.includes('@')) name = name.split('@')[0] ?? name;
+
+  return plausibleMerchant(name) ? name : null;
+}
+
+function plausibleMerchant(name: string): boolean {
+  const trimmed = name.trim();
+  if (trimmed.length < 2) return false;
+  if (MERCHANT_STOP_WORDS.has(foldToken(trimmed))) return false;
+  // A bare number, a date, or punctuation: all of these are the message's
+  // furniture rather than a shop.
+  if (/^[\d\s.,:/@#*-]+$/.test(trimmed)) return false;
+  return detectDate(trimmed, {}) === null;
+}
+
+function detectMerchant(
+  raw: string,
+  folded: string,
+  direction: TransactionDirection,
+): string | null {
+  PREPOSITION.lastIndex = 0;
+  for (const match of folded.matchAll(PREPOSITION)) {
+    if (match.index === undefined) continue;
+    const start = match.index + match[0].length;
+    const candidate = readMerchant(raw.slice(start, start + 96));
+    if (candidate) return candidate;
+  }
+
+  // "…debited for Rs 500.00 …; SWIGGY credited." — a transfer alert describes
+  // both sides, and the side that was credited is the shop.
+  if (direction === TransactionDirection.Debit) {
+    const payee = PAYEE_CREDITED.exec(folded);
+    if (payee?.[1] && payee.index !== undefined) {
+      const at = payee.index + payee[0].indexOf(payee[1]);
+      const name = raw.slice(at, at + payee[1].length).replace(/[.,;:]+$/, '');
+      if (plausibleMerchant(name) && !MERCHANT_NOISE.has(foldToken(name))) return name;
+    }
+  }
+
+  return null;
+}
+
+/* ------------------------------------------------------------------ *
+ * Direction
+ * ------------------------------------------------------------------ */
+
+/** Distance from `index` to the nearest match of `pattern`, or null for none. */
+function nearest(pattern: RegExp, text: string, index: number): number | null {
+  pattern.lastIndex = 0;
+  let best: number | null = null;
+  for (const match of text.matchAll(pattern)) {
+    if (match.index === undefined) continue;
+    const start = match.index;
+    const end = start + match[0].length;
+    const distance = index < start ? start - index : index > end ? index - end : 0;
+    if (best === null || distance < best) best = distance;
+  }
+  return best;
+}
+
+/**
+ * Which way the money went, decided by the verb *nearest the amount*.
+ *
+ * The old rule bailed whenever a message contained both a debit and a credit
+ * word, which loses ICICI's entire account-debit format: `debited for Rs 500.00
+ * … ; SWIGGY credited` describes both sides of one transfer and is a perfectly
+ * ordinary debit. Proximity reads it correctly and still refuses the case that
+ * matters — a message where the two are equally close is genuinely unreadable,
+ * and a credit booked as an expense is worse than no candidate at all.
+ */
+function decideDirection(masked: string, amountIndex: number): TransactionDirection | null {
+  const debit = nearest(DEBIT_WORDS, masked, amountIndex);
+  const credit = nearest(CREDIT_WORDS, masked, amountIndex);
+  if (debit === null && credit === null) return null;
+  if (credit === null) return TransactionDirection.Debit;
+  if (debit === null) return TransactionDirection.Credit;
+  if (debit === credit) return null;
+  return debit < credit ? TransactionDirection.Debit : TransactionDirection.Credit;
+}
+
+/* ------------------------------------------------------------------ *
+ * The parse
+ * ------------------------------------------------------------------ */
+
 /**
  * Read one message. Returns null when it is not a transaction at all — which
  * is most of them.
+ *
+ * `context` is optional everywhere. Given the user's region or locale the
+ * parser stops guessing at date order, decimal separators and shared currency
+ * symbols; given nothing it still answers, and says what it guessed.
  */
-export function parseSms(text: string): ParsedSms | null {
-  const body = text.replace(/\s+/g, ' ').trim();
-  if (!body) return null;
+export function parseSms(text: string, context: SmsParseContext = {}): ParsedSms | null {
+  if (!text) return null;
+  // NFKC, bidi marks out, native numerals to ASCII — so an Arabic or Hindi
+  // message reaches the same code path as an English one, and an RTL isolate
+  // around the amount does not hide a number that is plainly there.
+  // A concatenated SMS tops out around 1,600 characters. The cap is not about
+  // correctness, it is about a parser that runs over a whole inbox: the number
+  // patterns backtrack, and nothing should be able to hand this function a
+  // megabyte of digits and have it think about it.
+  const raw = normaliseForParsing(text.slice(0, 2000)).replace(/\s+/g, ' ').trim();
+  if (!raw) return null;
+
+  // Accents folded away, same length, so every index below is valid in both.
+  const folded = foldLatin(raw);
 
   // Checked before anything else: an OTP quotes a real amount from a real bank
   // and is the false positive most likely to be confirmed by accident.
-  if (NOT_A_TRANSACTION.test(body)) return null;
-  if (BALANCE_ONLY.test(body) && !DEBIT_WORDS.test(body) && !CREDIT_WORDS.test(body)) return null;
+  if (NOT_A_TRANSACTION.test(folded)) return null;
+  DEBIT_WORDS.lastIndex = 0;
+  CREDIT_WORDS.lastIndex = 0;
+  const saysMoneyMoved = DEBIT_WORDS.test(folded) || CREDIT_WORDS.test(folded);
+  if (BALANCE_ONLY.test(folded) && !saysMoneyMoved) return null;
 
-  const amountMatch = AMOUNT.exec(body);
-  if (!amountMatch?.[2]) return null;
+  const masked = maskCards(folded);
+  const amountMatch = findAmount(raw, masked);
+  if (!amountMatch) return null;
 
-  // Prefer the marker next to the amount; a body-wide scan can pick a different
-  // currency word than the one actually beside the number.
-  const currency = detectCurrency(amountMatch[1] ?? body);
-  const minor = toMinor(amountMatch[2], currency);
-  if (minor <= 0n) return null;
+  const { currency, inferred: currencyInferred } = resolveCurrency(amountMatch.marker, context);
+  if (!isCurrencyCode(currency)) return null;
+  const number = readNumber(amountMatch.token, currency, context);
+  if (!number || number.minor <= 0n) return null;
 
-  const debit = DEBIT_WORDS.test(body);
-  const credit = CREDIT_WORDS.test(body);
-  // Neither, or both, means we cannot tell which way the money went — and a
-  // credit booked as an expense is worse than no candidate at all.
-  if (debit === credit) return null;
+  const direction = decideDirection(masked, amountMatch.index);
+  if (!direction) return null;
 
-  const merchantMatch = MERCHANT.exec(body);
-  // "at SWIGGY. UPI Ref: …" — a merchant name can contain a dot (AMAZON.IN)
-  // but a dot followed by a space ends the sentence, and everything after it
-  // is the bank talking, not the shop's name.
-  const merchant =
-    merchantMatch?.[1]
-      ?.split(/\.\s/)[0]
-      ?.replace(/[.,;:]+$/, '')
-      .trim() || null;
-  const reference = REFERENCE.exec(body)?.[1] ?? null;
-  const accountTail = ACCOUNT_TAIL.exec(body)?.[1] ?? null;
-  const occurredAt = detectDate(body);
+  const merchant = detectMerchant(raw, masked, direction);
+  const reference = REFERENCE.exec(raw)?.[1] ?? null;
+  const accountTail = ACCOUNT_TAIL.exec(raw)?.[1] ?? null;
+  const date = detectDate(raw, context);
 
-  // Confidence is about how much of the message we actually understood, not
-  // about how plausible the number looks.
+  const inferred: InferredField[] = [];
+  if (currencyInferred) inferred.push('currency');
+  if (number.separatorInferred) inferred.push('decimalSeparator');
+  if (date?.orderInferred) inferred.push('dateOrder');
+
+  // Confidence is about how much of the message we understood *and how much of
+  // that we are entitled to believe*. The old score counted fields found, so a
+  // merchant reading `VPA` scored 1.0 and was pre-selected; a field that failed
+  // its plausibility test now counts for nothing, and every inference above
+  // costs what it is worth.
   let confidence = 0.55;
   if (merchant) confidence += 0.2;
   if (reference) confidence += 0.15;
-  if (occurredAt) confidence += 0.1;
+  if (date) confidence += 0.1;
   if (accountTail) confidence += 0.05;
+  if (looksLikeBankSender(context.sender)) confidence += 0.05;
+  if (currencyInferred) confidence -= 0.1;
+  if (number.separatorInferred) confidence -= 0.15;
+  if (date?.orderInferred) confidence -= 0.1;
 
   return {
-    amount: money(minor, currency),
-    direction: debit ? TransactionDirection.Debit : TransactionDirection.Credit,
+    amount: money(number.minor, currency),
+    direction,
     merchant,
     accountTail,
     reference,
-    occurredAt,
-    confidence: Math.min(1, Number(confidence.toFixed(2))),
+    occurredAt: date?.iso ?? null,
+    inferred,
+    confidence: Math.max(0, Math.min(1, Number(confidence.toFixed(2)))),
   };
 }
 
@@ -246,7 +737,9 @@ export interface SmsMessage {
   readonly body: string;
   /** When it arrived, ISO-8601. Used when the message carries no date itself. */
   readonly receivedAt: string;
-  /** Sender id, e.g. "AD-HDFCBK". Kept only so a person can recognise it. */
+  /** Sender id, e.g. "AD-HDFCBK". Kept so a person can recognise it — and, when
+   * it looks like a bank, as a small nudge to confidence. Never a filter: a
+   * bank the allowlist has not heard of is still a bank. */
   readonly sender?: string;
 }
 
@@ -282,6 +775,12 @@ export interface ProposeOptions {
    * dropped — re-scanning the inbox must not re-propose what was confirmed.
    */
   readonly alreadyImported?: ReadonlySet<string>;
+  /**
+   * What the caller knows that the messages do not: region, locale, the
+   * currency the group counts in. Every message is parsed with it, and each
+   * message's own sender is merged in on top.
+   */
+  readonly context?: SmsParseContext;
 }
 
 /** A window bound as a number, or ±Infinity when there is no usable bound. */
@@ -305,7 +804,7 @@ export function proposeFromSms(
   const candidates: ExpenseCandidate[] = [];
 
   for (const message of messages) {
-    const parsed = parseSms(message.body);
+    const parsed = parseSms(message.body, { ...options.context, sender: message.sender });
     if (!parsed) continue;
     // Money coming in is not an expense. Refunds are real and worth showing one
     // day, but as a reversal of a known expense — not as a negative one.

--- a/packages/core/src/sms/vocabulary.ts
+++ b/packages/core/src/sms/vocabulary.ts
@@ -1,0 +1,745 @@
+/**
+ * What a bank alert says, in the languages banks say it in.
+ *
+ * Split out of `parse.ts` because it is data, not logic: long ordered word
+ * lists that grow every time somebody tries the feature in a new country, and
+ * that nobody should have to read past to understand how the parser works.
+ *
+ * Three rules govern everything here.
+ *
+ * **Terms are written unaccented.** `parse.ts` folds the message to unaccented
+ * Latin *without changing its length*, so every index still points where it
+ * did, and every term below is written the way that fold leaves it: `débité`
+ * becomes `debite`, `ağustos` becomes `agustos`, `số dư` becomes `so du`.
+ * Writing the accented form here would produce a list that looks like French
+ * support and matches nothing.
+ *
+ * **Latin and non-Latin are kept apart.** JavaScript's `\b` is defined against
+ * `[A-Za-z0-9_]`, so there is no word boundary between a space and an Arabic,
+ * Thai or Devanagari letter — `/\bمرفوض\b/` matches nothing, ever, and would
+ * sit in the file looking like Arabic support while providing none. Latin terms
+ * get `\b`; everything else is matched as a plain substring, which is correct
+ * for scripts that do not separate words the way Latin does.
+ *
+ * **A word only earns its place if a false accept is unlikely.** This parser's
+ * worst outcome is proposing an expense nobody made, so a verb that is also an
+ * ordinary word in another language the parser might see is left out rather
+ * than guessed at.
+ */
+
+/** Latin terms joined into one alternation, word-bounded. */
+const latin = (terms: readonly string[]): string => `\\b(?:${terms.join('|')})\\b`;
+
+/** Non-Latin terms joined into one alternation, unbounded — see the note above. */
+const script = (terms: readonly string[]): string => `(?:${terms.join('|')})`;
+
+const either = (latinTerms: readonly string[], scriptTerms: readonly string[]): string =>
+  `(?:${latin(latinTerms)}|${script(scriptTerms)})`;
+
+/* ------------------------------------------------------------------ *
+ * Direction
+ * ------------------------------------------------------------------ */
+
+/**
+ * Money left the account.
+ *
+ * `transaction of` and `used for a transaction of` are here because that is how
+ * every card issuer writes a purchase; bare `transaction` is not, because
+ * "transaction declined" and "your transaction reference" are both common and
+ * neither is a debit.
+ */
+const DEBIT_LATIN = [
+  // English
+  'used for a transaction of',
+  'transaction of',
+  'txn of',
+  'debited',
+  'debit',
+  'spent',
+  'paid',
+  'purchased',
+  'purchase',
+  'withdrawn',
+  'withdrawal',
+  'sent',
+  'deducted',
+  'charged',
+  // Spanish
+  'cargo',
+  'cargado',
+  'cargada',
+  'compra',
+  'retiro',
+  'debitado',
+  'debitada',
+  'pagado',
+  'gastado',
+  // Portuguese
+  'saque',
+  'pago',
+  'cobrado',
+  // French
+  'debite',
+  'debitee',
+  'retrait',
+  'preleve',
+  'prelevement',
+  'achat',
+  'paye',
+  // German
+  'belastet',
+  'abbuchung',
+  'abgebucht',
+  'lastschrift',
+  'bezahlt',
+  'abgehoben',
+  // Italian / Dutch
+  'addebitato',
+  'addebito',
+  'afgeschreven',
+  'betaald',
+  'opname',
+  // Indonesian / Malay
+  'didebet',
+  'didebit',
+  'didebitkan',
+  'dipotong',
+  'belanja',
+  'pembelian',
+  // Turkish
+  'harcama',
+  'cekildi',
+  'odendi',
+  // Danish, Swedish, Norwegian — the markets the `kr` marker belongs to
+  'kortkop',
+  'kortkjop',
+  'debiteret',
+  'debiterats',
+  'dragits',
+  'trukket',
+  'uttag',
+  'hevet',
+  'betalt',
+  // Vietnamese, as the fold leaves it
+  'ghi no',
+  'thanh toan',
+  'tru tien',
+  // Russian, transliterated
+  'spisano',
+  'oplata',
+] as const;
+
+const DEBIT_SCRIPT = [
+  // Hindi
+  'डेबिट',
+  'निकाले',
+  'भुगतान',
+  'खर्च',
+  // Tamil
+  'பற்று',
+  'செலவு',
+  'செலுத்த',
+  // Arabic — خصم deducted, سحب withdrawn, شراء purchase, دفع paid
+  'خصم',
+  'مدين',
+  'سحب',
+  'شراء',
+  'دفع',
+  // Thai
+  'ถูกหัก',
+  'หักเงิน',
+  'ชำระเงิน',
+  'ใช้จ่าย',
+  // Russian
+  'списано',
+  'оплата',
+  'покупка',
+] as const;
+
+/** Money arrived. Deliberately includes `refunded`, which the old list missed. */
+const CREDIT_LATIN = [
+  // English
+  'credited',
+  'credit',
+  'received',
+  'refunded',
+  'refund',
+  'reversed',
+  'reversal',
+  'cashback',
+  'deposited',
+  // Spanish / Portuguese
+  'abonado',
+  'abono',
+  'acreditado',
+  'creditado',
+  'reembolsado',
+  'reembolso',
+  'deposito',
+  'recibido',
+  'devolucion',
+  'estorno',
+  // French
+  'credite',
+  'creditee',
+  'rembourse',
+  'remboursement',
+  // German / Dutch / Italian
+  'gutgeschrieben',
+  'gutschrift',
+  'erstattet',
+  'erstattung',
+  'bijgeschreven',
+  'ontvangen',
+  'accreditato',
+  'accredito',
+  'rimborso',
+  // Indonesian / Malay / Turkish
+  'dikreditkan',
+  'dikredit',
+  'diterima',
+  'iade',
+  'yatirildi',
+  // Danish, Swedish, Norwegian
+  'insatt',
+  'indsat',
+  'innsatt',
+  'tilbakebetalt',
+  'aterbetalning',
+  // Vietnamese / Russian, as the fold leaves them
+  'ghi co',
+  'hoan tien',
+  'zachislenie',
+] as const;
+
+const CREDIT_SCRIPT = [
+  'क्रेडिट',
+  'जमा',
+  'वापसी',
+  'வரவு',
+  'திரும்ப',
+  'إيداع',
+  'دائن',
+  'استرداد',
+  'أضيف',
+  'เข้าบัญชี',
+  'คืนเงิน',
+  'зачислено',
+  'возврат',
+] as const;
+
+/** The alternations on their own, so larger patterns can embed them. */
+export const DEBIT_SOURCE = either(DEBIT_LATIN, DEBIT_SCRIPT);
+export const CREDIT_SOURCE = either(CREDIT_LATIN, CREDIT_SCRIPT);
+
+export const DEBIT_WORDS = new RegExp(DEBIT_SOURCE, 'giu');
+export const CREDIT_WORDS = new RegExp(CREDIT_SOURCE, 'giu');
+
+/**
+ * "Credit Card" is not a credit, and reading it as one is the single failure in
+ * this parser that writes a wrong ledger entry rather than losing a right one.
+ * These phrases are blanked — replaced by spaces of the same length, so every
+ * other index into the message still points where it did — before direction is
+ * decided. `debit card` goes with it for the mirror-image reason.
+ */
+export const CARD_PHRASES = new RegExp(
+  [
+    '\\b(?:credit|debit)\\s*/?\\s*(?:credit|debit)?\\s*cards?\\b',
+    '\\btarjeta\\s+de\\s+(?:credito|debito)\\b',
+    '\\bcartao\\s+de\\s+(?:credito|debito)\\b',
+    '\\bcarte\\s+de\\s+(?:credit|debit)\\b',
+    '\\b(?:kredit|debit)\\s*-?\\s*karte\\b',
+    '\\bkartu\\s+(?:kredit|debit)\\b',
+    '\\bkredi\\s+kart\\w*\\b',
+    '\\bcarta\\s+di\\s+credito\\b',
+    '\\bthe\\s+(?:tin\\s+dung|ghi\\s+no)\\b',
+    'بطاقة\\s+(?:الائتمان|ائتمانية|الخصم)',
+    'क्रेडिट\\s*कार्ड',
+    'डेबिट\\s*कार्ड',
+    'கிரெடிட்\\s*கார்டு',
+    'டெபிட்\\s*கார்டு',
+    'บัตรเครดิต',
+    'บัตรเดบิต',
+  ].join('|'),
+  'giu',
+);
+
+/* ------------------------------------------------------------------ *
+ * Refusals
+ * ------------------------------------------------------------------ */
+
+/**
+ * Messages shaped like a transaction that are not one.
+ *
+ * A one-time password is the dangerous member of this set: right sender, right
+ * amount, right merchant, and a person tapping through confirms a purchase they
+ * were in the middle of *not* making. Every language added to the debit list
+ * above has to be added here too, or internationalising the parser means
+ * internationalising its worst false positive.
+ */
+export const NOT_A_TRANSACTION = new RegExp(
+  [
+    latin([
+      // English
+      'OTP',
+      'one[- ]time\\s*password',
+      'one[- ]time\\s*code',
+      'verification\\s+code',
+      'security\\s+code',
+      'will\\s+be\\s+debited',
+      'will\\s+be\\s+charged',
+      'will\\s+be\\s+deducted',
+      '(?:has|have)\\s+requested',
+      'request(?:ed)?\\s+(?:for|to)',
+      'is\\s+due',
+      'due\\s+on',
+      'due\\s+by',
+      'payment\\s+due',
+      'minimum\\s+due',
+      'reminder',
+      'failed',
+      'declined',
+      'unsuccessful',
+      'statement',
+      'e-?mandate',
+      'auto[- ]?pay\\s+scheduled',
+      'scheduled\\s+for',
+      // Spanish
+      'codigo\\s+(?:de\\s+)?(?:verificacion|seguridad)',
+      'clave\\s+temporal',
+      'rechazad[ao]',
+      'fallid[ao]',
+      'sera\\s+(?:cargado|debitado)',
+      'se\\s+debitara',
+      'vence\\s+el',
+      'fecha\\s+de\\s+vencimiento',
+      // Portuguese
+      'codigo\\s+de\\s+verificacao',
+      'recusad[ao]',
+      'negad[ao]',
+      'sera\\s+(?:debitado|cobrado)',
+      'vencimento',
+      // French
+      'code\\s+de\\s+(?:verification|securite)',
+      'refusees?',
+      'refusee',
+      'echec',
+      'sera\\s+(?:debite|preleve)',
+      'echeance',
+      // German
+      'einmalkennwort',
+      'einmalpasswort',
+      'bestatigungscode',
+      'abgelehnt',
+      'fehlgeschlagen',
+      // German puts the amount between the auxiliary and the participle —
+      // "wird mit EUR 49,90 belastet" — so the two cannot be required to be
+      // adjacent the way English's "will be debited" can.
+      'wird\\s+[^.]{0,48}?\\s*(?:belastet|abgebucht)',
+      'fallig\\s+am',
+      // Indonesian / Malay
+      'kode\\s+otp',
+      'kod\\s+otp',
+      'kode\\s+verifikasi',
+      'ditolak',
+      'gagal',
+      'jatuh\\s+tempo',
+      'akan\\s+didebet',
+      // Turkish
+      'dogrulama\\s+kodu',
+      'tek\\s+kullanimlik',
+      'reddedildi',
+      'basarisiz',
+      'son\\s+odeme',
+      // Vietnamese / Russian, as the fold leaves them
+      'ma\\s+otp',
+      'ma\\s+xac\\s+thuc',
+      'that\\s+bai',
+      'tu\\s+choi',
+      'den\\s+han',
+      'kod\\s+podtverzhdeniya',
+    ]),
+    script([
+      // Hindi
+      'ओटीपी',
+      'सत्यापन\\s*कोड',
+      'अस्वीकृत',
+      'विफल',
+      'देय\\s*तिथि',
+      'किया\\s*जाएगा',
+      // Tamil
+      'ஒருமுறை\\s*கடவுச்சொல்',
+      'நிராகரிக்கப்பட்டது',
+      'தோல்வி',
+      // Arabic
+      'رمز\\s*التحقق',
+      'كلمة\\s*المرور\\s*لمرة',
+      'مرفوض',
+      'فشل',
+      'مستحق',
+      'سيتم\\s*خصم',
+      'تاريخ\\s*الاستحقاق',
+      // Thai
+      'รหัสยืนยัน',
+      'ปฏิเสธ',
+      'ไม่สำเร็จ',
+      'ครบกำหนด',
+      // Russian
+      'код\\s*подтверждения',
+      'отклонен',
+      'отказано',
+    ]),
+  ].join('|'),
+  'iu',
+);
+
+/**
+ * Balance words. A running balance is a trailer on real debit alerts, so these
+ * only disqualify a message that says nothing about money moving — and they
+ * separately mark an amount as "this number is a balance, not a transaction",
+ * which is how the parser stops picking the wrong one of two amounts.
+ */
+export const BALANCE_WORDS = new RegExp(
+  [
+    latin([
+      'avl\\s*bal\\w*',
+      'avbl\\s*bal\\w*',
+      'avail(?:able)?\\s*bal(?:ance)?',
+      'balance',
+      'bal',
+      'saldo',
+      'solde',
+      'kontostand',
+      'guthaben',
+      'bakiye',
+      'baki',
+      'so\\s*du',
+      'ostatok',
+      'limit',
+    ]),
+    script(['الرصيد', 'शेष', 'बैलेंस', 'இருப்பு', 'ยอดคงเหลือ', 'остаток', 'баланс']),
+  ].join('|'),
+  'giu',
+);
+
+/** The subset that, alone, makes a message a balance report rather than a debit. */
+export const BALANCE_ONLY = new RegExp(
+  [
+    latin([
+      'balance\\s+is',
+      'avl\\s*bal\\w*',
+      'avbl\\s*bal\\w*',
+      'available\\s+balance\\s+is',
+      'saldo\\s+(?:es|e|disponivel|disponible|adalah)',
+      'solde\\s+disponible',
+      'ihr\\s+kontostand',
+      'so\\s*du\\s*kha\\s*dung',
+    ]),
+    script(['الرصيد\\s*المتاح', 'शेष\\s*राशि', 'ยอดคงเหลือ']),
+  ].join('|'),
+  'iu',
+);
+
+/* ------------------------------------------------------------------ *
+ * Fields
+ * ------------------------------------------------------------------ */
+
+/**
+ * The masked tail of an account or card.
+ *
+ * Written out rather than built with `latin()` for two reasons, both of which
+ * were bugs the first time round: `xx+` must not carry a *trailing* word
+ * boundary, because `xx1234` has none between the x and the 1; and the Arabic,
+ * Thai and Devanagari words must not carry a *leading* one, because `البطاقة`
+ * begins with letters `\b` does not recognise, so the pattern would have
+ * matched nothing in exactly the scripts it was added for.
+ */
+export const ACCOUNT_TAIL = new RegExp(
+  '(?:' +
+    '\\b(?:a\\/c|acct?|account|akaun|card|kart\\w*|conta|cuenta|compte|konto|rekening|hesab\\w*|xx+)' +
+    '|\\*+' +
+    '|บัญชี|حساب|بطاقة|खाता|கணக்கு' +
+    ')\\s*(?:no\\.?\\s*|nr\\.?\\s*|num\\.?\\s*)?[xX*·.]*(\\d{3,6})\\b',
+  'iu',
+);
+
+export const REFERENCE = new RegExp(
+  '(?:' +
+    latin([
+      'ref\\s*no',
+      'refno',
+      'ref(?:erence)?',
+      'txn(?:\\s*id)?',
+      'transaction(?:\\s*id)?',
+      'trn',
+      'rrn',
+      'utr',
+      'auth(?:\\s*code)?',
+      'referencia',
+      'referenz',
+      'belegnr',
+      'referensi',
+      'ma\\s*giao\\s*dich',
+    ]) +
+    '|' +
+    script(['مرجع', 'رقم\\s*العملية', 'संदर्भ', 'குறிப்பு', 'หมายเลขอ้างอิง']) +
+    ')\\s*(?:no\\.?|nr\\.?|id)?[:\\s]\\s*([A-Za-z0-9]{6,})',
+  'iu',
+);
+
+/**
+ * The words that introduce whoever was paid.
+ *
+ * Short function words from other languages are a real hazard here — Spanish
+ * `a`, French `à` and Portuguese `no` are all common English fragments too, and
+ * each one would mint a merchant out of the middle of an English sentence. They
+ * are left out on purpose; what survives is the set that is either unambiguous
+ * or long enough not to collide.
+ */
+export const MERCHANT_PREPOSITIONS = [
+  latin([
+    'to',
+    'at',
+    'towards?',
+    'in\\s+fav(?:ou)?r\\s+of',
+    'en', // es
+    'em',
+    'para', // pt
+    'chez', // fr
+    'bei', // de
+    'presso', // it
+    'bij', // nl
+    'di',
+    'ke',
+    'kepada',
+    'pada', // id / ms
+    'tai', // vi
+    'hos', // da / sv / nb
+  ]),
+  script(['ที่', 'لدى', 'إلى', 'في', 'को', 'இல்']),
+].join('|');
+
+/**
+ * Tokens that are the bank talking, not the shop's name. A captured phrase is
+ * cut at the first of these, which is what turns "SWIGGY Refno 526012345678"
+ * into "SWIGGY".
+ */
+export const MERCHANT_NOISE: ReadonlySet<string> = new Set([
+  // Every preposition is its own terminator: "TOKOPEDIA pada 12/09/2026" is a
+  // shop followed by a date, not a four-word shop.
+  'on',
+  'at',
+  'to',
+  'by',
+  'from',
+  'in',
+  'en',
+  'em',
+  'para',
+  'chez',
+  'bei',
+  'presso',
+  'bij',
+  'di',
+  'ke',
+  'kepada',
+  'pada',
+  'tai',
+  'hos',
+  'khoan',
+  'ngay',
+  'towards',
+  'toward',
+  'is',
+  'was',
+  'has',
+  // "with a card ending…" in the languages that say it after the shop's name.
+  'con',
+  'com',
+  'mit',
+  'met',
+  'avec',
+  'tarjeta',
+  'cartao',
+  'carte',
+  'karte',
+  'kart',
+  'kartu',
+  'no',
+  'na',
+  'بتاريخ',
+  'ref',
+  'refno',
+  'reference',
+  'referencia',
+  'referenz',
+  'upi',
+  'imps',
+  'neft',
+  'rtgs',
+  'txn',
+  'trn',
+  'rrn',
+  'utr',
+  'id',
+  'info',
+  'avl',
+  'avbl',
+  'bal',
+  'balance',
+  'saldo',
+  'solde',
+  'not',
+  'call',
+  'dt',
+  'date',
+  'using',
+  'via',
+  'card',
+  'a/c',
+  'ac',
+  'acct',
+  'account',
+  'conta',
+  'cuenta',
+  'compte',
+  'konto',
+  'rekening',
+  'am',
+  'um',
+  'auf',
+  'op',
+]);
+
+/** Tokens skipped when they *start* a capture: "to your HDFC Card" is not "your". */
+export const MERCHANT_DETERMINERS: ReadonlySet<string> = new Set([
+  'your',
+  'the',
+  'my',
+  'a',
+  'an',
+  'su',
+  'sua',
+  'seu',
+  'votre',
+  'ihr',
+  'ihre',
+  'uw',
+  'anda',
+  'vpa',
+  'upi',
+]);
+
+/**
+ * A capture that is one of these is not a merchant, whatever the grammar says.
+ * `VPA` and `A` are the two the old parser actually produced, and a row reading
+ * "A" is worse than a row reading nothing: it looks parsed.
+ */
+export const MERCHANT_STOP_WORDS: ReadonlySet<string> = new Set([
+  'vpa',
+  'upi',
+  'a',
+  'ac',
+  'a/c',
+  'acct',
+  'account',
+  'card',
+  'ref',
+  'refno',
+  'reference',
+  'txn',
+  'trn',
+  'transaction',
+  'transaksi',
+  'payment',
+  'purchase',
+  'merchant',
+  'bank',
+  'pos',
+  'atm',
+  'na',
+  'n/a',
+  'nil',
+  'null',
+  'cuenta',
+  'conta',
+  'compte',
+  'konto',
+  'rekening',
+  'saldo',
+  'solde',
+  'balance',
+  'bal',
+]);
+
+/* ------------------------------------------------------------------ *
+ * Months
+ * ------------------------------------------------------------------ */
+
+/**
+ * Month names, folded to unaccented lowercase, across the languages the app
+ * ships in and the ones its markets bank in. Looked up longest key first, which
+ * is how French `juin` (6) and `juillet` (7) stay apart when both start `jui`.
+ */
+export const MONTHS: Readonly<Record<string, number>> = Object.freeze({
+  // English
+  jan: 1,
+  feb: 2,
+  mar: 3,
+  apr: 4,
+  may: 5,
+  jun: 6,
+  jul: 7,
+  aug: 8,
+  sep: 9,
+  oct: 10,
+  nov: 11,
+  dec: 12,
+  // Spanish
+  ene: 1,
+  abr: 4,
+  ago: 8,
+  dic: 12,
+  // Portuguese
+  fev: 2,
+  mai: 5,
+  set: 9,
+  out: 10,
+  dez: 12,
+  // French — four-letter keys so juin and juillet do not collide
+  janv: 1,
+  fevr: 2,
+  mars: 3,
+  avr: 4,
+  juin: 6,
+  juil: 7,
+  aout: 8,
+  sept: 9,
+  // German
+  mrz: 3,
+  okt: 10,
+  // Italian
+  gen: 1,
+  mag: 5,
+  giu: 6,
+  lug: 7,
+  ott: 10,
+  // Dutch
+  mrt: 3,
+  maa: 3,
+  mei: 5,
+  // Indonesian / Malay
+  agu: 8,
+  ags: 8,
+  des: 12,
+  // Turkish
+  oca: 1,
+  sub: 2,
+  nis: 4,
+  haz: 6,
+  tem: 7,
+  eyl: 9,
+  eki: 10,
+  kas: 11,
+  ara: 12,
+});

--- a/packages/core/src/text/digits.ts
+++ b/packages/core/src/text/digits.ts
@@ -1,0 +1,98 @@
+/**
+ * Turning text somebody actually typed — or a bank actually sent — into
+ * something a digit-based parser can read.
+ *
+ * This lives in core rather than beside any one reader because the voice
+ * parser, the receipt reader and the SMS importer all hit the same problems,
+ * and three copies of a numeral table is three places for a locale to go
+ * missing. There is no locale data here beyond Unicode's own: nothing below
+ * decides what a number *means*, only which codepoints are digits.
+ */
+
+/**
+ * The digit blocks this app's locales and their neighbours actually type or
+ * speak: Devanagari (hi), Tamil (ta), Arabic-Indic and Eastern Arabic
+ * (ar, fa, ur), the other Indic scripts, Thai and Burmese.
+ *
+ * Each block is ten consecutive codepoints starting at the zero, which is a
+ * property of the Unicode standard rather than a coincidence, so a single
+ * subtraction converts any of them.
+ */
+const NATIVE_DIGIT_BLOCKS: readonly number[] = [
+  0x0660, // Arabic-Indic
+  0x06f0, // Extended Arabic-Indic (Persian, Urdu)
+  0x0966, // Devanagari
+  0x09e6, // Bengali
+  0x0be6, // Tamil
+  0x0c66, // Telugu
+  0x0ce6, // Kannada
+  0x0d66, // Malayalam
+  0x0e50, // Thai
+  0x1040, // Burmese
+];
+
+const NATIVE_DIGITS =
+  /[\u0660-\u0669\u06f0-\u06f9\u0966-\u096f\u09e6-\u09ef\u0be6-\u0bef\u0c66-\u0c6f\u0ce6-\u0cef\u0d66-\u0d6f\u0e50-\u0e59\u1040-\u1049]/g;
+
+/** Native numerals to ASCII, so Hindi, Tamil and Arabic amounts all read as numbers. */
+export function normaliseDigits(text: string): string {
+  return text.replace(NATIVE_DIGITS, (character) => {
+    const code = character.codePointAt(0) ?? 0;
+    for (const base of NATIVE_DIGIT_BLOCKS) {
+      if (code >= base && code <= base + 9) return String(code - base);
+    }
+    return character;
+  });
+}
+
+/**
+ * Bidirectional formatting controls, which carry no meaning for a parser but
+ * sit *inside* words and numbers in Arabic, Hebrew and Urdu text.
+ *
+ * An Arabic bank alert routinely wraps its amount in an isolate so the digits
+ * render left-to-right inside a right-to-left sentence. Those marks are
+ * invisible, and a regex that does not expect them simply fails to match a
+ * number that is plainly there — the failure looks like "the parser does not
+ * speak Arabic" when it is really "the parser does not speak Unicode".
+ */
+const BIDI_CONTROLS = /[\u200e\u200f\u061c\u202a-\u202e\u2066-\u2069]/g;
+
+export function stripBidiControls(text: string): string {
+  return text.replace(BIDI_CONTROLS, '');
+}
+
+/**
+ * Arabic's own separators to the ASCII ones. U+066B is the decimal separator
+ * and U+066C the thousands separator — the mirror image of the Latin habit, and
+ * reading them the wrong way round is a factor-of-a-thousand mistake rather
+ * than a cosmetic one.
+ */
+export function normaliseArabicSeparators(text: string): string {
+  return text.replace(/\u066b/g, '.').replace(/\u066c/g, ',');
+}
+
+/**
+ * Everything above, in the order it has to happen: compatibility folding first
+ * (so presentation forms and fullwidth digits become their ordinary shapes),
+ * then the invisible marks, then the numerals, then the separators.
+ *
+ * NFKC is deliberate. It is the normalisation that treats a presentation form
+ * and its plain equivalent as the same character, which is exactly what a
+ * parser reading somebody else's message wants; NFC would leave a fullwidth
+ * digit unreadable.
+ */
+export function normaliseForParsing(text: string): string {
+  return normaliseArabicSeparators(normaliseDigits(stripBidiControls(text.normalize('NFKC'))));
+}
+
+/**
+ * A word reduced to the letters and digits that identify it, with diacritics
+ * removed — "août" and "aout", "ağu" and "agu", read the same. Used for looking
+ * a token up in a table, never for display.
+ */
+export function foldToken(token: string): string {
+  return token
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+}

--- a/packages/core/src/text/index.ts
+++ b/packages/core/src/text/index.ts
@@ -1,0 +1,1 @@
+export * from './digits';

--- a/packages/core/test/sms.test.ts
+++ b/packages/core/test/sms.test.ts
@@ -11,7 +11,13 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { SMS_LOW_CONFIDENCE, parseSms, proposeFromSms, type SmsMessage } from '../src/index.js';
+import {
+  SMS_LOW_CONFIDENCE,
+  parseSms,
+  proposeFromSms,
+  senderHeader,
+  type SmsMessage,
+} from '../src/index.js';
 
 const sms = (body: string, receivedAt = '2026-03-02T10:00:00.000Z'): SmsMessage => ({
   body,
@@ -297,5 +303,547 @@ describe('no float ever exists between the text and the amount (ADR-003)', () =>
     ] as const) {
       expect(parseSms(text)?.amount.minor).toBe(minor);
     }
+  });
+});
+
+/* ================================================================== *
+ * The five messages the coverage study measured as failures.
+ * ================================================================== */
+
+describe('the formats that used to be dropped', () => {
+  it('reads SBI, which quotes no currency at all', () => {
+    // India's largest bank writes "debited by 150.0" with no Rs, no INR and no
+    // symbol. Requiring a currency token lost every one of its UPI alerts.
+    const parsed = parseSms(
+      'Dear UPI user A/C X1234 debited by 150.0 on date 12Sep26 trf to SWIGGY Refno 526012345678',
+      { region: 'IN' },
+    );
+    expect(parsed?.direction).toBe('debit');
+    expect(parsed?.amount.minor).toBe(15000n);
+    expect(parsed?.amount.currency).toBe('INR');
+    expect(parsed?.merchant).toBe('SWIGGY');
+    expect(parsed?.occurredAt?.slice(0, 10)).toBe('2026-09-12');
+  });
+
+  it('reads ICICI, which names both sides of the transfer', () => {
+    // "debited … ; SWIGGY credited" is one ordinary debit described from both
+    // ends. Bailing whenever both words appear lost the whole format; the verb
+    // nearest the amount is the one that means something.
+    const parsed = parseSms(
+      'ICICI Bank Acct XX123 debited for Rs 500.00 on 12-Sep-26; SWIGGY credited. UPI:526012345678',
+      { region: 'IN' },
+    );
+    expect(parsed?.direction).toBe('debit');
+    expect(parsed?.amount.minor).toBe(50000n);
+    expect(parsed?.merchant).toBe('SWIGGY');
+  });
+
+  it('does not read the word "credit" inside "Credit Card" as money coming in', () => {
+    // The only failure in the set that wrote a wrong ledger entry: a ₹2,500
+    // purchase booked as ₹2,500 received, looking entirely deliberate.
+    const parsed = parseSms(
+      'Your ICICI Bank Credit Card XX1234 has been used for a transaction of INR 2,500.00 on 12-Sep-26 at AMAZON.',
+    );
+    expect(parsed?.direction).toBe('debit');
+    expect(parsed?.amount.minor).toBe(250000n);
+    expect(parsed?.merchant).toBe('AMAZON');
+  });
+
+  it('reads a refund, whichever way the bank conjugates it', () => {
+    for (const text of [
+      'Rs.599.00 refunded to your HDFC Card xx1234 by AMAZON on 12-09-26',
+      'Rs.599.00 refund credited to your HDFC Card xx1234 on 12-09-26',
+    ]) {
+      expect(parseSms(text)?.direction).toBe('credit');
+    }
+  });
+
+  it('reads a currency written after the number', () => {
+    const parsed = parseSms('Your A/c XX1234 is debited with 350.00 INR on 12-09-26 at UBER.');
+    expect(parsed?.amount.minor).toBe(35000n);
+    expect(parsed?.amount.currency).toBe('INR');
+    expect(parsed?.merchant).toBe('UBER');
+  });
+});
+
+describe('who was actually paid', () => {
+  it('reads a capitalised preposition', () => {
+    // HDFC writes "To SWIGGY". A missing `i` flag meant it never matched.
+    expect(
+      parseSms('Sent Rs.245.00 From HDFC Bank A/C x1234 To SWIGGY On 12/09/26')?.merchant,
+    ).toBe('SWIGGY');
+  });
+
+  it('reads a lowercase merchant', () => {
+    expect(parseSms('rs.250 debited from a/c xx1234 at bigbasket on 12-09-26')?.merchant).toBe(
+      'bigbasket',
+    );
+  });
+
+  it('reads the handle out of a UPI address, not the word VPA', () => {
+    const parsed = parseSms('Rs.75.00 debited from A/c XX1234 to VPA swiggy@icici on 12-09-26');
+    expect(parsed?.merchant).toBe('swiggy');
+  });
+
+  it('never returns the "A" of "A/c" as a shop', () => {
+    // A row reading "A" is worse than a row reading nothing: it looks parsed,
+    // and somebody has to notice it is nonsense.
+    const parsed = parseSms('INR 85,000.00 credited to A/c XX1234 on 01-09-26 by NEFT');
+    expect(parsed?.merchant).toBeNull();
+  });
+
+  it('stops the name at the bank’s own words', () => {
+    expect(parseSms('Paid Rs.120 to SWIGGY using Paytm UPI. Txn ID 526012345678')?.merchant).toBe(
+      'SWIGGY',
+    );
+    expect(
+      parseSms('Rp 150.000 didebet dari rekening 1234 di TOKOPEDIA pada 12/09/2026', {
+        region: 'ID',
+      })?.merchant,
+    ).toBe('TOKOPEDIA');
+  });
+
+  it('does not score an implausible merchant, so it cannot be pre-selected on one', () => {
+    // The old score counted fields found, so the VPA bug scored 1.0.
+    const withName = parseSms('Rs.500 debited at CAFE on 02-03-26', { region: 'IN' });
+    const withNonsense = parseSms('Rs.500 debited to A/c XX1234 on 02-03-26', { region: 'IN' });
+    expect(withNonsense?.merchant).toBeNull();
+    expect(withNonsense!.confidence).toBeLessThan(withName!.confidence);
+  });
+});
+
+/* ================================================================== *
+ * Hazard A — the decimal comma. A silent 1000x error.
+ * ================================================================== */
+
+describe('a comma can be the decimal point', () => {
+  it('reads 1.234,56 as one thousand two hundred, not as one twenty-three', () => {
+    // Half of Europe and most of Latin America write it this way. Read as an
+    // English number it is €1.23 — a thousandfold error that looks valid.
+    for (const region of ['DE', 'ES', 'BR', 'ID', 'TR', undefined]) {
+      expect(parseSms('EUR 1.234,56 belastet Konto 3456', { region })?.amount.minor).toBe(123456n);
+    }
+  });
+
+  it('reads 1,234.56 the English way in the same breath', () => {
+    expect(parseSms('EUR 1,234.56 debited at IKEA', { region: 'IE' })?.amount.minor).toBe(123456n);
+  });
+
+  it('reads a lone dot with three digits after it as grouping, not as decimals', () => {
+    // "EUR 1.234" cannot be €1.234: the euro has two minor digits. The
+    // currency's own exponent settles this without needing a locale at all.
+    expect(parseSms('EUR 1.234 belastet Konto 3456', { region: 'DE' })?.amount.minor).toBe(123400n);
+    expect(parseSms('EUR 1.234 belastet Konto 3456')?.amount.minor).toBe(123400n);
+    expect(parseSms('EUR 1.234 belastet Konto 3456')?.inferred).not.toContain('decimalSeparator');
+  });
+
+  it('reads a space or a non-breaking space as grouping', () => {
+    const nbsp = String.fromCharCode(0x00a0);
+    expect(
+      parseSms('Votre compte 1234 a ete debite de 1 234,56 EUR le 12/09/2026', { region: 'FR' })
+        ?.amount.minor,
+    ).toBe(123456n);
+    expect(
+      parseSms(`Votre compte 1234 a ete debite de 1${nbsp}234,56 EUR le 12/09/2026`, {
+        region: 'FR',
+      })?.amount.minor,
+    ).toBe(123456n);
+  });
+
+  it('reads the Swiss apostrophe as grouping', () => {
+    expect(
+      parseSms("CHF 1'234.50 belastet Konto 4471 bei MIGROS", { region: 'CH' })?.amount.minor,
+    ).toBe(123450n);
+  });
+
+  it('reads Arabic’s own separators', () => {
+    // U+066B is the decimal separator and U+066C the thousands separator — the
+    // mirror image of the Latin habit.
+    const decimal = String.fromCharCode(0x066b);
+    expect(
+      parseSms(`AED 250${decimal}50 debited from Card 4471`, { region: 'AE' })?.amount.minor,
+    ).toBe(25050n);
+  });
+
+  it('still reads India’s two-digit grouping', () => {
+    expect(parseSms('Rs 1,23,456.78 debited at HOTEL TAJ')?.amount.minor).toBe(12345678n);
+  });
+});
+
+/* ================================================================== *
+ * Hazard B — the currency's exponent.
+ * ================================================================== */
+
+describe('a currency decides how many decimals it has', () => {
+  it('keeps all three digits of a Kuwaiti dinar', () => {
+    // KWD, BHD, OMR, JOD and TND have three minor digits. Capping the fraction
+    // at two silently turned 12.345 into 12.340.
+    const parsed = parseSms('KWD 12.345 debited from Account XX1234 at LULU', { region: 'KW' });
+    expect(parsed?.amount.minor).toBe(12345n);
+    expect(parsed?.inferred).not.toContain('decimalSeparator');
+  });
+
+  it('says so when three decimals could equally have been grouping', () => {
+    // With no locale, "KWD 12.345" is genuinely either twelve dinars and a bit
+    // or twelve thousand. It is answered, and it says it guessed.
+    const parsed = parseSms('KWD 12.345 debited from Account XX1234 at LULU');
+    expect(parsed?.amount.minor).toBe(12345n);
+    expect(parsed?.inferred).toContain('decimalSeparator');
+    expect(parsed!.confidence).toBeLessThan(
+      parseSms('KWD 12.345 debited from Account XX1234 at LULU', { region: 'KW' })!.confidence,
+    );
+  });
+
+  it('never gives a zero-decimal currency phantom minor units', () => {
+    expect(parseSms('JPY 1,234 spent on card 1234 at LAWSON')?.amount.minor).toBe(1234n);
+    expect(parseSms('JPY 1,234.00 spent on card 1234 at LAWSON')?.amount.minor).toBe(1234n);
+    expect(parseSms('KRW 50,000 spent at OLIVE YOUNG')?.amount.minor).toBe(50000n);
+  });
+});
+
+/* ================================================================== *
+ * Hazard C — day-first or month-first.
+ * ================================================================== */
+
+describe('08/05/2026 is two different days', () => {
+  const body = 'USD 42.50 spent on card ending 1234 at TARGET on 08/05/2026';
+
+  it('is the 5th of August in the United States', () => {
+    expect(parseSms(body, { region: 'US' })?.occurredAt?.slice(0, 10)).toBe('2026-08-05');
+  });
+
+  it('is the 8th of May in India', () => {
+    expect(parseSms(body, { region: 'IN' })?.occurredAt?.slice(0, 10)).toBe('2026-05-08');
+  });
+
+  it('falls back to day-first when nobody said, and says that it did', () => {
+    const parsed = parseSms(body);
+    expect(parsed?.occurredAt?.slice(0, 10)).toBe('2026-05-08');
+    expect(parsed?.inferred).toContain('dateOrder');
+    expect(parsed!.confidence).toBeLessThan(parseSms(body, { region: 'IN' })!.confidence);
+  });
+
+  it('does not guess when a component is over twelve', () => {
+    const parsed = parseSms('Rs.400 debited at CAFE on 28/02/26');
+    expect(parsed?.occurredAt?.slice(0, 10)).toBe('2026-02-28');
+    expect(parsed?.inferred).not.toContain('dateOrder');
+  });
+
+  it('takes an explicit order over the region', () => {
+    expect(parseSms(body, { region: 'IN', dateOrder: 'mdy' })?.occurredAt?.slice(0, 10)).toBe(
+      '2026-08-05',
+    );
+  });
+
+  it('reads an ISO date, which used to match nothing at all', () => {
+    expect(parseSms('EUR 20.00 debited from account 1234 at IKEA on 2026-09-12')?.occurredAt).toBe(
+      '2026-09-12T00:00:00.000Z',
+    );
+    expect(
+      parseSms("You've spent Rs.1500.00 via Debit Card xx1234 at AMAZON on 2026-09-12:14:23:05.")
+        ?.occurredAt,
+    ).toBe('2026-09-12T14:23:05.000Z');
+  });
+
+  it('reads a month name in either order', () => {
+    expect(parseSms('USD 42.50 spent at STARBUCKS on Sep 12, 2026')?.occurredAt?.slice(0, 10)).toBe(
+      '2026-09-12',
+    );
+    expect(parseSms('USD 42.50 spent at STARBUCKS on 12-Sep-2026')?.occurredAt?.slice(0, 10)).toBe(
+      '2026-09-12',
+    );
+    expect(parseSms('Rs 500 debited at CAFE on date 12Sep26')?.occurredAt?.slice(0, 10)).toBe(
+      '2026-09-12',
+    );
+  });
+
+  it('reads a month name in another language', () => {
+    for (const [text, day] of [
+      ['EUR 20,00 belastet Konto 1234 bei IKEA am 12. Okt 2026', '2026-10-12'],
+      ['EUR 20,00 debitado da conta 1234 em 12 de dezembro de 2026', '2026-12-12'],
+      ['EUR 20,00 debite du compte 1234 le 12 juillet 2026', '2026-07-12'],
+      ['EUR 20,00 debite du compte 1234 le 12 juin 2026', '2026-06-12'],
+      ['TRY 20,00 harcama 12 Agustos 2026 kart 1234', '2026-08-12'],
+    ] as const) {
+      expect(parseSms(text, { region: 'DE' })?.occurredAt?.slice(0, 10)).toBe(day);
+    }
+  });
+});
+
+/* ================================================================== *
+ * Hazard D — the language the bank is writing in.
+ * ================================================================== */
+
+describe('banks do not all write in English', () => {
+  it('reads a debit in the languages Waves ships in and the ones it banks in', () => {
+    for (const [text, context] of [
+      ['Ihr Konto DE12 wurde mit EUR 1.234,56 belastet am 12.09.2026 bei REWE.', { region: 'DE' }],
+      ['Compra de EUR 45,90 en MERCADONA con tarjeta 1234 el 12/09/2026', { region: 'ES' }],
+      ['Compra aprovada: R$ 1.234,56 em MERCADO LIVRE em 12/09/2026', { region: 'BR' }],
+      ['Votre compte 1234 a ete debite de 45,00 EUR le 12/09/2026 chez FNAC', { region: 'FR' }],
+      ['Rp 150.000 didebet dari rekening 1234 di TOKOPEDIA pada 12/09/2026', { region: 'ID' }],
+      ['Hesabinizdan 250,75 TL harcama yapildi. Kart 1234, 12.09.2026', { region: 'TR' }],
+      ['Akaun 1234 didebit RM 125.50 di MYDIN pada 12/09/2026', { region: 'MY' }],
+      ['Tai khoan 1234 ghi no 1.250.000 VND tai HIGHLANDS ngay 12/09/2026', { region: 'VN' }],
+      ['Kortkop 1 234,50 kr hos ICA 12/09/2026 kort 1234', { region: 'SE' }],
+    ] as const) {
+      expect(parseSms(text, context), text).not.toBeNull();
+      expect(parseSms(text, context)?.direction, text).toBe('debit');
+    }
+  });
+
+  it('reads Thai, which separates nothing with spaces', () => {
+    const parsed = parseSms('บัญชี 1234 ถูกหัก THB 1,250.00 ที่ 7-ELEVEN 12/09/2026', {
+      region: 'TH',
+    });
+    expect(parsed?.direction).toBe('debit');
+    expect(parsed?.amount.minor).toBe(125000n);
+    expect(parsed?.merchant).toBe('7-ELEVEN');
+  });
+
+  it('refuses the same six kinds of message in those languages too', () => {
+    // A false accept is worse than a false reject, and internationalising the
+    // debit verbs without internationalising these would internationalise the
+    // parser's worst false positive rather than its usefulness.
+    for (const [text, context] of [
+      [
+        'Su codigo de verificacion es 445566 para una compra de EUR 250,00 en ZARA.',
+        { region: 'ES' },
+      ],
+      ['Ihr Konto wird mit EUR 49,90 belastet am 15.09.2026 fuer NETFLIX.', { region: 'DE' }],
+      ['Votre transaction de 45,00 EUR chez FNAC a ete refusee.', { region: 'FR' }],
+      ['Saldo rekening 1234 adalah Rp 1.250.000 pada 12/09/2026.', { region: 'ID' }],
+      ['Kredi karti 1234 son odeme tarihi 18.09.2026, tutar 1.250,00 TL.', { region: 'TR' }],
+      ['Sua compra de R$ 250,00 foi recusada por saldo insuficiente.', { region: 'BR' }],
+    ] as const) {
+      expect(parseSms(text, context), text).toBeNull();
+    }
+  });
+});
+
+describe('right-to-left text', () => {
+  const isolateStart = String.fromCharCode(0x2066);
+  const isolateEnd = String.fromCharCode(0x2069);
+
+  it('reads an Arabic debit', () => {
+    const parsed = parseSms('تم خصم 250.50 د.إ من البطاقة 4471 لدى كارفور 12-09-2026', {
+      region: 'AE',
+    });
+    expect(parsed?.direction).toBe('debit');
+    expect(parsed?.amount.currency).toBe('AED');
+    expect(parsed?.amount.minor).toBe(25050n);
+    expect(parsed?.accountTail).toBe('4471');
+  });
+
+  it('is not defeated by an invisible bidi isolate around the amount', () => {
+    // An Arabic alert wraps its amount so the digits render left-to-right
+    // inside a right-to-left sentence. The marks are invisible; a parser that
+    // does not strip them simply fails to see a number that is plainly there.
+    const wrapped = `تم خصم ${isolateStart}AED 250.50${isolateEnd} من الحساب 4471`;
+    expect(parseSms(wrapped, { region: 'AE' })?.amount.minor).toBe(25050n);
+  });
+
+  it('refuses an Arabic one-time password', () => {
+    expect(parseSms('رمز التحقق 445566 لعملية شراء بقيمة 250.00 د.إ', { region: 'AE' })).toBeNull();
+  });
+});
+
+/* ================================================================== *
+ * Hazard E — numerals that are not 0-9.
+ * ================================================================== */
+
+describe('numerals that are not ASCII', () => {
+  it('reads Devanagari digits', () => {
+    const parsed = parseSms('आपके खाते XX1234 से ५००.०० रुपये डेबिट किए गए 12-09-2026', {
+      region: 'IN',
+    });
+    expect(parsed?.direction).toBe('debit');
+    expect(parsed?.amount.currency).toBe('INR');
+    expect(parsed?.amount.minor).toBe(50000n);
+  });
+
+  it('reads Arabic-Indic digits', () => {
+    const parsed = parseSms('تم خصم ٢٥٠.٥٠ د.إ من البطاقة ٤٤٧١', { region: 'AE' });
+    expect(parsed?.amount.minor).toBe(25050n);
+    expect(parsed?.accountTail).toBe('4471');
+  });
+});
+
+/* ================================================================== *
+ * Hazard F — currency coverage, and the symbols that are shared.
+ * ================================================================== */
+
+describe('a symbol is not a currency', () => {
+  const body = '$42.50 spent on card ending 1234 at STARBUCKS on 12-09-2026';
+
+  it('reads the dollar of the country it was told about', () => {
+    expect(parseSms(body, { region: 'CA' })?.amount.currency).toBe('CAD');
+    expect(parseSms(body, { region: 'AU' })?.amount.currency).toBe('AUD');
+    expect(parseSms(body, { region: 'SG' })?.amount.currency).toBe('SGD');
+    expect(parseSms(body, { region: 'CA' })?.inferred).not.toContain('currency');
+  });
+
+  it('falls back to the dollar most people mean, and says it guessed', () => {
+    const parsed = parseSms(body);
+    expect(parsed?.amount.currency).toBe('USD');
+    expect(parsed?.inferred).toContain('currency');
+  });
+
+  it('reads a qualified symbol without needing a region at all', () => {
+    expect(parseSms('R$ 1.234,56 debitado do cartao 1234')?.amount.currency).toBe('BRL');
+    expect(parseSms('S$ 42.50 spent on card 1234 at NTUC')?.amount.currency).toBe('SGD');
+  });
+
+  it('reads the Nordic krone by country', () => {
+    expect(
+      parseSms('Kortkop 1 234,50 kr hos ICA kort 1234', { region: 'SE' })?.amount.currency,
+    ).toBe('SEK');
+    expect(
+      parseSms('Kortkop 1 234,50 kr hos REMA kort 1234', { region: 'NO' })?.amount.currency,
+    ).toBe('NOK');
+  });
+
+  it('reads both the symbol and the code for the currencies Waves supports', () => {
+    for (const [text, code] of [
+      ['₹ 500 debited at CAFE', 'INR'],
+      ['INR 500 debited at CAFE', 'INR'],
+      ['€ 20,00 belastet bei IKEA', 'EUR'],
+      ['£ 20.00 debited at TESCO', 'GBP'],
+      ['AED 89.00 debited at CARREFOUR', 'AED'],
+      ['MYR 125.50 debited at MYDIN', 'MYR'],
+      ['RM 125.50 didebit di MYDIN', 'MYR'],
+      ['Rp 150.000 didebet di TOKOPEDIA', 'IDR'],
+      ['THB 1,250.00 debited at 7-ELEVEN', 'THB'],
+      ['฿ 1,250.00 debited at 7-ELEVEN', 'THB'],
+      ['VND 1.250.000 debited at HIGHLANDS', 'VND'],
+      ['ZAR 250.00 debited at WOOLWORTHS', 'ZAR'],
+      ['CHF 20.00 belastet bei MIGROS', 'CHF'],
+      ['TRY 250,75 harcama MIGROS', 'TRY'],
+      ['LKR 500 debited at KEELLS', 'LKR'],
+    ] as const) {
+      expect(parseSms(text, { region: undefined })?.amount.currency, text).toBe(code);
+    }
+  });
+
+  it('takes a caller’s default when the message names nothing', () => {
+    const parsed = parseSms('Account XX1234 debited by 150.0 at CAFE on 12-09-2026', {
+      defaultCurrency: 'GBP',
+    });
+    expect(parsed?.amount.currency).toBe('GBP');
+    expect(parsed?.amount.minor).toBe(15000n);
+    expect(parsed?.inferred).not.toContain('currency');
+  });
+
+  it('takes the region’s currency before falling back to rupees', () => {
+    expect(
+      parseSms('Account XX1234 debited by 150.0 at CAFE', { region: 'DE' })?.amount.currency,
+    ).toBe('EUR');
+    const nothing = parseSms('Account XX1234 debited by 150.0 at CAFE');
+    expect(nothing?.amount.currency).toBe('INR');
+    expect(nothing?.inferred).toContain('currency');
+  });
+});
+
+/* ================================================================== *
+ * Hazard G — the sender.
+ * ================================================================== */
+
+describe('the sender is a hint, never a filter', () => {
+  it('strips the operator prefix, which differs by carrier and circle', () => {
+    expect(senderHeader('AD-HDFCBK')).toBe('HDFCBK');
+    expect(senderHeader('VM-HDFCBK')).toBe('HDFCBK');
+    expect(senderHeader('JD-HDFCBK-S')).toBe('HDFCBK');
+    // Nothing here assumes the Indian shape: a bare short code is itself.
+    expect(senderHeader('SANTANDER')).toBe('SANTANDER');
+    expect(senderHeader('')).toBeNull();
+  });
+
+  it('raises confidence when the sender looks like a bank', () => {
+    const body = 'Rs.500 debited at CAFE on 02-03-26';
+    const known = parseSms(body, { region: 'IN', sender: 'AD-HDFCBK' });
+    const unknown = parseSms(body, { region: 'IN', sender: '+919876543210' });
+    expect(known!.confidence).toBeGreaterThan(unknown!.confidence);
+  });
+
+  it('never drops a message because the sender is not recognised', () => {
+    // A bank the list has not heard of is still a bank, and a person who pasted
+    // a message has already decided it is worth reading.
+    for (const sender of ['ZZ-NEVERHEARDOF', '+441234567890', undefined]) {
+      expect(parseSms('EUR 20.00 debited at IKEA on 12-09-2026', { sender })).not.toBeNull();
+    }
+  });
+});
+
+/* ================================================================== *
+ * Two amounts, and which one is the transaction.
+ * ================================================================== */
+
+describe('a message that quotes a balance as well', () => {
+  it('takes the transaction even when the balance comes first', () => {
+    // The old parser took the first number and was right by luck, because
+    // Indian banks quote the transaction first.
+    const parsed = parseSms(
+      'Avl Bal Rs 9,999.00. Rs.450.00 debited from A/c XX1234 at DOMINOS on 12-09-26',
+      { region: 'IN' },
+    );
+    expect(parsed?.amount.minor).toBe(45000n);
+    expect(parsed?.merchant).toBe('DOMINOS');
+  });
+
+  it('still takes the transaction when the balance trails', () => {
+    expect(
+      parseSms('Rs.450.00 debited from A/c XX1234 at DOMINOS on 12-09-26. Avl Bal: Rs.9,999.00')
+        ?.amount.minor,
+    ).toBe(45000n);
+  });
+});
+
+/* ================================================================== *
+ * The rule the whole file is written around.
+ * ================================================================== */
+
+describe('never guess silently', () => {
+  it('reports nothing as inferred when every signal was present', () => {
+    const parsed = parseSms(
+      'INR 1,234.00 debited from A/c no. XX3456 on 2026-09-12 at AMAZON. Ref: 412703998812',
+      { region: 'IN' },
+    );
+    expect(parsed?.inferred).toEqual([]);
+    expect(parsed?.confidence).toBeGreaterThanOrEqual(SMS_LOW_CONFIDENCE);
+  });
+
+  it('names each field it had to decide for itself', () => {
+    const parsed = parseSms('$ 1.234 debited at CAFE on 08/05/26');
+    expect(parsed?.inferred).toContain('currency');
+    expect(parsed?.inferred).toContain('dateOrder');
+  });
+
+  it('lowers confidence far enough that a guessed row is not pre-selected', () => {
+    const proposed = proposeFromSms([
+      { body: 'KWD 12.345 debited on 08/05/26', receivedAt: '2026-05-08T10:00:00.000Z' },
+    ]);
+    expect(proposed[0]?.preselect).toBe(false);
+    expect(proposed[0]?.inferred).toContain('decimalSeparator');
+  });
+
+  it('passes the caller’s context to every message, and the sender on top', () => {
+    const proposed = proposeFromSms(
+      [
+        {
+          body: '$42.50 spent on card ending 1234 at TARGET on 08/05/2026',
+          receivedAt: '2026-08-05T10:00:00.000Z',
+          sender: 'CHASE',
+        },
+      ],
+      { context: { region: 'US' } },
+    );
+    expect(proposed[0]?.amount.currency).toBe('USD');
+    expect(proposed[0]?.at.slice(0, 10)).toBe('2026-08-05');
+    expect(proposed[0]?.inferred).toEqual([]);
+    expect(proposed[0]?.preselect).toBe(true);
+  });
+
+  it('refuses a pathological body rather than thinking about it', () => {
+    expect(parseSms(`Rs ${'1'.repeat(5000)} debited at CAFE`)).not.toBeUndefined();
   });
 });


### PR DESCRIPTION
Branches from `feat/sms-import` (#796), not `main` — that PR owns the paste screen and the current `parse.ts`. Merge it after #796.

The docs from `docs/sms-parser-coverage` (#797) were **cherry-picked** onto this branch (`a37a27d0`), not recreated, so that PR's history is preserved; this PR then updates their measured results.

## The bug that started it

`EUR 1.234,56 debited from card 1234 at REWE` — corpus case 61 — was **accepted** by the old parser, scored **0.9**, pre-selected, and recorded as **€1.23**. `AMOUNT` matched `1.23` out of `1.234,56` and stopped, reading the first dot as the decimal point. A thousandfold error, in a row that looks correctly parsed, in a shared ledger where somebody else is owed the difference.

That is worse than every failure the coverage study listed put together: a dropped message is visible and the person pastes it again.

## What changed

**Amounts.** The decimal separator is now decided, not assumed. Both a dot and a comma present → the later one is the decimal (`1,234.56` and `1.234,56` are both settled outright). One kind twice → grouping (`1.234.567`, India's `1,23,456`). One separator, fewer than three digits after → decimal. One separator, exactly three digits → the currency's **exponent** settles it, because a two-decimal currency cannot carry three; only KWD/BHD/OMR/JOD/TND are genuinely open, and those now keep all three digits instead of being truncated to two. Zero-decimal currencies (JPY, KRW, VND…) never acquire phantom minor units. Space, non-breaking-space and Swiss-apostrophe grouping are read. Digits still go straight to `bigint` minor units via `minorUnitExponent` — no float anywhere between the text and the amount (ADR-003).

**Never guess silently.** `parseSms(text, context)` takes an optional `SmsParseContext` — region, locale, default currency, sender. Where the context does not settle an ambiguity the parser uses one documented fallback **and reports it** in the new `ParsedSms.inferred` (`currency` / `decimalSeparator` / `dateOrder`), with confidence lowered to match, so the UI can point at the field to check. Every path works when given no context at all.

| ambiguity | resolved by | with nothing at all |
| --- | --- | --- |
| `08/05/2026` | a component over 12; else the region's order | day-first, marked `dateOrder` |
| one separator, 3 digits after | the currency's exponent | grouping — a deduction, **not** marked |
| the same, 3-decimal currency | the locale's decimal separator | the currency's own precision, marked |
| `$`, `kr`, `Rs`, `ريال` | the region | the family's commonest member, marked |
| no currency token at all | the caller's default, then the region | INR, marked |

**Dates.** ISO (`2026-09-12`, including the `:`-joined time form) used to match nothing at all. Month-first named forms (`Sep 12, 2026`), Romance long forms (`12 de dezembro de 2026`), and month names in fifteen languages. Numeric order is region-driven, never hardcoded day-first.

**Direction.** The verb *nearest the amount* decides, rather than bailing whenever both a debit and a credit word appear — which recovers ICICI's entire account-debit format. `Credit Card` and `Debit Card` are blanked (with spaces of the same length, so every other index still holds) before the test, which fixes the only failure that wrote a wrong ledger entry.

**Confidence.** Re-based on plausibility. A merchant that is a stop-word, a bare number or a date scores nothing and is skipped rather than returned, so the parser keeps looking — `to VPA swiggy@icici` yields `swiggy`, not `VPA` at confidence 1.0; `credited to A/c` yields nothing, not `A`.

**Language.** Debit and credit verbs, refusals, prepositions and month names in en/ta/hi/ar plus es, pt, fr, de, it, nl, id, ms, tr, th, vi and the Nordic languages. Every language added to the verb list is added to the refusal list too — internationalising the debit verbs without internationalising the OTP list would internationalise this parser's worst false positive rather than its usefulness. Latin terms are word-bounded, non-Latin ones are not, because `\b` is defined against `[A-Za-z0-9_]` and `/\bمرفوض\b/` matches nothing, ever.

**Numerals and RTL.** `normalizeDigits` was in `apps/mobile/src/lib/voiceExpense.ts` (not `packages/core/src/voice/`, which does not exist); it moved to `packages/core/src/text/digits.ts` and the voice parser re-exports it, so there is one table. Bidi controls are stripped — an Arabic alert wraps its amount in an isolate, and a parser that does not expect that fails to see a number that is plainly there.

**Sender.** Used at last: the operator prefix is stripped (`AD-HDFCBK` / `VM-HDFCBK` → `HDFCBK`) and a bank-looking header raises confidence. Never a filter, and nothing assumes India's shape — `SANTANDER` reads as itself.

**Also.** The amount is no longer just "the first number": one sitting behind a balance word is skipped, so a bank that leads with the balance no longer books the balance as the expense.

## Measured

Both parsers run against the same 61 messages (the original 25 unchanged, renumbered not at all, plus 36 international ones):

|                     | direction     |
| ------------------- | ------------- |
| `01b5f678` (before) | **35 / 61**   |
| this branch         | **61 / 61**   |
| original 25 only    | 20/25 → **25/25** |

All twelve negatives still refused, now in six languages. No case regressed. Four of the old parser's 35 "passes" carried a silently wrong field — an amount (case 61), a balance mistaken for the transaction (59), a currency (51) and a date (38); all four are right now.

## Compatibility

`proposeFromSms`'s existing callers are untouched — #796's paste screen, `smsDrafts.ts`, `smsReader.ts`. `parseSms`'s second argument and `ProposeOptions.context` are both optional. `ParsedSms` gains one required field, `inferred`; `import/email.ts` is the only place in the tree that constructs one, and it is updated.

Pure, on-device, no writes, no network (ADR-013).

## Gates

`format`, `lint`, `typecheck`, core (1052), mobile (1538), api, web, edge — all green. `packages/db` typecheck fails in a fresh worktree for want of `DIRECT_URL`; nothing here touches it.

## Not done

- The sender allowlist as a cheap first filter over a whole inbox (the performance half; only the accuracy half is wired).
- Telling a bank name from a merchant name — corpus case 14 reads `HDFC` where the shop is `AMAZON`.
- `de`, `a` and `no` as merchant prepositions: left out on purpose, since each is also an ordinary English fragment. Costs a merchant on two Spanish/Portuguese shapes.
- Nothing has been run on a device, and no real inbox was read. The corpus is written, not captured.

https://claude.ai/code/session_015jhzmZz5fkjnZZ14YxHGfS
